### PR TITLE
STORM-365: Add support for Python 3 to the storm command

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -426,7 +426,7 @@ def print_classpath():
 
 def print_commands():
     """Print all client commands and link to documentation"""
-    print("Commands:\n\t " +  "\n\t".join(sorted(COMMANDS.keys())))
+    print("Commands:\n\t" +  "\n\t".join(sorted(COMMANDS.keys())))
     print("\nHelp: \n\thelp \n\thelp <command>")
     print("\nDocumentation for the storm client can be found at http://storm.incubator.apache.org/documentation/Command-line-client.html\n")
     print("Configs can be overridden using one or more -c flags, e.g. \"storm list -c nimbus.host=nimbus.mycompany.com\"\n")


### PR DESCRIPTION
This patch makes the storm command work with both Python 2 and Python 3.
