### PR TITLE
[STORM-630] Support for Clojure 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
         <test.extra.args>-Djava.net.preferIPv4Stack=true</test.extra.args>
 
         <!-- dependency versions -->
-        <clojure.version>1.5.1</clojure.version>
+        <clojure.version>1.6.0</clojure.version>
         <compojure.version>1.1.3</compojure.version>
         <hiccup.version>0.3.6</hiccup.version>
         <commons-io.version>2.4</commons-io.version>

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -617,7 +617,7 @@
   (while (not (apredicate))
     (Time/sleep 100)))
 
-(defn some?
+(defn some-in-seq?
   [pred aseq]
   ((complement nil?) (some pred aseq)))
 
@@ -854,7 +854,7 @@
 (defn zip-contains-dir?
   [zipfile target]
   (let [entries (->> zipfile (ZipFile.) .entries enumeration-seq (map (memfn getName)))]
-    (some? #(.startsWith % (str target "/")) entries)))
+    (some-in-seq? #(.startsWith % (str target "/")) entries)))
 
 (defn url-encode
   [s]


### PR DESCRIPTION
Through upgrading clojure 1.6.0, there are name space conflicts in `zip-contains-dir?`. Renamed it.
It looks there is no other dependencies of `some?` function and a topology, `ExclamationTopology` seems fine on my test cluster. If there is any other concern about upgrading clojure, please let me know.