### PR TITLE
STORM-291: upgrade http-client to 4.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <clojure.math.numeric-tower.version>0.0.1</clojure.math.numeric-tower.version>
         <carbonite.version>1.4.0</carbonite.version>
         <snakeyaml.version>1.11</snakeyaml.version>
-        <httpclient.version>4.1.1</httpclient.version>
+        <httpclient.version>4.3.3</httpclient.version>
         <clojure.tools.cli.version>0.2.2</clojure.tools.cli.version>
         <disruptor.version>2.10.1</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>


### PR DESCRIPTION
I have tested this both in isolation as well as with the other dependency upgrades combined (commons-io, clojure, kryo, etc.).
