### PR TITLE
Removed duplicate key: :javac-options

### DIFF
--- a/storm-core/project.clj
+++ b/storm-core/project.clj
@@ -49,7 +49,7 @@
   :test-paths ["test/clj"]
   :resource-paths ["../conf"]
   :target-path "target"
-  :javac-options ["-target" "1.6" "-source" "1.6"]
+  :javac-options ["-target" "1.6" "-source" "1.6" "-g"]
   :profiles {:dev {:resource-paths ["src/dev"]
                    :dependencies [[org.mockito/mockito-all "1.9.5"]]}
              :release {}
@@ -61,7 +61,6 @@
   :repositories {"sonatype"
                  "http://oss.sonatype.org/content/groups/public/"}
 
-  :javac-options ["-g"]
   :jvm-opts ["-Djava.library.path=/usr/local/lib:/opt/local/lib:/usr/lib"]
 
   :aot :all)


### PR DESCRIPTION
Building storm causes errors due to a duplicate `:javac-options`
entries in the `storm-core/project.clj`.

```
Caused by: java.lang.IllegalArgumentException: Duplicate key:
:javac-options
```

I have merged the `:javac-options` into a single entry.
