### PR TITLE
STORM-461: exit-process! does not always exit the process, but throws an...

### DIFF
--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -316,7 +316,7 @@
 
 (defn exit-process!
   [val & msg]
-  (log-error (RuntimeException. msg) "Halting process: " msg)
+  (log-error (RuntimeException. (str msg)) "Halting process: " msg)
   (.exit (Runtime/getRuntime) val))
 
 (defn sum


### PR DESCRIPTION
... exception instead
