### PR TITLE
STORM-577：supervisor heartbeat and handle event use separate timer

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -290,10 +290,14 @@
    :assignment-id (.getAssignmentId isupervisor)
    :my-hostname (hostname conf)
    :curr-assignment (atom nil) ;; used for reporting used ports when heartbeating
-   :timer (mk-timer :kill-fn (fn [t]
+   :heartbeat-timer (mk-timer :kill-fn (fn [t]
                                (log-error t "Error when processing event")
                                (exit-process! 20 "Error when processing an event")
                                ))
+   :event-timer (mk-timer :kill-fn (fn [t]
+                                         (log-error t "Error when processing event")
+                                         (exit-process! 20 "Error when processing an event")
+                                         ))
    :assignment-versions (atom {})
    :sync-retry (atom 0)
    })
@@ -482,15 +486,15 @@
                                                 ((:uptime supervisor)))))]
     (heartbeat-fn)
     ;; should synchronize supervisor so it doesn't launch anything after being down (optimization)
-    (schedule-recurring (:timer supervisor)
+    (schedule-recurring (:heartbeat-timer supervisor)
                         0
                         (conf SUPERVISOR-HEARTBEAT-FREQUENCY-SECS)
                         heartbeat-fn)
     (when (conf SUPERVISOR-ENABLE)
       ;; This isn't strictly necessary, but it doesn't hurt and ensures that the machine stays up
       ;; to date even if callbacks don't all work exactly right
-      (schedule-recurring (:timer supervisor) 0 10 (fn [] (.add event-manager synchronize-supervisor)))
-      (schedule-recurring (:timer supervisor)
+      (schedule-recurring (:event-timer supervisor) 0 10 (fn [] (.add event-manager synchronize-supervisor)))
+      (schedule-recurring (:event-timer supervisor)
                           0
                           (conf SUPERVISOR-MONITOR-FREQUENCY-SECS)
                           (fn [] (.add processes-event-manager sync-processes))))
@@ -500,7 +504,8 @@
      (shutdown [this]
                (log-message "Shutting down supervisor " (:supervisor-id supervisor))
                (reset! (:active supervisor) false)
-               (cancel-timer (:timer supervisor))
+               (cancel-timer (:heartbeat-timer supervisor))
+               (cancel-timer (:event-timer supervisor))
                (.shutdown event-manager)
                (.shutdown processes-event-manager)
                (.disconnect (:storm-cluster-state supervisor)))
@@ -518,7 +523,8 @@
      (waiting? [this]
        (or (not @(:active supervisor))
            (and
-            (timer-waiting? (:timer supervisor))
+            (timer-waiting? (:heartbeat-timer supervisor))
+            (timer-waiting? (:event-timer supervisor))
             (every? (memfn waiting?) managers)))
            ))))
 


### PR DESCRIPTION
PR for [STORM-577](https://issues.apache.org/jira/browse/STORM-577)

Supervisor heartbeat and sync-processes use the same timer, when sync-processed use a lot time that greater than nimbus.supervisor.timeout.secs, nimbus will this supervisor was dead and move worker from this supervisor to others. At most time, block happens when worker launch consume too long time.
