### PR TITLE
update supervisor.clj add a comment to supervisor-data function

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -207,7 +207,7 @@
    :isupervisor isupervisor
    :active (atom true)
    :uptime (uptime-computer)
-   :worker-thread-pids-atom (atom {})
+   :worker-thread-pids-atom (atom {}) ;; used for saving jvm thread id when running in local mode
    :storm-cluster-state (cluster/mk-storm-cluster-state conf)
    :local-state (supervisor-state conf)
    :supervisor-id (.getSupervisorId isupervisor)

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -207,7 +207,7 @@
    :isupervisor isupervisor
    :active (atom true)
    :uptime (uptime-computer)
-   :worker-thread-pids-atom (atom {}) ;; used for saving jvm thread id when running in local mode
+   :worker-thread-pids-atom (atom {})
    :storm-cluster-state (cluster/mk-storm-cluster-state conf)
    :local-state (supervisor-state conf)
    :supervisor-id (.getSupervisorId isupervisor)

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -295,11 +295,7 @@
                      #(HashMap. (apply dissoc (into {} %1) %&))
                      remove-connections)
               
-              (let [missing-tasks (->> needed-tasks
-                                       (filter (complement my-assignment)))]
-                (when-not (empty? missing-tasks)
-                  (log-warn "Missing assignment for following tasks: " (pr-str missing-tasks))
-                  )))))))
+            )))))
 
 (defn refresh-storm-active
   ([worker]


### PR DESCRIPTION
update supervisor.clj add a comment "used for saving jvm thread id when running in local mode" to keyword :worker-thread-pids-atom supervisor-data function