### PR TITLE
STORM-289: trident DRPC bug fix

### DIFF
--- a/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchTriggerer.java
+++ b/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchTriggerer.java
@@ -158,6 +158,7 @@ public class RichSpoutBatchTriggerer implements IRichSpout {
                 long r = _rand.nextLong();
                 _collector.emitDirect(t, _coordStream, new Values(batchId, count), r);
                 finish.vals.add(r);
+                _msgIdToBatchId.put(r, batchIdVal);
             }
             _finishConditions.put(batchIdVal, finish);
             return tasks;


### PR DESCRIPTION
ack/fail will not remove FinishCondition due to unknown batchId for each
DRPC invocation. It makes the HashMap "_finishConditions" size
increasing. This patch fix the bug.
