### PR TITLE
[STORM-233] Removed inline heartbeats to avoid being killed when under heavy ZK load

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -352,7 +352,11 @@
     (touch (worker-pid-path conf worker-id (process-pid))))
   (let [worker (worker-data conf shared-mq-context storm-id assignment-id port worker-id)
         heartbeat-fn #(do-heartbeat worker)
-        
+
+        ;; do this here so that the worker process dies if this fails
+        ;; it's important that worker heartbeat to supervisor ASAP when launching so that the supervisor knows it's running (and can move on)
+        _ (heartbeat-fn)
+ 
         executors (atom nil)
         ;; launch heartbeat threads immediately so that slow-loading tasks don't cause the worker to timeout
         ;; to the supervisor


### PR DESCRIPTION
I removed the inline heartbeats, although I am happy to switch it over so that the ZK heartbeat happens first.  That should also fix the issue.
