### PR TITLE
add hook methods to TridentOperationContext

### DIFF
--- a/storm-core/src/jvm/storm/trident/operation/TridentOperationContext.java
+++ b/storm-core/src/jvm/storm/trident/operation/TridentOperationContext.java
@@ -17,6 +17,7 @@
  */
 package storm.trident.operation;
 
+import backtype.storm.hooks.ITaskHook;
 import backtype.storm.metric.api.CombinedMetric;
 import backtype.storm.metric.api.ICombiner;
 import backtype.storm.metric.api.IMetric;
@@ -25,6 +26,7 @@ import backtype.storm.metric.api.ReducedMetric;
 import backtype.storm.task.IMetricsContext;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.tuple.Fields;
+import java.util.Collection;
 import storm.trident.tuple.TridentTuple;
 import storm.trident.tuple.TridentTupleView.ProjectionFactory;
 
@@ -56,10 +58,20 @@ public class TridentOperationContext implements IMetricsContext{
     public <T extends IMetric> T registerMetric(String name, T metric, int timeBucketSizeInSecs) {
         return _topoContext.registerMetric(name, metric, timeBucketSizeInSecs);
     }
+
     public ReducedMetric registerMetric(String name, IReducer reducer, int timeBucketSizeInSecs) {
         return _topoContext.registerMetric(name, new ReducedMetric(reducer), timeBucketSizeInSecs);
     }
+
     public CombinedMetric registerMetric(String name, ICombiner combiner, int timeBucketSizeInSecs) {
         return _topoContext.registerMetric(name, new CombinedMetric(combiner), timeBucketSizeInSecs);
+    }
+  
+    public void addTaskHook(ITaskHook hook) {
+        _topoContext.addTaskHook(hook);
+    }
+
+    public Collection<ITaskHook> getHooks() {
+        return _topoContext.getHooks();
     }
 }


### PR DESCRIPTION
This would allow adding hooks to e.g. tasks that include a Trident function. There's a bit of a disconnect since the task that has the hook will likely be running e.g. more than a single function. So ideally perhaps there would be another Trident-specific hooks API. Regardless, I think having task-level hooks might be useful, and it is very simple to support.
