### PR TITLE
STORM-258: update commons-io dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <clojure.version>1.4.0</clojure.version>
         <compojure.version>1.1.3</compojure.version>
         <hiccup.version>0.3.6</hiccup.version>
-        <commons-io.verson>1.4</commons-io.verson>
+        <commons-io.verson>2.4</commons-io.verson>
         <commons-lang.version>2.5</commons-lang.version>
         <commons-exec.version>1.1</commons-exec.version>
         <clj-time.version>0.4.1</clj-time.version>


### PR DESCRIPTION
This fixes a dependency conflict can occur when using the Hadoop 2.x HDFS client, as well some other projects in a topology.

I have tested this in multiple scenarios on a distributed cluster and not encountered any issues.
