### PR TITLE
STORM-265: upgrade to clojure 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <test.extra.args>-Djava.net.preferIPv4Stack=true</test.extra.args>
 
         <!-- dependency versions -->
-        <clojure.version>1.4.0</clojure.version>
+        <clojure.version>1.5.1</clojure.version>
         <compojure.version>1.1.3</compojure.version>
         <hiccup.version>0.3.6</hiccup.version>
         <commons-io.verson>1.4</commons-io.verson>


### PR DESCRIPTION
Upgrade to 1.5.1 was clean (no code modifications necessary). 1.6.x introduces some namespace conflicts.
