### PR TITLE
STORM-270 don't package .clj files in release jars.

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -190,6 +190,10 @@
                         <testSourceDirectory>test/clj</testSourceDirectory>
                     </testSourceDirectories>
                     <warnOnReflection>false</warnOnReflection>
+                    <copyDeclaredNamespaceOnly>true</copyDeclaredNamespaceOnly>
+                    <copiedNamespaces>
+                        <copiedNamespace>none</copiedNamespace>
+                    </copiedNamespaces>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This makes it so that .clj files are no longer packaged in the storm-core jar.  I left storm-starter untouched.
