### PR TITLE
STORM-558 change "swap!" to "reset!" to fix assignment-versions always empty in supervisor

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -441,7 +441,7 @@
       (.put local-state
             LS-LOCAL-ASSIGNMENTS
             new-assignment)
-      (swap! (:assignment-versions supervisor) versions)
+      (reset! (:assignment-versions supervisor) versions)
       (reset! (:curr-assignment supervisor) new-assignment)
       ;; remove any downloaded code that's no longer assigned or active
       ;; important that this happens after setting the local assignment so that


### PR DESCRIPTION
This PR is for JIRA STORM-558 to fix #167 .
