### PR TITLE
STORM-603 Log errors when required kafka params are missing

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
@@ -41,6 +41,14 @@ public class DynamicBrokersReader {
     private String _topic;
 
     public DynamicBrokersReader(Map conf, String zkStr, String zkPath, String topic) {
+        // Check required parameters
+        if(conf == null) {LOG.error("conf cannot be null");}
+        validateConfig(conf);
+
+        if(zkStr == null) {LOG.error("zkString cannot be null");}
+        if(zkPath == null) {LOG.error("zkPath cannot be null");}
+        if(topic == null) {LOG.error("topic cannot be null");}
+
         _zkPath = zkPath;
         _topic = topic;
         try {
@@ -53,6 +61,7 @@ public class DynamicBrokersReader {
             _curator.start();
         } catch (Exception ex) {
             LOG.error("Couldn't connect to zookeeper", ex);
+            throw new RuntimeException(ex);
         }
     }
 
@@ -146,6 +155,21 @@ public class DynamicBrokersReader {
             return new Broker(host, port);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private void validateConfig(final Map conf) {
+        if(conf.get(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT) == null) {
+            LOG.error("{} cannot be null", Config.STORM_ZOOKEEPER_SESSION_TIMEOUT);
+        }
+        if(conf.get(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT) == null) {
+            LOG.error("{} cannot be null", Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT);
+        }
+        if(conf.get(Config.STORM_ZOOKEEPER_RETRY_TIMES) == null) {
+            LOG.error("{} cannot be null", Config.STORM_ZOOKEEPER_RETRY_TIMES);
+        }
+        if(conf.get(Config.STORM_ZOOKEEPER_RETRY_INTERVAL) == null) {
+            LOG.error("{} cannot be null", Config.STORM_ZOOKEEPER_RETRY_INTERVAL);
         }
     }
 

--- a/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
@@ -19,6 +19,7 @@ package storm.kafka;
 
 import backtype.storm.Config;
 import backtype.storm.utils.Utils;
+import com.google.common.base.Preconditions;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryNTimes;
@@ -42,12 +43,13 @@ public class DynamicBrokersReader {
 
     public DynamicBrokersReader(Map conf, String zkStr, String zkPath, String topic) {
         // Check required parameters
-        if(conf == null) {LOG.error("conf cannot be null");}
+        Preconditions.checkNotNull(conf, "conf cannot be null");
+
         validateConfig(conf);
 
-        if(zkStr == null) {LOG.error("zkString cannot be null");}
-        if(zkPath == null) {LOG.error("zkPath cannot be null");}
-        if(topic == null) {LOG.error("topic cannot be null");}
+        Preconditions.checkNotNull(zkStr,"zkString cannot be null");
+        Preconditions.checkNotNull(zkPath, "zkPath cannot be null");
+        Preconditions.checkNotNull(topic, "topic cannot be null");
 
         _zkPath = zkPath;
         _topic = topic;
@@ -158,19 +160,19 @@ public class DynamicBrokersReader {
         }
     }
 
+    /**
+     * Validate required parameters in the input configuration Map
+     * @param conf
+     */
     private void validateConfig(final Map conf) {
-        if(conf.get(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT) == null) {
-            LOG.error("{} cannot be null", Config.STORM_ZOOKEEPER_SESSION_TIMEOUT);
-        }
-        if(conf.get(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT) == null) {
-            LOG.error("{} cannot be null", Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT);
-        }
-        if(conf.get(Config.STORM_ZOOKEEPER_RETRY_TIMES) == null) {
-            LOG.error("{} cannot be null", Config.STORM_ZOOKEEPER_RETRY_TIMES);
-        }
-        if(conf.get(Config.STORM_ZOOKEEPER_RETRY_INTERVAL) == null) {
-            LOG.error("{} cannot be null", Config.STORM_ZOOKEEPER_RETRY_INTERVAL);
-        }
+        Preconditions.checkNotNull(conf.get(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT),
+                "%s cannot be null", Config.STORM_ZOOKEEPER_SESSION_TIMEOUT);
+        Preconditions.checkNotNull(conf.get(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT),
+                "%s cannot be null", Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT);
+        Preconditions.checkNotNull(conf.get(Config.STORM_ZOOKEEPER_RETRY_TIMES),
+                "%s cannot be null", Config.STORM_ZOOKEEPER_RETRY_TIMES);
+        Preconditions.checkNotNull(conf.get(Config.STORM_ZOOKEEPER_RETRY_INTERVAL),
+                "%s cannot be null", Config.STORM_ZOOKEEPER_RETRY_INTERVAL);
     }
 
 }

--- a/external/storm-kafka/src/test/storm/kafka/DynamicBrokersReaderTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/DynamicBrokersReaderTest.java
@@ -170,4 +170,17 @@ public class DynamicBrokersReaderTest {
         assertEquals(newPort, brokerInfo.getBrokerFor(partition).port);
         assertEquals(newHost, brokerInfo.getBrokerFor(partition).host);
     }
+
+    @Test(expected = RuntimeException.class)
+    public void testErrorLogsWhenConfigIsMissing() throws Exception {
+        String connectionString = server.getConnectString();
+        Map conf = new HashMap();
+        conf.put(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT, 1000);
+//        conf.put(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT, 1000);
+        conf.put(Config.STORM_ZOOKEEPER_RETRY_TIMES, 4);
+        conf.put(Config.STORM_ZOOKEEPER_RETRY_INTERVAL, 5);
+
+        DynamicBrokersReader dynamicBrokersReader1 = new DynamicBrokersReader(conf, connectionString, masterPath, topic);
+
+    }
 }

--- a/external/storm-kafka/src/test/storm/kafka/DynamicBrokersReaderTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/DynamicBrokersReaderTest.java
@@ -171,7 +171,7 @@ public class DynamicBrokersReaderTest {
         assertEquals(newHost, brokerInfo.getBrokerFor(partition).host);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = NullPointerException.class)
     public void testErrorLogsWhenConfigIsMissing() throws Exception {
         String connectionString = server.getConnectString();
         Map conf = new HashMap();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-603

I was upgrading our topologies to storm-0.9.3 this [commit](https://github.com/apache/storm/commit/2596e335f27a57784a93a57823bd93dde587909f) introduced a change that threw me for a loop. When submitting my topology I got the following error.
```
[main] ERROR storm.kafka.DynamicBrokersReader - Couldn't connect to zookeeper
 java.lang.IllegalArgumentException: Don't know how to convert null to int
 	at backtype.storm.utils.Utils.getInt(Utils.java:301) ~[storm-core-0.9.3.jar:0.9.3]
 	at storm.kafka.DynamicBrokersReader.<init>(DynamicBrokersReader.java:47) ~[gambit-storm-threads-0.0.1-SNAPSHOT-jar-with-dependencies.jar:na]
 	at com.pearson.gambit.threads.storm.ThreadsTopology.main(ThreadsTopology.java:45) [gambit-storm-threads-0.0.1-SNAPSHOT-jar-with-dependencies.jar:na]
 Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: java.lang.NullPointerException
 	at storm.kafka.DynamicBrokersReader.getBrokerInfo(DynamicBrokersReader.java:81)
 	at com.pearson.gambit.threads.storm.ThreadsTopology.main(ThreadsTopology.java:48)
 Caused by: java.lang.RuntimeException: java.lang.NullPointerException
 	at storm.kafka.DynamicBrokersReader.getNumPartitions(DynamicBrokersReader.java:94)
 	at storm.kafka.DynamicBrokersReader.getBrokerInfo(DynamicBrokersReader.java:65)
 	... 1 more
 Caused by: java.lang.NullPointerException
 	at storm.kafka.DynamicBrokersReader.getNumPartitions(DynamicBrokersReader.java:91)
 	... 2 more 
```

It took me a while to figure out that this error stems from missing the `backtype.storm.Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT` property in the `conf` map provided to the `storm.kafka.DynamicBrokersReader` constructer. It would be nice to check the required configuration parameters and throw a RuntimeException if any are missing. 
This pull requests adds logging when required errors are missing. 