### PR TITLE
[STORM-480] change maven-dependency-plugin version 2.6 -> 2.8

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -404,7 +404,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.6</version>
+                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>


### PR DESCRIPTION
Changes the version of the plugin to the one [listed as "compatible."](https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound)
