### PR TITLE
STORM-517: Adding JAVA_SERVICE_NAME to bin/storm

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -76,6 +76,7 @@ init_storm_env()
 CONFIG_OPTS = []
 CONFFILE = ""
 JAR_JVM_OPTS = shlex.split(os.getenv('STORM_JAR_JVM_OPTS', ''))
+JAVA_SERVICE_NAME = os.getenv('JAVA_SERVICE_NAME', None)
 JAVA_HOME = os.getenv('JAVA_HOME', None)
 JAVA_CMD = 'java' if not JAVA_HOME else os.path.join(JAVA_HOME, 'bin', 'java')
 
@@ -167,7 +168,8 @@ def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]
     if(storm_log_dir == None or storm_log_dir == "nil"):
         storm_log_dir = STORM_DIR+"/logs"
     all_args = [
-        JAVA_CMD, jvmtype, get_config_opts(),
+        JAVA_CMD, jvmtype, JAVA_SERVICE_NAME,
+        get_config_opts(),
         "-Dstorm.home=" + STORM_DIR,
         "-Dstorm.log.dir=" + storm_log_dir, 
         "-Djava.library.path=" + confvalue("java.library.path", extrajars),


### PR DESCRIPTION
STORM-517: Adding JAVA_SERVICE_NAME to bin/storm

- Adds reading an JAVA_SERVICE_NAME environment
  variable to bin/storm and reads it in as part of
  generating all_args in exec_storm_class()

Meant to be set to something like:

```
export JAVA_SERVICE_NAME="-Dservice=storm-nimbus'
```

See https://github.com/solarce/storm-cookbook/blob/master/templates/default/storm-upstart-conf.erb#L19 for an example with Chef