### PR TITLE
[STORM-442] multilang ShellBolt/ShellSpout die() can be hang when Exception happened

### DIFF
--- a/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -152,8 +152,9 @@ public class ShellSpout implements ISpout {
                 }
             }
         } catch (Exception e) {
-            String processInfo = _process.getProcessInfoString() + _process.getProcessTerminationInfoString();
-            throw new RuntimeException(processInfo, e);
+            LOG.error("Halting process: ShellSpout died.", e);
+            _collector.reportError(e);
+            System.exit(11);
         }
     }
 

--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -290,8 +290,9 @@ public class ShellBolt implements IBolt {
     }
 
     private void die(Throwable exception) {
-        String processInfo = _process.getProcessInfoString() + _process.getProcessTerminationInfoString();
-        _exception = new RuntimeException(processInfo, exception);
+        LOG.error("Halting process: ShellBolt died.", exception);
+        _collector.reportError(exception);
+        System.exit(11);
     }
 
 }


### PR DESCRIPTION
In ShellBolt, the _readerThread read command from python/shell process, and handle like this:
 try
 { 
    ShellMsg shellMsg = _process.readShellMsg(); 
    ... 
 } catch (InterruptedException e) {
 } catch (Throwable t) { 
    die(t); 
 }

And in the die function, getProcessTerminationInfoString will read getErrorsString() from processErrorStream.

private void die(Throwable exception) { 
     String processInfo = _process.getProcessInfoString() + _process.getProcessTerminationInfoString(); 
     _exception = new RuntimeException(processInfo, exception); 
}

so when ShellBolt got exception(for example, readShellMsg() throw NPE ) , but it is not an error from sub process, then getProcessTerminationInfoString will be hang because processErrorStream have no data to read.
