### PR TITLE
storm-starter: remove leiningen section because leiningen is not used anymore

### DIFF
--- a/examples/storm-starter/README.markdown
+++ b/examples/storm-starter/README.markdown
@@ -47,16 +47,6 @@ If you want to learn more about how Storm works, please head over to the
 [Storm project page](http://storm.incubator.apache.org).
 
 
-<a name="leiningen"></a>
-
-# Using storm-starter with Leiningen
-
-## Install Leiningen
-
-The storm-starter build uses [Leiningen](http://leiningen.org/) 2.0.  Install Leiningen by following the
-[leiningen installation instructions](https://github.com/technomancy/leiningen).
-
-
 <a name="maven"></a>
 
 # Using storm-starter with Maven


### PR DESCRIPTION
storm-starter is built with maven now, and leinigen is not supported anymore.
