### PR TITLE
STORM-351 multilang python process fall into endless loop

### DIFF
--- a/storm-core/src/multilang/py/storm.py
+++ b/storm-core/src/multilang/py/storm.py
@@ -33,10 +33,12 @@ json_decode = lambda x: json.loads(x)
 def readMsg():
     msg = ""
     while True:
-        line = sys.stdin.readline()[0:-1]
-        if line == "end":
+        line = sys.stdin.readline()
+        if not line:
+            raise Exception('Read EOF from stdin')
+        if line[0:-1] == "end":
             break
-        msg = msg + line + "\n"
+        msg = msg + line
     return json_decode(msg[0:-1])
 
 MODE = None


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-351
1. steps to reproduce
   1) write a topology with a python bolt, run the topology on storm; then there will be two process for the bolt: the worker(java process for ShellBolt), python process.
   2）kill -9 the worker(java process for ShellBolt);
2. expected behavior
   the worker exit and the python process exist
3. actual, incorrect behavior
   the worker exit, but the python process never exit and fall into endless loop
4. analyse
   in storm.py，read tuple from stdin with follow function:
   def readMsg():
   msg = ""
   while True:
   line = sys.stdin.readline()[0:-1]
   if line == "end":
   break
   msg = msg + line + "\n"
   return json_decode(msg[0:-1])
   when sys.stdin is closed, EOF is encountered, readline() return None, so readMsg fall into endless loop.
