### PR TITLE
STORM-488: Exit with 254 error code if storm CLI is run with unknown command

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -467,6 +467,7 @@ def print_usage(command=None):
 def unknown_command(*args):
     print("Unknown command: [storm %s]" % ' '.join(sys.argv[1:]))
     print_usage()
+    sys.exit(254)
 
 COMMANDS = {"jar": jar, "kill": kill, "shell": shell, "nimbus": nimbus, "ui": ui, "logviewer": logviewer,
             "drpc": drpc, "supervisor": supervisor, "localconfvalue": print_localconfvalue,


### PR DESCRIPTION
This change follows the existing semantics when the `storm` CLI tool is invoked without _any_ parameters.

With this change, whenever the user tries to run `storm <cmd>` with an unknown command the `storm` script will print the usage help (existing behavior) AND then exit with a 254 error code.

I decided not to re-use the 255 error code, which is returned by the `storm` CLI tool when being invoked without any parameters.  Having two separate error codes allows downstream applications (including Ansible, Puppet) to better understand what went wrong and react accordingly -- e.g. giving the user more meaningful feedback.
