### PR TITLE
[STORM-406] Fix for reconnect logic in netty client 

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -108,7 +108,8 @@ zmq.hwm: 0
 storm.messaging.netty.server_worker_threads: 1
 storm.messaging.netty.client_worker_threads: 1
 storm.messaging.netty.buffer_size: 5242880 #5MB buffer
-storm.messaging.netty.max_retries: 120
+# Since nimbus.task.launch.secs and supervisor.worker.start.timeout.secs are 120, other workers should also wait at least that long before giving up on connecting to the other worker.
+storm.messaging.netty.max_retries: 300
 storm.messaging.netty.max_wait_ms: 1000
 storm.messaging.netty.min_wait_ms: 100
 

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
@@ -207,6 +207,7 @@ public class Client implements IConnection {
         while (msgs.hasNext()) {
             if (!channel.isConnected()) {
                 connect();
+                channel = channelRef.get();
             }
             TaskMessage message = msgs.next();
             if (null == messageBatch) {
@@ -351,3 +352,4 @@ public class Client implements IConnection {
         });
     }
 }
+


### PR DESCRIPTION
- Check if channel `isConnected`.
- Reconnect if not before start of each batch.
- Increase max-retried for netty client so that other worker get enough time to start/restart and starts accepting new netty connections.
