### PR TITLE
STORM-455 Report error-level messages from ShellBolt children

### DIFF
--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -21,6 +21,7 @@ import backtype.storm.Config;
 import backtype.storm.generated.ShellComponent;
 import backtype.storm.metric.api.IMetric;
 import backtype.storm.metric.api.rpc.IShellMetric;
+import backtype.storm.topology.ReportedFailedException;
 import backtype.storm.tuple.MessageId;
 import backtype.storm.tuple.Tuple;
 import backtype.storm.utils.ShellProcess;
@@ -257,6 +258,7 @@ public class ShellBolt implements IBolt {
                 break;
             case ERROR:
                 LOG.error(msg);
+                _collector.reportError(new ReportedFailedException(msg));
                 break;
             default:
                 LOG.info(msg);


### PR DESCRIPTION
The idea here is that it'd be nice to see reported errors from `ShellBolt` in the Storm UI, and now that we have support for multiple logging levels, we can assume that `error` level messages are errors to be reported.
