### PR TITLE
Fix for STORM-402: FileNotFoundException when using storm with apache tika

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -533,7 +533,7 @@
               url
               (do
                 (log-message "Copying resources at " (str url) " to " target-dir)
-                (if (.startsWith (str url) "jar:file:" )
+                (if (= (.getProtocol url) "jar" )
                     (extract-dir-from-jar (.getFile (.getJarFileURL (.openConnection url))) RESOURCES-SUBDIR stormroot)
                     (FileUtils/copyDirectory (File. (.getFile url)) (File. target-dir)))
                 )


### PR DESCRIPTION
This is a fix for STORM-402: FileNotFoundException when using storm with apache tika:

https://issues.apache.org/jira/browse/STORM-402
