### PR TITLE
Prevent Nimbus from hanging if random data is sent to nimbus thrift port

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -23,6 +23,7 @@ storm.messaging.transport: "backtype.storm.messaging.zmq"
 ### nimbus.* configs are for the master
 nimbus.host: "localhost"
 nimbus.thrift.port: 6627
+nimbus.thrift.max_buffer_size: 1048576
 nimbus.childopts: "-Xmx1024m"
 nimbus.task.timeout.secs: 30
 nimbus.supervisor.timeout.secs: 60

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -1137,14 +1137,13 @@
         options (-> (TNonblockingServerSocket. (int (conf NIMBUS-THRIFT-PORT)))
                     (THsHaServer$Args.)
                     (.workerThreads 64)
-                    (.protocolFactory (TBinaryProtocol$Factory.))
+                    (.protocolFactory (TBinaryProtocol$Factory. false true (conf NIMBUS-THRIFT-MAX-BUFFER-SIZE)))
                     (.processor (Nimbus$Processor. service-handler))
                     )
-       server (THsHaServer. options)]
+       server (THsHaServer. (do (set! (. options maxReadBufferBytes)(conf NIMBUS-THRIFT-MAX-BUFFER-SIZE)) options))]
     (.addShutdownHook (Runtime/getRuntime) (Thread. (fn [] (.shutdown service-handler) (.stop server))))
     (log-message "Starting Nimbus server...")
     (.serve server)))
-
 
 ;; distributed implementation
 

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -204,6 +204,12 @@ public class Config extends HashMap<String, Object> {
     public static final String NIMBUS_THRIFT_PORT = "nimbus.thrift.port";
     public static final Object NIMBUS_THRIFT_PORT_SCHEMA = Number.class;
 
+    /**
+     * The maximum buffer size thrift should use when reading messages.
+     */
+    public static final String NIMBUS_THRIFT_MAX_BUFFER_SIZE = "nimbus.thrift.max_buffer_size";
+    public static final Object NIMBUS_THRIFT_MAX_BUFFER_SIZE_SCHEMA = Number.class;
+
 
     /**
      * This parameter is used by the storm-deploy project to configure the


### PR DESCRIPTION
Currently if random data is sent to Nimbus' thrift port, it will result in the following error, causing Nimbus to hang:

`java.lang.OutOfMemoryError: Java heap space`

Situations where this can happen:
- Inadvertently ssh'ing to the nimbus port (`ssh nimbus -p 6627`)
- Telnetting to the nimbus port (`telnet nimbus 6627`)
- Network security/vulnerability scans that probe port 6627

The solution is to set a limit on the size of the buffers Thrift uses for reading messages. With this fix in place when any of the above occurs, the following will appear in the nimbus log (but nimbus will not hang or crash):

```
2013-12-13 17:10:52 o.a.t.s.TNonblockingServer [ERROR] Read a frame size of 1397966893, which is bigger than the maximum allowable buffer size for ALL connections.
```
