### PR TITLE
Remove 'provided' from storm-kafka pom.xml example

### DIFF
--- a/external/storm-kafka/README.md
+++ b/external/storm-kafka/README.md
@@ -121,7 +121,6 @@ use Kafka 0.8.1.1 built against Scala 2.10, you would use the following dependen
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.10</artifactId>
             <version>0.8.1.1</version>
-            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
Per this documentation, the kafka dependency of storm-kafka is in the
'provided' scope so that users can choose which Scala distribution they
include.

Thus, this example of how to fulfill the dependency should not itself use
the 'provided' scope, or else kafka will still not be included.
