### PR TITLE
[STORM-653] missing DRPC HTTP port in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,7 @@ IPsec to encrypt all traffic being sent between the hosts in the cluster.
 | 8000 | `logviewer.port` | Client Web Browsers | Logviewer |
 | 3772 | `drpc.port` | External DRPC Clients | DRPC |
 | 3773 | `drpc.invocations.port` | Worker Processes | DRPC |
+| 3774 | `drpc.http.port` | External HTTP DRPC Clients | DRPC |
 | 670{0,1,2,3} | `supervisor.slots.ports` | Worker Processes | Worker Processes |
 
 ### UI/Logviewer


### PR DESCRIPTION
There is no description about DRPC HTTP port in SECURITY.md.
This port is used by DRPC Client as default 3774