### PR TITLE
STORM-506: Do not count bolt acks & fails in total stats

### DIFF
--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -341,10 +341,11 @@
         (merge-with + s1 s2))
       (select-keys
         agg-bolt-stats
-        [:emitted :transferred :acked :failed :complete-latencies])
-      (select-keys
-        agg-spout-stats
-        [:emitted :transferred :acked :failed :complete-latencies]))))
+        ;; Include only keys that will be used.  We want to count acked and
+        ;; failed only for the "tuple trees," so we do not include those keys
+        ;; from the bolt executors.
+        [:emitted :transferred])
+      agg-spout-stats)))
 
 (defn stats-times
   [stats-map]


### PR DESCRIPTION
Reverts part of [7f058e19](https://github.com/apache/storm/commit/7f058e19425ff712d9f8034b3641c06af885535e#diff-ef5b8078af20ef7de78826105625b4c9R287) and adds a comment explaining better what the stats are trying to do here.
