### PR TITLE
[STORM-447] shade/relocate packages of dependencies that are common causes of dependency conflicts

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -53,6 +53,12 @@
         <dependency>
             <groupId>ring</groupId>
             <artifactId>ring-jetty-adapter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>


### PR DESCRIPTION
This shades and does package relocation of several of Storm's dependencies that frequently conflict with user code (Netty, Guava, etc.).

This also fixes: STORM-356, STORM-268

Note that due to transitive dependencies, some additional dependencies had to be shaded as well (Curator and ZooKeeper).
