### PR TITLE
STORM-316: added validation to registermetrics to have timebucketSizeInSecs >= 1

### DIFF
--- a/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
+++ b/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
@@ -236,8 +236,8 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
         }
 
         if (timeBucketSizeInSecs <= 0) {
-            throw new RuntimeException("TopologyContext.registerMetric can only be called with timeBucketSizeInSecs " +
-                                       "greater than or equal to 1 second.");
+            throw new IllegalArgumentException("TopologyContext.registerMetric can only be called with timeBucketSizeInSecs " +
+                                               "greater than or equal to 1 second.");
         }
         
         Map m1 = _registeredMetrics;


### PR DESCRIPTION
added validation so one cannot register a metric with timeBucketSizeInSecs <= 0 (that crashes the topology)
