### PR TITLE
STORM-454: Update STORM-UI-REST-API.md to reflect seconds instead of milliseconds for windows

### DIFF
--- a/STORM-UI-REST-API.md
+++ b/STORM-UI-REST-API.md
@@ -129,7 +129,7 @@ Request Parameters:
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
 |id   	   |String (required)| Topology Id  |
-|window    |String. Default value :all-time| Window duration for metrics in ms|
+|window    |String. Default value :all-time| Window duration for metrics in seconds|
 |sys       |String. Values 1 or 0. Default value 0| Controls including sys stats part of the response|
 
 
@@ -336,7 +336,7 @@ Returns detailed metrics and executor information
 |----------|--------|-------------|
 |id   	   |String (required)| Topology Id  |
 |component |String (required)| Component Id |
-|window    |String. Default value :all-time| window duration for metrics in ms|
+|window    |String. Default value :all-time| window duration for metrics in seconds|
 |sys       |String. Values 1 or 0. Default value 0| controls including sys stats part of the response|
 
 Response Fields:


### PR DESCRIPTION
It appears that the window parameter is in seconds, not milliseconds.  Very small issue, but thought it might trip people up.
