### PR TITLE
Submit jvmopts as array of argument values

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -45,7 +45,8 @@ if (not os.path.isfile(USER_CONF_DIR + "/storm.yaml")):
     USER_CONF_DIR = CLUSTER_CONF_DIR
 CONFIG_OPTS = []
 CONFFILE = ""
-JAR_JVM_OPTS = os.getenv('STORM_JAR_JVM_OPTS', '')
+DEFAULT_JVM_OPTS = ''
+JAR_JVM_OPTS = os.getenv('STORM_JAR_JVM_OPTS', DEFAULT_JVM_OPTS)
 
 
 def get_config_opts():
@@ -150,12 +151,17 @@ def jar(jarfile, klass, *args):
     (http://nathanmarz.github.com/storm/doc/backtype/storm/StormSubmitter.html)
     will upload the jar at topology-jar-path when the topology is submitted.
     """
+    jvmopts = ["-Dstorm.jar=" + jarfile]
+
+    if JAR_JVM_OPTS != DEFAULT_JVM_OPTS:
+        jvmopts += JAR_JVM_OPTS.split(' ')
+
     exec_storm_class(
         klass,
         jvmtype="-client",
         extrajars=[jarfile, USER_CONF_DIR, STORM_DIR + "/bin"],
         args=args,
-        jvmopts=[' '.join(filter(None, [JAR_JVM_OPTS, "-Dstorm.jar=" + jarfile]))])
+        jvmopts=jvmopts)
 
 def kill(*args):
     """Syntax: [storm kill topology-name [-w wait-time-secs]]


### PR DESCRIPTION
jvmopts was being supplied as an array of a single string element. Executing the following command to submit a topology would not supply the `STORM_JAR_JVM_OPTS` value appropriately:

`STORM_JAR_JVM_OPTS="-Dhurricane.env=production" storm jar target/scala-2.9.2/hurricane-assembly-0.1.jar topologies.HeavenTopology`

I modeled jvmopts off of other examples in the same script.
