### PR TITLE
[STORM-254] one Spout/Bolt can register metric twice with same name in different timeBucket

### DIFF
--- a/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
+++ b/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
@@ -251,6 +251,10 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
                                                "greater than or equal to 1 second.");
         }
         
+        if (getRegisteredMetricByName(name) != null) {
+            throw new RuntimeException("The same metric name `" + name + "` was registered twice." );
+        }
+
         Map m1 = _registeredMetrics;
         if(!m1.containsKey(timeBucketSizeInSecs)) {
             m1.put(timeBucketSizeInSecs, new HashMap());


### PR DESCRIPTION
In a Bolt's prepare method, we can register metrics twice with the same name, using different timeBucketSizeInSecs parameter, like this:

---

public void prepare(Map stormConf, TopologyContext context)
{ 
    mapper = new ObjectMapper(); 
    CountMetric cMetric = new CountMetric(); 
    context.registerMetric("JavaBoltCount", cMetric, 120); 
    CountMetric ccMetric = new CountMetric(); 
    context.registerMetric("JavaBoltCount", ccMetric, 60); 
}

---

This is caused by TopologyContext's registerMetric. 
In TopologyContext, all registered metrics holds in a map defined below:
private Map < Integer, Map < Integer,  Map < String, IMetric>>> _registeredMetrics;
timeBucketSizeInSecs ----> __taskId ----> metricName ----> metirc
But the same name check just at the innermost layer.
