### PR TITLE
STORM-267 - Corrected namespace for LoggingMetricsConsumer

### DIFF
--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -40,7 +40,7 @@
 
 ## Metrics Consumers
 # topology.metrics.consumer.register:
-#   - class: "backtype.storm.metrics.LoggingMetricsConsumer"
+#   - class: "backtype.storm.metric.LoggingMetricsConsumer"
 #     parallelism.hint: 1
 #   - class: "org.mycompany.MyMetricsConsumer"
 #     parallelism.hint: 1


### PR DESCRIPTION
Simple change from plural to non-plural to match the namespace as described in the JIRA ticket.

https://issues.apache.org/jira/browse/STORM-267
