### PR TITLE
STORM-162: Load Balancing Shuffle Grouping

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -199,5 +199,6 @@ topology.testing.always.try.serialize: false
 topology.classpath: null
 topology.environment: null
 topology.bolts.outgoing.overflow.buffer.enable: false
+topology.disable.loadaware: false
 
 dev.zookeeper.path: "/tmp/dev-storm-zookeeper"

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -199,6 +199,6 @@ topology.testing.always.try.serialize: false
 topology.classpath: null
 topology.environment: null
 topology.bolts.outgoing.overflow.buffer.enable: false
-topology.disable.loadaware: false
+topology.disable.loadaware.messaging: false
 
 dev.zookeeper.path: "/tmp/dev-storm-zookeeper"

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -24,6 +24,7 @@
             EmitInfo BoltFailInfo BoltAckInfo BoltExecuteInfo])
   (:import [backtype.storm.metric.api IMetric IMetricsConsumer$TaskInfo IMetricsConsumer$DataPoint])
   (:import [backtype.storm Config])
+  (:import [backtype.storm.grouping LoadAwareCustomStreamGrouping])
   (:import [java.util.concurrent ConcurrentLinkedQueue])
   (:require [backtype.storm [tuple :as tuple]])
   (:require [backtype.storm.daemon [task :as task]])
@@ -34,51 +35,64 @@
 (defn- mk-fields-grouper [^Fields out-fields ^Fields group-fields ^List target-tasks]
   (let [num-tasks (count target-tasks)
         task-getter (fn [i] (.get target-tasks i))]
-    (fn [task-id ^List values]
+    (fn [task-id ^List values load]
       (-> (.select out-fields group-fields values)
           tuple/list-hash-code
           (mod num-tasks)
           task-getter))))
 
-(defn- mk-shuffle-grouper [^List target-tasks]
-  (let [choices (rotating-random-range target-tasks)]
-    (fn [task-id tuple]
-      (acquire-random-range-id choices))))
+(defn mk-shuffle-grouper [^List target-tasks conf]
+  (if (or (.get conf TOPOLOGY-DISABLE-LOADAWARE) false)
+    (let [choices (rotating-random-range target-tasks)]
+      (fn [task-id tuple load]
+        (acquire-random-range-id choices)))
+    (let [rnd (Random.)]
+      (fn [task-id tuple load]
+        (let [loads (for [target target-tasks] (int (- 101 (* 100 (.get load target)))))
+              total (reduce + loads)
+              selected (.nextInt rnd total)]
+          (loop [index 0 sum 0]
+            (let [new-sum (+ sum (.get loads index))]
+              (if (< selected new-sum)
+                (.get target-tasks index)
+                (recur (inc index) new-sum)))))))))
 
 (defn- mk-custom-grouper [^CustomStreamGrouping grouping ^WorkerTopologyContext context ^String component-id ^String stream-id target-tasks]
   (.prepare grouping context (GlobalStreamId. component-id stream-id) target-tasks)
-  (fn [task-id ^List values]
-    (.chooseTasks grouping task-id values)
-    ))
+  (if (instance? LoadAwareCustomStreamGrouping grouping)
+    (fn [task-id ^List values load]
+        (.chooseTasks grouping task-id values load))
+    (fn [task-id ^List values load]
+      (.chooseTasks grouping task-id values))))
 
 (defn- mk-grouper
   "Returns a function that returns a vector of which task indices to send tuple to, or just a single task index."
-  [^WorkerTopologyContext context component-id stream-id ^Fields out-fields thrift-grouping ^List target-tasks]
+  [^WorkerTopologyContext context component-id stream-id ^Fields out-fields thrift-grouping ^List target-tasks conf]
   (let [num-tasks (count target-tasks)
         random (Random.)
         target-tasks (vec (sort target-tasks))]
     (condp = (thrift/grouping-type thrift-grouping)
       :fields
         (if (thrift/global-grouping? thrift-grouping)
-          (fn [task-id tuple]
+          (fn [task-id tuple load]
             ;; It's possible for target to have multiple tasks if it reads multiple sources
             (first target-tasks))
           (let [group-fields (Fields. (thrift/field-grouping thrift-grouping))]
             (mk-fields-grouper out-fields group-fields target-tasks)
             ))
       :all
-        (fn [task-id tuple] target-tasks)
+        (fn [task-id tuple load] target-tasks)
       :shuffle
-        (mk-shuffle-grouper target-tasks)
+        (mk-shuffle-grouper target-tasks conf)
       :local-or-shuffle
         (let [same-tasks (set/intersection
                            (set target-tasks)
                            (set (.getThisWorkerTasks context)))]
           (if-not (empty? same-tasks)
-            (mk-shuffle-grouper (vec same-tasks))
-            (mk-shuffle-grouper target-tasks)))
+            (mk-shuffle-grouper (vec same-tasks) conf)
+            (mk-shuffle-grouper target-tasks conf)))
       :none
-        (fn [task-id tuple]
+        (fn [task-id tuple load]
           (let [i (mod (.nextInt random) num-tasks)]
             (get target-tasks i)
             ))
@@ -92,7 +106,7 @@
         :direct
       )))
 
-(defn- outbound-groupings [^WorkerTopologyContext worker-context this-component-id stream-id out-fields component->grouping]
+(defn- outbound-groupings [^WorkerTopologyContext worker-context this-component-id stream-id out-fields component->grouping conf]
   (->> component->grouping
        (filter-key #(-> worker-context
                         (.getComponentTasks %)
@@ -106,13 +120,13 @@
                             out-fields
                             tgrouping
                             (.getComponentTasks worker-context component)
-                            )]))
+                            conf)]))
        (into {})
        (HashMap.)))
 
 (defn outbound-components
   "Returns map of stream id to component id to grouper"
-  [^WorkerTopologyContext worker-context component-id]
+  [^WorkerTopologyContext worker-context component-id conf]
   (->> (.getTargets worker-context component-id)
         clojurify-structure
         (map (fn [[stream-id component->grouping]]
@@ -122,7 +136,8 @@
                   component-id
                   stream-id
                   (.getComponentOutputFields worker-context component-id stream-id)
-                  component->grouping)]))
+                  component->grouping
+                  conf)]))
          (into {})
          (HashMap.)))
 
@@ -239,7 +254,7 @@
      :stats (mk-executor-stats <> (sampling-rate storm-conf))
      :interval->task->metric-registry (HashMap.)
      :task->component (:task->component worker)
-     :stream->component->grouper (outbound-components worker-context component-id)
+     :stream->component->grouper (outbound-components worker-context component-id (:conf worker))
      :report-error (throttled-report-error-fn <>)
      :report-error-and-die (fn [error]
                              ((:report-error <>) error)

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -42,7 +42,7 @@
           task-getter))))
 
 (defn mk-shuffle-grouper [^List target-tasks conf]
-  (if (.get conf TOPOLOGY-DISABLE-LOADAWARE)
+  (if (.get conf TOPOLOGY-DISABLE-LOADAWARE-MESSAGING)
     (let [choices (rotating-random-range target-tasks)]
       (fn [task-id tuple load]
         (acquire-random-range-id choices)))

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -42,7 +42,7 @@
           task-getter))))
 
 (defn mk-shuffle-grouper [^List target-tasks conf]
-  (if (or (.get conf TOPOLOGY-DISABLE-LOADAWARE) false)
+  (if (.get conf TOPOLOGY-DISABLE-LOADAWARE)
     (let [choices (rotating-random-range target-tasks)]
       (fn [task-id tuple load]
         (acquire-random-range-id choices)))

--- a/storm-core/src/clj/backtype/storm/daemon/task.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/task.clj
@@ -18,6 +18,7 @@
   (:use [backtype.storm bootstrap])
   (:import [backtype.storm.hooks ITaskHook])
   (:import [backtype.storm.tuple Tuple])
+  (:import [backtype.storm.grouping LoadMapping])
   (:import [backtype.storm.generated SpoutSpec Bolt StateSpoutSpec])
   (:import [backtype.storm.hooks.info SpoutAckInfo SpoutFailInfo
             EmitInfo BoltFailInfo BoltAckInfo])
@@ -120,6 +121,7 @@
 (defn mk-tasks-fn [task-data]
   (let [task-id (:task-id task-data)
         executor-data (:executor-data task-data)
+        ^LoadMapping load-mapping (:load-mapping (:worker executor-data))
         component-id (:component-id executor-data)
         ^WorkerTopologyContext worker-context (:worker-context executor-data)
         storm-conf (:storm-conf executor-data)
@@ -150,7 +152,7 @@
                (when (= :direct grouper)
                   ;;  TODO: this is wrong, need to check how the stream was declared
                   (throw (IllegalArgumentException. "Cannot do regular emit to direct stream")))
-               (let [comp-tasks (grouper task-id values)]
+               (let [comp-tasks (grouper task-id values load-mapping)]
                  (if (or (sequential? comp-tasks) (instance? Collection comp-tasks))
                    (.addAll out-tasks comp-tasks)
                    (.add out-tasks comp-tasks)

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -506,7 +506,7 @@
     (.credentials (:storm-cluster-state worker) storm-id (fn [args] (check-credentials-changed)))
     (schedule-recurring (:refresh-credentials-timer worker) 0 (conf TASK-CREDENTIALS-POLL-SECS) check-credentials-changed)
     ;; The jitter allows the clients to get the data at different times, and avoids thundering herd
-    (when-not (.get conf TOPOLOGY-DISABLE-LOADAWARE)
+    (when-not (.get conf TOPOLOGY-DISABLE-LOADAWARE-MESSAGING)
       (schedule-recurring-with-jitter (:refresh-load-timer worker) 0 1 500 refresh-load))
     (schedule-recurring (:refresh-connections-timer worker) 0 (conf TASK-REFRESH-POLL-SECS) refresh-connections)
     (schedule-recurring (:refresh-active-timer worker) 0 (conf TASK-REFRESH-POLL-SECS) (partial refresh-storm-active worker))

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -20,6 +20,7 @@
   (:import [java.util.concurrent Executors])
   (:import [java.util ArrayList HashMap])
   (:import [backtype.storm.utils TransferDrainer])
+  (:import [backtype.storm.grouping LoadMapping])
   (:import [backtype.storm.messaging TransportFactory])
   (:import [backtype.storm.messaging TaskMessage IContext IConnection])
   (:import [backtype.storm.security.auth AuthUtils])
@@ -227,6 +228,7 @@
       :refresh-connections-timer (mk-halting-timer "refresh-connections-timer")
       :refresh-credentials-timer (mk-halting-timer "refresh-credentials-timer")
       :refresh-active-timer (mk-halting-timer "refresh-active-timer")
+      :refresh-load-timer (mk-halting-timer "refresh-load-timer")
       :executor-heartbeat-timer (mk-halting-timer "executor-heartbeat-timer")
       :user-timer (mk-halting-timer "user-timer")
       :task->component (HashMap. (storm-task-info topology storm-conf)) ; for optimized access when used in tasks later on
@@ -250,6 +252,7 @@
       :receiver-thread-count (get storm-conf WORKER-RECEIVER-THREAD-COUNT)
       :transfer-fn (mk-transfer-fn <>)
       :assignment-versions assignment-versions
+      :load-mapping (LoadMapping.)
       )))
 
 (defn- endpoint->string [[node port]]
@@ -259,6 +262,24 @@
   (let [[port-str node] (.split s "/" 2)]
     [node (Integer/valueOf port-str)]
     ))
+
+(defn mk-refresh-load [worker]
+  (let [local-tasks (set (:task-ids worker))
+        remote-tasks (set/difference (worker-outbound-tasks worker) local-tasks)
+        short-executor-receive-queue-map (:short-executor-receive-queue-map worker)
+        next-update (atom 0)]
+    (fn this
+      ([] 
+        (let [^LoadMapping load-mapping (:load-mapping worker)
+              local-pop (into {} (for [[exec queue] short-executor-receive-queue-map] [exec (/ (double (.population queue)) (.capacity queue))]))
+              remote-load (reduce merge (for [[np conn] @(:cached-node+port->socket worker)] (into {} (.getLoad conn remote-tasks))))
+              now (System/currentTimeMillis)]
+          (.setLocal load-mapping local-pop)
+          (.setRemote load-mapping remote-load)
+          (when (> now @next-update)
+            (.sendLoadMetrics (:receiver worker) local-pop)
+            (reset! next-update (+ 5000 now)))
+          )))))
 
 (defn mk-refresh-connections [worker]
   (let [outbound-tasks (worker-outbound-tasks worker)
@@ -407,6 +428,7 @@
         _ (schedule-recurring (:executor-heartbeat-timer worker) 0 (conf TASK-HEARTBEAT-FREQUENCY-SECS) #(do-executor-heartbeats worker :executors @executors))
 
         refresh-connections (mk-refresh-connections worker)
+        refresh-load (mk-refresh-load worker)
 
         _ (refresh-connections nil)
         _ (refresh-storm-active worker nil)
@@ -446,6 +468,7 @@
                     (cancel-timer (:refresh-active-timer worker))
                     (cancel-timer (:executor-heartbeat-timer worker))
                     (cancel-timer (:user-timer worker))
+                    (cancel-timer (:refresh-load-timer worker))
                     
                     (close-resources worker)
                     
@@ -466,6 +489,7 @@
                (and
                  (timer-waiting? (:heartbeat-timer worker))
                  (timer-waiting? (:refresh-connections-timer worker))
+                 (timer-waiting? (:refresh-load-timer worker))
                  (timer-waiting? (:refresh-credentials-timer worker))
                  (timer-waiting? (:refresh-active-timer worker))
                  (timer-waiting? (:executor-heartbeat-timer worker))
@@ -482,6 +506,9 @@
       ]
     (.credentials (:storm-cluster-state worker) storm-id (fn [args] (check-credentials-changed)))
     (schedule-recurring (:refresh-credentials-timer worker) 0 (conf TASK-CREDENTIALS-POLL-SECS) check-credentials-changed)
+    ;; The jitter allows the clients to get the data at different times, and avoids thundering herd
+    (when-not (or (.get conf TOPOLOGY-DISABLE-LOADAWARE) false)
+      (schedule-recurring-with-jitter (:refresh-load-timer worker) 0 1 500 refresh-load))
     (schedule-recurring (:refresh-connections-timer worker) 0 (conf TASK-REFRESH-POLL-SECS) refresh-connections)
     (schedule-recurring (:refresh-active-timer worker) 0 (conf TASK-REFRESH-POLL-SECS) (partial refresh-storm-active worker))
 

--- a/storm-core/src/clj/backtype/storm/messaging/local.clj
+++ b/storm-core/src/clj/backtype/storm/messaging/local.clj
@@ -15,7 +15,7 @@
 ;; limitations under the License.
 (ns backtype.storm.messaging.local
   (:refer-clojure :exclude [send])
-  (:use [backtype.storm log])
+  (:use [backtype.storm log util])
   (:import [backtype.storm.messaging IContext IConnection TaskMessage])
   (:import [backtype.storm.grouping Load])
   (:import [java.util.concurrent LinkedBlockingQueue])
@@ -33,8 +33,6 @@
       (when-not (contains? @queues-map id)
         (swap! queues-map assoc id (LinkedBlockingQueue.))))
     (@queues-map id)))
-
-(def not-nil? (complement nil?))
 
 (deftype LocalConnection [storm-id port queues-map lock queue task->load]
   IConnection

--- a/storm-core/src/clj/backtype/storm/messaging/local.clj
+++ b/storm-core/src/clj/backtype/storm/messaging/local.clj
@@ -17,10 +17,15 @@
   (:refer-clojure :exclude [send])
   (:use [backtype.storm log])
   (:import [backtype.storm.messaging IContext IConnection TaskMessage])
+  (:import [backtype.storm.grouping Load])
   (:import [java.util.concurrent LinkedBlockingQueue])
-  (:import [java.util Map Iterator])
+  (:import [java.util Map Iterator Collection])
   (:import [java.util Iterator ArrayList])
   (:gen-class))
+
+(defn update-load! [cached-task->load lock task->load]
+  (locking lock
+    (swap! cached-task->load merge task->load)))
 
 (defn add-queue! [queues-map lock storm-id port]
   (let [id (str storm-id "-" port)]
@@ -29,7 +34,9 @@
         (swap! queues-map assoc id (LinkedBlockingQueue.))))
     (@queues-map id)))
 
-(deftype LocalConnection [storm-id port queues-map lock queue]
+(def not-nil? (complement nil?))
+
+(deftype LocalConnection [storm-id port queues-map lock queue task->load]
   IConnection
   (^Iterator recv [this ^int flags ^int clientId]
     (when-not queue
@@ -50,24 +57,35 @@
       (while (.hasNext iter) 
          (.put send-queue (.next iter)))
       ))
-  (^void close [this]
-    ))
+  (^void sendLoadMetrics [this ^Map taskToLoad]
+    (update-load! task->load lock taskToLoad))
+  (^Map getLoad [this ^Collection tasks] 
+    (locking lock
+      (into {}
+        (for [task tasks
+              :let [load (.get @task->load task)]
+              :when (not-nil? load)]
+          ;; for now we are ignoring the connection load locally
+          [task (Load. true load 0.0)]))))
+  (^void close [this]))
 
 
 (deftype LocalContext [^{:unsynchronized-mutable true} queues-map
-                       ^{:unsynchronized-mutable true} lock]
+                       ^{:unsynchronized-mutable true} lock
+                       ^{:unsynchronized-mutable true} task->load]
   IContext
   (^void prepare [this ^Map storm-conf]
     (set! queues-map (atom {}))
+    (set! task->load (atom {}))
     (set! lock (Object.)))
   (^IConnection bind [this ^String storm-id ^int port]
-    (LocalConnection. storm-id port queues-map lock (add-queue! queues-map lock storm-id port)))
+    (LocalConnection. storm-id port queues-map lock (add-queue! queues-map lock storm-id port) task->load))
   (^IConnection connect [this ^String storm-id ^String host ^int port]
-    (LocalConnection. storm-id port queues-map lock nil))
+    (LocalConnection. storm-id port queues-map lock nil task->load))
   (^void term [this]
     ))
 
 (defn mk-context [] 
-  (let [context  (LocalContext. nil nil)]
+  (let [context  (LocalContext. nil nil nil)]
     (.prepare ^IContext context nil)
     context))

--- a/storm-core/src/clj/backtype/storm/timer.clj
+++ b/storm-core/src/clj/backtype/storm/timer.clj
@@ -16,7 +16,7 @@
 
 (ns backtype.storm.timer
   (:import [backtype.storm.utils Time])
-  (:import [java.util PriorityQueue Comparator])
+  (:import [java.util PriorityQueue Comparator Random])
   (:import [java.util.concurrent Semaphore])
   (:use [backtype.storm util log]))
 
@@ -76,6 +76,7 @@
      :queue queue
      :active active
      :lock lock
+     :random (Random.)
      :cancel-notifier notifier}))
 
 (defn- check-active!
@@ -84,12 +85,14 @@
     (throw (IllegalStateException. "Timer is not active"))))
 
 (defnk schedule
-  [timer delay-secs afn :check-active true]
+  [timer delay-secs afn :check-active true :jitter-ms 0]
   (when check-active (check-active! timer))
   (let [id (uuid)
-        ^PriorityQueue queue (:queue timer)]
+        ^PriorityQueue queue (:queue timer)
+        end-time-ms (+ (current-time-millis) (secs-to-millis-long delay-secs))
+        end-time-ms (if (> 0 jitter-ms) (+ (.nextInt jitter-ms) end-time-ms) end-time-ms) ]
     (locking (:lock timer)
-      (.add queue [(+ (current-time-millis) (secs-to-millis-long delay-secs)) afn id]))))
+      (.add queue [end-time-ms afn id]))))
 
 (defn schedule-recurring
   [timer delay-secs recur-secs afn]
@@ -99,6 +102,15 @@
               (afn)
               ; This avoids a race condition with cancel-timer.
               (schedule timer recur-secs this :check-active false))))
+
+(defn schedule-recurring-with-jitter
+  [timer delay-secs recur-secs jitter-ms afn]
+  (schedule timer
+            delay-secs
+            (fn this []
+              (afn)
+              ; This avoids a race condition with cancel-timer.
+              (schedule timer recur-secs this :check-active false :jitter-ms jitter-ms))))
 
 (defn cancel-timer
   [timer]

--- a/storm-core/src/clj/backtype/storm/timer.clj
+++ b/storm-core/src/clj/backtype/storm/timer.clj
@@ -90,7 +90,7 @@
   (let [id (uuid)
         ^PriorityQueue queue (:queue timer)
         end-time-ms (+ (current-time-millis) (secs-to-millis-long delay-secs))
-        end-time-ms (if (> 0 jitter-ms) (+ (.nextInt jitter-ms) end-time-ms) end-time-ms) ]
+        end-time-ms (if (< 0 jitter-ms) (+ (.nextInt (:random timer) jitter-ms) end-time-ms) end-time-ms)]
     (locking (:lock timer)
       (.add queue [end-time-ms afn id]))))
 

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -199,6 +199,12 @@ public class Config extends HashMap<String, Object> {
     public static final Object TOPOLOGY_TUPLE_SERIALIZER_SCHEMA = String.class;
 
     /**
+     * Disable load aware grouping support.
+     */
+    public static final String TOPOLOGY_DISABLE_LOADAWARE = "topology.disable.loadaware";
+    public static final Object TOPOLOGY_DISABLE_LOADAWARE_SCHEMA = Boolean.class;
+
+    /**
      * Try to serialize all tuples, even for local transfers.  This should only be used
      * for testing, as a sanity check that all of your tuples are setup properly.
      */

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -201,8 +201,8 @@ public class Config extends HashMap<String, Object> {
     /**
      * Disable load aware grouping support.
      */
-    public static final String TOPOLOGY_DISABLE_LOADAWARE = "topology.disable.loadaware";
-    public static final Object TOPOLOGY_DISABLE_LOADAWARE_SCHEMA = Boolean.class;
+    public static final String TOPOLOGY_DISABLE_LOADAWARE_MESSAGING = "topology.disable.loadaware.messaging";
+    public static final Object TOPOLOGY_DISABLE_LOADAWARE_MESSAGING_SCHEMA = Boolean.class;
 
     /**
      * Try to serialize all tuples, even for local transfers.  This should only be used

--- a/storm-core/src/jvm/backtype/storm/grouping/Load.java
+++ b/storm-core/src/jvm/backtype/storm/grouping/Load.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.grouping;
+
+import java.io.Serializable;
+
+/**
+ * Represents the load that a Bolt is currently under to help in
+ * deciding where to route a tuple, to help balance the load.
+ */
+public class Load {
+    private boolean hasMetrics = false;
+    private double boltLoad = 0.0; //0 no load to 1 fully loaded
+    private double connectionLoad = 0.0; //0 no load to 1 fully loaded
+
+    /**
+     * Create a new load
+     * @param hasMetrics have metrics been reported yet?
+     * @param boltLoad the load as reported by the bolt 0.0 no load 1.0 fully loaded
+     * @param connectionLoad the load as reported by the connection to the bolt 0.0 no load 1.0 fully loaded. 
+     */ 
+    public Load(boolean hasMetrics, double boltLoad, double connectionLoad) {
+        this.hasMetrics = hasMetrics;
+        this.boltLoad = boltLoad;
+        this.connectionLoad = connectionLoad;
+    }
+
+    /**
+     * @return true if metrics have been reported so far.
+     */ 
+    public boolean hasMetrics() {
+        return hasMetrics;
+    }
+
+    /**
+     * @return the load as reported by the bolt.
+     */ 
+    public double getBoltLoad() {
+        return boltLoad;
+    }
+
+    /**
+     * @return the load as reported by the connection
+     */
+    public double getConnectionLoad() {
+        return connectionLoad;
+    }
+
+    /**
+     * @return the load that is a combination of sub loads.
+     */
+    public double getLoad() {
+        if (!hasMetrics) {
+            return 1.0;
+        }
+        return connectionLoad > boltLoad ? connectionLoad : boltLoad; 
+    }
+
+    public String toString() {
+        return "[:load "+boltLoad+" "+connectionLoad+"]";
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/grouping/LoadAwareCustomStreamGrouping.java
+++ b/storm-core/src/jvm/backtype/storm/grouping/LoadAwareCustomStreamGrouping.java
@@ -15,27 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package backtype.storm.messaging.netty;
+package backtype.storm.grouping;
 
-import java.net.ConnectException;
+import java.util.List;
 
-import org.jboss.netty.channel.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-public class StormClientErrorHandler extends SimpleChannelUpstreamHandler  {
-    private static final Logger LOG = LoggerFactory.getLogger(StormClientErrorHandler.class);
-    private String name;
-    
-    StormClientErrorHandler(String name) {
-        this.name = name;
-    }
-
-    @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent event) {
-        Throwable cause = event.getCause();
-        if (!(cause instanceof ConnectException)) {
-            LOG.info("Connection failed " + name, cause);
-        } 
-    }
+public interface LoadAwareCustomStreamGrouping extends CustomStreamGrouping {
+   List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load); 
 }

--- a/storm-core/src/jvm/backtype/storm/grouping/LoadMapping.java
+++ b/storm-core/src/jvm/backtype/storm/grouping/LoadMapping.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.grouping;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+ * Holds a list of the current loads
+ */
+public class LoadMapping {
+    private static final Load NOT_CONNECTED = new Load(false, 1.0, 1.0);
+    private final AtomicReference<Map<Integer,Load>> _local = new AtomicReference<Map<Integer,Load>>(new HashMap<Integer,Load>());
+    private final AtomicReference<Map<Integer,Load>> _remote = new AtomicReference<Map<Integer,Load>>(new HashMap<Integer,Load>());
+
+    public void setLocal(Map<Integer, Double> local) {
+        Map<Integer, Load> newLocal = new HashMap<Integer, Load>();
+        if (local != null) {
+          for (Map.Entry<Integer, Double> entry: local.entrySet()) {
+            newLocal.put(entry.getKey(), new Load(true, entry.getValue(), 0.0));
+          }
+        }
+        _local.set(newLocal);
+    }
+
+    public void setRemote(Map<Integer, Load> remote) {
+        if (remote != null) {
+          _remote.set(new HashMap<Integer, Load>(remote));
+        } else {
+          _remote.set(new HashMap<Integer, Load>());
+        }
+    }
+
+    public Load getLoad(int task) {
+        Load ret = _local.get().get(task);
+        if (ret == null) {
+          ret = _remote.get().get(task);
+        }
+        if (ret == null) {
+          ret = NOT_CONNECTED;
+        }
+        return ret;
+    }
+
+    public double get(int task) {
+        return getLoad(task).getLoad();
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/grouping/LoadMapping.java
+++ b/storm-core/src/jvm/backtype/storm/grouping/LoadMapping.java
@@ -61,4 +61,8 @@ public class LoadMapping {
     public double get(int task) {
         return getLoad(task).getLoad();
     }
+
+    public String toString() {
+        return "LoadMapping: local: "+_local.get()+" remote: "+_remote.get();
+    }
 }

--- a/storm-core/src/jvm/backtype/storm/messaging/IConnection.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/IConnection.java
@@ -17,7 +17,10 @@
  */
 package backtype.storm.messaging;
 
+import backtype.storm.grouping.Load;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 
 public interface IConnection {   
     
@@ -27,6 +30,12 @@ public interface IConnection {
      * @return
      */
     public Iterator<TaskMessage> recv(int flags, int clientId);
+
+    /**
+     * Send load metrics to all downstream connections.
+     * @param taskToLoad a map from the task id to the load for that task.
+     */
+    public void sendLoadMetrics(Map<Integer, Double> taskToLoad);
     
     /**
      * send a message with taskId and payload
@@ -42,6 +51,13 @@ public interface IConnection {
 
     public void send(Iterator<TaskMessage> msgs);
     
+    /**
+     * Get the current load for the given tasks
+     * @param tasks the tasks to look for.
+     * @return a Load for each of the tasks it knows about.
+     */
+    public Map<Integer, Load> getLoad(Collection<Integer> tasks);
+
     /**
      * close this connection
      */

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
@@ -22,6 +22,7 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Timer;
@@ -42,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import backtype.storm.Config;
+import backtype.storm.grouping.Load;
 import backtype.storm.metric.api.IStatefulObject;
 import backtype.storm.messaging.IConnection;
 import backtype.storm.messaging.TaskMessage;
@@ -77,6 +79,7 @@ public class Client implements IConnection, IStatefulObject{
     private AtomicLong flushCheckTimer;
     private int flushCheckInterval;
     private ScheduledExecutorService scheduler;
+    private volatile Map<Integer, Double> serverLoad = null;
 
     @SuppressWarnings("rawtypes")
     Client(Map storm_conf, ChannelFactory factory, 
@@ -320,6 +323,26 @@ public class Client implements IConnection, IStatefulObject{
         }
     }
 
+    void setLoadMetrics(Map<Integer, Double> taskToLoad) {
+        this.serverLoad = taskToLoad;
+    }
+
+    @Override
+    public Map<Integer, Load> getLoad(Collection<Integer> tasks) {
+        Map<Integer, Double> loadCache = serverLoad;
+        Map<Integer, Load> ret = new HashMap<Integer, Load>();
+        if (loadCache != null) {
+            double clientLoad = Math.max(pendings.get(), 1024)/1024.0;
+            for (Integer task : tasks) {
+                Double found = loadCache.get(task);
+                if (found != null) {
+                    ret.put(task, new Load(true, found, clientLoad));
+                }
+            }
+        }
+        return ret;
+    }
+
     @Override
     public Iterator<TaskMessage> recv(int flags, int clientId) {
         throw new RuntimeException("Client connection should not receive any messages");
@@ -361,6 +384,10 @@ public class Client implements IConnection, IStatefulObject{
                 }
             }
         });
+    }
+
+    public void sendLoadMetrics(Map<Integer, Double> taskToLoad) {
+        throw new RuntimeException("Client connection should not send load metrics");
     }
 
     @Override

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
@@ -332,7 +332,7 @@ public class Client implements IConnection, IStatefulObject{
         Map<Integer, Double> loadCache = serverLoad;
         Map<Integer, Load> ret = new HashMap<Integer, Load>();
         if (loadCache != null) {
-            double clientLoad = Math.max(pendings.get(), 1024)/1024.0;
+            double clientLoad = Math.min(pendings.get(), 1024)/1024.0;
             for (Integer task : tasks) {
                 Double found = loadCache.get(task);
                 if (found != null) {

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Server.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Server.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -40,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import backtype.storm.Config;
+import backtype.storm.grouping.Load;
 import backtype.storm.messaging.IConnection;
 import backtype.storm.messaging.TaskMessage;
 import backtype.storm.metric.api.IStatefulObject;
@@ -263,10 +265,24 @@ class Server implements IConnection, IStatefulObject {
         }
     }
 
+    @Override
+    public void sendLoadMetrics(Map<Integer, Double> taskToLoad) {
+        MessageBatch mb = new MessageBatch(1);
+        mb.add(new TaskMessage(-1, Utils.serialize(taskToLoad)));
+        allChannels.write(mb);
+    }
+
+    @Override
+    public Map<Integer, Load> getLoad(Collection<Integer> tasks) {
+        throw new RuntimeException("Server connection cannot get load");
+    }
+
+    @Override
     public void send(int task, byte[] message) {
         throw new RuntimeException("Server connection should not send any messages");
     }
     
+    @Override
     public void send(Iterator<TaskMessage> msgs) {
       throw new RuntimeException("Server connection should not send any messages");
     }

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/StormClientHandler.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/StormClientHandler.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.messaging.netty;
+
+import backtype.storm.messaging.TaskMessage;
+import backtype.storm.utils.Utils;
+
+import java.net.ConnectException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Map;
+import java.util.List;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StormClientHandler extends SimpleChannelUpstreamHandler  {
+    private static final Logger LOG = LoggerFactory.getLogger(StormClientHandler.class);
+    private Client client;
+    
+    StormClientHandler(Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public void messageReceived(ChannelHandlerContext ctx, MessageEvent event) {
+        //examine the response message from server
+        Object message = event.getMessage();
+        if (message instanceof ControlMessage) {
+          ControlMessage msg = (ControlMessage)message;
+          if (msg==ControlMessage.FAILURE_RESPONSE) {
+              LOG.info("failure response:{}", msg);
+          }
+          //All others are ignored
+        } else if (message instanceof List) {
+          //This should be the metrics, and there should only be one of them
+          List<TaskMessage> list = (List<TaskMessage>)message;
+          if (list.size() != 1) throw new RuntimeException("Expected to only see one message for load metrics");
+          TaskMessage tm = ((List<TaskMessage>)message).get(0);
+          if (tm.task() != -1) throw new RuntimeException("Metrics messages are sent to the system task");
+          Object metrics = Utils.deserialize(tm.message());
+          if (!(metrics instanceof Map)) throw new RuntimeException("metrics are expected to be a map");
+          client.setLoadMetrics((Map<Integer, Double>)metrics);
+        } else {
+          throw new RuntimeException("Don't know how to handle a message of type "+message);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent event) {
+        Throwable cause = event.getCause();
+        if (!(cause instanceof ConnectException)) {
+            LOG.info("Connection to "+client.name()+" failed", cause);
+        }
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/StormClientPipelineFactory.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/StormClientPipelineFactory.java
@@ -39,15 +39,16 @@ class StormClientPipelineFactory implements ChannelPipelineFactory {
         // Encoder
         pipeline.addLast("encoder", new MessageEncoder());
 
-        boolean isNettyAuth = (Boolean) this.client.storm_conf
+        Boolean isNettyAuth = (Boolean) this.client.storm_conf
                 .get(Config.STORM_MESSAGING_NETTY_AUTHENTICATION);
+        if (isNettyAuth == null) isNettyAuth = false;
         if (isNettyAuth) {
             // Authenticate: Removed after authentication completes
             pipeline.addLast("saslClientHandler", new SaslStormClientHandler(
                     client));
         }
         // business logic.
-        pipeline.addLast("handler", new StormClientErrorHandler(client.name()));
+        pipeline.addLast("handler", new StormClientHandler(client));
 
         return pipeline;
     }

--- a/storm-core/test/clj/backtype/storm/integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/integration_test.clj
@@ -62,13 +62,13 @@
   (with-simulated-time-local-cluster [cluster :supervisors 4]
     (let [topology (thrift/mk-topology
                     {"1" (thrift/mk-spout-spec (TestWordSpout. true))}
-                    {"2" (thrift/mk-bolt-spec {"1" :shuffle} emit-task-id
+                    {"2" (thrift/mk-bolt-spec {"1" :all} emit-task-id
                       :parallelism-hint 3
                       :conf {TOPOLOGY-TASKS 6})
                      })
           results (complete-topology cluster
                                      topology
-                                     :mock-sources {"1" [["a"] ["a"] ["a"] ["a"] ["a"] ["a"]]})]
+                                     :mock-sources {"1" [["a"]]})]
       (is (ms= [[0] [1] [2] [3] [4] [5]]
                (read-tuples results "2")))
       )))

--- a/storm-core/test/clj/backtype/storm/messaging/netty_integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging/netty_integration_test.clj
@@ -55,5 +55,4 @@
                                                          ["a"] ["b"]
                                                          ]}
                                      )]
-      (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
-               (read-tuples results "2"))))))
+        (is (= (* 6 4) (.size (read-tuples results "2")))))))

--- a/storm-core/test/clj/backtype/storm/messaging_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging_test.clj
@@ -53,8 +53,7 @@
                                                            ["a"] ["b"]
                                                            ]}
                                        )]
-        (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
-                 (read-tuples results "2")))))))
+        (is (= (* 6 4) (.size (read-tuples results "2"))))))))
 
 (extend-type TestEventLogSpout
   CompletableSpout


### PR DESCRIPTION
This pull request adds a notion of load that is measured and sent to upstream workers through the messaging system.  Shuffle grouping was then updated so that if it is configured to do so it will take the load into account.