### PR TITLE
Could not find artifact org.jgrapht:jgrapht-core:jar:0.9.0

### DIFF
--- a/storm-core/project.clj
+++ b/storm-core/project.clj
@@ -38,7 +38,7 @@
                  [org.apache.httpcomponents/httpclient "4.1.1"]
                  [org.clojure/tools.cli "0.2.2"]
                  [com.googlecode.disruptor/disruptor "2.10.1"]
-                 [org.jgrapht/jgrapht-core "0.9.0"]
+                 [org.jgrapht/jgrapht-core "0.9.0-SNAPSHOT"]
                  [com.google.guava/guava "13.0"]
                  [ch.qos.logback/logback-classic "1.0.6"]
                  [org.slf4j/log4j-over-slf4j "1.6.6"]


### PR DESCRIPTION
Artifact `org.jgrapht:jgrapht-core:jar:0.9.0` does not seem to exist in
any of the referenced repositories. The following artifacts are
available from
[oss.sonatype.org](https://oss.sonatype.org/index.html#nexus-search;quic
k~jgraph
t-core):
- 0.8.3-SNAPSHOT
- 0.9.0-SNAPSHOT
- 0.9.1-SNAPSHOT

I have changed the entry in storm-core/project.clj to use
0.9.0-SNAPSHOT.
