### PR TITLE
Fixes config schema for kryo TOPOLOGY_KRYO_REGISTER

### DIFF
--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -556,7 +556,7 @@ public class Config extends HashMap<String, Object> {
      * See Kryo's documentation for more information about writing custom serializers.
      */
     public static final String TOPOLOGY_KRYO_REGISTER = "topology.kryo.register";
-    public static final Object TOPOLOGY_KRYO_REGISTER_SCHEMA = ConfigValidation.StringsValidator;
+    public static final Object TOPOLOGY_KRYO_REGISTER_SCHEMA = ConfigValidation.KryoRegValidator;
 
     /**
      * A list of classes that customize storm's kryo instance during start-up.

--- a/storm-core/src/jvm/backtype/storm/ConfigValidation.java
+++ b/storm-core/src/jvm/backtype/storm/ConfigValidation.java
@@ -103,4 +103,36 @@ public class ConfigValidation {
             throw new IllegalArgumentException("Field " + name + " must be a power of 2.");
         }
     };
+
+    /**
+     * Validates Kryo Registration
+     */
+    public static Object KryoRegValidator = new FieldValidator() {
+        @Override
+        public void validateField(String name, Object o) throws IllegalArgumentException {
+            if (o == null) {
+                // A null value is acceptable.
+                return;
+            }
+            if (o instanceof Iterable) {
+                for (Object e : (Iterable)o) {
+                    if (e instanceof Map) {
+                        for (Map.Entry<Object,Object> entry: ((Map<Object,Object>)e).entrySet()) {
+                            if (!(entry.getKey() instanceof String) ||
+                                !(entry.getValue() instanceof String)) {
+                                throw new IllegalArgumentException(
+                                    "Each element of the list " + name + " must be a String or a Map of Strings");
+                            }
+                        }
+                    } else if (!(e instanceof String)) {
+                        throw new IllegalArgumentException(
+                                "Each element of the list " + name + " must be a String or a Map of Strings");
+                    }
+                }
+                return;
+            }
+            throw new IllegalArgumentException(
+                    "Field " + name + " must be an Iterable containing only Strings or Maps of Strings");
+        }
+    };
 }

--- a/storm-core/test/clj/backtype/storm/serialization_test.clj
+++ b/storm-core/test/clj/backtype/storm/serialization_test.clj
@@ -18,6 +18,7 @@
   (:import [backtype.storm.serialization KryoTupleSerializer KryoTupleDeserializer
             KryoValuesSerializer KryoValuesDeserializer])
   (:import [backtype.storm.testing TestSerObject TestKryoDecorator])
+  (:import [backtype.storm ConfigValidation])
   (:use [backtype.storm util config])
   )
 
@@ -39,6 +40,24 @@
   ([vals] (roundtrip vals {}))
   ([vals conf]
     (deserialize (serialize vals conf) conf)))
+
+(deftest validate-kryo-conf-basic
+  (.validateField ConfigValidation/KryoRegValidator "test" ["a" "b" "c" {"d" "e"} {"f" "g"}]))
+
+(deftest validate-kryo-conf-fail
+  (try
+    (.validateField ConfigValidation/KryoRegValidator "test" {"f" "g"})
+    (assert false)
+    (catch IllegalArgumentException e))
+  (try
+    (.validateField ConfigValidation/KryoRegValidator "test" [1])
+    (assert false)
+    (catch IllegalArgumentException e))
+  (try
+    (.validateField ConfigValidation/KryoRegValidator "test" [{"a" 1}])
+    (assert false)
+    (catch IllegalArgumentException e))
+)
 
 (deftest test-java-serialization
   (letlocals


### PR DESCRIPTION
Corrects `TOPOLOGY_KRYO_REGISTER_SCHEMA` by adding a new validator for Strings or Maps of Strings, and tests for the new validator.

This should fix integration-test case failures:

`test-component-specific-config`
`test-ack-branching`
`test-acking-self-anchor`

exposed by #11 and found in https://github.com/apache/incubator-storm/pull/14#issuecomment-31796033

Thanks to @revans2 for this work.
