### PR TITLE
use generics when implementing TupleToKafkaMapper in FieldNameBasedTuple..

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/bolt/mapper/FieldNameBasedTupleToKafkaMapper.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/bolt/mapper/FieldNameBasedTupleToKafkaMapper.java
@@ -19,7 +19,7 @@ package storm.kafka.bolt.mapper;
 
 import backtype.storm.tuple.Tuple;
 
-public class FieldNameBasedTupleToKafkaMapper<K,V> implements TupleToKafkaMapper {
+public class FieldNameBasedTupleToKafkaMapper<K,V> implements TupleToKafkaMapper<K, V> {
 
     public static final String BOLT_KEY = "key";
     public static final String BOLT_MESSAGE = "message";


### PR DESCRIPTION
- use generics when implementing TupleToKafkaMapper in FieldNameBasedTupleToKafkaMapper

It fixes unchecked assignment warning in the following piece of code:

``` java
 public KafkaBolt kafkaBolt() {
        return new KafkaBolt<String, String>()
                .withTopicSelector(new DefaultTopicSelector(topicName))
                .withTupleToKafkaMapper(new FieldNameBasedTupleToKafkaMapper<String, String>());
}
```
