### PR TITLE
STORM-508: Update DEVELOPER.md now that Storm has graduated from Incubator

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -74,7 +74,7 @@ and summarize the desired functionality.  Set the form field "Issue type" to "Ne
 issue tracker before you will need to register an account (free), log in, and then click on the blue "Create Issue"
 button in the top navigation bar.
 
-You can also opt to send a message to the [Storm Users mailing list](http://storm.incubator.apache.org/community.html).
+You can also opt to send a message to the [Storm Users mailing list](http://storm.apache.org/community.html).
 
 
 <a name="contribute-code"></a>
@@ -83,7 +83,7 @@ You can also opt to send a message to the [Storm Users mailing list](http://stor
 
 Before you set out to contribute code we recommend that you familiarize yourself with the Storm codebase, notably by
 reading through the
-[Implementation documentation](http://storm.incubator.apache.org/documentation/Implementation-docs.html).
+[Implementation documentation](http://storm.apache.org/documentation/Implementation-docs.html).
 
 _If you are interested in contributing code to Storm but do not know where to begin:_
 In this case you should
@@ -124,7 +124,7 @@ GitHub.
 ## Contribute documentation
 
 Documentation contributions are very welcome!  The best way to send contributions is as emails through the
-[Storm Developers](http://storm.incubator.apache.org/community.html) mailing list.
+[Storm Developers](http://storm.apache.org/community.html) mailing list.
 
 
 <a name="pull-requests"></a>
@@ -137,13 +137,13 @@ Documentation contributions are very welcome!  The best way to send contribution
 ### Create a pull request
 
 Pull requests should be done against the read-only git repository at
-[https://github.com/apache/incubator-storm](https://github.com/apache/incubator-storm).
+[https://github.com/apache/storm](https://github.com/apache/storm).
 
 Take a look at [Creating a pull request](https://help.github.com/articles/creating-a-pull-request).  In a nutshell you
 need to:
 
 1. [Fork](https://help.github.com/articles/fork-a-repo) the Storm GitHub repository at
-   [https://github.com/apache/incubator-storm/](https://github.com/apache/incubator-storm/) to your personal GitHub
+   [https://github.com/apache/storm/](https://github.com/apache/storm/) to your personal GitHub
    account.  See [Fork a repo](https://help.github.com/articles/fork-a-repo) for detailed instructions.
 2. Commit any changes to your fork.
 3. Send a [pull request](https://help.github.com/articles/creating-a-pull-request) to the Storm GitHub repository
@@ -152,7 +152,7 @@ need to:
    ticket number (e.g. `STORM-123: ...`).
 
 You may want to read [Syncing a fork](https://help.github.com/articles/syncing-a-fork) for instructions on how to keep
-your fork up to date with the latest changes of the upstream (official) `incubator-storm` repository.
+your fork up to date with the latest changes of the upstream (official) `storm` repository.
 
 
 <a name="approve-pull-request"></a>
@@ -175,11 +175,11 @@ _This section applies to committers only._
 **Important: A pull request must first be properly approved before you are allowed to merge it.**
 
 Committers that are integrating patches or pull requests should use the official Apache repository at
-[https://git-wip-us.apache.org/repos/asf/incubator-storm.git](https://git-wip-us.apache.org/repos/asf/incubator-storm.git).
+[https://git-wip-us.apache.org/repos/asf/storm.git](https://git-wip-us.apache.org/repos/asf/storm.git).
 
 To pull in a merge request you should generally follow the command line instructions sent out by GitHub.
 
-1. Go to your local copy of the [Apache git repo](https://git-wip-us.apache.org/repos/asf/incubator-storm.git), switch
+1. Go to your local copy of the [Apache git repo](https://git-wip-us.apache.org/repos/asf/storm.git), switch
    to the `master` branch, and make sure it is up to date.
 
         $ git checkout master
@@ -297,21 +297,21 @@ The source code of Storm is managed via [git](http://git-scm.com/).  For a numbe
 repository associated with Storm.
 
 * **Committers only:**
-  [https://git-wip-us.apache.org/repos/asf/incubator-storm.git](https://git-wip-us.apache.org/repos/asf/incubator-storm.git)
+  [https://git-wip-us.apache.org/repos/asf/storm.git](https://git-wip-us.apache.org/repos/asf/storm.git)
   is the official and authoritative git repository for Storm, managed under the umbrella of the Apache Software
   Foundation.  Only official Storm committers will interact with this repository.
   When you push the first time to this repository git will prompt you for your username and password.  Use your Apache
   user ID and password, i.e. the credentials you configured via [https://id.apache.org/](https://id.apache.org/) after
   you were [onboarded as a committer](http://www.apache.org/dev/new-committers-guide.html#account-creation).
 * **Everybody else:**
-  [https://github.com/apache/incubator-storm/](https://github.com/apache/incubator-storm/) is a read-only mirror of the
+  [https://github.com/apache/storm/](https://github.com/apache/storm/) is a read-only mirror of the
   official git repository.  If you are not a Storm committer (most people) this is the repository you should work
   against.  See _Development workflow_ above on how you can create a pull request, for instance.
 
 An automated bot (called _[ASF GitHub Bot](https://issues.apache.org/jira/secure/ViewProfile.jspa?name=githubbot)_ in
 [Storm JIRA](https://issues.apache.org/jira/browse/STORM)) runs periodically to merge changes in the
-[official Apache repo](https://git-wip-us.apache.org/repos/asf/incubator-storm.git) to the read-only
-[GitHub mirror repository](https://github.com/apache/incubator-storm/), and to merge comments in GitHub pull requests to
+[official Apache repo](https://git-wip-us.apache.org/repos/asf/storm.git) to the read-only
+[GitHub mirror repository](https://github.com/apache/storm/), and to merge comments in GitHub pull requests to
 the [Storm JIRA](https://issues.apache.org/jira/browse/STORM).
 
 
@@ -335,7 +335,7 @@ If you do not have a JIRA account yet, then you can create one via the link abov
 # Questions?
 
 If you have any questions after reading this document, then please reach out to us via the
-[Storm Developers](http://storm.incubator.apache.org/community.html) mailing list.
+[Storm Developers](http://storm.apache.org/community.html) mailing list.
 
 And of course we also welcome any contributions to improve the information in this document!
 <a name="workflow"></a>


### PR DESCRIPTION
Storm has recently graduated from Apache Incubator, which resulted in hyperlink changes to the Storm website (now http://storm.apache.org/) and to our ASF and GitHub git repositories, respectively.
