### PR TITLE
STORM-499

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -278,8 +278,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
-                    <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
+                    <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
+                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <minimizeJar>false</minimizeJar>
                     <artifactSet>


### PR DESCRIPTION
This simply removes shaded/relocated artifacts from the published POM and promotes transitive dependencies.
