### PR TITLE
STORM-498: make ZK connection timeout configurable in Kafka spout

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
@@ -47,7 +47,7 @@ public class DynamicBrokersReader {
             _curator = CuratorFrameworkFactory.newClient(
                     zkStr,
                     Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT)),
-                    15000,
+                    Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT)),
                     new RetryNTimes(Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_RETRY_TIMES)),
                             Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_RETRY_INTERVAL))));
             _curator.start();


### PR DESCRIPTION
This change is backwards compatible to the previous semantics because Storm's defaults.yaml sets the default ZK connection timeout to 15 seconds, which is equal to the previously hardcoded timeout setting in the Kafka spout.
