### PR TITLE
STORM-325: Change scope to provided

### DIFF
--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -94,9 +94,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.9.2</artifactId>
+            <artifactId>kafka_2.10</artifactId>
             <version>0.8.1.1</version>
-            <!-- use provided scope, so users can pull in whichever scala version they choose -->
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
o use 2.10 as default
o Scala library is pulled in as transitive dependency; no need to be explicit
