### PR TITLE
STORM-287: Fix the position of documentation strings

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/common.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/common.clj
@@ -244,13 +244,15 @@
        (second)
        (reverse)))
 
-(defn number-duplicates [coll]
+(defn number-duplicates
   "(number-duplicates [\"a\", \"b\", \"a\"]) => [\"a\", \"b\", \"a#2\"]"
+  [coll]
   (map-occurrences (fn [x occurences] (if (>= occurences 2) (str x "#" occurences) x)) coll))
 
-(defn metrics-consumer-register-ids [storm-conf]
+(defn metrics-consumer-register-ids
   "Generates a list of component ids for each metrics consumer
    e.g. [\"__metrics_org.mycompany.MyMetricsConsumer\", ..] "
+  [storm-conf]
   (->> (get storm-conf TOPOLOGY-METRICS-CONSUMER-REGISTER)         
        (map #(get % "class"))
        (number-duplicates)


### PR DESCRIPTION
A documentation string should be between a function name
and a parameter list.
