### PR TITLE
STORM-449: Updated ShellBolt to not exit when shutting down.

### DIFF
--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -295,13 +295,12 @@ public class ShellBolt implements IBolt {
     }
 
     private void die(Throwable exception) {
-        if (_running) { //Don't exit if running tests
-            String processInfo = _process.getProcessInfoString() + _process.getProcessTerminationInfoString();
-            _exception = new RuntimeException(processInfo, exception);
-            LOG.error("Halting process: ShellBolt died.", exception);
-            _collector.reportError(exception);
+        String processInfo = _process.getProcessInfoString() + _process.getProcessTerminationInfoString();
+        _exception = new RuntimeException(processInfo, exception);
+        LOG.error("Halting process: ShellBolt died.", exception);
+        _collector.reportError(exception);
+        if (_running || (exception instanceof Error)) { //don't exit if not running, unless it is an Error
             System.exit(11);
         }
     }
-
 }


### PR DESCRIPTION
I modified the test that was having issues to run 100 times in a row.  Previously it would fail after 1 or 2 times through the loop.  Now it passes all of the times no problem.  I didn't include the test change because it is overkill here.
