### PR TITLE
STORM-273. Error while running storm topologies on Windows using "storm ...

### DIFF
--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -759,7 +759,7 @@
 
 (defn zip-contains-dir? [zipfile target]
   (let [entries (->> zipfile (ZipFile.) .entries enumeration-seq (map (memfn getName)))]
-    (some? #(.startsWith % (str target file-path-separator)) entries)
+    (some? #(.startsWith % (str target "/")) entries)
     ))
 
 (defn url-encode [s]


### PR DESCRIPTION
Patch changes the path separator to the separator used by the jar file.
