### PR TITLE
[STORM-639] storm-maven-plugin not found

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -228,6 +228,8 @@ To pull in a merge request you should generally follow the command line instruct
 The following commands must be run from the top-level directory.
 
     # Build the code and run the tests (requires nodejs, python and ruby installed) 
+    # `mvn clean package` will fail because storm-core requires storm-maven-plugin.
+    # This plugin should be installed before compiling storm-core.
     $ mvn clean install
 
     # Build the code and run the tests, with specifying default test timeout (in millisecond)

--- a/storm-buildtools/storm-maven-plugins/pom.xml
+++ b/storm-buildtools/storm-maven-plugins/pom.xml
@@ -76,6 +76,16 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-install-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>default-install</id>
+                    <phase>package</phase>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 </project>

--- a/storm-buildtools/storm-maven-plugins/pom.xml
+++ b/storm-buildtools/storm-maven-plugins/pom.xml
@@ -76,16 +76,6 @@
           </execution>
         </executions>
       </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-install-plugin</artifactId>
-            <executions>
-                <execution>
-                    <id>default-install</id>
-                    <phase>package</phase>
-                </execution>
-            </executions>
-        </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
maven compile is fail due to missing storm-maven-plugin. 
This plugin should be installed before compiling storm-core project.