### PR TITLE
[STORM-281] ensures we close the config file

### DIFF
--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -29,6 +29,7 @@ import com.netflix.curator.retry.ExponentialBackoffRetry;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -135,7 +136,13 @@ public class Utils {
             }
             URL resource = resources.iterator().next();
             Yaml yaml = new Yaml();
-            Map ret = (Map) yaml.load(new InputStreamReader(resource.openStream()));
+            Map ret = null;
+            InputStream input = resource.openStream();
+            try {
+                ret = (Map) yaml.load(new InputStreamReader(input));
+            } finally {
+                input.close();
+            }
             if(ret==null) ret = new HashMap();
             
 


### PR DESCRIPTION
Unit tests pass.

I manually tested by calling Utils#findAndReadConfigFile in a tight loop and counting open fds to the file with lsof using the process id.
