### PR TITLE
STORM-613: Fix wrong getOffset return value

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
@@ -115,7 +115,7 @@ public class KafkaUtils {
                         }
                         long latestTimeOffset = getOffset(consumer, _topic, partition.partition, kafka.api.OffsetRequest.LatestTime());
                         long earliestTimeOffset = getOffset(consumer, _topic, partition.partition, kafka.api.OffsetRequest.EarliestTime());
-                        if (latestTimeOffset == 0) {
+                        if (latestTimeOffset == KafkaUtils.NO_OFFSET) {
                             LOG.warn("No data found in Kafka Partition " + partition.getId());
                             return null;
                         }


### PR DESCRIPTION
PR for [STORM-613](https://issues.apache.org/jira/browse/STORM-613)

When judge getOffset return value, use 0 not NO_OFFSET as invalid offset return value.