### PR TITLE
Supervisor logs stdout and stderr of launched workers

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -542,9 +542,14 @@
           command (->> command (map str) (filter (complement empty?)))
           shell-cmd (->> command
                          (map #(str \' (clojure.string/escape % {\' "\\'"}) \'))
-                         (clojure.string/join " "))]
-      (log-message "Launching worker with command: " shell-cmd)
-      (launch-process command :environment topology-worker-environment)
+                         (clojure.string/join " "))
+          _ (log-message "Launching worker with command: " shell-cmd)
+          process (launch-process command :environment topology-worker-environment)
+          process-out (slurp (.getInputStream process))
+          process-err (slurp (.getErrorStream process))
+          ]
+      (log-message "Worker out:" process-out)
+      (log-message "Worker err:" process-err)
       ))
 
 ;; local implementation


### PR DESCRIPTION
Currently the stdout and the stderr of the launcher worker process are dropped. Sometimes there are helpful troubleshooting messages in that output.

This can be helpful for troubleshooting the case where workers don't start successfully and the only logging is the supervisor's `<:worker-id> still hasn't started` (see below for example cases on the mailing list). In a recent case that I was debugging, the issue turned out to be a bad worker child opt; at any rate, these cases are not uncommon and could be easier to debug.

http://grokbase.com/t/gg/storm-user/139scqrv7n/supervisor-stil-hasnt-started-error
http://grokbase.com/t/gg/storm-user/131v9gv614/supervisor-is-not-able-to-start-worker-log-files-are-empty
