### PR TITLE
Fix spout close: close spout when emitter closed

### DIFF
--- a/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchExecutor.java
+++ b/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchExecutor.java
@@ -140,6 +140,7 @@ public class RichSpoutBatchExecutor implements ITridentSpout {
         
         @Override
         public void close() {
+            _spout.close();
         }
         
     }


### PR DESCRIPTION
Close the spout when the emitter of TridentSpout closed.