### PR TITLE
Add capability to remove keys from MemoryMapState 

### DIFF
--- a/storm-core/src/jvm/storm/trident/state/map/OpaqueMap.java
+++ b/storm-core/src/jvm/storm/trident/state/map/OpaqueMap.java
@@ -43,7 +43,11 @@ public class OpaqueMap<T> implements MapState<T> {
         for(CachedBatchReadsMap.RetVal<OpaqueValue> retval: curr) {
             OpaqueValue val = retval.val;
             if(val!=null) {
-                ret.add((T) val.get(_currTx));
+                if(retval.cached) {
+                    ret.add((T) val.getCurr());
+                } else {
+                    ret.add((T) val.get(_currTx));
+                }
             } else {
                 ret.add(null);
             }

--- a/storm-core/src/jvm/storm/trident/state/map/RemovableMapState.java
+++ b/storm-core/src/jvm/storm/trident/state/map/RemovableMapState.java
@@ -1,0 +1,8 @@
+package storm.trident.state.map;
+
+import java.util.List;
+import storm.trident.state.State;
+
+public interface RemovableMapState<T> extends State {
+    void multiRemove(List<List<Object>> keys);
+}


### PR DESCRIPTION
The implementation maintains proper opaque semantics, so if the batch is retried the keys will still be there. Keys are officially removed once the next batch starts. This also fixes a bug in OpaqueMap where get after put/update in the same batch wasn't working properly.
