### PR TITLE
STORM-498: make ZK connection timeout configurable in Kafka spout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
  * STORM-336: Logback version should be upgraded
  * STORM-386: nodejs multilang protocol implementation and examples
  * STORM-500: Add Spinner when UI is loading stats from nimbus
+ * STORM-498: make ZK connection timeout configurable in Kafka spout
 
 ## 0.9.2-incubating
  * STORM-66: send taskid on initial handshake

--- a/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
@@ -47,7 +47,7 @@ public class DynamicBrokersReader {
             _curator = CuratorFrameworkFactory.newClient(
                     zkStr,
                     Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT)),
-                    15000,
+                    Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT)),
                     new RetryNTimes(Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_RETRY_TIMES)),
                             Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_RETRY_INTERVAL))));
             _curator.start();

--- a/external/storm-kafka/src/test/storm/kafka/DynamicBrokersReaderTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/DynamicBrokersReaderTest.java
@@ -50,6 +50,7 @@ public class DynamicBrokersReaderTest {
         String connectionString = server.getConnectString();
         Map conf = new HashMap();
         conf.put(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT, 1000);
+        conf.put(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT, 1000);
         conf.put(Config.STORM_ZOOKEEPER_RETRY_TIMES, 4);
         conf.put(Config.STORM_ZOOKEEPER_RETRY_INTERVAL, 5);
         ExponentialBackoffRetry retryPolicy = new ExponentialBackoffRetry(1000, 3);


### PR DESCRIPTION
This change is backwards compatible to the previous semantics because Storm's `defaults.yaml` sets the default ZK connection timeout to 15 seconds, which is equal to the previously hardcoded timeout setting in the Kafka spout.

This pull request supersedes the previous pull request https://github.com/apache/storm/pull/256, and fixes the NPE in the `DynamicBrokersReaderTest` test suite.
