### PR TITLE
[STORM-370] Add check for empty table before sorting dom in UI on security

### DIFF
--- a/storm-core/src/ui/public/component.html
+++ b/storm-core/src/ui/public/component.html
@@ -80,22 +80,32 @@ $(document).ready(function() {
             componentSummary.append(Mustache.render($(template).filter("#component-summary-template").html(),response));
             if(response["componentType"] == "spout") {
                 componentStatsDetail.append(Mustache.render($(template).filter("#spout-stats-detail-template").html(),response));
-                $("#spout-stats-table").tablesorter({ sortList: [[0,0]], headers: {0: { sorter: "stormtimestr"}}});
+                if (response["spoutSummary"].length > 0) {
+                    $("#spout-stats-table").tablesorter({ sortList: [[0,0]], headers: {0: { sorter: "stormtimestr"}}});
+                }
                 outputStats.append(Mustache.render($(template).filter("#output-stats-template").html(),response));
-                $("#output-stats-table").tablesorter({ sortList: [[0,0]], headers: {0: { sorter: "stormtimestr"}}});
+                if (response["outputStats"].length > 0) {
+                    $("#output-stats-table").tablesorter({ sortList: [[0,0]], headers: {0: { sorter: "stormtimestr"}}});
+                }
                 executorStats.append(Mustache.render($(template).filter("#executor-stats-template").html(),response));
-                $("#executor-stats-table").tablesorter({ sortList: [[0,0]], headers: {1: { sorter: "stormtimestr"}}});
+                if (response["executorStats"].length > 0) {
+                    $("#executor-stats-table").tablesorter({ sortList: [[0,0]], headers: {1: { sorter: "stormtimestr"}}});
+                }
             } else {
                 componentStatsDetail.append(Mustache.render($(template).filter("#bolt-stats-template").html(),response));
-                $("#bolt-stats-table").tablesorter({ sortList: [[0,0]], headers: {0: { sorter: "stormtimestr"}}});
+                if (response["boltStats"].length > 0) {
+                    $("#bolt-stats-table").tablesorter({ sortList: [[0,0]], headers: {0: { sorter: "stormtimestr"}}});
+                }
                 inputStats.append(Mustache.render($(template).filter("#bolt-input-stats-template").html(),response));
                 if (response["inputStats"].length > 0) {
                     $("#bolt-input-stats-table").tablesorter({ sortList: [[0,0]], headers: {}});
                 }
                 outputStats.append(Mustache.render($(template).filter("#bolt-output-stats-template").html(),response));
-                $("#bolt-output-stats-table").tablesorter({ sortList: [[0,0]], headers: {}});
+                if (response["outputStats"].length > 0) {
+                    $("#bolt-output-stats-table").tablesorter({ sortList: [[0,0]], headers: {}});
+                }
                 executorStats.append(Mustache.render($(template).filter("#bolt-executor-template").html(),response));
-                if(response["outputStats"].length > 0) {
+                if(response["executorStats"].length > 0) {
                     $("#bolt-executor-table").tablesorter({ sortList: [[0,0]], headers: {}});
                 }
             }

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -89,7 +89,9 @@ $(document).ready(function() {
             topologySummary.append(Mustache.render($(template).filter("#topology-summary-template").html(),response));
             topologyActions.append(Mustache.render($(template).filter("#topology-actions-template").html(),buttonJsonData));
             topologyStats.append(Mustache.render($(template).filter("#topology-stats-template").html(),response));
-            $("#topology-stats-table").tablesorter({ sortList: [[0,0]], headers: {0: { sorter: "stormtimestr"}}});
+            if(response["topologyStats"].length > 0) {
+                $("#topology-stats-table").tablesorter({ sortList: [[0,0]], headers: {0: { sorter: "stormtimestr"}}});
+            }
             spoutStats.append(Mustache.render($(template).filter("#spout-stats-template").html(),response));
             if(response["spouts"].length > 0) {
                 $("#spout-stats-table").tablesorter({sortList: [[0,0]], headers:{}});


### PR DESCRIPTION
To avoid `tablesorter` from throwing exception - requires additional check to ensure that table sorter is not invoked on empty recordset.  
