### PR TITLE
Enable Kryo serialization in storm-kafka (STORM-332)

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/Broker.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/Broker.java
@@ -22,9 +22,14 @@ import com.google.common.base.Objects;
 import java.io.Serializable;
 
 public class Broker implements Serializable, Comparable<Broker> {
-    public final String host;
-    public final int port;
+    public String host;
+    public int port;
 
+    // for kryo compatibility
+    private Broker() {
+	
+    }
+    
     public Broker(String host, int port) {
         this.host = host;
         this.port = port;

--- a/external/storm-kafka/src/jvm/storm/kafka/Partition.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/Partition.java
@@ -23,9 +23,14 @@ import storm.trident.spout.ISpoutPartition;
 
 public class Partition implements ISpoutPartition {
 
-    public final Broker host;
-    public final int partition;
+    public Broker host;
+    public int partition;
 
+    // for kryo compatibility
+    private Partition() {
+	
+    }
+    
     public Partition(Broker host, int partition) {
         this.host = host;
         this.partition = partition;


### PR DESCRIPTION
Add a no args constructor to storm-kafka's Broker and Partition classes to enable Kryo serialization when using the storm-kafka spout (STORM-332)
