### PR TITLE
STORM-336: Logback version should be upgraded to 1.0.1[2|3] from 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <disruptor.version>2.10.1</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>13.0</guava.version>
-        <logback-classic.version>1.0.6</logback-classic.version>
+        <logback-classic.version>1.0.13</logback-classic.version>
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
         <netty.version>3.6.3.Final</netty.version>
         <clojure.tools.nrepl.version>0.2.3</clojure.tools.nrepl.version>


### PR DESCRIPTION
Updated the pom file to include logback 1.0.13... seems more popular than 1.0.12
