### PR TITLE
STORM-317: Add SECURITY.md to release binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.9.2-incubating (unreleased)
+ * STORM-317: Add SECURITY.md to release binaries
  * STORM-214: Windows: storm.cmd does not properly handle multiple -c arguments
  * STORM-306: Add security documentation
  * STORM-302: Fix Indentation for pom.xml in storm-dist

--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -132,5 +132,10 @@
             <source>${project.basedir}/../../CHANGELOG.md</source>
             <outputDirectory>/</outputDirectory>
         </file>
+
+        <file>
+            <source>${project.basedir}/../../SECURITY.md</source>
+            <outputDirectory>/</outputDirectory>
+        </file>
     </files>
 </assembly>


### PR DESCRIPTION
I manually verified the proper inclusion of SECURITY.md by creating a distribution (binaries) locally.
