### PR TITLE
update worker.clj-delete "missing-tasks" checking

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -295,11 +295,7 @@
                      #(HashMap. (apply dissoc (into {} %1) %&))
                      remove-connections)
               
-              (let [missing-tasks (->> needed-tasks
-                                       (filter (complement my-assignment)))]
-                (when-not (empty? missing-tasks)
-                  (log-warn "Missing assignment for following tasks: " (pr-str missing-tasks))
-                  )))))))
+           )))))
 
 (defn refresh-storm-active
   ([worker]


### PR DESCRIPTION
missing-tasks set is created by two times filter my-assignment map, so i think keys(my-assignment) contains missing-tasks set.
missing-tasks is always empty. (empty? missing-tasks) always return true. 

(let [missing-tasks (->> needed-tasks
                                       (filter (complement my-assignment)))]
                (when-not (empty? missing-tasks)
                  (log-warn "Missing assignment for following tasks: " (pr-str missing-tasks))
                  ))