### PR TITLE
[STORM-663] Create javadocs for BoltDeclarer

### DIFF
--- a/storm-core/src/jvm/backtype/storm/topology/BoltDeclarer.java
+++ b/storm-core/src/jvm/backtype/storm/topology/BoltDeclarer.java
@@ -17,6 +17,10 @@
  */
 package backtype.storm.topology;
 
+/**
+ * BoltDeclarer includes grouping APIs for storm topology.
+ * @see <a href="https://storm.apache.org/documentation/Concepts.html">Concepts -Stream groupings-</a>
+ */
 public interface BoltDeclarer extends InputDeclarer<BoltDeclarer>, ComponentConfigurationDeclarer<BoltDeclarer> {
     
 }

--- a/storm-core/src/jvm/backtype/storm/topology/InputDeclarer.java
+++ b/storm-core/src/jvm/backtype/storm/topology/InputDeclarer.java
@@ -24,31 +24,159 @@ import backtype.storm.tuple.Fields;
 
 
 public interface InputDeclarer<T extends InputDeclarer> {
+    /**
+     * The stream is partitioned by the fields specified in the grouping.
+     * @param componentId
+     * @param fields
+     * @return
+     */
     public T fieldsGrouping(String componentId, Fields fields);
+
+    /**
+     * The stream is partitioned by the fields specified in the grouping.
+     * @param componentId
+     * @param streamId
+     * @param fields
+     * @return
+     */
     public T fieldsGrouping(String componentId, String streamId, Fields fields);
 
+    /**
+     * The entire stream goes to a single one of the bolt's tasks.
+     * Specifically, it goes to the task with the lowest id.
+     * @param componentId
+     * @return
+     */
     public T globalGrouping(String componentId);
+
+    /**
+     * The entire stream goes to a single one of the bolt's tasks.
+     * Specifically, it goes to the task with the lowest id.
+     * @param componentId
+     * @param streamId
+     * @return
+     */
     public T globalGrouping(String componentId, String streamId);
 
+    /**
+     * Tuples are randomly distributed across the bolt's tasks in a way such that
+     * each bolt is guaranteed to get an equal number of tuples.
+     * @param componentId
+     * @return
+     */
     public T shuffleGrouping(String componentId);
+
+    /**
+     * Tuples are randomly distributed across the bolt's tasks in a way such that
+     * each bolt is guaranteed to get an equal number of tuples.
+     * @param componentId
+     * @param streamId
+     * @return
+     */
     public T shuffleGrouping(String componentId, String streamId);
 
+    /**
+     * If the target bolt has one or more tasks in the same worker process,
+     * tuples will be shuffled to just those in-process tasks.
+     * Otherwise, this acts like a normal shuffle grouping.
+     * @param componentId
+     * @return
+     */
     public T localOrShuffleGrouping(String componentId);
+
+    /**
+     * If the target bolt has one or more tasks in the same worker process,
+     * tuples will be shuffled to just those in-process tasks.
+     * Otherwise, this acts like a normal shuffle grouping.
+     * @param componentId
+     * @param streamId
+     * @return
+     */
     public T localOrShuffleGrouping(String componentId, String streamId);
 
+    /**
+     * This grouping specifies that you don't care how the stream is grouped.
+     * @param componentId
+     * @return
+     */
     public T noneGrouping(String componentId);
+
+    /**
+     * This grouping specifies that you don't care how the stream is grouped.
+     * @param componentId
+     * @param streamId
+     * @return
+     */
     public T noneGrouping(String componentId, String streamId);
 
+    /**
+     * The stream is replicated across all the bolt's tasks. Use this grouping with care.
+     * @param componentId
+     * @return
+     */
     public T allGrouping(String componentId);
+
+    /**
+     * The stream is replicated across all the bolt's tasks. Use this grouping with care.
+     * @param componentId
+     * @param streamId
+     * @return
+     */
     public T allGrouping(String componentId, String streamId);
 
+    /**
+     * A stream grouped this way means that the producer of the tuple decides
+     * which task of the consumer will receive this tuple.
+     * @param componentId
+     * @return
+     */
     public T directGrouping(String componentId);
+
+    /**
+     * A stream grouped this way means that the producer of the tuple decides
+     * which task of the consumer will receive this tuple.
+     * @param componentId
+     * @param streamId
+     * @return
+     */
     public T directGrouping(String componentId, String streamId);
 
+    /**
+     * Tuples are passed to two hashing functions and each target task is
+     * decided based on the comparison of the state of candidate nodes.
+     * @see   https://melmeric.files.wordpress.com/2014/11/the-power-of-both-choices-practical-load-balancing-for-distributed-stream-processing-engines.pdf
+     * @param componentId
+     * @param fields
+     * @return
+     */
     public T partialKeyGrouping(String componentId, Fields fields);
+
+    /**
+     * Tuples are passed to two hashing functions and each target task is
+     * decided based on the comparison of the state of candidate nodes.
+     * @see   https://melmeric.files.wordpress.com/2014/11/the-power-of-both-choices-practical-load-balancing-for-distributed-stream-processing-engines.pdf
+     * @param componentId
+     * @param streamId
+     * @param fields
+     * @return
+     */
     public T partialKeyGrouping(String componentId, String streamId, Fields fields);
 
+    /**
+     * A custom stream grouping by implementing the CustomStreamGrouping interface.
+     * @param componentId
+     * @param grouping
+     * @return
+     */
     public T customGrouping(String componentId, CustomStreamGrouping grouping);
+
+    /**
+     * A custom stream grouping by implementing the CustomStreamGrouping interface.
+     * @param componentId
+     * @param streamId
+     * @param grouping
+     * @return
+     */
     public T customGrouping(String componentId, String streamId, CustomStreamGrouping grouping);
     
     public T grouping(GlobalStreamId id, Grouping grouping);


### PR DESCRIPTION
Add a link to stream grouping for BoltDeclarer which define the API of grouping.
And more specific explanation about grouping API to javadoc.