### PR TITLE
STORM-476: external/storm-kafka: avoid NPE on null message payloads

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
@@ -202,6 +202,9 @@ public class KafkaUtils {
     public static Iterable<List<Object>> generateTuples(KafkaConfig kafkaConfig, Message msg) {
         Iterable<List<Object>> tups;
         ByteBuffer payload = msg.payload();
+        if (payload == null) {
+            return null;
+        }
         ByteBuffer key = msg.key();
         if (key != null && kafkaConfig.scheme instanceof KeyValueSchemeAsMultiScheme) {
             tups = ((KeyValueSchemeAsMultiScheme) kafkaConfig.scheme).deserializeKeyAndValue(Utils.toByteArray(key), Utils.toByteArray(payload));


### PR DESCRIPTION
Null message payloads in kafka will result in an NPE and a failing spout. This null check eliminates that possibility and follows the existing semantic of acking a null message silently.
