### PR TITLE
Kafka spout failure config

### DIFF
--- a/external/storm-kafka/README.md
+++ b/external/storm-kafka/README.md
@@ -8,7 +8,7 @@ We support both trident and core storm spouts. For both spout implementation we 
 tracks kafka broker host to partition mapping and kafkaConfig that controls some kafka related parameters.
  
 ###BrokerHosts
-In order to initialize your kafka spout/emitter you need to construct and instance of the marker interface BrokerHosts. 
+In order to initialize your kafka spout/emitter you need to construct an instance of the marker interface BrokerHosts. 
 Currently we support following two implementations:
 
 ####ZkHosts
@@ -18,7 +18,7 @@ Kafka's zookeeper's entries to track brokerHost -> partition mapping. You can in
     public ZkHosts(String brokerZkStr, String brokerZkPath) 
     public ZkHosts(String brokerZkStr)
 ```
-Where brokerZkStr is just ip:port e.g. localhost:9092. brokerZkPath is the root directory under which all the topics and
+Where brokerZkStr is just ip:port e.g. localhost:2181. brokerZkPath is the root directory under which all the topics and
 partition information is stored. by Default this is /brokers which is what default kafka implementation uses.
 
 By default the broker-partition mapping is refreshed every 60 seconds from zookeeper. If you want to change it you
@@ -46,22 +46,34 @@ The second thing needed for constructing a kafkaSpout is an instance of KafkaCon
     public KafkaConfig(BrokerHosts hosts, String topic, String clientId)
 ```
 
-The BorkerHosts can be any implementation of BrokerHosts interface as described above. the Topic is name of kafka topic.
+The BrokerHosts can be any implementation of BrokerHosts interface as described above. the Topic is name of kafka topic.
 The optional ClientId is used as a part of the zookeeper path where the spout's current consumption offset is stored.
 
 There are 2 extensions of KafkaConfig currently in use.
 
-Spoutconfig is an extension of KafkaConfig that supports 2 additional fields, zkroot and id. The Zkroot will be used
-as root to store your consumer's offset. The id should uniquely identify your spout.
+Spoutconfig is an extension of KafkaConfig that supports additional fields with ZooKeeper connection info and for controlling
+behavior specific to KafkaSpout. The Zkroot will be used as root to store your consumer's offset. The id should uniquely
+identify your spout.
 ```java
 public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id);
+public SpoutConfig(BrokerHosts hosts, String topic, String id);
+```
+In addition to these parameters, SpoutConfig contains the following fields that control how KafkaSpout behaves:
+```java
+    // setting for how often to save the current kafka offset to ZooKeeper
+    public long stateUpdateIntervalMs = 2000;
+
+    // Exponential back-off retry settings.  These are used when retrying messages after a bolt
+    // calls OutputCollector.fail().
+    // Note: be sure to set backtype.storm.Config.MESSAGE_TIMEOUT_SECS appropriately to prevent
+    // resubmitting the message while still retrying.
+    public long retryInitialDelayMs = 0;
+    public double retryDelayMultiplier = 1.0;
+    public long retryDelayMaxMs = 60 * 1000;
 ```
 Core KafkaSpout only accepts an instance of SpoutConfig.
 
 TridentKafkaConfig is another extension of KafkaConfig.
-```java
-public SpoutConfig(BrokerHosts hosts, String topic, String id);
-```
 TridentKafkaEmitter only accepts TridentKafkaConfig.
 
 The KafkaConfig class also has bunch of public variables that controls your application's behavior. Here are defaults:
@@ -71,7 +83,7 @@ The KafkaConfig class also has bunch of public variables that controls your appl
     public int fetchMaxWait = 10000;
     public int bufferSizeBytes = 1024 * 1024;
     public MultiScheme scheme = new RawMultiScheme();
-    public boolean forceFromStart = false;
+    public boolean ignoreZkOffsets = false;
     public long startOffsetTime = kafka.api.OffsetRequest.EarliestTime();
     public long maxOffsetBehind = Long.MAX_VALUE;
     public boolean useStartOffsetTimeIfOffsetOutOfRange = true;
@@ -88,18 +100,23 @@ also controls the naming of your output field.
   public Fields getOutputFields();
 ```
 
-The default RawMultiScheme just takes the byte[] and returns a tuple with byte[] as is. The name of the outputField is
-"bytes". There are alternative implementation like SchemeAsMultiScheme and KeyValueSchemeAsMultiScheme which can convert
-the byte[] to String. 
+The default `RawMultiScheme` just takes the `byte[]` and returns a tuple with `byte[]` as is. The name of the
+outputField is "bytes".  There are alternative implementation like `SchemeAsMultiScheme` and
+`KeyValueSchemeAsMultiScheme` which can convert the `byte[]` to `String`.
+
+
 ### Examples
-####Core Spout
+
+#### Core Spout
+
 ```java
 BrokerHosts hosts = new ZkHosts(zkConnString);
 SpoutConfig spoutConfig = new SpoutConfig(hosts, topicName, "/" + topicName, UUID.randomUUID().toString());
-spoutConf.scheme = new SchemeAsMultiScheme(new StringScheme());
+spoutConfig.scheme = new SchemeAsMultiScheme(new StringScheme());
 KafkaSpout kafkaSpout = new KafkaSpout(spoutConfig);
 ```
-####Trident Spout
+
+#### Trident Spout
 ```java
 TridentTopology topology = new TridentTopology();
 BrokerHosts zk = new ZkHosts("localhost");
@@ -107,6 +124,33 @@ TridentKafkaConfig spoutConf = new TridentKafkaConfig(zk, "test-topic");
 spoutConf.scheme = new SchemeAsMultiScheme(new StringScheme());
 OpaqueTridentKafkaSpout spout = new OpaqueTridentKafkaSpout(spoutConf);
 ```
+
+
+### How KafkaSpout stores offsets of a Kafka topic and recovers in case of failures
+
+As shown in the above KafkaConfig properties, you can control from where in the Kafka topic the spout begins to read by
+setting `KafkaConfig.startOffsetTime` as follows:
+
+1. `kafka.api.OffsetRequest.EarliestTime()`:  read from the beginning of the topic (i.e. from the oldest messages onwards)
+2. `kafka.api.OffsetRequest.LatestTime()`: read from the end of the topic (i.e. any new messsages that are being written to the topic)
+3. A Unix timestamp aka seconds since the epoch (e.g. via `System.currentTimeMillis()`):
+   see [How do I accurately get offsets of messages for a certain timestamp using OffsetRequest?](https://cwiki.apache.org/confluence/display/KAFKA/FAQ#FAQ-HowdoIaccuratelygetoffsetsofmessagesforacertaintimestampusingOffsetRequest?) in the Kafka FAQ
+
+As the topology runs the Kafka spout keeps track of the offsets it has read and emitted by storing state information
+under the ZooKeeper path `SpoutConfig.zkRoot+ "/" + SpoutConfig.id`.  In the case of failures it recovers from the last
+written offset in ZooKeeper.
+
+> **Important:**  When re-deploying a topology make sure that the settings for `SpoutConfig.zkRoot` and `SpoutConfig.id`
+> were not modified, otherwise the spout will not be able to read its previous consumer state information (i.e. the
+> offsets) from ZooKeeper -- which may lead to unexpected behavior and/or to data loss, depending on your use case.
+
+This means that when a topology has run once the setting `KafkaConfig.startOffsetTime` will not have an effect for
+subsequent runs of the topology because now the topology will rely on the consumer state information (offsets) in
+ZooKeeper to determine from where it should begin (more precisely: resume) reading.
+If you want to force the spout to ignore any consumer state information stored in ZooKeeper, then you should
+set the parameter `KafkaConfig.ignoreZkOffsets` to `true`.  If `true`, the spout will always begin reading from the
+offset defined by `KafkaConfig.startOffsetTime` as described above.
+
 
 ## Using storm-kafka with different versions of Scala
 
@@ -191,8 +235,8 @@ For the bolt :
         spout.setCycle(true);
         builder.setSpout("spout", spout, 5);
         KafkaBolt bolt = new KafkaBolt()
-                .withKafkaTopicSelector(new DefaultTopicSelector("test"))
-                .withTridentTupleToKafkaMapper(new FieldNameBasedTupleToKafkaMapper());
+                .withTopicSelector(new DefaultTopicSelector("test"))
+                .withTupleToKafkaMapper(new FieldNameBasedTupleToKafkaMapper());
         builder.setBolt("forwardToKafka", bolt, 8).shuffleGrouping("spout");
         
         Config conf = new Config();
@@ -201,7 +245,7 @@ For the bolt :
         props.put("metadata.broker.list", "localhost:9092");
         props.put("request.required.acks", "1");
         props.put("serializer.class", "kafka.serializer.StringEncoder");
-        conf.put(TridentKafkaState.KAFKA_BROKER_PROPERTIES, props);
+        conf.put(KafkaBolt.KAFKA_BROKER_PROPERTIES, props);
         
         StormSubmitter.submitTopology("kafkaboltTest", conf, builder.createTopology());
 ```

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -21,17 +21,37 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.9.3</version>
+        <version>0.9.4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <packaging>jar</packaging>
     <artifactId>storm-kafka</artifactId>
     <name>storm-kafka</name>
+    <version>0.9.4.0-PHEED</version>
     <description>Storm Spouts for Apache Kafka</description>
     <build>
         <plugins>
-
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.2.201409121644</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-initialize</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <sourceDirectory>src/jvm</sourceDirectory>
         <testSourceDirectory>src/test</testSourceDirectory>
@@ -95,7 +115,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.9.2</artifactId>
-            <version>0.8.1.1</version>
+            <version>0.8.2.0</version>
             <!-- use provided scope, so users can pull in whichever scala version they choose -->
             <scope>provided</scope>
             <exclusions>
@@ -112,7 +132,7 @@
         <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-core</artifactId>
-            <version>${project.version}</version>
+            <version>0.9.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -28,7 +28,7 @@
     <packaging>jar</packaging>
     <artifactId>storm-kafka</artifactId>
     <name>storm-kafka</name>
-    <version>0.9.4.4-PHEED</version>
+    <version>0.9.4.5-PHEED</version>
     <description>Storm Spouts for Apache Kafka</description>
     <build>
         <plugins>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -28,7 +28,7 @@
     <packaging>jar</packaging>
     <artifactId>storm-kafka</artifactId>
     <name>storm-kafka</name>
-    <version>0.9.4.1-PHEED</version>
+    <version>0.9.4.3-PHEED</version>
     <description>Storm Spouts for Apache Kafka</description>
     <build>
         <plugins>
@@ -138,7 +138,7 @@
       <dependency>
         <groupId>com.datastax.cassandra</groupId>
         <artifactId>cassandra-driver-core</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.1</version>
       </dependency>
     </dependencies>
 </project>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -28,7 +28,7 @@
     <packaging>jar</packaging>
     <artifactId>storm-kafka</artifactId>
     <name>storm-kafka</name>
-    <version>0.9.4.8-PHEED</version>
+    <version>0.9.4.9-PHEED</version>
     <description>Storm Spouts for Apache Kafka</description>
     <build>
         <plugins>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -28,7 +28,7 @@
     <packaging>jar</packaging>
     <artifactId>storm-kafka</artifactId>
     <name>storm-kafka</name>
-    <version>0.9.4.0-PHEED</version>
+    <version>0.9.4.1-PHEED</version>
     <description>Storm Spouts for Apache Kafka</description>
     <build>
         <plugins>
@@ -135,5 +135,10 @@
             <version>0.9.4</version>
             <scope>provided</scope>
         </dependency>
+      <dependency>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-core</artifactId>
+        <version>2.1.6</version>
+      </dependency>
     </dependencies>
 </project>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -28,7 +28,7 @@
     <packaging>jar</packaging>
     <artifactId>storm-kafka</artifactId>
     <name>storm-kafka</name>
-    <version>0.9.4.3-PHEED</version>
+    <version>0.9.4.4-PHEED</version>
     <description>Storm Spouts for Apache Kafka</description>
     <build>
         <plugins>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -28,7 +28,7 @@
     <packaging>jar</packaging>
     <artifactId>storm-kafka</artifactId>
     <name>storm-kafka</name>
-    <version>0.9.4.7-PHEED</version>
+    <version>0.9.4.8-PHEED</version>
     <description>Storm Spouts for Apache Kafka</description>
     <build>
         <plugins>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -28,7 +28,7 @@
     <packaging>jar</packaging>
     <artifactId>storm-kafka</artifactId>
     <name>storm-kafka</name>
-    <version>0.9.4.5-PHEED</version>
+    <version>0.9.4.6-PHEED</version>
     <description>Storm Spouts for Apache Kafka</description>
     <build>
         <plugins>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -28,7 +28,7 @@
     <packaging>jar</packaging>
     <artifactId>storm-kafka</artifactId>
     <name>storm-kafka</name>
-    <version>0.9.4.6-PHEED</version>
+    <version>0.9.4.7-PHEED</version>
     <description>Storm Spouts for Apache Kafka</description>
     <build>
         <plugins>

--- a/external/storm-kafka/src/jvm/storm/kafka/CassandraOffsetInfoStorage.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/CassandraOffsetInfoStorage.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CassandraOffsetInfoStorage implements IOffsetInfoStorage {
 
-    public static final Logger LOG = LoggerFactory.getLogger(PartitionManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CassandraOffsetInfoStorage.class);
     final private String TABLE = "storm_kafka_offsets";
 
     private Session session;

--- a/external/storm-kafka/src/jvm/storm/kafka/CassandraOffsetInfoStorage.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/CassandraOffsetInfoStorage.java
@@ -7,12 +7,15 @@ import java.net.UnknownHostException;
 import java.util.*;
 
 import org.json.simple.JSONValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by olgagorun on 5/25/15.
  */
 public class CassandraOffsetInfoStorage implements IOffsetInfoStorage {
 
+    public static final Logger LOG = LoggerFactory.getLogger(PartitionManager.class);
     final private String TABLE = "storm_kafka_offsets";
 
     private Session session;
@@ -21,6 +24,7 @@ public class CassandraOffsetInfoStorage implements IOffsetInfoStorage {
     private PreparedStatement selectStatement;
 
     CassandraOffsetInfoStorage(List<String> addressList, String keyspace) throws UnknownHostException {
+        LOG.info("provided addresses:" + addressList.toString());
         List<InetAddress> inetAddresses = new ArrayList<InetAddress>();
         for (String item : addressList) {
             inetAddresses.add(InetAddress.getByName(item));
@@ -31,6 +35,7 @@ public class CassandraOffsetInfoStorage implements IOffsetInfoStorage {
                 "( spoutid text, partitionid text, data text,\n" +
                 " PRIMARY KEY ((spoutid), partitionid))"
                );
+        LOG.info("table " + TABLE + " created");
 
         insertStatement = session.prepare("INSERT INTO " + TABLE + " (spoutId, partitionId, data) VALUES (?, ?, ?)");
         selectStatement = session.prepare("SELECT * FROM " + TABLE + " WHERE spoutId = ? AND partitionId = ?");

--- a/external/storm-kafka/src/jvm/storm/kafka/CassandraOffsetInfoStorage.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/CassandraOffsetInfoStorage.java
@@ -1,0 +1,56 @@
+package storm.kafka;
+
+import com.datastax.driver.core.*;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+
+import org.json.simple.JSONValue;
+
+/**
+ * Created by olgagorun on 5/25/15.
+ */
+public class CassandraOffsetInfoStorage implements IOffsetInfoStorage {
+
+    final private String TABLE = "storm_kafka_offsets";
+
+    private Session session;
+
+    private PreparedStatement insertStatement;
+    private PreparedStatement selectStatement;
+
+    CassandraOffsetInfoStorage(List<String> addressList, String keyspace) throws UnknownHostException {
+        List<InetAddress> inetAddresses = new ArrayList<InetAddress>();
+        for (String item : addressList) {
+            inetAddresses.add(InetAddress.getByName(item));
+        }
+        Cluster cluster = Cluster.builder().addContactPoints(inetAddresses).build();
+        session = cluster.connect(keyspace);
+        session.execute("CREATE TABLE IF NOT EXISTS " + TABLE + " \n" +
+                "( spoutid text, partitionid text, data text,\n" +
+                " PRIMARY KEY ((spoutid), partitionid))"
+               );
+
+        insertStatement = session.prepare("INSERT INTO " + TABLE + " (spoutId, partitionId, data) VALUES (?, ?, ?)");
+        selectStatement = session.prepare("SELECT * FROM " + TABLE + " WHERE spoutId = ? AND partitionId = ?");
+    }
+
+    @Override
+    public void set(String spoutId, String partitionId, Map<Object, Object> data) {
+        BoundStatement boundStatement = new BoundStatement(insertStatement);
+        session.execute(boundStatement.bind(spoutId, partitionId, JSONValue.toJSONString(data)));
+    }
+
+    @Override
+    public Map<Object, Object> get(String spoutId, String partitionId) {
+        BoundStatement boundStatement = new BoundStatement(selectStatement);
+        Row row = session.execute(boundStatement.bind(spoutId, partitionId)).one();
+        return row == null ? null : (Map<Object,Object>)JSONValue.parse(row.getString("data"));
+    }
+
+    public void close() {
+        session.close();
+    }
+
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/ConfigurableRetriesFailureHandler.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ConfigurableRetriesFailureHandler.java
@@ -36,7 +36,7 @@ public class ConfigurableRetriesFailureHandler implements IMassageFailureHandler
 
     @Override
     public long getOffset(Long expectedOffset) {
-        return !failed.isEmpty() ? failed.entrySet().iterator().next().getKey() : -1;
+        return !failed.isEmpty() ? failed.entrySet().iterator().next().getKey() : expectedOffset;
     }
 
     @Override

--- a/external/storm-kafka/src/jvm/storm/kafka/ConfigurableRetriesFailureHandler.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ConfigurableRetriesFailureHandler.java
@@ -1,0 +1,94 @@
+package storm.kafka;
+
+import kafka.message.MessageAndOffset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import storm.kafka.failures.IMassageFailureHandler;
+
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * Created by olgagorun on 1/29/15.
+ *
+ * Note: this class is not moved to failures package to be able to use package access level members of PartitionManager
+ */
+public class ConfigurableRetriesFailureHandler implements IMassageFailureHandler {
+    public static final Logger LOG = LoggerFactory.getLogger(ConfigurableRetriesFailureHandler.class);
+
+    ConcurrentSkipListMap<Long,Integer> failed;
+    ConcurrentSkipListMap<Long,Integer> pending;
+
+    long numberFailed;
+    long maxOffsetBehind;
+    int _retriesNumber;
+    PartitionManager _pm;
+
+    public ConfigurableRetriesFailureHandler(PartitionManager pm, int retriesNumber) {
+        failed = new ConcurrentSkipListMap<Long, Integer>();
+        pending = new ConcurrentSkipListMap<Long, Integer>();
+
+        numberFailed = 0;
+        _pm = pm;
+        maxOffsetBehind = pm._spoutConfig.maxOffsetBehind;
+
+        _retriesNumber = retriesNumber;
+    }
+
+    @Override
+    public long getOffset(Long expectedOffset) {
+        return !failed.isEmpty() ? failed.entrySet().iterator().next().getKey() : -1;
+    }
+
+    @Override
+    public boolean isOffsetFailed(long offset) {
+        return failed.containsKey(offset);
+    }
+
+    @Override
+    public void startMessageProcessing(MessageAndOffset enrichedMessage) {
+        Long cur_offset = enrichedMessage.offset();
+        if (failed.containsKey(cur_offset)) {
+            Integer value = failed.remove(cur_offset);
+            pending.put(cur_offset, value);
+        }
+    }
+
+    @Override
+    public void fail(Long offset) throws RuntimeException {
+        if (offset < _pm._emittedToOffset - maxOffsetBehind) {
+            failed.remove(offset);
+            pending.remove(offset);
+            LOG.info(
+                    "Skipping failed tuple at offset=" + offset +
+                            " because it's more than maxOffsetBehind=" + maxOffsetBehind +
+                            " behind _emittedToOffset=" + _pm._emittedToOffset
+            );
+            return;
+        }
+
+        numberFailed++;
+        if (_pm.numberAcked == 0 && numberFailed > maxOffsetBehind) {
+            throw new RuntimeException("Too many tuple failures");
+        }
+
+        LOG.debug("failing at offset=" + offset + " with _pending.size()=" + _pm._pending.size() + " pending and _emittedToOffset=" + _pm._emittedToOffset);
+        Integer number = pending.remove(offset);
+        number = number == null ? 1 : number + 1;
+        pending.remove(offset);
+
+        if (number >= _retriesNumber) {
+            LOG.debug(String.format("failing at offset=%s %s of times. Configured limit: %s", offset, number, _retriesNumber));
+            failed.remove(offset);
+        }
+        else {
+            failed.put(offset, number);
+        }
+
+    }
+
+    @Override
+    public void ack(Long offset) {
+        failed.remove(offset);
+        pending.remove(offset);
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/ConfigurableRetriesFailureHandler.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ConfigurableRetriesFailureHandler.java
@@ -78,7 +78,8 @@ public class ConfigurableRetriesFailureHandler implements IMassageFailureHandler
 
         if (number >= _retriesNumber) {
             LOG.debug(String.format("failing at offset=%s %s of times. Configured limit: %s", offset, number, _retriesNumber));
-            failed.remove(offset);
+            // failed.remove(offset);
+            _pm.ack(offset);
         }
         else {
             failed.put(offset, number);

--- a/external/storm-kafka/src/jvm/storm/kafka/DefaultFailureHandler.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/DefaultFailureHandler.java
@@ -1,0 +1,66 @@
+package storm.kafka;
+
+import kafka.message.MessageAndOffset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import storm.kafka.failures.MassageFailureHandler;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Created by olgagorun on 1/28/15.
+ */
+public class DefaultFailureHandler implements MassageFailureHandler {
+    public static final Logger LOG = LoggerFactory.getLogger(DefaultFailureHandler.class);
+
+    SortedSet<Long> failed;
+    long numberFailed;
+    long maxOffsetBehind;
+    PartitionManager _pm;
+
+    public DefaultFailureHandler(PartitionManager pm) {
+        failed = new TreeSet<Long>();
+        numberFailed = 0;
+        _pm = pm;
+        maxOffsetBehind = pm._spoutConfig.maxOffsetBehind;
+    }
+
+    @Override
+    public long getOffset(Long expectedOffset) {
+        return !failed.isEmpty() ? failed.first() : -1;
+    }
+
+    @Override
+    public boolean isOffsetFailed(long offset) {
+        return failed.contains(offset);
+    }
+
+    @Override
+    public void startMessageProcessing(MessageAndOffset enrichedMessage) {
+        Long cur_offset = enrichedMessage.offset();
+        if (failed.contains(cur_offset)) {
+           failed.remove(cur_offset);
+        }
+    }
+
+    @Override
+    public void fail(Long offset) throws RuntimeException {
+
+        if (offset < _pm._emittedToOffset - maxOffsetBehind) {
+            LOG.info(
+                    "Skipping failed tuple at offset=" + offset +
+                            " because it's more than maxOffsetBehind=" + maxOffsetBehind +
+                            " behind _emittedToOffset=" + _pm._emittedToOffset
+            );
+        } else {
+            LOG.debug("failing at offset=" + offset + " with _pending.size()=" + _pm._pending.size() + " pending and _emittedToOffset=" + _pm._emittedToOffset);
+            failed.add(offset);
+            numberFailed++;
+            if (_pm.numberAcked == 0 && numberFailed > maxOffsetBehind) {
+                throw new RuntimeException("Too many tuple failures");
+            }
+        }
+
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/DefaultFailureHandler.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/DefaultFailureHandler.java
@@ -3,15 +3,18 @@ package storm.kafka;
 import kafka.message.MessageAndOffset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import storm.kafka.failures.MassageFailureHandler;
+import storm.kafka.failures.IMassageFailureHandler;
 
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 /**
  * Created by olgagorun on 1/28/15.
+ *
+ * Note: this class is not moved to failures package to be able to use package access level members of PartitionManager
+ *
  */
-public class DefaultFailureHandler implements MassageFailureHandler {
+public class DefaultFailureHandler implements IMassageFailureHandler {
     public static final Logger LOG = LoggerFactory.getLogger(DefaultFailureHandler.class);
 
     SortedSet<Long> failed;
@@ -63,4 +66,6 @@ public class DefaultFailureHandler implements MassageFailureHandler {
         }
 
     }
+
+    public void ack(Long offset) {}
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/DefaultFailureHandler.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/DefaultFailureHandler.java
@@ -31,7 +31,7 @@ public class DefaultFailureHandler implements IMassageFailureHandler {
 
     @Override
     public long getOffset(Long expectedOffset) {
-        return !failed.isEmpty() ? failed.first() : -1;
+        return !failed.isEmpty() ? failed.first() : expectedOffset;
     }
 
     @Override

--- a/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
@@ -19,6 +19,7 @@ package storm.kafka;
 
 import backtype.storm.Config;
 import backtype.storm.utils.Utils;
+import com.google.common.base.Preconditions;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryNTimes;
@@ -41,6 +42,15 @@ public class DynamicBrokersReader {
     private String _topic;
 
     public DynamicBrokersReader(Map conf, String zkStr, String zkPath, String topic) {
+        // Check required parameters
+        Preconditions.checkNotNull(conf, "conf cannot be null");
+
+        validateConfig(conf);
+
+        Preconditions.checkNotNull(zkStr,"zkString cannot be null");
+        Preconditions.checkNotNull(zkPath, "zkPath cannot be null");
+        Preconditions.checkNotNull(topic, "topic cannot be null");
+
         _zkPath = zkPath;
         _topic = topic;
         try {
@@ -53,6 +63,7 @@ public class DynamicBrokersReader {
             _curator.start();
         } catch (Exception ex) {
             LOG.error("Couldn't connect to zookeeper", ex);
+            throw new RuntimeException(ex);
         }
     }
 
@@ -147,6 +158,21 @@ public class DynamicBrokersReader {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Validate required parameters in the input configuration Map
+     * @param conf
+     */
+    private void validateConfig(final Map conf) {
+        Preconditions.checkNotNull(conf.get(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT),
+                "%s cannot be null", Config.STORM_ZOOKEEPER_SESSION_TIMEOUT);
+        Preconditions.checkNotNull(conf.get(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT),
+                "%s cannot be null", Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT);
+        Preconditions.checkNotNull(conf.get(Config.STORM_ZOOKEEPER_RETRY_TIMES),
+                "%s cannot be null", Config.STORM_ZOOKEEPER_RETRY_TIMES);
+        Preconditions.checkNotNull(conf.get(Config.STORM_ZOOKEEPER_RETRY_INTERVAL),
+                "%s cannot be null", Config.STORM_ZOOKEEPER_RETRY_INTERVAL);
     }
 
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManager.java
@@ -28,7 +28,7 @@ import java.util.Queue;
 
 public class ExponentialBackoffMsgRetryManager implements FailedMsgRetryManager {
 
-    public static final Logger LOG = LoggerFactory.getLogger(PartitionManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ExponentialBackoffMsgRetryManager.class);
 
     private final long retryInitialDelayMs;
     private final double retryDelayMultiplier;

--- a/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManager.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package storm.kafka;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+
+public class ExponentialBackoffMsgRetryManager implements FailedMsgRetryManager {
+
+    private final long retryInitialDelayMs;
+    private final double retryDelayMultiplier;
+    private final long retryDelayMaxMs;
+    private final long maxRetriesNumber;
+
+    private Queue<MessageRetryRecord> waiting = new PriorityQueue<MessageRetryRecord>(11, new RetryTimeComparator());
+    private Map<Long,MessageRetryRecord> records = new HashMap<Long,MessageRetryRecord>();
+
+    public ExponentialBackoffMsgRetryManager(long retryInitialDelayMs, double retryDelayMultiplier, long retryDelayMaxMs, long maxRetriesNumber) {
+        this.retryInitialDelayMs = retryInitialDelayMs;
+        this.retryDelayMultiplier = retryDelayMultiplier;
+        this.retryDelayMaxMs = retryDelayMaxMs;
+        this.maxRetriesNumber = maxRetriesNumber;
+    }
+
+    @Override
+    public void failed(Long offset) {
+        MessageRetryRecord oldRecord = this.records.get(offset);
+        MessageRetryRecord newRecord = oldRecord == null ?
+                                       new MessageRetryRecord(offset) :
+                                       oldRecord.createNextRetryRecord();
+        this.records.put(offset, newRecord);
+        this.waiting.add(newRecord);
+    }
+
+    @Override
+    public void acked(Long offset) {
+        MessageRetryRecord record = this.records.remove(offset);
+        if (record != null) {
+            this.waiting.remove(record);
+        }
+    }
+
+    @Override
+    public void retryStarted(Long offset) {
+        MessageRetryRecord record = this.records.get(offset);
+        if (record == null || !this.waiting.contains(record)) {
+            throw new IllegalStateException("cannot retry a message that has not failed");
+        } else {
+            this.waiting.remove(record);
+        }
+    }
+
+    @Override
+    public Long nextFailedMessageToRetry() {
+        if (this.waiting.size() > 0) {
+            MessageRetryRecord first = this.waiting.peek();
+            if (System.currentTimeMillis() >= first.retryTimeUTC) {
+                if (this.records.containsKey(first.offset)) {
+                    return first.offset;
+                } else {
+                    // defensive programming - should be impossible
+                    this.waiting.remove(first);
+                    return nextFailedMessageToRetry();
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean shouldRetryMsg(Long offset) {
+        MessageRetryRecord record = this.records.get(offset);
+        return record != null &&
+                this.waiting.contains(record) &&
+                System.currentTimeMillis() >= record.retryTimeUTC;
+    }
+
+    /**
+     * A MessageRetryRecord holds the data of how many times a message has
+     * failed and been retried, and when the last failure occurred.  It can
+     * determine whether it is ready to be retried by employing an exponential
+     * back-off calculation using config values stored in SpoutConfig:
+     * <ul>
+     *  <li>retryInitialDelayMs - time to delay before the first retry</li>
+     *  <li>retryDelayMultiplier - multiplier by which to increase the delay for each subsequent retry</li>
+     *  <li>retryDelayMaxMs - maximum retry delay (once this delay time is reached, subsequent retries will
+     *                        delay for this amount of time every time)
+     *  </li>
+     * </ul>
+     */
+    class MessageRetryRecord {
+        private final long offset;
+        private final int retryNum;
+        private final long retryTimeUTC;
+
+        public MessageRetryRecord(long offset) {
+            this(offset, 1);
+        }
+
+        private MessageRetryRecord(long offset, int retryNum) {
+            this.offset = offset;
+            this.retryNum = retryNum;
+            this.retryTimeUTC = System.currentTimeMillis() + calculateRetryDelay();
+        }
+
+        /**
+         * Create a MessageRetryRecord for the next retry that should occur after this one.
+         * @return MessageRetryRecord with the next retry time, or null to indicate that another
+         *         retry should not be performed.  The latter case can happen if we are about to
+         *         run into the backtype.storm.Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS in the Storm
+         *         configuration.
+         */
+        public MessageRetryRecord createNextRetryRecord() {
+            return new MessageRetryRecord(this.offset, this.retryNum + 1);
+        }
+
+        private long calculateRetryDelay() {
+            Long maxLong = Long.MAX_VALUE;
+            long delayThisRetryMs = 0;
+            if (this.retryNum <= maxRetriesNumber) {
+                double delay = retryInitialDelayMs * Math.pow(retryDelayMultiplier, this.retryNum - 1);
+                delayThisRetryMs = Math.min(delay >= maxLong.doubleValue() ?  maxLong : (long) delay, retryDelayMaxMs);
+            }
+            else {
+                delayThisRetryMs = maxLong - System.currentTimeMillis() - 1;
+            }
+            return delayThisRetryMs;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return (other instanceof MessageRetryRecord
+                    && this.offset == ((MessageRetryRecord) other).offset);
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.valueOf(this.offset).hashCode();
+        }
+    }
+
+    class RetryTimeComparator implements Comparator<MessageRetryRecord> {
+
+        @Override
+        public int compare(MessageRetryRecord record1, MessageRetryRecord record2) {
+            return Long.valueOf(record1.retryTimeUTC).compareTo(Long.valueOf(record2.retryTimeUTC));
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return false;
+        }
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/FailedMsgRetryManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/FailedMsgRetryManager.java
@@ -18,7 +18,7 @@
 package storm.kafka;
 
 public interface FailedMsgRetryManager {
-    public void failed(Long offset);
+    public boolean failed(Long offset);
     public void acked(Long offset);
     public void retryStarted(Long offset);
     public Long nextFailedMessageToRetry();

--- a/external/storm-kafka/src/jvm/storm/kafka/FailedMsgRetryManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/FailedMsgRetryManager.java
@@ -17,27 +17,10 @@
  */
 package storm.kafka;
 
-import java.io.Serializable;
-import java.util.List;
-
-public class SpoutConfig extends KafkaConfig implements Serializable {
-    public List<String> zkServers = null;
-    public Integer zkPort = null;
-    public String zkRoot = null;
-    public String id = null;
-
-    // setting for how often to save the current kafka offset to ZooKeeper
-    public long stateUpdateIntervalMs = 2000;
-
-    // Exponential back-off retry settings.  These are used when retrying messages after a bolt
-    // calls OutputCollector.fail().
-    public long retryInitialDelayMs = 0;
-    public double retryDelayMultiplier = 1.0;
-    public long retryDelayMaxMs = 60 * 1000;
-
-    public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id) {
-        super(hosts, topic);
-        this.zkRoot = zkRoot;
-        this.id = id;
-    }
+public interface FailedMsgRetryManager {
+    public void failed(Long offset);
+    public void acked(Long offset);
+    public void retryStarted(Long offset);
+    public Long nextFailedMessageToRetry();
+    public boolean shouldRetryMsg(Long offset);
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/FailureRepositoryFactoryContainer.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/FailureRepositoryFactoryContainer.java
@@ -1,0 +1,17 @@
+package storm.kafka;
+
+/**
+ * Created by olgagorun on 6/29/15.
+ */
+public class FailureRepositoryFactoryContainer {
+
+    private static IFailureRepositoryFactory factory = null;
+
+    public static IFailureRepositoryFactory get() {
+        return factory;
+    }
+
+    public static void set(IFailureRepositoryFactory repositoryFactory) {
+        factory = repositoryFactory;
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/IFailureRepository.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/IFailureRepository.java
@@ -1,0 +1,9 @@
+package storm.kafka;
+
+/**
+ * Created by olgagorun on 6/29/15.
+ */
+public interface IFailureRepository {
+    public void putTuple(Object tuple, long offset);
+    public Object get(long offset);
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/IFailureRepository.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/IFailureRepository.java
@@ -4,6 +4,6 @@ package storm.kafka;
  * Created by olgagorun on 6/29/15.
  */
 public interface IFailureRepository {
-    public void putTuple(Object tuple, long offset);
+    public void putTuple(Object tuple, long offset, String topic, String partition);
     public Object get(long offset);
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/IFailureRepositoryFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/IFailureRepositoryFactory.java
@@ -1,0 +1,8 @@
+package storm.kafka;
+
+/**
+ * Created by olgagorun on 6/29/15.
+ */
+public interface IFailureRepositoryFactory {
+    public IFailureRepository getRepository();
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/IOffsetInfoStorage.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/IOffsetInfoStorage.java
@@ -1,0 +1,15 @@
+package storm.kafka;
+
+import java.util.Map;
+
+/**
+ * Created by olgagorun on 5/25/15.
+ */
+public interface IOffsetInfoStorage {
+
+    public void set(String spoutId, String partitionId, Map<Object,Object> data);
+
+    public Map<Object,Object> get(String spoutId, String partitionId);
+
+    public void close();
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaConfig.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaConfig.java
@@ -33,7 +33,7 @@ public class KafkaConfig implements Serializable {
     public int fetchMaxWait = 10000;
     public int bufferSizeBytes = 1024 * 1024;
     public MultiScheme scheme = new RawMultiScheme();
-    public boolean forceFromStart = false;
+    public boolean ignoreZkOffsets = false;
     public long startOffsetTime = kafka.api.OffsetRequest.EarliestTime();
     public long maxOffsetBehind = Long.MAX_VALUE;
     public boolean useStartOffsetTimeIfOffsetOutOfRange = true;

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import storm.kafka.PartitionManager.KafkaMessageId;
 
+import java.net.UnknownHostException;
 import java.util.*;
 
 // TODO: need to add blacklisting
@@ -56,7 +57,7 @@ public class KafkaSpout extends BaseRichSpout {
     SpoutOutputCollector _collector;
     PartitionCoordinator _coordinator;
     DynamicPartitionConnections _connections;
-    ZkState _state;
+    IOffsetInfoStorage _state;
 
     long _lastUpdateMs = 0;
 
@@ -82,7 +83,20 @@ public class KafkaSpout extends BaseRichSpout {
         stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_SERVERS, zkServers);
         stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_PORT, zkPort);
         stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_ROOT, _spoutConfig.zkRoot);
-        _state = new ZkState(stateConf);
+        _state = OffsetStorageFactory.getStorage(stateConf);
+//        if (stateConf.get(STORAGE_TYPE) == "CASSANDRA") {
+//            try {
+//                _state = new CassandraOffsetInfoStorage((List<String>)stateConf.get("cassandra_storage_addresses"), (String)stateConf.get("cassandra_storage_keyspace"));
+//            } catch (UnknownHostException e) {
+//                throw new RuntimeException("Unhandled cassandra hosts");
+//            }
+//        }
+//        else {
+//            stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_SERVERS, zkServers);
+//            stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_PORT, zkPort);
+//            stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_ROOT, _spoutConfig.zkRoot);
+//            _state =  new ZkState(_spoutConfig.zkRoot, stateConf);
+//        }
 
         _connections = new DynamicPartitionConnections(_spoutConfig, KafkaUtils.makeBrokerReader(conf, _spoutConfig));
 

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
@@ -84,20 +84,6 @@ public class KafkaSpout extends BaseRichSpout {
         stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_PORT, zkPort);
         stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_ROOT, _spoutConfig.zkRoot);
         _state = OffsetStorageFactory.getStorage(stateConf);
-//        if (stateConf.get(STORAGE_TYPE) == "CASSANDRA") {
-//            try {
-//                _state = new CassandraOffsetInfoStorage((List<String>)stateConf.get("cassandra_storage_addresses"), (String)stateConf.get("cassandra_storage_keyspace"));
-//            } catch (UnknownHostException e) {
-//                throw new RuntimeException("Unhandled cassandra hosts");
-//            }
-//        }
-//        else {
-//            stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_SERVERS, zkServers);
-//            stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_PORT, zkPort);
-//            stateConf.put(Config.TRANSACTIONAL_ZOOKEEPER_ROOT, _spoutConfig.zkRoot);
-//            _state =  new ZkState(_spoutConfig.zkRoot, stateConf);
-//        }
-
         _connections = new DynamicPartitionConnections(_spoutConfig, KafkaUtils.makeBrokerReader(conf, _spoutConfig));
 
         // using TransactionalState like this is a hack

--- a/external/storm-kafka/src/jvm/storm/kafka/LoggingFailuresRepository.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/LoggingFailuresRepository.java
@@ -1,0 +1,21 @@
+package storm.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by olgagorun on 6/29/15.
+ */
+public class LoggingFailuresRepository implements IFailureRepository{
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingFailuresRepository.class);
+
+    public void putTuple(Object tuple, long offset) {
+      LOG.info("putTuple(" + tuple.toString() + ", " + offset + ")");
+
+    }
+
+    public Object get(long offset) {
+        LOG.info("get(" + offset + ")");
+        return null;
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/LoggingFailuresRepository.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/LoggingFailuresRepository.java
@@ -9,8 +9,8 @@ import org.slf4j.LoggerFactory;
 public class LoggingFailuresRepository implements IFailureRepository{
     private static final Logger LOG = LoggerFactory.getLogger(LoggingFailuresRepository.class);
 
-    public void putTuple(Object tuple, long offset) {
-      LOG.info("putTuple(" + tuple.toString() + ", " + offset + ")");
+    public void putTuple(Object tuple, long offset, String topic, String partition) {
+      LOG.info("putTuple(" + tuple.toString() + ", " + offset + ", " + topic + ", " + partition + ")");
 
     }
 

--- a/external/storm-kafka/src/jvm/storm/kafka/OffsetStorageFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/OffsetStorageFactory.java
@@ -1,6 +1,8 @@
 package storm.kafka;
 
 import backtype.storm.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -11,6 +13,7 @@ import java.util.Map;
 * Created by olgagorun on 5/26/15.
 */
 public class OffsetStorageFactory {
+    public static final Logger LOG = LoggerFactory.getLogger(PartitionManager.class);
 
     public static final String STORAGE_TYPE = "STORAGE_TYPE";
     public static final String CASSANDRA_STORAGE_ADDRESS = "cassandra_storage_addresses";
@@ -19,14 +22,18 @@ public class OffsetStorageFactory {
     public static IOffsetInfoStorage getStorage(Map conf) {
         IOffsetInfoStorage storage = null;
         if (conf.get(STORAGE_TYPE).equals("CASSANDRA")) {
+            LOG.info("cassandra storage chosen");
             try {
                storage = new CassandraOffsetInfoStorage(Arrays.asList(( (String)conf.get(CASSANDRA_STORAGE_ADDRESS)).split(",")), (String)conf.get(CASSANDRA_STORAGE_KEYSPACE));
+               LOG.info("cassandra storage created");
             } catch (UnknownHostException e) {
+               LOG.error("UnknownHostException while creating storage");
                throw new RuntimeException("unhandled");
             }
         }
         else {
             storage = new ZkState((String)conf.get(Config.TRANSACTIONAL_ZOOKEEPER_ROOT), conf);
+            LOG.info("zookeeper storage created");
         }
 
         return storage;

--- a/external/storm-kafka/src/jvm/storm/kafka/OffsetStorageFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/OffsetStorageFactory.java
@@ -1,0 +1,34 @@
+package storm.kafka;
+
+import backtype.storm.Config;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+* Created by olgagorun on 5/26/15.
+*/
+public class OffsetStorageFactory {
+
+    public static final String STORAGE_TYPE = "STORAGE_TYPE";
+    public static final String CASSANDRA_STORAGE_ADDRESS = "cassandra_storage_addresses";
+    public static final String CASSANDRA_STORAGE_KEYSPACE = "cassandra_storage_keyspace";
+
+    public static IOffsetInfoStorage getStorage(Map conf) {
+        IOffsetInfoStorage storage = null;
+        if (conf.get(STORAGE_TYPE).equals("CASSANDRA")) {
+            try {
+               storage = new CassandraOffsetInfoStorage(Arrays.asList(( (String)conf.get(CASSANDRA_STORAGE_ADDRESS)).split(",")), (String)conf.get(CASSANDRA_STORAGE_KEYSPACE));
+            } catch (UnknownHostException e) {
+               throw new RuntimeException("unhandled");
+            }
+        }
+        else {
+            storage = new ZkState((String)conf.get(Config.TRANSACTIONAL_ZOOKEEPER_ROOT), conf);
+        }
+
+        return storage;
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import storm.kafka.KafkaSpout.EmitState;
 import storm.kafka.KafkaSpout.MessageAndRealOffset;
-import storm.kafka.failures.MassageFailureHandler;
+import storm.kafka.failures.IMassageFailureHandler;
 import storm.kafka.failures.MessageFailureHandlerFactoryRepository;
 import storm.kafka.trident.MaxMetric;
 
@@ -57,7 +57,7 @@ public class PartitionManager {
     Map _stormConf;
     //long numberFailed, numberAcked;
     long numberAcked;
-    MassageFailureHandler _failureHandler;
+    IMassageFailureHandler _failureHandler;
 
 
     public PartitionManager(DynamicPartitionConnections connections, String topologyInstanceId, ZkState state, Map stormConf, SpoutConfig spoutConfig, Partition id) {
@@ -201,6 +201,7 @@ public class PartitionManager {
         }
         _pending.remove(offset);
         numberAcked++;
+        _failureHandler.ack(offset);
     }
 
     public void fail(Long offset) {
@@ -246,6 +247,14 @@ public class PartitionManager {
 
     public void close() {
         _connections.unregister(_partition.host, _partition.partition);
+    }
+
+    public Map getStormConfig() {
+        return _stormConf;
+    }
+
+    public SpoutConfig getSpoutConfig() {
+        return _spoutConfig;
     }
 
     static class KafkaMessageId {

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -237,7 +237,7 @@ public class PartitionManager {
                 _pending.remove(offset);
                 _finalFailureCountMetric.incr();
                 //_finalFailurePerEventCountMetric.scope(tuplesStr).incr();
-                 failuresRepository.putTuple(tuples.iterator().next(), offset);
+                 failuresRepository.putTuple(tuples.iterator().next(), offset, _spoutConfig.topic, _partition.getId());
 
             }
             else {

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -229,7 +229,9 @@ public class PartitionManager {
                 throw new RuntimeException("Too many tuple failures");
             }
 
-            this._failedMsgRetryManager.failed(offset);
+            if (!this._failedMsgRetryManager.failed(offset)) {
+                _pending.remove(offset);
+            }
         }
     }
 

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -227,6 +227,10 @@ public class PartitionManager {
               tuplesStr += tup.toString();
             }
             LOG.info(String.format("Failed message with offset %s from timestamp %s: %s", offset, convertTime(record.getTimestamp()), tuplesStr));
+            if (!this._failedMsgRetryManager.failed(offset)) {
+                LOG.error(String.format("Message failed finally: offset %s from timestamp %s: %s", offset, convertTime(record.getTimestamp()), tuplesStr));
+                _pending.remove(offset);
+            }
         }
 
         if (offset < _emittedToOffset - _spoutConfig.maxOffsetBehind) {
@@ -240,10 +244,6 @@ public class PartitionManager {
             numberFailed++;
             if (numberAcked == 0 && numberFailed > _spoutConfig.maxOffsetBehind) {
                 throw new RuntimeException("Too many tuple failures");
-            }
-
-            if (!this._failedMsgRetryManager.failed(offset)) {
-                _pending.remove(offset);
             }
         }
     }

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -127,11 +127,11 @@ public class PartitionManager {
 
     public Map getMetricsDataMap() {
         Map ret = new HashMap();
-        ret.put(_partition + "/fetchAPILatencyMax", _fetchAPILatencyMax.getValueAndReset());
-        ret.put(_partition + "/fetchAPILatencyMean", _fetchAPILatencyMean.getValueAndReset());
-        ret.put(_partition + "/fetchAPICallCount", _fetchAPICallCount.getValueAndReset());
-        ret.put(_partition + "/fetchAPIMessageCount", _fetchAPIMessageCount.getValueAndReset());
-        ret.put(_partition + "/finalFailureCountMetric", _finalFailureCountMetric.getValueAndReset());
+        ret.put(_partition.getId() + "/fetchAPILatencyMax", _fetchAPILatencyMax.getValueAndReset());
+        ret.put(_partition.getId() + "/fetchAPILatencyMean", _fetchAPILatencyMean.getValueAndReset());
+        ret.put(_partition.getId() + "/fetchAPICallCount", _fetchAPICallCount.getValueAndReset());
+        ret.put(_partition.getId() + "/fetchAPIMessageCount", _fetchAPIMessageCount.getValueAndReset());
+        ret.put(_partition.getId() + "/finalFailureCountMetric", _finalFailureCountMetric.getValueAndReset());
         //ret.put(_partition + "/finalFailurePerEventCountMetric", _finalFailurePerEventCountMetric.getValueAndReset());
         return ret;
     }

--- a/external/storm-kafka/src/jvm/storm/kafka/StaticCoordinator.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/StaticCoordinator.java
@@ -27,7 +27,7 @@ public class StaticCoordinator implements PartitionCoordinator {
     Map<Partition, PartitionManager> _managers = new HashMap<Partition, PartitionManager>();
     List<PartitionManager> _allManagers = new ArrayList();
 
-    public StaticCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig config, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId) {
+    public StaticCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig config, IOffsetInfoStorage state, int taskIndex, int totalTasks, String topologyInstanceId) {
         StaticHosts hosts = (StaticHosts) config.hosts;
         List<Partition> myPartitions = KafkaUtils.calculatePartitionsForTask(hosts.getPartitionInformation(), totalTasks, taskIndex);
         for (Partition myPartition : myPartitions) {

--- a/external/storm-kafka/src/jvm/storm/kafka/TopicOffsetOutOfRangeException.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/TopicOffsetOutOfRangeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,27 +17,9 @@
  */
 package storm.kafka;
 
-import java.io.Serializable;
-import java.util.List;
+public class TopicOffsetOutOfRangeException extends RuntimeException {
 
-public class SpoutConfig extends KafkaConfig implements Serializable {
-    public List<String> zkServers = null;
-    public Integer zkPort = null;
-    public String zkRoot = null;
-    public String id = null;
-
-    // setting for how often to save the current kafka offset to ZooKeeper
-    public long stateUpdateIntervalMs = 2000;
-
-    // Exponential back-off retry settings.  These are used when retrying messages after a bolt
-    // calls OutputCollector.fail().
-    public long retryInitialDelayMs = 0;
-    public double retryDelayMultiplier = 1.0;
-    public long retryDelayMaxMs = 60 * 1000;
-
-    public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id) {
-        super(hosts, topic);
-        this.zkRoot = zkRoot;
-        this.id = id;
+    public TopicOffsetOutOfRangeException(String message) {
+        super(message);
     }
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/ZkCoordinator.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ZkCoordinator.java
@@ -38,14 +38,14 @@ public class ZkCoordinator implements PartitionCoordinator {
     int _refreshFreqMs;
     DynamicPartitionConnections _connections;
     DynamicBrokersReader _reader;
-    ZkState _state;
+    IOffsetInfoStorage _state;
     Map _stormConf;
 
-    public ZkCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig spoutConfig, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId) {
+    public ZkCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig spoutConfig, IOffsetInfoStorage state, int taskIndex, int totalTasks, String topologyInstanceId) {
         this(connections, stormConf, spoutConfig, state, taskIndex, totalTasks, topologyInstanceId, buildReader(stormConf, spoutConfig));
     }
 
-    public ZkCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig spoutConfig, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId, DynamicBrokersReader reader) {
+    public ZkCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig spoutConfig, IOffsetInfoStorage state, int taskIndex, int totalTasks, String topologyInstanceId, DynamicBrokersReader reader) {
         _spoutConfig = spoutConfig;
         _connections = connections;
         _taskIndex = taskIndex;

--- a/external/storm-kafka/src/jvm/storm/kafka/bolt/mapper/FieldNameBasedTupleToKafkaMapper.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/bolt/mapper/FieldNameBasedTupleToKafkaMapper.java
@@ -19,7 +19,7 @@ package storm.kafka.bolt.mapper;
 
 import backtype.storm.tuple.Tuple;
 
-public class FieldNameBasedTupleToKafkaMapper<K,V> implements TupleToKafkaMapper {
+public class FieldNameBasedTupleToKafkaMapper<K,V> implements TupleToKafkaMapper<K, V> {
 
     public static final String BOLT_KEY = "key";
     public static final String BOLT_MESSAGE = "message";

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/IMassageFailureHandler.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/IMassageFailureHandler.java
@@ -5,7 +5,7 @@ import kafka.message.MessageAndOffset;
 /**
  * Created by olgagorun on 1/28/15.
  */
-public interface MassageFailureHandler {
+public interface IMassageFailureHandler {
 
     long getOffset(Long expectedOffset);
 
@@ -14,4 +14,6 @@ public interface MassageFailureHandler {
     void startMessageProcessing(MessageAndOffset enrichedMessage);
 
     void fail(Long offset) throws RuntimeException;
+
+    void ack(Long offset);
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/IMessageFailureHandlerFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/IMessageFailureHandlerFactory.java
@@ -1,0 +1,13 @@
+package storm.kafka.failures;
+
+import storm.kafka.PartitionManager;
+
+import java.util.Map;
+
+/**
+ * Created by olgagorun on 1/29/15.
+ */
+public interface IMessageFailureHandlerFactory {
+
+    public MassageFailureHandler getHandler(PartitionManager pm, Map conf);
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/IMessageFailureHandlerFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/IMessageFailureHandlerFactory.java
@@ -9,5 +9,5 @@ import java.util.Map;
  */
 public interface IMessageFailureHandlerFactory {
 
-    public MassageFailureHandler getHandler(PartitionManager pm, Map conf);
+    public IMassageFailureHandler getHandler(PartitionManager pm, Map conf);
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/IMessageFailureHandlerFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/IMessageFailureHandlerFactory.java
@@ -1,5 +1,6 @@
 package storm.kafka.failures;
 
+import storm.kafka.FailedMsgRetryManager;
 import storm.kafka.PartitionManager;
 
 import java.util.Map;
@@ -9,5 +10,5 @@ import java.util.Map;
  */
 public interface IMessageFailureHandlerFactory {
 
-    public IMassageFailureHandler getHandler(PartitionManager pm, Map conf);
+    public FailedMsgRetryManager getHandler(PartitionManager pm, Map conf);
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/MassageFailureHandler.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/MassageFailureHandler.java
@@ -1,0 +1,17 @@
+package storm.kafka.failures;
+
+import kafka.message.MessageAndOffset;
+
+/**
+ * Created by olgagorun on 1/28/15.
+ */
+public interface MassageFailureHandler {
+
+    long getOffset(Long expectedOffset);
+
+    boolean isOffsetFailed(long offset);
+
+    void startMessageProcessing(MessageAndOffset enrichedMessage);
+
+    void fail(Long offset) throws RuntimeException;
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerDefaultFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerDefaultFactory.java
@@ -1,0 +1,34 @@
+package storm.kafka.failures;
+
+import storm.kafka.DefaultFailureHandler;
+import storm.kafka.PartitionManager;
+
+import java.util.Map;
+
+/**
+ * Created by olgagorun on 1/29/15.
+ */
+public class MessageFailureHandlerDefaultFactory implements IMessageFailureHandlerFactory {
+
+    private enum FactoryType { DEFAULT, CONFIGURED_RETRY; }
+
+    private FactoryType _factoryType;
+
+    public MessageFailureHandlerDefaultFactory(String factoryType) {
+        _factoryType = FactoryType.valueOf(factoryType);
+    }
+
+    @Override
+    public MassageFailureHandler getHandler(PartitionManager pm, Map conf) {
+        MassageFailureHandler handler = null;
+        switch (_factoryType) {
+            case DEFAULT:
+                handler = new DefaultFailureHandler(pm);
+                break;
+            default:
+                throw new RuntimeException("Unsupported factory type: " + _factoryType);
+
+        }
+        return handler;
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerDefaultFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerDefaultFactory.java
@@ -41,10 +41,11 @@ public class MessageFailureHandlerDefaultFactory implements IMessageFailureHandl
         String key = "kafka.spout." + pm.getSpoutConfig().id + ".retries";
         Map stormConf = pm.getStormConfig();
         if (stormConf.containsKey(key)) {
-            retriesNumber = (Integer)stormConf.get(key);
+            //retriesNumber = Integer.parseInt((String)stormConf.get(key));
+            retriesNumber = ((Long)stormConf.get(key)).intValue();
         }
         else if (stormConf.containsKey("kafka.spout.retries")) {
-            retriesNumber = (Integer)stormConf.get("kafka.spout.retries");
+            retriesNumber = ((Long)stormConf.get("kafka.spout.retries")).intValue();
         }
 
         return retriesNumber;

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerDefaultFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerDefaultFactory.java
@@ -1,8 +1,6 @@
 package storm.kafka.failures;
 
-import storm.kafka.ConfigurableRetriesFailureHandler;
-import storm.kafka.DefaultFailureHandler;
-import storm.kafka.PartitionManager;
+import storm.kafka.*;
 
 import java.util.Map;
 
@@ -20,19 +18,20 @@ public class MessageFailureHandlerDefaultFactory implements IMessageFailureHandl
     }
 
     @Override
-    public IMassageFailureHandler getHandler(PartitionManager pm, Map conf) {
-        IMassageFailureHandler handler = null;
-        switch (_factoryType) {
-            case DEFAULT:
-                handler = new DefaultFailureHandler(pm);
-                break;
-            case CONFIGURED_RETRY:
-                handler = new ConfigurableRetriesFailureHandler(pm, getRetriesConfiguration(pm));
-                break;
-            default:
-                throw new RuntimeException("Unsupported factory type: " + _factoryType);
-
-        }
+    public FailedMsgRetryManager getHandler(PartitionManager pm, Map conf) {
+        FailedMsgRetryManager handler = null;
+//        switch (_factoryType) {
+//            case DEFAULT:
+//                handler = new DefaultFailureHandler(pm);
+//                break;
+//            case CONFIGURED_RETRY:
+//                handler = new ConfigurableRetriesFailureHandler(pm, getRetriesConfiguration(pm));
+//                break;
+//            default:
+//                throw new RuntimeException("Unsupported factory type: " + _factoryType);
+//
+//        }
+        handler = new ExponentialBackoffMsgRetryManager(1, 1, 1, 1);
         return handler;
     }
 

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerFactoryRepository.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerFactoryRepository.java
@@ -1,0 +1,22 @@
+package storm.kafka.failures;
+
+/**
+ * Created by olgagorun on 1/29/15.
+ */
+public final class MessageFailureHandlerFactoryRepository {
+
+    private static IMessageFailureHandlerFactory _factory;
+
+    private MessageFailureHandlerFactoryRepository() {    }
+
+    public static void setFactory(IMessageFailureHandlerFactory factory) {
+        _factory = factory;
+    }
+
+    public static IMessageFailureHandlerFactory getFactory() {
+        if (_factory == null) {
+            _factory = new MessageFailureHandlerDefaultFactory("DEFAULT");
+        }
+        return _factory;
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerFactoryRepository.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerFactoryRepository.java
@@ -15,7 +15,7 @@ public final class MessageFailureHandlerFactoryRepository {
 
     public static IMessageFailureHandlerFactory getFactory() {
         if (_factory == null) {
-            _factory = new MessageFailureHandlerDefaultFactory("DEFAULT");
+            _factory = new MessageFailureHandlerDefaultFactory("CONFIGURED_RETRY");
         }
         return _factory;
     }

--- a/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerFactoryRepository.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/failures/MessageFailureHandlerFactoryRepository.java
@@ -15,7 +15,7 @@ public final class MessageFailureHandlerFactoryRepository {
 
     public static IMessageFailureHandlerFactory getFactory() {
         if (_factory == null) {
-            _factory = new MessageFailureHandlerDefaultFactory("CONFIGURED_RETRY");
+            _factory = new MessageFailureHandlerDefaultFactory("DEFAULT");
         }
         return _factory;
     }

--- a/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
@@ -29,10 +29,8 @@ import kafka.message.Message;
 import kafka.message.MessageAndOffset;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import storm.kafka.DynamicPartitionConnections;
-import storm.kafka.FailedFetchException;
-import storm.kafka.KafkaUtils;
-import storm.kafka.Partition;
+import storm.kafka.*;
+import storm.kafka.TopicOffsetOutOfRangeException;
 import storm.trident.operation.TridentCollector;
 import storm.trident.spout.IOpaquePartitionedTridentSpout;
 import storm.trident.spout.IPartitionedTridentSpout;
@@ -102,7 +100,7 @@ public class TridentKafkaEmitter {
             if (lastTopoMeta != null) {
                 lastInstanceId = (String) lastTopoMeta.get("id");
             }
-            if (_config.forceFromStart && !_topologyInstanceId.equals(lastInstanceId)) {
+            if (_config.ignoreZkOffsets && !_topologyInstanceId.equals(lastInstanceId)) {
                 offset = KafkaUtils.getOffset(consumer, _config.topic, partition.partition, _config.startOffsetTime);
             } else {
                 offset = (Long) lastMeta.get("nextOffset");
@@ -110,7 +108,17 @@ public class TridentKafkaEmitter {
         } else {
             offset = KafkaUtils.getOffset(consumer, _config.topic, partition.partition, _config);
         }
-        ByteBufferMessageSet msgs = fetchMessages(consumer, partition, offset);
+
+        ByteBufferMessageSet msgs = null;
+        try {
+            msgs = fetchMessages(consumer, partition, offset);
+        } catch (TopicOffsetOutOfRangeException e) {
+            long newOffset = KafkaUtils.getOffset(consumer, _config.topic, partition.partition, kafka.api.OffsetRequest.EarliestTime());
+            LOG.warn("OffsetOutOfRange: Updating offset from offset = " + offset + " to offset = " + newOffset);
+            offset = newOffset;
+            msgs = KafkaUtils.fetchMessages(_config, consumer, partition, offset);
+        }
+
         long endoffset = offset;
         for (MessageAndOffset msg : msgs) {
             emit(collector, msg.message());
@@ -129,7 +137,8 @@ public class TridentKafkaEmitter {
 
     private ByteBufferMessageSet fetchMessages(SimpleConsumer consumer, Partition partition, long offset) {
         long start = System.nanoTime();
-        ByteBufferMessageSet msgs = KafkaUtils.fetchMessages(_config, consumer, partition, offset);
+        ByteBufferMessageSet msgs = null;
+        msgs = KafkaUtils.fetchMessages(_config, consumer, partition, offset);
         long end = System.nanoTime();
         long millis = (end - start) / 1000000;
         _kafkaMeanFetchLatencyMetric.update(millis);
@@ -148,20 +157,24 @@ public class TridentKafkaEmitter {
     private void reEmitPartitionBatch(TransactionAttempt attempt, TridentCollector collector, Partition partition, Map meta) {
         LOG.info("re-emitting batch, attempt " + attempt);
         String instanceId = (String) meta.get("instanceId");
-        if (!_config.forceFromStart || instanceId.equals(_topologyInstanceId)) {
+        if (!_config.ignoreZkOffsets || instanceId.equals(_topologyInstanceId)) {
             SimpleConsumer consumer = _connections.register(partition);
             long offset = (Long) meta.get("offset");
             long nextOffset = (Long) meta.get("nextOffset");
-            ByteBufferMessageSet msgs = fetchMessages(consumer, partition, offset);
-            for (MessageAndOffset msg : msgs) {
-                if (offset == nextOffset) {
-                    break;
+            ByteBufferMessageSet msgs = null;
+            msgs = fetchMessages(consumer, partition, offset);
+
+            if(msgs != null) {
+                for (MessageAndOffset msg : msgs) {
+                    if (offset == nextOffset) {
+                        break;
+                    }
+                    if (offset > nextOffset) {
+                        throw new RuntimeException("Error when re-emitting batch. overshot the end offset");
+                    }
+                    emit(collector, msg.message());
+                    offset = msg.nextOffset();
                 }
-                if (offset > nextOffset) {
-                    throw new RuntimeException("Error when re-emitting batch. overshot the end offset");
-                }
-                emit(collector, msg.message());
-                offset = msg.nextOffset();
             }
         }
     }

--- a/external/storm-kafka/src/test/storm/kafka/DynamicBrokersReaderTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/DynamicBrokersReaderTest.java
@@ -170,4 +170,17 @@ public class DynamicBrokersReaderTest {
         assertEquals(newPort, brokerInfo.getBrokerFor(partition).port);
         assertEquals(newHost, brokerInfo.getBrokerFor(partition).host);
     }
+
+    @Test(expected = NullPointerException.class)
+    public void testErrorLogsWhenConfigIsMissing() throws Exception {
+        String connectionString = server.getConnectString();
+        Map conf = new HashMap();
+        conf.put(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT, 1000);
+//        conf.put(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT, 1000);
+        conf.put(Config.STORM_ZOOKEEPER_RETRY_TIMES, 4);
+        conf.put(Config.STORM_ZOOKEEPER_RETRY_INTERVAL, 5);
+
+        DynamicBrokersReader dynamicBrokersReader1 = new DynamicBrokersReader(conf, connectionString, masterPath, topic);
+
+    }
 }

--- a/external/storm-kafka/src/test/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
@@ -1,0 +1,194 @@
+package storm.kafka;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class ExponentialBackoffMsgRetryManagerTest {
+
+    private static final Long TEST_OFFSET = 101L;
+    private static final Long TEST_OFFSET2 = 102L;
+
+    @Test
+    public void testImmediateRetry() throws Exception {
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(0, 0d, 0, 100);
+        manager.failed(TEST_OFFSET);
+        Long next = manager.nextFailedMessageToRetry();
+        assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
+        assertTrue("message should be ready for retry immediately", manager.shouldRetryMsg(TEST_OFFSET));
+
+        manager.retryStarted(TEST_OFFSET);
+
+        manager.failed(TEST_OFFSET);
+        next = manager.nextFailedMessageToRetry();
+        assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
+        assertTrue("message should be ready for retry immediately", manager.shouldRetryMsg(TEST_OFFSET));
+    }
+
+    @Test
+    public void testSingleDelay() throws Exception {
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(10, 1d, 100, 100);
+        manager.failed(TEST_OFFSET);
+        Thread.sleep(5);
+        Long next = manager.nextFailedMessageToRetry();
+        assertNull("expect no message ready for retry yet", next);
+        assertFalse("message should not be ready for retry yet", manager.shouldRetryMsg(TEST_OFFSET));
+
+        Thread.sleep(10);
+        next = manager.nextFailedMessageToRetry();
+        assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
+        assertTrue("message should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
+    }
+
+    @Test
+    public void testExponentialBackoff() throws Exception {
+        final long initial = 10;
+        final double mult = 2d;
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(initial, mult, initial * 10, 100);
+
+        long expectedWaitTime = initial;
+        for (long i = 0L; i < 3L; ++i) {
+            manager.failed(TEST_OFFSET);
+
+            Thread.sleep((expectedWaitTime + 1L) / 2L);
+            assertFalse("message should not be ready for retry yet", manager.shouldRetryMsg(TEST_OFFSET));
+
+            Thread.sleep((expectedWaitTime + 1L) / 2L);
+            Long next = manager.nextFailedMessageToRetry();
+            assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
+            assertTrue("message should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
+
+            manager.retryStarted(TEST_OFFSET);
+            expectedWaitTime *= mult;
+        }
+    }
+
+    @Test
+    public void testRetryOrder() throws Exception {
+        final long initial = 10;
+        final double mult = 2d;
+        final long max = 20;
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(initial, mult, max, 100);
+
+        manager.failed(TEST_OFFSET);
+        Thread.sleep(initial);
+
+        manager.retryStarted(TEST_OFFSET);
+        manager.failed(TEST_OFFSET);
+        manager.failed(TEST_OFFSET2);
+
+        // although TEST_OFFSET failed first, it's retry delay time is longer b/c this is the second retry
+        // so TEST_OFFSET2 should come first
+
+        Thread.sleep(initial * 2);
+        assertTrue("message "+TEST_OFFSET+"should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
+        assertTrue("message "+TEST_OFFSET2+"should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET2));
+
+        Long next = manager.nextFailedMessageToRetry();
+        assertEquals("expect first message to retry is "+TEST_OFFSET2, TEST_OFFSET2, next);
+
+        Thread.sleep(initial);
+
+        // haven't retried yet, so first should still be TEST_OFFSET2
+        next = manager.nextFailedMessageToRetry();
+        assertEquals("expect first message to retry is "+TEST_OFFSET2, TEST_OFFSET2, next);
+        manager.retryStarted(next);
+
+        // now it should be TEST_OFFSET
+        next = manager.nextFailedMessageToRetry();
+        assertEquals("expect message to retry is now "+TEST_OFFSET, TEST_OFFSET, next);
+        manager.retryStarted(next);
+
+        // now none left
+        next = manager.nextFailedMessageToRetry();
+        assertNull("expect no message to retry now", next);
+    }
+
+    @Test
+    public void testQueriesAfterRetriedAlready() throws Exception {
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(0, 0d, 0, 100);
+        manager.failed(TEST_OFFSET);
+        Long next = manager.nextFailedMessageToRetry();
+        assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
+        assertTrue("message should be ready for retry immediately", manager.shouldRetryMsg(TEST_OFFSET));
+
+        manager.retryStarted(TEST_OFFSET);
+        next = manager.nextFailedMessageToRetry();
+        assertNull("expect no message ready after retried", next);
+        assertFalse("message should not be ready after retried", manager.shouldRetryMsg(TEST_OFFSET));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRetryWithoutFail() throws Exception {
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(0, 0d, 0, 100);
+        manager.retryStarted(TEST_OFFSET);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testFailRetryRetry() throws Exception {
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(0, 0d, 0, 100);
+        manager.failed(TEST_OFFSET);
+        try {
+            manager.retryStarted(TEST_OFFSET);
+        } catch (IllegalStateException ise) {
+            fail("IllegalStateException unexpected here: " + ise);
+        }
+
+        assertFalse("message should not be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
+        manager.retryStarted(TEST_OFFSET);
+    }
+
+    @Test
+    public void testMaxBackoff() throws Exception {
+        final long initial = 10;
+        final double mult = 2d;
+        final long max = 20;
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(initial, mult, max, 100);
+
+        long expectedWaitTime = initial;
+        for (long i = 0L; i < 4L; ++i) {
+            manager.failed(TEST_OFFSET);
+
+            Thread.sleep((expectedWaitTime + 1L) / 2L);
+            assertFalse("message should not be ready for retry yet", manager.shouldRetryMsg(TEST_OFFSET));
+
+            Thread.sleep((expectedWaitTime + 1L) / 2L);
+            Long next = manager.nextFailedMessageToRetry();
+            assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
+            assertTrue("message should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
+
+            manager.retryStarted(TEST_OFFSET);
+            expectedWaitTime = Math.min((long) (expectedWaitTime * mult), max);
+        }
+    }
+
+    @Test
+    public void testFailThenAck() throws Exception {
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(0, 0d, 0, 100);
+        manager.failed(TEST_OFFSET);
+        assertTrue("message should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
+
+        manager.acked(TEST_OFFSET);
+
+        Long next = manager.nextFailedMessageToRetry();
+        assertNull("expect no message ready after acked", next);
+        assertFalse("message should not be ready after acked", manager.shouldRetryMsg(TEST_OFFSET));
+    }
+
+    @Test
+    public void testAckThenFail() throws Exception {
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(0, 0d, 0, 100);
+        manager.acked(TEST_OFFSET);
+        assertFalse("message should not be ready after acked", manager.shouldRetryMsg(TEST_OFFSET));
+
+        manager.failed(TEST_OFFSET);
+
+        Long next = manager.nextFailedMessageToRetry();
+        assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
+        assertTrue("message should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
+    }
+}

--- a/external/storm-kafka/src/test/storm/kafka/KafkaUtilsTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/KafkaUtilsTest.java
@@ -99,7 +99,7 @@ public class KafkaUtilsTest {
                 new Partition(Broker.fromString(broker.getBrokerConnectionString()), 0), -99);
     }
 
-    @Test(expected = UpdateOffsetException.class)
+    @Test(expected = TopicOffsetOutOfRangeException.class)
     public void fetchMessagesWithInvalidOffsetAndDefaultHandlingEnabled() throws Exception {
         config = new KafkaConfig(brokerHosts, "newTopic");
         String value = "test";
@@ -110,17 +110,17 @@ public class KafkaUtilsTest {
 
     @Test
     public void getOffsetFromConfigAndDontForceFromStart() {
-        config.forceFromStart = false;
+        config.ignoreZkOffsets = false;
         config.startOffsetTime = OffsetRequest.EarliestTime();
         createTopicAndSendMessage();
-        long latestOffset = KafkaUtils.getOffset(simpleConsumer, config.topic, 0, OffsetRequest.LatestTime());
+        long latestOffset = KafkaUtils.getOffset(simpleConsumer, config.topic, 0, OffsetRequest.EarliestTime());
         long offsetFromConfig = KafkaUtils.getOffset(simpleConsumer, config.topic, 0, config);
         assertThat(latestOffset, is(equalTo(offsetFromConfig)));
     }
 
     @Test
     public void getOffsetFromConfigAndFroceFromStart() {
-        config.forceFromStart = true;
+        config.ignoreZkOffsets = true;
         config.startOffsetTime = OffsetRequest.EarliestTime();
         createTopicAndSendMessage();
         long earliestOffset = KafkaUtils.getOffset(simpleConsumer, config.topic, 0, OffsetRequest.EarliestTime());

--- a/external/storm-kafka/src/test/storm/kafka/ZkCoordinatorTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/ZkCoordinatorTest.java
@@ -59,7 +59,7 @@ public class ZkCoordinatorTest {
         hosts.refreshFreqSecs = 1;
         spoutConfig = new SpoutConfig(hosts, "topic", "/test", "id");
         Map conf = buildZookeeperConfig(server);
-        state = new ZkState(conf);
+        state = new ZkState("storm", conf);
         simpleConsumer = new SimpleConsumer("localhost", broker.getPort(), 60000, 1024, "testClient");
         when(dynamicPartitionConnections.register(any(Broker.class), anyInt())).thenReturn(simpleConsumer);
     }

--- a/external/storm-kafka/src/test/storm/kafka/bolt/KafkaBoltTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/bolt/KafkaBoltTest.java
@@ -18,6 +18,7 @@
 package storm.kafka.bolt;
 
 import backtype.storm.Config;
+import backtype.storm.Constants;
 import backtype.storm.task.GeneralTopologyContext;
 import backtype.storm.task.IOutputCollector;
 import backtype.storm.task.OutputCollector;
@@ -26,6 +27,7 @@ import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Tuple;
 import backtype.storm.tuple.TupleImpl;
 import backtype.storm.tuple.Values;
+import backtype.storm.utils.TupleUtils;
 import backtype.storm.utils.Utils;
 import kafka.api.OffsetRequest;
 import kafka.javaapi.consumer.SimpleConsumer;
@@ -45,7 +47,10 @@ import java.util.HashMap;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class KafkaBoltTest {
 
@@ -81,6 +86,18 @@ public class KafkaBoltTest {
         BrokerHosts brokerHosts = new StaticHosts(globalPartitionInformation);
         kafkaConfig = new KafkaConfig(brokerHosts, TEST_TOPIC);
         simpleConsumer = new SimpleConsumer("localhost", broker.getPort(), 60000, 1024, "testClient");
+    }
+
+    @Test
+    public void shouldAcknowledgeTickTuples() throws Exception {
+        // Given
+        Tuple tickTuple = mockTickTuple();
+
+        // When
+        bolt.execute(tickTuple);
+
+        // Then
+        verify(collector).ack(tickTuple);
     }
 
     @Test
@@ -143,7 +160,7 @@ public class KafkaBoltTest {
         String message = "value-234";
         Tuple tuple = generateTestTuple(message);
         bolt.execute(tuple);
-        verify(collector).ack(tuple);
+        verify(collector).fail(tuple);
     }
 
 
@@ -185,4 +202,14 @@ public class KafkaBoltTest {
         };
         return new TupleImpl(topologyContext, new Values(message), 1, "");
     }
+
+    private Tuple mockTickTuple() {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getSourceComponent()).thenReturn(Constants.SYSTEM_COMPONENT_ID);
+        when(tuple.getSourceStreamId()).thenReturn(Constants.SYSTEM_TICK_STREAM_ID);
+        // Sanity check
+        assertTrue(TupleUtils.isTick(tuple));
+        return tuple;
+    }
+
 }

--- a/external/storm-kafka/src/test/storm/kafka/bolt/KafkaBoltTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/bolt/KafkaBoltTest.java
@@ -27,7 +27,7 @@ import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Tuple;
 import backtype.storm.tuple.TupleImpl;
 import backtype.storm.tuple.Values;
-import backtype.storm.utils.TupleUtils;
+//import backtype.storm.utils.TupleUtils;
 import backtype.storm.utils.Utils;
 import kafka.api.OffsetRequest;
 import kafka.javaapi.consumer.SimpleConsumer;
@@ -208,8 +208,12 @@ public class KafkaBoltTest {
         when(tuple.getSourceComponent()).thenReturn(Constants.SYSTEM_COMPONENT_ID);
         when(tuple.getSourceStreamId()).thenReturn(Constants.SYSTEM_TICK_STREAM_ID);
         // Sanity check
-        assertTrue(TupleUtils.isTick(tuple));
+        assertTrue(isTickTuple(tuple));
         return tuple;
+    }
+
+    private boolean isTickTuple(Tuple tuple) {
+        return tuple.getSourceComponent().equals(Constants.SYSTEM_COMPONENT_ID) && tuple.getSourceStreamId().equals(Constants.SYSTEM_TICK_STREAM_ID);
     }
 
 }


### PR DESCRIPTION
This pull request offers plugable MessageFailureHandler for failed message.

Solution structure. 
PartitionManger uses instance of class that implements IMassageFailureHandler interface for failure handling.
For instance creation it uses factory object stored in MessageFailureHandlerFactoryRepository.
  
This request provides 2 implementations for IMessageFailureHanlder: 
- DefaultFailureHandler repeats current KafkaSpout behaviour
- ConfigurableRetriesFailureHandler enables possibility to configure number of retires per message.

There is also one implementation of IMessageFailureHandlerFactory: MessageFailureHandlerDefaultFactory that provides possibility to create either  DefaultFailureHandler or ConfigurableRetriesFailureHandler.

By default, if nobody filled MessageFailureHandlerFactoryRepository, it returns MessageFailureHandlerDefaultFactory object that creates DefaultFailureHandler object.
