### PR TITLE
Add locking in acquire-random-range-id

### DIFF
--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -638,10 +638,11 @@
     [(MutableInt. -1) choices rand]))
 
 (defn acquire-random-range-id [[^MutableInt curr ^List state ^Random rand]]
-  (when (>= (.increment curr) (.size state))
-    (.set curr 0)
-    (Collections/shuffle state rand))
-  (.get state (.get curr)))
+  (locking curr
+    (when (>= (.increment curr) (.size state))
+      (.set curr 0)
+      (Collections/shuffle state rand))
+    (.get state (.get curr))))
 
 ; this can be rewritten to be tail recursive
 (defn interleave-all [& colls]


### PR DESCRIPTION
This fixes a threadsafety issue documented in STORM-120. This is an
acceptable temporary fix, but the cause of concurrent access to this
variable should still be identified.

@revans2 suggested this fix.

Refs STORM-120
