### PR TITLE
STORM-422 Allow more arguments to be passed to storm jar

### DIFF
--- a/bin/storm.cmd
+++ b/bin/storm.cmd
@@ -69,7 +69,16 @@
     set STORM_OPTS=%STORM_CLIENT_OPTS% %STORM_OPTS% -Dstorm.jar=%2
     set CLASSPATH=%CLASSPATH%;%2
     set CLASS=%3
-    set storm-command-arguments=%4 %5 %6 %7 %8 %9
+    set args=%4
+    shift
+    :start
+    if [%4] == [] goto done
+    set args=%args% %4
+    shift
+    goto start
+
+    :done
+    set storm-command-arguments=%args%
   )
   
   if not defined STORM_LOG_FILE (


### PR DESCRIPTION
This change removes the argument limit for the 'storm jar' command on
Windows
