### PR TITLE
[STORM-620] Duplicate maven plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -723,10 +723,6 @@
                 </configuration>
             </plugin>
             <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <version>0.11</version>


### PR DESCRIPTION
Fix duplicate maven-javadoc-plugin declaration in pom.xml reporting section