### PR TITLE
don't discard unfinished messages that are not old

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -188,10 +188,9 @@ public class PartitionManager {
     public void ack(Long offset) {
         if (!_pending.isEmpty() && _pending.first() < offset - _spoutConfig.maxOffsetBehind) {
             // Too many things pending!
-            _pending.headSet(offset).clear();
-        } else {
-            _pending.remove(offset);
+            _pending.headSet(offset - _spoutConfig.maxOffsetBehind).clear();
         }
+        _pending.remove(offset);
         numberAcked++;
     }
 


### PR DESCRIPTION
the ack() message in PartitionManager appears to have a bug that will
cause it to discard messages that have not been acknowledged even though
they have not fallen behind by maxOffsetBehind.

This can happen if there is at least one message that _is_ behind by
maxOffsetBehind.  The code correctly identifies that one or more
messages in _pending are old, but then potentially discards some that
are not.

Note: I can't figure out how to run the automated tests on my laptop.  I get an error like this:
java.lang.RuntimeException: backtype.storm.multilang.NoOutputException: Pipe to subprocess seems to be broken! No output read.
