### PR TITLE
STORM-309 storm-starter Readme: Main class param should be quoted

### DIFF
--- a/examples/storm-starter/README.markdown
+++ b/examples/storm-starter/README.markdown
@@ -77,6 +77,10 @@ compile and run `WordCountTopology` in local mode, use the command:
 You can also run clojure topologies with Maven:
 
     $ mvn compile exec:java -Dstorm.topology=storm.starter.clj.word_count
+    
+In Windows parameter should be quoted, like this: 
+
+    $ mvn compile exec:java "-Dstorm.topology=storm.starter.clj.word_count"
 
 ## Packaging storm-starter for use on a Storm cluster
 


### PR DESCRIPTION
In windows, maven throws "Unknown lifecycle phase" if mainclass parameter is not quoted
