### PR TITLE
[STORM-569] Add Configuration to enable/disable Bolt's outgoing overflow-buffer

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -196,5 +196,6 @@ topology.trident.batch.emit.interval.millis: 500
 topology.testing.always.try.serialize: false
 topology.classpath: null
 topology.environment: null
+topology.bolts.outgoing.overflow.buffer.enable: false
 
 dev.zookeeper.path: "/tmp/dev-storm-zookeeper"

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -681,7 +681,7 @@
         ;; buffers filled up)
         ;; the overflow buffer is might gradually fill degrading the performance gradually
         ;; eventually running out of memory, but at least prevent live-locks/deadlocks.
-        overflow-buffer (ConcurrentLinkedQueue.)]
+        overflow-buffer (if (storm-conf TOPOLOGY-BOLTS-OUTGOING-OVERFLOW-BUFFER-ENABLE) (ConcurrentLinkedQueue.) nil)]
     
     ;; TODO: can get any SubscribedState objects out of the context now
 
@@ -798,7 +798,7 @@
             (disruptor/consume-batch-when-available receive-queue event-handler)
             ;; try to clear the overflow-buffer
             (try-cause
-              (while (not (.isEmpty overflow-buffer))
+              (while (and overflow-buffer (not (.isEmpty overflow-buffer)))
                 (let [[out-task out-tuple] (.peek overflow-buffer)]
                   (transfer-fn out-task out-tuple false nil)
                   (.poll overflow-buffer)))

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1030,6 +1030,16 @@ public class Config extends HashMap<String, Object> {
      public static final String TOPOLOGY_ENVIRONMENT="topology.environment";
      public static final Object TOPOLOGY_ENVIRONMENT_SCHEMA = Map.class;
 
+    /*
+     * Topology-specific option to disable/enable bolt's outgoing overflow buffer.
+     * Enabling this option ensures that the bolt can always clear the incoming messages,
+     * preventing live-lock for the topology with cyclic flow.
+     * The overflow buffer can fill degrading the performance gradually,
+     * eventually running out of memory.
+     */
+    public static final String TOPOLOGY_BOLTS_OUTGOING_OVERFLOW_BUFFER_ENABLE="topology.bolts.outgoing.overflow.buffer.enable";
+    public static final Object TOPOLOGY_BOLTS_OUTGOING_OVERFLOW_BUFFER_ENABLE_SCHEMA = Boolean.class;
+
     /**
      * This config is available for TransactionalSpouts, and contains the id ( a String) for
      * the transactional topology. This id is used to store the state of the transactional


### PR DESCRIPTION
- Added topology level flag `topology.bolts.outgoing.overflow.buffer.enable` - which defaults to `true`
- Create bolt's overflow buffer only if `topology.bolts.outgoing.overflow.buffer.enable` is set
- tested manually using topology with cyclic flow for below scenarios for both 
  - When set to`false` executors hit live-lock and get restarted as `DisruptorQueue` get full
  - When set to `true` executors use overflow buffer to handle spikes and instead of live-lock, they consume more memory.
