### PR TITLE
[STORM-573]Allow users to pass TEST-TIMEOUT-MS as param for complete-topology for Java

### DIFF
--- a/storm-core/src/clj/backtype/storm/testing4j.clj
+++ b/storm-core/src/clj/backtype/storm/testing4j.clj
@@ -54,17 +54,20 @@
 
 (defn -completeTopology
   ([^ILocalCluster cluster ^StormTopology topology ^CompleteTopologyParam completeTopologyParam]
-     (let [mocked-sources (or (-> completeTopologyParam .getMockedSources .getData) {})
-           storm-conf (or (.getStormConf completeTopologyParam) {})
-           cleanup-state (or (.getCleanupState completeTopologyParam) true)
-           topology-name (.getTopologyName completeTopologyParam)]
-       (complete-topology (.getState cluster) topology
-                          :mock-sources mocked-sources
-                          :storm-conf storm-conf
-                          :cleanup-state cleanup-state
-                          :topology-name topology-name)))
+    (let [mocked-sources (or (-> completeTopologyParam .getMockedSources .getData) {})
+          storm-conf (or (.getStormConf completeTopologyParam) {})
+          cleanup-state (or (.getCleanupState completeTopologyParam) true)
+          topology-name (.getTopologyName completeTopologyParam)
+          timeout-ms (or (.getTimeoutMs completeTopologyParam) TEST-TIMEOUT-MS)]
+      (complete-topology (.getState cluster) topology
+        :mock-sources mocked-sources
+        :storm-conf storm-conf
+        :cleanup-state cleanup-state
+        :topology-name topology-name
+        :timeout-ms timeout-ms)))
   ([^ILocalCluster cluster ^StormTopology topology]
-     (-completeTopology cluster topology (CompleteTopologyParam.))))
+    (-completeTopology cluster topology (CompleteTopologyParam.))))
+
 
 (defn -withSimulatedTime
   [^Runnable code]

--- a/storm-core/src/jvm/backtype/storm/testing/CompleteTopologyParam.java
+++ b/storm-core/src/jvm/backtype/storm/testing/CompleteTopologyParam.java
@@ -39,29 +39,49 @@ public class CompleteTopologyParam {
 	 * the topology name you want to submit to the cluster
 	 */
 	private String topologyName;
-	
+
+	/**
+	 * the timeout of topology you want to submit to the cluster
+	 */
+	private Integer timeoutMs;
+
 	public MockedSources getMockedSources() {
 		return mockedSources;
 	}
+
 	public void setMockedSources(MockedSources mockedSources) {
 		this.mockedSources = mockedSources;
 	}
+
 	public Config getStormConf() {
 		return stormConf;
 	}
+
 	public void setStormConf(Config stormConf) {
 		this.stormConf = stormConf;
 	}
+
 	public Boolean getCleanupState() {
 		return cleanupState;
 	}
+
 	public void setCleanupState(Boolean cleanupState) {
 		this.cleanupState = cleanupState;
 	}
+
 	public String getTopologyName() {
 		return topologyName;
 	}
+
 	public void setTopologyName(String topologyName) {
 		this.topologyName = topologyName;
+	}
+
+	public Integer getTimeoutMs() {
+		return timeoutMs;
+	}
+
+	public void setTimeoutMs(Integer timeoutMs) {
+		this.timeoutMs = timeoutMs;
 	}
 }


### PR DESCRIPTION
`timeout-ms` value can be passed as param to `comlete-topology` in testing4j.clj for Java projects now.
