### PR TITLE
STORM-453 - migrated to curator 2.5.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <commons-lang.version>2.5</commons-lang.version>
         <commons-exec.version>1.1</commons-exec.version>
         <clj-time.version>0.4.1</clj-time.version>
-        <curator.version>2.4.0</curator.version>
+        <curator.version>2.5.0</curator.version>
         <json-simple.version>1.1</json-simple.version>
         <ring.version>0.3.11</ring.version>
         <clojure.tools.logging.version>0.2.3</clojure.tools.logging.version>
@@ -196,16 +196,16 @@
         <clojure.tools.cli.version>0.2.4</clojure.tools.cli.version>
         <disruptor.version>2.10.1</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>
-        <guava.version>13.0</guava.version>
+        <guava.version>14.0.1</guava.version>
         <logback-classic.version>1.0.6</logback-classic.version>
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
-        <netty.version>3.6.3.Final</netty.version>
+        <netty.version>3.7.0.Final</netty.version>
         <clojure.tools.nrepl.version>0.2.3</clojure.tools.nrepl.version>
         <clojure-complete.version>0.2.3</clojure-complete.version>
         <mockito.version>1.9.5</mockito.version>
         <reply.version>0.3.0</reply.version>
         <conjure.version>2.1.3</conjure.version>
-        <zookeeper.version>3.4.5</zookeeper.version>
+        <zookeeper.version>3.4.6</zookeeper.version>
 
     </properties>
 


### PR DESCRIPTION
Migrated code to curator 2.5.0 (updated zookeeper version, netty version, guava version). I was not able to find any issue running existing topologies on this code.
This change will allow Cassandra driver integration in bolt/spout without dependencies shadowing or other tricks...
