### PR TITLE
STORM-451:updated the pom.xml in storm-hdfs to be the correct version

### DIFF
--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.9.2-incubating-SNAPSHOT</version>
+        <version>0.9.3-incubating-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Wrong version was set in the pom causing the builds to fail
