### PR TITLE
Nimbus validates topo conf on submission

### DIFF
--- a/storm-core/src/clj/backtype/storm/config.clj
+++ b/storm-core/src/clj/backtype/storm/config.clj
@@ -105,7 +105,7 @@
 (defn read-default-config []
   (clojurify-structure (Utils/readDefaultConfig)))
 
-(defn- validate-configs-with-schemas [conf]
+(defn validate-configs-with-schemas [conf]
   (doseq [[k v] conf
          :let [schema (CONFIG-SCHEMA-MAP k)]]
     (if (not (nil? schema))

--- a/storm-core/src/jvm/backtype/storm/StormSubmitter.java
+++ b/storm-core/src/jvm/backtype/storm/StormSubmitter.java
@@ -98,7 +98,7 @@ public class StormSubmitter {
                         client.getClient().submitTopology(name, submittedJar, serConf, topology);                                            
                     }
                 } catch(InvalidTopologyException e) {
-                    LOG.warn("Topology submission exception", e);
+                    LOG.warn("Topology submission exception: "+e.get_msg());
                     throw e;
                 } catch(AlreadyAliveException e) {
                     LOG.warn("Topology already alive exception", e);

--- a/storm-core/test/clj/backtype/storm/nimbus_test.clj
+++ b/storm-core/test/clj/backtype/storm/nimbus_test.clj
@@ -815,3 +815,12 @@
        (nimbus/clean-inbox dir-location 10)
        (assert-files-in-dir [])
        ))))
+
+(deftest test-validate-topo-config-on-submit
+  (with-local-cluster [cluster]
+    (let [nimbus (:nimbus cluster)
+          topology (thrift/mk-topology {} {})
+          bad-config {"topology.workers" "3"}]
+      (is (thrown-cause? InvalidTopologyException
+        (submit-local-topology-with-opts nimbus "test" bad-config topology
+                                         (SubmitOptions.)))))))


### PR DESCRIPTION
StormSubmitter logs the actual exception message for invalid topologies,
and it does not log the stack trace twice.

For https://issues.apache.org/jira/browse/STORM-181
