### PR TITLE
STORM-492 with reverting previous merge

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -229,6 +229,10 @@ The following commands must be run from the top-level directory.
     # Build the code and run the tests (requires nodejs, python and ruby installed) 
     $ mvn clean install
 
+    # Build the code and run the tests, with specifying default test timeout (in millisecond)
+    $ export STORM_TEST_TIMEOUT_MS=10000
+    $ mvn clean install
+
     # Build the code but skip the tests
     $ mvn clean install -DskipTests=true
 

--- a/storm-core/src/clj/backtype/storm/testing.clj
+++ b/storm-core/src/clj/backtype/storm/testing.clj
@@ -187,7 +187,9 @@
       ;; on windows, the host process still holds lock on the logfile
       (catch Exception e (log-message (.getMessage e)))) ))
 
-(def TEST-TIMEOUT-MS 5000)
+(def TEST-TIMEOUT-MS
+  (let [timeout (System/getenv "STORM_TEST_TIMEOUT_MS")]
+    (parse-int (if timeout timeout "5000"))))
 
 (defmacro while-timeout [timeout-ms condition & body]
   `(let [end-time# (+ (System/currentTimeMillis) ~timeout-ms)]
@@ -594,7 +596,7 @@
                            (not= (global-amt track-id "transferred")                                 
                                  (global-amt track-id "processed"))
                            ))]
-        (while-timeout TEST-TIMEOUT-MS (waiting?)
+        (while-timeout timeout-ms (waiting?)
                        ;; (println "Spout emitted: " (global-amt track-id "spout-emitted"))
                        ;; (println "Processed: " (global-amt track-id "processed"))
                        ;; (println "Transferred: " (global-amt track-id "transferred"))

--- a/storm-core/src/clj/backtype/storm/testing4j.clj
+++ b/storm-core/src/clj/backtype/storm/testing4j.clj
@@ -44,6 +44,7 @@
              ^:static [mkTrackedTopology [backtype.storm.ILocalCluster backtype.storm.generated.StormTopology] backtype.storm.testing.TrackedTopology]
              ^:static [trackedWait [backtype.storm.testing.TrackedTopology] void]
              ^:static [trackedWait [backtype.storm.testing.TrackedTopology Integer] void]
+             ^:static [trackedWait [backtype.storm.testing.TrackedTopology Integer Integer] void]
              ^:static [advanceClusterTime [backtype.storm.ILocalCluster Integer Integer] void]
              ^:static [advanceClusterTime [backtype.storm.ILocalCluster Integer] void]
              ^:static [multiseteq [java.util.Collection java.util.Collection] boolean]
@@ -123,6 +124,8 @@
       (TrackedTopology.)))
 
 (defn -trackedWait
+  ([^TrackedTopology trackedTopology ^Integer amt ^Integer timeout-ms]
+   (tracked-wait trackedTopology amt timeout-ms))
   ([^TrackedTopology trackedTopology ^Integer amt]
    (tracked-wait trackedTopology amt))
   ([^TrackedTopology trackedTopology]


### PR DESCRIPTION
First of all, I'm sorry for mistake.
It's for reverting broken #279 and reapply correct patch (using System Environment, not JVM Property).
I reverted #279, and rearrange #279's changesets into one commit.
You can find further information from #279.

If Storm project has a rule about reverting and this PR doesn't fit, I'm sure to wait @clockfly to revert, and re-create PR.

@ptgoetz @clockfly @harshach Please take a look and comment. Thanks in advance.
