### PR TITLE
Correct capitalization in a test namespace

### DIFF
--- a/storm-core/test/clj/backtype/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer_test.clj
@@ -1,4 +1,4 @@
-(ns backtype.storm.security.auth.authorizer.DRPCSimpleAclAuthorizer-test
+(ns backtype.storm.security.auth.authorizer.DRPCSimpleACLAuthorizer-test
   (:use [clojure test])
   (:import [org.mockito Mockito])
   (:import [backtype.storm Config])


### PR DESCRIPTION
Just a correction to the spelling of the test namespace that originated while developing on a case-insensitive file system.
