### PR TITLE
STORM-540: Change default time format in logs to ISO8601 in order to include timezone

### DIFF
--- a/logback/cluster.xml
+++ b/logback/cluster.xml
@@ -30,7 +30,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n</pattern>
+      <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZZ} %c{1} [%p] %m%n</pattern>
     </encoder>
  </appender>
 
@@ -47,7 +47,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss} %c{1} [%p] %m%n</pattern>
+      <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZZ} %c{1} [%p] %m%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
See [STORM-540](https://issues.apache.org/jira/browse/STORM-540)
