### PR TITLE
Sliding window counter wipe zero counts

### DIFF
--- a/examples/storm-starter/src/jvm/storm/starter/tools/SlidingWindowCounter.java
+++ b/examples/storm-starter/src/jvm/storm/starter/tools/SlidingWindowCounter.java
@@ -100,8 +100,7 @@ public final class SlidingWindowCounter<T> implements Serializable {
    * @return The current (total) counts of all tracked objects.
    */
   public Map<T, Long> getCountsThenAdvanceWindow() {
-    Map<T, Long> counts = objCounter.getCounts();
-    objCounter.wipeZeros();
+    Map<T, Long> counts = objCounter.getNonZeroCountsAndWipeZeros();
     objCounter.wipeSlot(tailSlot);
     advanceHead();
     return counts;

--- a/examples/storm-starter/src/jvm/storm/starter/tools/SlotBasedCounter.java
+++ b/examples/storm-starter/src/jvm/storm/starter/tools/SlotBasedCounter.java
@@ -114,5 +114,21 @@ public final class SlotBasedCounter<T> implements Serializable {
       objToCounts.remove(obj);
     }
   }
-
+    public Map<T, Long> getNonZeroCountsAndWipeZeros() {
+        Map<T, Long> result = new HashMap<T, Long>();
+        Set<T> objToBeRemoved = new HashSet<T>();
+        long cnt = 0;
+        for (T obj : objToCounts.keySet()) {
+            cnt = computeTotalCount(obj);
+            if (cnt == 0) {
+                objToBeRemoved.add(obj);
+                continue;
+            }
+            result.put(obj, computeTotalCount(obj));
+        }
+        for (T obj : objToBeRemoved) {
+            objToCounts.remove(obj);
+        }
+        return result;
+    }
 }

--- a/examples/storm-starter/test/jvm/storm/starter/tools/SlidingWindowCounterTest.java
+++ b/examples/storm-starter/test/jvm/storm/starter/tools/SlidingWindowCounterTest.java
@@ -83,7 +83,7 @@ public class SlidingWindowCounterTest {
       long expCounts = expCountsPerIteration[i];
       // Objects are absent if they were zero both this iteration
       // and the last -- if only this one, we need to report zero.
-      boolean expAbsent = ((expCounts == 0) && ((i == 0) || (expCountsPerIteration[i - 1] == 0)));
+      boolean expAbsent = ((expCounts == 0));
 
       // given (for this iteration)
       for (int j = 0; j < numIncrements; j++) {


### PR DESCRIPTION
Do not emit zero counts and computeTotalCount() only once per tick in SlidingWindowCounter
