### PR TITLE
STORM-464: Simulated time advanced after test cluster exits causes inter...

### DIFF
--- a/storm-core/src/clj/backtype/storm/testing.clj
+++ b/storm-core/src/clj/backtype/storm/testing.clj
@@ -235,10 +235,11 @@
          (log-error t# "Error in cluster")
          (throw t#))
        (finally
-         (let [keep-waiting?# (atom true)]
-           (future (while @keep-waiting?# (simulate-wait ~cluster-sym)))
+         (let [keep-waiting?# (atom true)
+               f# (future (while @keep-waiting?# (simulate-wait ~cluster-sym)))]
            (kill-local-storm-cluster ~cluster-sym)
-           (reset! keep-waiting?# false))))))
+           (reset! keep-waiting?# false)
+            @f#)))))
 
 (defmacro with-simulated-time-local-cluster
   [& args]


### PR DESCRIPTION
...mitent test failures
