### PR TITLE
STORM-290: Exclude log4j and slf4j-log4j12 from curator dependency

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -111,6 +111,16 @@
         <dependency>
             <groupId>com.netflix.curator</groupId>
             <artifactId>curator-framework</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
This fixes a log binding conflict that occurs when using storm-core as a project dependency.
