### PR TITLE
Fix calls to submit-mocked-assignment: executor id should be of the form [first-task last-task]

### DIFF
--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -90,10 +90,10 @@
                            2 "1"
                            3 "1"
                            4 "1"}
-                          {[1] ["sup1" 1]
-                           [2] ["sup1" 2]
-                           [3] ["sup1" 3]
-                           [4] ["sup1" 3]
+                          {[1 1] ["sup1" 1]
+                           [2 2] ["sup1" 2]
+                           [3 3] ["sup1" 3]
+                           [4 4] ["sup1" 3]
                            })
                         (advance-cluster-time cluster 2)
                         (heartbeat-workers cluster "sup1" [1 2 3])
@@ -141,10 +141,10 @@
                            2 "1"
                            3 "1"
                            4 "1"}
-                          {[1] ["sup1" 1]
-                           [2] ["sup1" 2]
-                           [3] ["sup2" 1]
-                           [4] ["sup2" 1]
+                          {[1 1] ["sup1" 1]
+                           [2 2] ["sup1" 2]
+                           [3 3] ["sup2" 1]
+                           [4 4] ["sup2" 1]
                            })
                         (advance-cluster-time cluster 2)
                         (heartbeat-workers cluster "sup1" [1 2])
@@ -162,9 +162,9 @@
                           {1 "1"
                            2 "1"
                            3 "1"}
-                          {[1] ["sup1" 3]
-                           [2] ["sup1" 3]
-                           [3] ["sup2" 2]
+                          {[1 1] ["sup1" 3]
+                           [2 2] ["sup1" 3]
+                           [3 3] ["sup2" 2]
                            })
                         (advance-cluster-time cluster 2)
                         (heartbeat-workers cluster "sup1" [3])
@@ -439,8 +439,8 @@
                      topology1
                      {1 "1"
                       2 "1"}
-                     {[1] ["sup1" 1]
-                      [2] ["sup1" 2]
+                     {[1 1] ["sup1" 1]
+                      [2 2] ["sup1" 2]
                       })
                     (submit-mocked-assignment
                      (:nimbus cluster)
@@ -449,8 +449,8 @@
                      topology2
                      {1 "1"
                       2 "1"}
-                     {[1] ["sup1" 1]
-                      [2] ["sup1" 2]
+                     {[1 1] ["sup1" 1]
+                      [2 2] ["sup1" 2]
                       })
                     (advance-cluster-time cluster 10)
                     ))


### PR DESCRIPTION
These tests are causing null reference errors when executor-id->tasks is called on these erroneous executor ids.