### PR TITLE
[STORM-643] KafkaUtils repeatedly fetches messages whose offset is out of range

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -176,6 +176,7 @@ under the License.
 * Dane Hammer ([@danehammer](https://github.com/danehammer))
 * Christophe Carre' ([@chrisz](https://github.com/chrisz))
 * Anya Tchernishov ([@anyatch](https://github.com/anyatch))
+* Xin Wang ([@vesense](https://github.com/vesense))
 
 ## Acknowledgements
 

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
@@ -180,9 +180,7 @@ public class KafkaUtils {
         if (fetchResponse.hasError()) {
             KafkaError error = KafkaError.getError(fetchResponse.errorCode(topic, partitionId));
             if (error.equals(KafkaError.OFFSET_OUT_OF_RANGE) && config.useStartOffsetTimeIfOffsetOutOfRange) {
-                LOG.warn("Got fetch request with offset out of range: [" + offset + "]; " +
-                        "retrying with default start offset time from configuration. " +
-                        "configured start offset time: [" + config.startOffsetTime + "]");
+                LOG.warn("Got fetch request with offset out of range: [" + offset + "]");
                 throw new UpdateOffsetException();
             } else {
                 String message = "Error fetching data from [" + partition + "] for topic [" + topic + "]: [" + error + "]";

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -164,6 +164,12 @@ public class PartitionManager {
             _emittedToOffset = KafkaUtils.getOffset(_consumer, _spoutConfig.topic, _partition.partition, _spoutConfig);
             LOG.warn("Using new offset: {}", _emittedToOffset);
             // fetch failed, so don't update the metrics
+            
+            //fix bug [STORM-643] : remove this offset from failed list when it is OutOfRange
+            if (had_failed) {
+                failed.remove(offset);
+            }
+            
             return;
         }
         long end = System.nanoTime();

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -167,7 +167,26 @@ public class PartitionManager {
             
             //fix bug [STORM-643] : remove this offset from failed list when it is OutOfRange
             if (had_failed) {
-                failed.remove(offset);
+                // For the case of EarliestTime it would be better to discard
+                // all the failed offsets, that are earlier than actual EarliestTime
+                // offset, since they are anyway not there.
+                // These calls to broker API will be then saved.
+
+                // In case of LatestTime - it is a question, if we still need to try out and
+                // reach those that are failed (they still may be available).
+                // But, by moving to LatestTime we are discarding messages in kafka queue.
+                // Since it is configured so, assume that it is ok for user to loose information
+                // and user cares about newest messages first.
+                // It makes sense not to do exceptions for those that are failed and discard them as well.
+
+                SortedSet<Long> omitted = failed.headSet(_emittedToOffset);
+
+                // Use tail, since sortedSet maintains its elements in ascending order
+                // Using tailSet will set a 'range' on original implementation
+                // so we couldn't then add objects that are out of range.
+                // For that reason we copy tail into new Set, where range is not set.
+                failed = new TreeSet<Long>(failed.tailSet(_emittedToOffset));
+                LOG.warn("Removing the failed offsets that are out of range: {}", omitted);
             }
             
             return;


### PR DESCRIPTION
Fix bug [STORM-643] KafkaUtils repeatedly fetches messages whose offset is out of range.
This happened when failed list(SortedSet<Long> failed) is not empty and some offset in it is OutOfRange.