### PR TITLE
STORM-337 Expose managed spout ids publicly

### DIFF
--- a/storm-core/src/jvm/storm/trident/topology/MasterBatchCoordinator.java
+++ b/storm-core/src/jvm/storm/trident/topology/MasterBatchCoordinator.java
@@ -76,6 +76,10 @@ public class MasterBatchCoordinator extends BaseRichSpout {
         _spouts = spouts;
     }
 
+    public List<String> getManagedSpoutIds(){
+        return _managedSpoutIds;
+    }
+
     @Override
     public void activate() {
         _active = true;


### PR DESCRIPTION
I'd like to do some work with topology visualization and also make the UI more useful for trident topologies.  The first issue I've run into is not being able to get a more friendly name from the spouts under the umbrella of a MasterBatchCoordinator.  
