### PR TITLE
STORM-213. Decouple In-Process ZooKeeper from LocalCluster.

### DIFF
--- a/storm-core/src/clj/backtype/storm/LocalCluster.clj
+++ b/storm-core/src/clj/backtype/storm/LocalCluster.clj
@@ -19,7 +19,7 @@
   (:gen-class
    :init init
    :implements [backtype.storm.ILocalCluster]
-   :constructors {[] [] [java.util.Map] []}
+   :constructors {[] [] [java.util.Map] [] [String Long] []}
    :state state ))
 
 (defn -init
@@ -27,6 +27,11 @@
      (let [ret (mk-local-storm-cluster :daemon-conf {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true})]
        [[] ret]
        ))
+  ([^String zk-host ^Long zk-port]
+     (let [ret (mk-local-storm-cluster :daemon-conf {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true
+                                                     STORM-ZOOKEEPER-SERVERS (list zk-host)
+                                                     STORM-ZOOKEEPER-PORT zk-port})]
+       [[] zk-host zk-port]))
   ([^Map stateMap]
      [[] stateMap]))
 
@@ -75,4 +80,3 @@
 
 (defn -getState [this]
   (.state this))
-


### PR DESCRIPTION
Added a constructor to LocalCluster to pass in zookeeper host and port. 
Users can call LocalCluster with external zookeeper
(let [cluster (LocalCluster. "localhost" 2181)]
