### PR TITLE
STORM-269: prevent logviewer from serving files outside the log directory

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
@@ -33,18 +33,18 @@
 (defn tail-file [path tail root-dir]
   (let [flen (.length (clojure.java.io/file path))
         skip (- flen tail)
-        log-dir (File. root-dir)
+        log-dir (.getCanonicalFile (File. root-dir))
         log-file (File. path)]
     (if (= log-dir (.getParentFile log-file))
-    (with-open [input (clojure.java.io/input-stream path)
-                output (java.io.ByteArrayOutputStream.)]
-      (if (> skip 0) (.skip input skip))
-        (let [buffer (make-array Byte/TYPE 1024)]
-          (loop []
-            (let [size (.read input buffer)]
-              (when (and (pos? size) (< (.size output) tail))
-                (do (.write output buffer 0 size)
-                    (recur))))))
+      (with-open [input (clojure.java.io/input-stream path)
+                  output (java.io.ByteArrayOutputStream.)]
+        (if (> skip 0) (.skip input skip))
+          (let [buffer (make-array Byte/TYPE 1024)]
+            (loop []
+              (let [size (.read input buffer)]
+                (when (and (pos? size) (< (.size output) tail))
+                  (do (.write output buffer 0 size)
+                      (recur))))))
         (.toString output)) "File not found")
     ))
 


### PR DESCRIPTION
This is a quick fix to prevent the log viewer from serving files outside of the log directory. It simply checks that the requested file has the root log directory as a parent. If this is not the case, it will not serve the file.
