### PR TITLE
[STORM-486] avoid adding multiple jetty handlers

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/drpc.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/drpc.clj
@@ -30,7 +30,6 @@
   (:use [backtype.storm.ui helpers])
   (:use compojure.core)
   (:use ring.middleware.reload)
-  (:use [ring.adapter.jetty :only [run-jetty]])
   (:require [compojure.handler :as handler])
   (:gen-class))
 
@@ -190,9 +189,9 @@
           (if http-creds-handler
             (.populateContext http-creds-handler (ReqContext/context)
                               servlet-request))
-    (.execute handler func "")))
-                (wrap-reload '[backtype.storm.daemon.drpc])
-                handle-request))
+          (.execute handler func "")))
+    (wrap-reload '[backtype.storm.daemon.drpc])
+    handle-request))
 
 (defn launch-server!
   ([]
@@ -230,15 +229,15 @@
               https-ks-password (conf DRPC-HTTPS-KEYSTORE-PASSWORD)
               https-ks-type (conf DRPC-HTTPS-KEYSTORE-TYPE)]
 
-          (run-jetty app
-            {:port drpc-http-port :join? false
-             :configurator (fn [server]
-                             (config-ssl server
-                                         https-port 
-                                         https-ks-path 
-                                         https-ks-password
-                                         https-ks-type)
-                             (config-filter server app filters-confs))})))
+          (storm-run-jetty
+           {:port drpc-http-port
+            :configurator (fn [server]
+                            (config-ssl server
+                                        https-port
+                                        https-ks-path
+                                        https-ks-password
+                                        https-ks-type)
+                            (config-filter server app filters-confs))})))
       (when handler-server
         (.serve handler-server)))))
 

--- a/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
@@ -20,7 +20,6 @@
   (:use [hiccup core page-helpers])
   (:use [backtype.storm config util log timer])
   (:use [backtype.storm.ui helpers])
-  (:use [ring.adapter.jetty :only [run-jetty]])
   (:import [org.slf4j LoggerFactory])
   (:import [ch.qos.logback.classic Logger])
   (:import [ch.qos.logback.core FileAppender])
@@ -351,11 +350,9 @@ Note that if anything goes wrong, this will throw an Error and exit."
                           [{:filter-class "org.eclipse.jetty.servlets.GzipFilter"
                             :filter-name "Gzipper"
                             :filter-params {}}])]
-      (run-jetty middle 
-                        {:port (int (conf LOGVIEWER-PORT))
-                         :join? false
-                         :configurator (fn [server]
-                                         (config-filter server middle filters-confs))}))
+      (storm-run-jetty {:port (int (conf LOGVIEWER-PORT))
+                        :configurator (fn [server]
+                                        (config-filter server middle filters-confs))}))
   (catch Exception ex
     (log-error ex))))
 

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -22,7 +22,6 @@
   (:use [backtype.storm.ui helpers])
   (:use [backtype.storm.daemon [common :only [ACKER-COMPONENT-ID ACKER-INIT-STREAM-ID ACKER-ACK-STREAM-ID
                                               ACKER-FAIL-STREAM-ID system-id? mk-authorization-handler]]])
-  (:use [ring.adapter.jetty :only [run-jetty]])
   (:use [clojure.string :only [blank? lower-case trim]])
   (:import [backtype.storm.utils Utils])
   (:import [backtype.storm.generated ExecutorSpecificStats
@@ -967,12 +966,11 @@
           header-buffer-size (int (.get conf UI-HEADER-BUFFER-BYTES))
           filters-confs [{:filter-class (conf UI-FILTER)
                           :filter-params (conf UI-FILTER-PARAMS)}]]
-      (run-jetty app {:port (conf UI-PORT)
-                          :join? false
-                          :configurator (fn [server]
-                                          (doseq [connector (.getConnectors server)]
-                                            (.setRequestHeaderSize connector header-buffer-size))
-                                          (config-filter server app filters-confs))}))
+      (storm-run-jetty {:port (conf UI-PORT)
+                        :configurator (fn [server]
+                                        (doseq [connector (.getConnectors server)]
+                                          (.setRequestHeaderSize connector header-buffer-size))
+                                        (config-filter server app filters-confs))}))
    (catch Exception ex
      (log-error ex))))
 


### PR DESCRIPTION
Big thanks to @knusbaum for tracking this down and providing the initial code.

This works by coping a private helper function from ring, so that we do not double-set handlers.
