### PR TITLE
STORM-214. Windows: storm.cmd does not properly handle multiple -c arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <carbonite.version>1.4.0</carbonite.version>
         <snakeyaml.version>1.11</snakeyaml.version>
         <httpclient.version>4.1.1</httpclient.version>
-        <clojure.tools.cli.version>0.2.2</clojure.tools.cli.version>
+        <clojure.tools.cli.version>0.2.4</clojure.tools.cli.version>
         <disruptor.version>2.10.1</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>13.0</guava.version>

--- a/storm-core/src/clj/backtype/storm/command/rebalance.clj
+++ b/storm-core/src/clj/backtype/storm/command/rebalance.clj
@@ -30,7 +30,12 @@
   (let [[{wait :wait executor :executor num-workers :num-workers} [name] _]
                   (cli args ["-w" "--wait" :default nil :parse-fn #(Integer/parseInt %)]
                             ["-n" "--num-workers" :default nil :parse-fn #(Integer/parseInt %)]
-                            ["-e" "--executor" :combine-fn merge :parse-fn parse-executor])
+                            ["-e" "--executor"  :parse-fn parse-executor
+                             :assoc-fn (fn [previous key val]
+                                         (assoc previous key
+                                                (if-let [oldval (get previous key)]
+                                                  (merge oldval val)
+                                                  val)))])
         opts (RebalanceOptions.)]
     (if wait (.set_wait_secs opts wait))
     (if executor (.set_num_executors opts executor))


### PR DESCRIPTION
:combine-fn merge doesn't have any affect on multiple args. New version of cli provides a  :assoc-fn capability which can be used  to merge multiple params for same arg. 
Tested on linux and windows.
