### PR TITLE
Windows fork option

### DIFF
--- a/bin/storm-config.cmd
+++ b/bin/storm-config.cmd
@@ -16,6 +16,7 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
+set FORK=false
 
 set STORM_HOME=%~dp0
 for %%i in (%STORM_HOME%.) do (

--- a/bin/storm-config.cmd
+++ b/bin/storm-config.cmd
@@ -16,7 +16,6 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
-set FORK=false
 
 set STORM_HOME=%~dp0
 for %%i in (%STORM_HOME%.) do (

--- a/bin/storm.cmd
+++ b/bin/storm.cmd
@@ -89,7 +89,11 @@
     %JAVA% %JAVA_HEAP_MAX% %STORM_OPTS% %STORM_LOG_FILE% %CLASS% %storm-command-arguments%
   )
   set path=%PATH%;%STORM_BIN_DIR%;%STORM_SBIN_DIR%
-  call start /b %JAVA% %JAVA_HEAP_MAX% %STORM_OPTS% %STORM_LOG_FILE% %CLASS% %storm-command-arguments%
+  if "%FORK%"=="true" (
+	call start /b %JAVA% %JAVA_HEAP_MAX% %STORM_OPTS% %STORM_LOG_FILE% %CLASS% %storm-command-arguments%
+  ) else (
+    %JAVA% %JAVA_HEAP_MAX% %STORM_OPTS% %STORM_LOG_FILE% %CLASS% %storm-command-arguments%
+  )
   goto :eof
 
 

--- a/bin/storm.cmd
+++ b/bin/storm.cmd
@@ -89,10 +89,10 @@
     %JAVA% %JAVA_HEAP_MAX% %STORM_OPTS% %STORM_LOG_FILE% %CLASS% %storm-command-arguments%
   )
   set path=%PATH%;%STORM_BIN_DIR%;%STORM_SBIN_DIR%
-  if "%FORK%"=="true" (
-	call start /b %JAVA% %JAVA_HEAP_MAX% %STORM_OPTS% %STORM_LOG_FILE% %CLASS% %storm-command-arguments%
-  ) else (
+  if "%STORM_FORK%"=="false" (
     %JAVA% %JAVA_HEAP_MAX% %STORM_OPTS% %STORM_LOG_FILE% %CLASS% %storm-command-arguments%
+  ) else (
+	call start /b %JAVA% %JAVA_HEAP_MAX% %STORM_OPTS% %STORM_LOG_FILE% %CLASS% %storm-command-arguments%
   )
   goto :eof
 


### PR DESCRIPTION
Ported Nathan Marz's Python changes to DOS batch file. This allows Storm to be started so that a process manager like NSSM can track the correct process ID. I followed the same pattern as the STORM_DEBUG setting with default behavior being the current behavior.

Original pull request:
https://github.com/nathanmarz/storm/pull/238
