### PR TITLE
STORM-575: Specify UI/Jetty interface to bind to (ui.host)

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -67,6 +67,7 @@ nimbus.topology.validator: "backtype.storm.nimbus.DefaultTopologyValidator"
 nimbus.credential.renewers.freq.secs: 600
 
 ### ui.* configs are for the master
+ui.host: 0.0.0.0
 ui.port: 8080
 ui.childopts: "-Xmx768m"
 ui.actions.enabled: true

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -978,6 +978,7 @@
           filters-confs [{:filter-class (conf UI-FILTER)
                           :filter-params (conf UI-FILTER-PARAMS)}]]
       (storm-run-jetty {:port (conf UI-PORT)
+                        :host (conf UI-HOST)
                         :configurator (fn [server]
                                         (doseq [connector (.getConnectors server)]
                                           (.setRequestHeaderSize connector header-buffer-size))

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -455,6 +455,12 @@ public class Config extends HashMap<String, Object> {
     public static final Object NIMBUS_AUTO_CRED_PLUGINS_SCHEMA = ConfigValidation.StringsValidator;
 
     /**
+     * Storm UI binds to this host/interface.
+     */
+    public static final String UI_HOST = "ui.host";
+    public static final Object UI_HOST_SCHEMA = String.class;
+    
+    /**
      * Storm UI binds to this port.
      */
     public static final String UI_PORT = "ui.port";


### PR DESCRIPTION
Ability to add UI host/interface to bind to using 'ui.host'. Defaults to '0.0.0.0' (all interfaces).
