### PR TITLE
[STORM-380] Kafka spout: throw RuntimeException if a leader cannot be found for a partition

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
@@ -120,6 +120,8 @@ public class DynamicBrokersReader {
                 throw new RuntimeException("No leader found for partition " + partition);
             }
             return leader;
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
If one of the partitions of the Kafka queue has no leader available, DynamicBrokersReader.getLeaderFor(partition) returns -1.  This is logged in DynamicBrokersReader.getBrokerInfo (as there's no ZK node for a broker id -1) but there is no further action.

In this situation the spout will carry on emitting only for those partitions that are available.

My assumption is that if some partitions for a queue are unavailable, there's a problem that needs to be addressed before processing continues.  Happy to discuss further.
