### PR TITLE
[STORM-575] Specify UI/Jetty interface to bind to (ui.host)

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -54,6 +54,7 @@ nimbus.file.copy.expiration.secs: 600
 nimbus.topology.validator: "backtype.storm.nimbus.DefaultTopologyValidator"
 
 ### ui.* configs are for the master
+ui.host: 0.0.0.0
 ui.port: 8080
 ui.childopts: "-Xmx768m"
 

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -918,6 +918,7 @@
 (defn start-server!
   []
   (run-jetty app {:port (Integer. (*STORM-CONF* UI-PORT))
+                  :host (*STORM-CONF* UI-HOST)
                   :join? false}))
 
 (defn -main [] (start-server!))

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -336,6 +336,12 @@ public class Config extends HashMap<String, Object> {
     public static final Object NIMBUS_AUTHORIZER_SCHEMA = String.class;
 
     /**
+     * Storm UI binds to this host/interface.
+     */
+    public static final String UI_HOST = "ui.host";
+    public static final Object UI_HOST_SCHEMA = String.class;
+    
+    /**
      * Storm UI binds to this port.
      */
     public static final String UI_PORT = "ui.port";


### PR DESCRIPTION
Provides the ability to specify the Jetty host configuration as 'ui.host'. Defaults to '0.0.0.0' to bind to all interfaces.
