### PR TITLE
STORM-414: support logging level to multilang protocol spout and bolt

### DIFF
--- a/storm-core/src/jvm/backtype/storm/multilang/JsonSerializer.java
+++ b/storm-core/src/jvm/backtype/storm/multilang/JsonSerializer.java
@@ -144,7 +144,12 @@ public class JsonSerializer implements ISerializer {
         shellMsg.setMetricName(metricName);
         
         Object paramsObj = msg.get("params");
-        shellMsg.setMetricParams(paramsObj); 
+        shellMsg.setMetricParams(paramsObj);
+
+        if (command.equals("log")) {
+            long logLevel = (Long)msg.get("level");
+            shellMsg.setLogLevel((int)logLevel);
+        }
 
         return shellMsg;
     }

--- a/storm-core/src/jvm/backtype/storm/multilang/ShellMsg.java
+++ b/storm-core/src/jvm/backtype/storm/multilang/ShellMsg.java
@@ -46,6 +46,24 @@ public class ShellMsg {
     private String metricName;
     private Object metricParams;
 
+    //logLevel
+    public enum ShellLogLevel {
+        TRACE, DEBUG, INFO, WARN, ERROR;
+
+        public static ShellLogLevel fromInt(int i) {
+            switch (i) {
+                case 0: return TRACE;
+                case 1: return DEBUG;
+                case 2: return INFO;
+                case 3: return WARN;
+                case 4: return ERROR;
+                default: return INFO;
+            }
+        }
+    }
+
+    private ShellLogLevel logLevel = ShellLogLevel.INFO;
+
     public String getCommand() {
         return command;
     }
@@ -138,5 +156,13 @@ public class ShellMsg {
 
     public Object getMetricParams() {
         return metricParams;
+    }
+
+    public ShellLogLevel getLogLevel() {
+        return logLevel;
+    }
+
+    public void setLogLevel(int logLevel) {
+        this.logLevel = ShellLogLevel.fromInt(logLevel);
     }
 }

--- a/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -131,8 +131,7 @@ public class ShellSpout implements ISpout {
                 if (command.equals("sync")) {
                     return;
                 } else if (command.equals("log")) {
-                    String msg = shellMsg.getMsg();
-                    LOG.info("Shell msg: " + msg + _process.getProcessInfoString());
+                    handleLog(shellMsg);
                 } else if (command.equals("emit")) {
                     String stream = shellMsg.getStream();
                     Long task = shellMsg.getTask();
@@ -155,6 +154,33 @@ public class ShellSpout implements ISpout {
         } catch (Exception e) {
             String processInfo = _process.getProcessInfoString() + _process.getProcessTerminationInfoString();
             throw new RuntimeException(processInfo, e);
+        }
+    }
+
+    private void handleLog(ShellMsg shellMsg) {
+        String msg = shellMsg.getMsg();
+        msg = "ShellLog " + _process.getProcessInfoString() + " " + msg;
+        ShellMsg.ShellLogLevel logLevel = shellMsg.getLogLevel();
+
+        switch (logLevel) {
+            case TRACE:
+                LOG.trace(msg);
+                break;
+            case DEBUG:
+                LOG.debug(msg);
+                break;
+            case INFO:
+                LOG.info(msg);
+                break;
+            case WARN:
+                LOG.warn(msg);
+                break;
+            case ERROR:
+                LOG.error(msg);
+                break;
+            default:
+                LOG.info(msg);
+                break;
         }
     }
 

--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -122,8 +122,7 @@ public class ShellBolt implements IBolt {
                         } else if (command.equals("error")) {
                             handleError(shellMsg.getMsg());
                         } else if (command.equals("log")) {
-                            String msg = shellMsg.getMsg();
-                            LOG.info("Shell msg: " + msg + _process.getProcessInfoString());
+                            handleLog(shellMsg);
                         } else if (command.equals("emit")) {
                             handleEmit(shellMsg);
                         } else if (command.equals("metrics")) {
@@ -234,7 +233,34 @@ public class ShellBolt implements IBolt {
                     shellMsg.getStream(), anchors, shellMsg.getTuple());
         }
     }
-    
+
+    private void handleLog(ShellMsg shellMsg) {
+        String msg = shellMsg.getMsg();
+        msg = "ShellLog " + _process.getProcessInfoString() + " " + msg;
+        ShellMsg.ShellLogLevel logLevel = shellMsg.getLogLevel();
+
+        switch (logLevel) {
+            case TRACE:
+                LOG.trace(msg);
+                break;
+            case DEBUG:
+                LOG.debug(msg);
+                break;
+            case INFO:
+                LOG.info(msg);
+                break;
+            case WARN:
+                LOG.warn(msg);
+                break;
+            case ERROR:
+                LOG.error(msg);
+                break;
+            default:
+                LOG.info(msg);
+                break;
+        }
+    }
+
     private void handleMetrics(ShellMsg shellMsg) {
         //get metric name
         String name = shellMsg.getMetricName();

--- a/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
@@ -173,7 +173,7 @@ public class ShellProcess implements Serializable {
     }
 
     public String getProcessInfoString() {
-        return String.format(" pid:%s, name:%s ", pid, componentName);
+        return String.format("pid:%s, name:%s", pid, componentName);
     }
 
     public String getProcessTerminationInfoString() {

--- a/storm-core/src/multilang/py/storm.py
+++ b/storm-core/src/multilang/py/storm.py
@@ -135,8 +135,23 @@ def fail(tup):
 def reportError(msg):
     sendMsgToParent({"command": "error", "msg": msg})
 
-def log(msg):
-    sendMsgToParent({"command": "log", "msg": msg})
+def log(msg, level=2):
+    sendMsgToParent({"command": "log", "msg": msg, "level":level})
+
+def logTrace(msg):
+    log(msg, 0)
+
+def logDebug(msg):
+    log(msg, 1)
+
+def logInfo(msg):
+    log(msg, 2)
+
+def logWarn(msg):
+    log(msg, 3)
+
+def logError(msg):
+    log(msg, 4)
 
 def rpcMetrics(name, params):
     sendMsgToParent({"command": "metrics", "name": name, "params": params})

--- a/storm-core/src/multilang/rb/storm.rb
+++ b/storm-core/src/multilang/rb/storm.rb
@@ -124,8 +124,28 @@ module Storm
       send_msg_to_parent :command => :error, :msg => msg.to_s
     end
 
-    def log(msg)
-      send_msg_to_parent :command => :log, :msg => msg.to_s
+    def log(msg, level=2)
+      send_msg_to_parent :command => :log, :msg => msg.to_s, :level => level
+    end
+
+    def logTrace(msg)
+      log(msg, 0)
+    end
+
+    def logDebug(msg)
+      log(msg, 1)
+    end
+
+    def logInfo(msg)
+      log(msg, 2)
+    end
+
+    def logWarn(msg)
+      log(msg, 3)
+    end
+
+    def logError(msg)
+      log(msg, 4)
     end
 
     def handshake


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-414

@mahall create a PR: https://github.com/apache/incubator-storm/pull/24 , Added logging level to multilang protocol spout and bolt. But he closed it with no reason.

@msukmanowsky create a PR before to apache: https://github.com/nathanmarz/storm/pull/626 , Allow ShellBolts to optionally specify the logging level. But he did not modify ShellSpout and storm.py.

This improvement add optional logging level to Multilang Protocol's log method. And add implementation in python and ruby.
