### PR TITLE
STORM-670: restore java 1.6 compatibility (storm-kafka)

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManager.java
@@ -156,7 +156,7 @@ public class ExponentialBackoffMsgRetryManager implements FailedMsgRetryManager 
 
         @Override
         public int compare(MessageRetryRecord record1, MessageRetryRecord record2) {
-            return Long.compare(record1.retryTimeUTC, record2.retryTimeUTC);
+            return Long.valueOf(record1.retryTimeUTC).compareTo(Long.valueOf(record2.retryTimeUTC));
         }
 
         @Override


### PR DESCRIPTION
Not sure how long we want to cling to 1.6 compatibility, but this is a very small change.