### PR TITLE
[STORM-607] storm-hbase HBaseMapState should support user to customize the hbase-key & hbase-qualifier

### DIFF
--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/mapper/SimpleTridentHBaseMapMapper.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/mapper/SimpleTridentHBaseMapMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hbase.trident.mapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+public class SimpleTridentHBaseMapMapper implements TridentHBaseMapMapper {
+    private String qualifier;
+
+    public SimpleTridentHBaseMapMapper(String qualifier) {
+        this.qualifier = qualifier;
+    }
+
+    @Override
+    public byte[] rowKey(List<Object> keys) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try {
+            for (Object key : keys) {
+                bos.write(String.valueOf(key).getBytes());
+            }
+            bos.close();
+        } catch (IOException e){
+            throw new RuntimeException("IOException creating HBase row key.", e);
+        }
+        return bos.toByteArray();
+    }
+
+    @Override
+    public String qualifier(List<Object> keys) {
+        return this.qualifier;
+    }
+}

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/mapper/TridentHBaseMapMapper.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/mapper/TridentHBaseMapMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hbase.trident.mapper;
+
+import java.io.Serializable;
+import java.util.List;
+
+public interface TridentHBaseMapMapper extends Serializable {
+    /**
+     * Given a tuple's grouped key list, return the HBase rowkey.
+     *
+     * @param keys
+     * @return
+     */
+    public byte[] rowKey(List<Object> keys);
+
+    /**
+     * Given a tuple's grouped key list, return the HBase qualifier.
+     *
+     * @param keys
+     * @return
+     */
+    public String qualifier(List<Object> keys);
+}

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/state/HBaseMapState.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/state/HBaseMapState.java
@@ -26,12 +26,12 @@ import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.storm.hbase.security.HBaseSecurityUtil;
+import org.apache.storm.hbase.trident.mapper.TridentHBaseMapMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import storm.trident.state.*;
 import storm.trident.state.map.*;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.Serializable;
@@ -102,7 +102,7 @@ public class HBaseMapState<T> implements IBackingMap<T> {
         public String configKey = "hbase.config";
         public String tableName;
         public String columnFamily;
-        public String qualifier;
+        public TridentHBaseMapMapper mapMapper;
     }
 
 
@@ -155,6 +155,10 @@ public class HBaseMapState<T> implements IBackingMap<T> {
             if (this.options.serializer == null) {
                 throw new RuntimeException("Serializer should be specified for type: " + stateType);
             }
+
+            if (this.options.mapMapper == null) {
+                throw new RuntimeException("MapMapper should be specified for type: " + stateType);
+            }
         }
 
         @SuppressWarnings({"rawtypes", "unchecked"})
@@ -189,17 +193,22 @@ public class HBaseMapState<T> implements IBackingMap<T> {
     public List<T> multiGet(List<List<Object>> keys) {
         List<Get> gets = new ArrayList<Get>();
         for(List<Object> key : keys){
-            LOG.info("Partition: {}, GET: {}", this.partitionNum, key);
-            Get get = new Get(toRowKey(key));
-            get.addColumn(this.options.columnFamily.getBytes(), this.options.qualifier.getBytes());
+            byte[] hbaseKey = this.options.mapMapper.rowKey(key);
+            String qualifier = this.options.mapMapper.qualifier(key);
+
+            LOG.info("Partition: {}, GET: {}", this.partitionNum, new String(hbaseKey));
+            Get get = new Get(hbaseKey);
+            get.addColumn(this.options.columnFamily.getBytes(), qualifier.getBytes());
             gets.add(get);
         }
 
         List<T> retval = new ArrayList<T>();
         try {
             Result[] results = this.table.get(gets);
-            for (Result result : results) {
-                byte[] value = result.getValue(this.options.columnFamily.getBytes(), this.options.qualifier.getBytes());
+            for (int i = 0; i < keys.size(); i++) {
+                String qualifier = this.options.mapMapper.qualifier(keys.get(i));
+                Result result = results[i];
+                byte[] value = result.getValue(this.options.columnFamily.getBytes(), qualifier.getBytes());
                 if(value != null) {
                     retval.add(this.serializer.deserialize(value));
                 } else {
@@ -216,11 +225,13 @@ public class HBaseMapState<T> implements IBackingMap<T> {
     public void multiPut(List<List<Object>> keys, List<T> values) {
         List<Put> puts = new ArrayList<Put>(keys.size());
         for (int i = 0; i < keys.size(); i++) {
-            LOG.info("Partiton: {}, Key: {}, Value: {}", new Object[]{this.partitionNum, keys.get(i), new String(this.serializer.serialize(values.get(i)))});
-            Put put = new Put(toRowKey(keys.get(i)));
+            byte[] hbaseKey = this.options.mapMapper.rowKey(keys.get(i));
+            String qualifier = this.options.mapMapper.qualifier(keys.get(i));
+            LOG.info("Partiton: {}, Key: {}, Value: {}", new Object[]{this.partitionNum, new String(hbaseKey), new String(this.serializer.serialize(values.get(i)))});
+            Put put = new Put(hbaseKey);
             T val = values.get(i);
             put.add(this.options.columnFamily.getBytes(),
-                    this.options.qualifier.getBytes(),
+                    qualifier.getBytes(),
                     this.serializer.serialize(val));
 
             puts.add(put);
@@ -232,19 +243,5 @@ public class HBaseMapState<T> implements IBackingMap<T> {
         } catch (RetriesExhaustedWithDetailsException e) {
             throw new FailedException("Retries exhaused while writing to HBase", e);
         }
-    }
-
-
-    private byte[] toRowKey(List<Object> keys) {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        try {
-            for (Object key : keys) {
-                bos.write(String.valueOf(key).getBytes());
-            }
-            bos.close();
-        } catch (IOException e){
-            throw new RuntimeException("IOException creating HBase row key.", e);
-        }
-        return bos.toByteArray();
     }
 }


### PR DESCRIPTION
In HBaseMapState, user can specific hbase-qualifier by Options, and the hbase-key is composed by all the keys by multiPut's  keys.
for example, If I have stream with (deal_id, date, pv ), grouped by (deal_id, date), then, the hbase-key is composed by(deal_id, date), the hbase-qualifier is pv.
But when I want hbase-key is deal_id, and hbase-qualifier is pv+date, HBaseMapState can not support this.

==================================================================================

With this patch, user can customize the hbase-key & hbase-qualifier by interface TridentHBaseMapMapper. 

As a old user, can use the old style like this:
HBaseMapState.Options hbaseOptions = new HBaseMapState.Options();
hbaseOptions.mapMapper = new SimpleTridentHBaseMapMapper("pv");

Also, you can customize the hbase-key & hbase-qualifier like this:

    public class WithDateHBaseMapMapper implements TridentHBaseMapMapper {
        private String qualifierPrefix;

        public WithDateHBaseMapMapper(String qualifierPrefix) {
            this.qualifierPrefix = qualifierPrefix;
        }

        @Override
        public byte[] rowKey(List<Object> keys) {
            String dealId = String.valueOf(keys.get(0));
            return dealId.getBytes();
        }

        @Override
        public String qualifier(List<Object> keys) {
            String dateStr = String.valueOf(keys.get(1));
            return qualifierPrefix + "_" + dateStr;
        }
    }

HBaseMapState.Options hbaseOptions = new HBaseMapState.Options();
hbaseOptions.mapMapper = new WithDateHBaseMapMapper("pv");
