### PR TITLE
Change clojure class called by `storm repl`

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -293,7 +293,7 @@ def repl():
     on the classpath. Useful for debugging.
     """
     cppaths = [CLUSTER_CONF_DIR]
-    exec_storm_class("clojure.lang.Repl", jvmtype="-client", extrajars=cppaths)
+    exec_storm_class("clojure.main", jvmtype="-client", extrajars=cppaths)
 
 def nimbus(klass="backtype.storm.daemon.nimbus"):
     """Syntax: [storm nimbus]


### PR DESCRIPTION
Currently using `storm repl` there's a message saying that the `clojure.lang.Repl` class is deprecated.

```
WARNING: clojure.lang.Repl is deprecated.
Instead, use clojure.main like this:
java -cp clojure.jar clojure.main -i init.clj -r args...
Clojure 1.5.1
```

This change merely take the suggestion of the output, and updates the class to `clojure.main`.

https://issues.apache.org/jira/browse/STORM-504
