### PR TITLE
STORM-275 Topologies, Spouts and Bolts with special characters in name cannot be viewed in ui

### DIFF
--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -1016,34 +1016,40 @@
        (-> (main-page)
            ui-template))
   (GET "/topology/:id" [:as {cookies :cookies} id & m]
-       (let [include-sys? (get-include-sys? cookies)]
+       (let [include-sys? (get-include-sys? cookies)
+            id (java.net.URLDecoder/decode id)]
          (try
            (-> (topology-page id (:window m) include-sys?)
              (concat [(mk-system-toggle-button include-sys?)])
              ui-template)
            (catch Exception e (resp/redirect "/")))))
   (GET "/topology/:id/component/:component" [:as {cookies :cookies} id component & m]
-       (let [include-sys? (get-include-sys? cookies)]
-         (-> (component-page id (java.net.URLDecoder/decode component) (:window m) include-sys?)
+       (let [include-sys? (get-include-sys? cookies)
+            id (java.net.URLDecoder/decode id)
+            component (java.net.URLDecoder/decode component)]
+         (-> (component-page id component (:window m) include-sys?)
              (concat [(mk-system-toggle-button include-sys?)])
              ui-template)))
   (POST "/topology/:id/activate" [id]
     (with-nimbus nimbus
-      (let [tplg (.getTopologyInfo ^Nimbus$Client nimbus id)
+      (let [id (java.net.URLDecoder/decode id)
+            tplg (.getTopologyInfo ^Nimbus$Client nimbus id)
             name (.get_name tplg)]
         (.activate nimbus name)
         (log-message "Activating topology '" name "'")))
     (resp/redirect (str "/topology/" id)))
   (POST "/topology/:id/deactivate" [id]
     (with-nimbus nimbus
-      (let [tplg (.getTopologyInfo ^Nimbus$Client nimbus id)
+      (let [id (java.net.URLDecoder/decode id)
+            tplg (.getTopologyInfo ^Nimbus$Client nimbus id)
             name (.get_name tplg)]
         (.deactivate nimbus name)
         (log-message "Deactivating topology '" name "'")))
     (resp/redirect (str "/topology/" id)))
   (POST "/topology/:id/rebalance/:wait-time" [id wait-time]
     (with-nimbus nimbus
-      (let [tplg (.getTopologyInfo ^Nimbus$Client nimbus id)
+      (let [id (java.net.URLDecoder/decode id)
+            tplg (.getTopologyInfo ^Nimbus$Client nimbus id)
             name (.get_name tplg)
             options (RebalanceOptions.)]
         (.set_wait_secs options (Integer/parseInt wait-time))
@@ -1052,7 +1058,8 @@
     (resp/redirect (str "/topology/" id)))
   (POST "/topology/:id/kill/:wait-time" [id wait-time]
     (with-nimbus nimbus
-      (let [tplg (.getTopologyInfo ^Nimbus$Client nimbus id)
+      (let [id (java.net.URLDecoder/decode id)
+            tplg (.getTopologyInfo ^Nimbus$Client nimbus id)
             name (.get_name tplg)
             options (KillOptions.)]
         (.set_wait_secs options (Integer/parseInt wait-time))


### PR DESCRIPTION
If you run a topology with a spout or bolt that contains a whitespace in the name (i.e.  "Do some thing") then the URL towards the component page will look something like this: 

```
/topology/TOPONAME-12-12345678/component/Do+some+thing
```

The page that is opened on that link will try to show a component called 

```
Do+some+thing
```

which it doesn't have.
This fix is a simple URL decoding step for just the component field.
