### PR TITLE
Introduce Trident SerializerFactory and Kryo serializers

### DIFF
--- a/storm-core/src/jvm/storm/trident/state/JSONSerializerFactory.java
+++ b/storm-core/src/jvm/storm/trident/state/JSONSerializerFactory.java
@@ -1,0 +1,19 @@
+package storm.trident.state;
+
+import java.util.Map;
+
+public class JSONSerializerFactory implements SerializerFactory {
+
+    @Override
+    public Serializer makeSerializer(Map conf, StateType stateType) {
+        if (stateType == StateType.NON_TRANSACTIONAL) {
+            return new JSONNonTransactionalSerializer();
+        }
+        
+        if (stateType == StateType.TRANSACTIONAL) {
+            return new JSONTransactionalSerializer();
+        }
+        
+        return new JSONOpaqueSerializer();
+    }
+}

--- a/storm-core/src/jvm/storm/trident/state/KryoNonTransactionalSerializer.java
+++ b/storm-core/src/jvm/storm/trident/state/KryoNonTransactionalSerializer.java
@@ -1,0 +1,38 @@
+package storm.trident.state;
+
+import java.util.ArrayList;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+public class KryoNonTransactionalSerializer implements Serializer {
+
+    private final Kryo     _kryo;
+    private final Output   _out;
+    
+    public KryoNonTransactionalSerializer(Kryo kryo, int bufferSize) {
+        _kryo = kryo;
+        _out = new Output(bufferSize);
+    }
+
+    @Override
+    public byte[] serialize(Object obj) {
+        // Wrap in list to avoid having to specify class of instance being serialized.
+        ArrayList li = new ArrayList(1);
+        li.add(obj);
+        
+        _out.clear();
+        _kryo.writeObject(_out, li);
+        return _out.toBytes();
+    }
+
+    @Override
+    public Object deserialize(byte[] b) {
+        Input in = new Input(b);
+        ArrayList o = _kryo.readObject(in, ArrayList.class);
+        in.close();
+        return o.get(0);
+    }
+
+}

--- a/storm-core/src/jvm/storm/trident/state/KryoOpaqueSerializer.java
+++ b/storm-core/src/jvm/storm/trident/state/KryoOpaqueSerializer.java
@@ -1,0 +1,39 @@
+package storm.trident.state;
+
+import java.util.ArrayList;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+public class KryoOpaqueSerializer implements Serializer<OpaqueValue> {
+
+    private final Kryo   _kryo;
+    private final Output _out;
+
+    public KryoOpaqueSerializer(Kryo kryo, int bufferSize) {
+        _kryo = kryo;
+        _out = new Output(bufferSize);
+    }
+
+    @Override
+    public byte[] serialize(OpaqueValue obj) {
+        ArrayList li = new ArrayList(3);
+        li.add(obj.currTxid);
+        li.add(obj.curr);
+        li.add(obj.prev);
+
+        _out.clear();
+        _kryo.writeObject(_out, li);
+        return _out.toBytes();
+    }
+
+    @Override
+    public OpaqueValue deserialize(byte[] b) {
+        Input in = new Input(b);
+        ArrayList li = _kryo.readObject(in, ArrayList.class);
+        in.close();
+        return new OpaqueValue((Long) li.get(0), li.get(1), li.get(2));
+    }
+
+}

--- a/storm-core/src/jvm/storm/trident/state/KryoSerializerFactory.java
+++ b/storm-core/src/jvm/storm/trident/state/KryoSerializerFactory.java
@@ -1,0 +1,38 @@
+package storm.trident.state;
+
+import java.util.Map;
+
+import com.esotericsoftware.kryo.Kryo;
+
+import backtype.storm.serialization.SerializationFactory;
+
+public class KryoSerializerFactory implements SerializerFactory {
+
+    private static final int DEFAULT_BUFFER_SIZE = 4096;
+
+    private final int        _bufferSize;
+    
+    public KryoSerializerFactory() {
+        this(DEFAULT_BUFFER_SIZE);
+    }
+
+    public KryoSerializerFactory(int bufferSize) {
+        _bufferSize = bufferSize;
+    }
+
+    @Override
+    public Serializer makeSerializer(Map conf, StateType stateType) {
+        Kryo kryo = SerializationFactory.getKryo(conf);
+        
+        if (stateType == StateType.NON_TRANSACTIONAL) {
+            return new KryoNonTransactionalSerializer(kryo, _bufferSize);
+        }
+
+        if (stateType == StateType.TRANSACTIONAL) {
+            return new KryoTransactionalSerializer(kryo, _bufferSize);
+        }
+
+        return new KryoOpaqueSerializer(kryo, _bufferSize);
+    }
+
+}

--- a/storm-core/src/jvm/storm/trident/state/KryoTransactionalSerializer.java
+++ b/storm-core/src/jvm/storm/trident/state/KryoTransactionalSerializer.java
@@ -1,0 +1,38 @@
+package storm.trident.state;
+
+import java.util.ArrayList;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+public class KryoTransactionalSerializer implements Serializer<TransactionalValue> {
+
+    private final Kryo   _kryo;
+    private final Output _out;
+
+    public KryoTransactionalSerializer(Kryo kryo, int bufferSize) {
+        _kryo = kryo;
+        _out = new Output(bufferSize);
+    }
+
+    @Override
+    public byte[] serialize(TransactionalValue obj) {
+        ArrayList li = new ArrayList(2);
+        li.add(obj.getTxid());
+        li.add(obj.getVal());
+
+        _out.clear();
+        _kryo.writeObject(_out, li);
+        return _out.toBytes();
+    }
+
+    @Override
+    public TransactionalValue deserialize(byte[] b) {
+        Input in = new Input(b);
+        ArrayList li = _kryo.readObject(in, ArrayList.class);
+        in.close();
+        return new TransactionalValue((Long) li.get(0), li.get(1));
+    }
+
+}

--- a/storm-core/src/jvm/storm/trident/state/SerializerFactory.java
+++ b/storm-core/src/jvm/storm/trident/state/SerializerFactory.java
@@ -1,0 +1,8 @@
+package storm.trident.state;
+
+import java.util.Map;
+
+public interface SerializerFactory<T> {
+
+    Serializer<T> makeSerializer( Map conf, StateType stateType );
+}


### PR DESCRIPTION
Some topologies use Trident-State to store intermediate data as POJOs which are then transferred downstream to other functions or aggregators. It doesn't matter how these POJOs are stored as long as it is efficient. 

Storm uses a Kryo serializer to serialize the POJO when it is part of a Tuple and requires #registerSerialization be called on the topology configuration. This change enables the same Kryo serializer configuration to be used in a Trident Serializer.