### PR TITLE
STORM-213: fixed NullPointerException

### DIFF
--- a/storm-core/src/clj/backtype/storm/LocalCluster.clj
+++ b/storm-core/src/clj/backtype/storm/LocalCluster.clj
@@ -30,10 +30,10 @@
                {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true})]
      [[] ret]))
   ([^String zk-host ^Long zk-port]
-     (let [ret (mk-local-storm-cluster :daemon-conf {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true
+   (let [ret (mk-local-storm-cluster :daemon-conf {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true
                                                      STORM-ZOOKEEPER-SERVERS (list zk-host)
                                                      STORM-ZOOKEEPER-PORT zk-port})]
-       [[] zk-host zk-port]))
+     [[] ret]))
   ([^Map stateMap]
    [[] stateMap]))
 


### PR DESCRIPTION
fixed NPE when submitting a topology to a LocalCluster with a decoupled ZK
