### PR TITLE
STORM-514: Refer to post-graduation Storm website and git repos

### DIFF
--- a/examples/storm-starter/README.markdown
+++ b/examples/storm-starter/README.markdown
@@ -26,7 +26,7 @@ Next, make sure you have the storm-starter code available on your machine.  Git/
 following command to download the latest storm-starter code and change to the new directory that contains the downloaded
 code.
 
-    $ git clone git://github.com/apache/incubator-storm.git && cd incubator-storm/examples/storm-starter
+    $ git clone git://github.com/apache/storm.git && cd storm/examples/storm-starter
 
 
 ## storm-starter overview
@@ -45,7 +45,7 @@ After you have familiarized yourself with these topologies, take a look at the o
 for more advanced implementations.
 
 If you want to learn more about how Storm works, please head over to the
-[Storm project page](http://storm.incubator.apache.org).
+[Storm project page](http://storm.apache.org).
 
 
 <a name="maven"></a>
@@ -74,8 +74,7 @@ of Storm in this local Maven repository at `$HOME/.m2/repository`.
 
 ## Running topologies with Maven
 
-Note: All following examples require that you run `cd examples/storm-starter`
-beforehand.
+> Note: All following examples require that you run `cd examples/storm-starter` beforehand.
 
 storm-starter topologies can be run with the maven-exec-plugin. For example, to
 compile and run `WordCountTopology` in local mode, use the command:
@@ -143,7 +142,7 @@ The following instructions will import storm-starter as a new project in Intelli
 
 
 * Open _File > Import Project..._ and navigate to the storm-starter directory of your storm clone (e.g.
-  `~/git/incubator-storm/examples/storm-starter`).
+  `~/git/storm/examples/storm-starter`).
 * Select _Import project from external model_, select "Maven", and click _Next_.
 * In the following screen, enable the checkbox _Import Maven projects automatically_.  Leave all other values at their
   defaults.  Click _Next_.


### PR DESCRIPTION
Also, we highlight even more that users must `cd` into the storm-starter
sub-directory.

This pull request only touches the README of storm-starter.
