### PR TITLE
STORM-469

### DIFF
--- a/storm-core/src/ui/public/templates/component-page-template.html
+++ b/storm-core/src/ui/public/templates/component-page-template.html
@@ -479,7 +479,7 @@
         <td>{{errorHost}}</td>
         <td><a href="{{errorWorkerLogLink}}">{{errorPort}}</a></td>
         <td>
-          <span id="{{errorLapsedSecs}}" class="errorSpan">{{error}}</span>
+          <span id="{{errorLapsedSecs}}" class="errorSpan"><a href="{{errorWorkerLogLink}}">{{error}}</a></span>
         </td>
       </tr>
       {{/componentErrors}}

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -242,7 +242,7 @@
         <td>{{errorHost}}</td>
         <td><a href="{{errorWorkerLogLink}}">{{errorPort}}</a></td>
         <td>
-          <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
+          <span id="{{errorLapsedSecs}}" class="errorSpan"><a href="{{errorWorkerLogLink}}">{{lastError}}</a></span>
         </td>
         {{/spouts}}
     </tbody>
@@ -331,7 +331,7 @@
         <td>{{errorHost}}</td>
         <td><a href="{{errorWorkerLogLink}}">{{errorPort}}</a></td>
         <td>
-          <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
+          <span id="{{errorLapsedSecs}}" class="errorSpan"><a href="{{errorWorkerLogLink}}">{{lastError}}</a></span>
         </td>
         {{/bolts}}
     </tbody>


### PR DESCRIPTION
@harshach @Parth-Brahmbhatt For https://issues.apache.org/jira/browse/STORM-469
IMO, if a truncated errormsg is shown , a link on it to the logs is a good ui design., and more user friendly.
Agree with Jason Kania on it.So just that.It might be even cooler to show last few bytes of log link, or complete log link…as in hadoop jobtracker design.