### PR TITLE
Fix for [STORM-343] Add missing missing acls on znodes under errors

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -229,7 +229,8 @@
      :batch-transfer-queue batch-transfer->worker
      :transfer-fn (mk-executor-transfer-fn batch-transfer->worker storm-conf)
      :suicide-fn (:suicide-fn worker)
-     :storm-cluster-state (cluster/mk-storm-cluster-state (:cluster-state worker))
+     :storm-cluster-state (cluster/mk-storm-cluster-state (:cluster-state worker) 
+                                                          :acls (Utils/getWorkerACL storm-conf))
      :type executor-type
      ;; TODO: should refactor this to be part of the executor specific map (spout or bolt with :common field)
      :stats (mk-executor-stats <> (sampling-rate storm-conf))


### PR DESCRIPTION
Add missing ACLs to error znodes and remove auto vivification of error znodes from the nimbus side when trying to access the topologyinfo and errors.
