### PR TITLE
STORM-331: Update version of Kafka dependency to 0.8.1.1

### DIFF
--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>${kafkaArtifact}</artifactId>
-            <version>0.8.1</version>
+            <version>0.8.1.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
I tested this pull requested by successfully running:

```
$ cd external/storm-kafka
$ mvn clean install  # for Scala 2.9.2 (default profile)
$ mvn clean install -P Scala-2.10  # for Scala 2.10(.3)
```
