### PR TITLE
STORM-280. storm unit tests are failing on windows.

### DIFF
--- a/storm-core/src/clj/backtype/storm/testing.clj
+++ b/storm-core/src/clj/backtype/storm/testing.clj
@@ -53,7 +53,10 @@
   (dorun
     (for [t paths]
       (if (.exists (File. t))
-        (FileUtils/forceDelete (File. t))
+        (try
+          (FileUtils/forceDelete (File. t))
+          (catch Exception e
+            (log-message (.getMessage e))))
         ))))
 
 (defmacro with-local-tmp [[& tmp-syms] & body]


### PR DESCRIPTION
On windows storm-core unit tests are failing by throwing IOException: Unable to delete file. This happens when unit tests tries to kill local storm cluster and zookeeper holding a lock on transaction logs. 
