### PR TITLE
[STORM-443] fix the problem of log level implementation to compatible with old log p...

### DIFF
--- a/storm-core/src/jvm/backtype/storm/multilang/JsonSerializer.java
+++ b/storm-core/src/jvm/backtype/storm/multilang/JsonSerializer.java
@@ -147,8 +147,11 @@ public class JsonSerializer implements ISerializer {
         shellMsg.setMetricParams(paramsObj);
 
         if (command.equals("log")) {
-            long logLevel = (Long)msg.get("level");
-            shellMsg.setLogLevel((int)logLevel);
+            Object logLevelObj = msg.get("level");
+            if (logLevelObj != null && logLevelObj instanceof Long) {
+                long logLevel = (Long)logLevelObj;
+                shellMsg.setLogLevel((int)logLevel);
+            }
         }
 
         return shellMsg;


### PR DESCRIPTION
Storm now support logging level to multilang protocol spout and bolt. But the implementation is not compatible with old log protocol with no logging level.

With old topology who use old protocol, when they send log with no loglevel, JsonSerializer's readShellMsg function will throw NPE at:

 if (command.equals("log"))
 { 
     long logLevel = (Long)msg.get("level"); //throw NPE at here 
     shellMsg.setLogLevel((int)logLevel); 
 }

ShellBolt will catch the NPE, and call die(), and die() will get error info from sub process's error stream in _process.getProcessTerminationInfoString(), but the error stream have no data come, it will hangs.

 private void die(Throwable exception)
 { 
     String processInfo = _process.getProcessInfoString() + _process.getProcessTerminationInfoString(); 
     _exception = new RuntimeException(processInfo, exception); 
  }

This PR will fix the problem of log level implementation to compatible with old log protocol. And the die problem should be solved by Kang Xiao 's PR https://github.com/apache/incubator-storm/pull/46
