### PR TITLE
STORM-702: Exhibitor support

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -35,6 +35,8 @@ storm.zookeeper.retry.interval: 1000
 storm.zookeeper.retry.intervalceiling.millis: 30000
 storm.zookeeper.auth.user: null
 storm.zookeeper.auth.password: null
+storm.exhibitor.port: 8080
+storm.exhibitor.poll.uripath: "/exhibitor/v1/cluster/list"
 storm.cluster.mode: "distributed" # can be distributed or local
 storm.local.mode.zmq: false
 storm.thrift.transport: "backtype.storm.security.auth.SimpleTransportPlugin"

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -156,14 +156,15 @@ public class Config extends HashMap<String, Object> {
      * A list of hosts of Exhibitor servers used to discover/maintain connection to ZooKeeper cluster.
      * Any configured ZooKeeper servers will be used for the curator/exhibitor backup connection string.
      */
+    @isStringList
     public static final String STORM_EXHIBITOR_SERVERS = "storm.exhibitor.servers";
-    public static final Object STORM_EXHIBITOR_SERVERS_SCHEMA = ConfigValidation.StringsValidator;
 
     /**
      * The port Storm will use to connect to each of the exhibitor servers.
      */
+    @isInteger
+    @isPositiveNumber
     public static final String STORM_EXHIBITOR_PORT = "storm.exhibitor.port";
-    public static final Object STORM_EXHIBITOR_PORT_SCHEMA = ConfigValidation.IntegerValidator;
 
     /**
      * A directory on the local filesystem used by Storm for any local
@@ -358,32 +359,32 @@ public class Config extends HashMap<String, Object> {
     /*
      * How often to poll Exhibitor cluster in millis.
      */
+    @isString
     public static final String STORM_EXHIBITOR_URIPATH="storm.exhibitor.poll.uripath";
-    public static final Object STORM_EXHIBITOR_URIPATH_SCHEMA = String.class;
 
     /**
      * How often to poll Exhibitor cluster in millis.
      */
+    @isInteger
     public static final String STORM_EXHIBITOR_POLL="storm.exhibitor.poll.millis";
-    public static final Object STORM_EXHIBITOR_POLL_SCHEMA = ConfigValidation.IntegerValidator;
 
     /**
      * The number of times to retry an Exhibitor operation.
      */
+    @isInteger
     public static final String STORM_EXHIBITOR_RETRY_TIMES="storm.exhibitor.retry.times";
-    public static final Object STORM_EXHIBITOR_RETRY_TIMES_SCHEMA = ConfigValidation.IntegerValidator;
 
     /**
      * The interval between retries of an Exhibitor operation.
      */
+    @isInteger
     public static final String STORM_EXHIBITOR_RETRY_INTERVAL="storm.exhibitor.retry.interval";
-    public static final Object STORM_EXHIBITOR_RETRY_INTERVAL_SCHEMA = ConfigValidation.IntegerValidator;
 
     /**
      * The ceiling of the interval between retries of an Exhibitor operation.
      */
+    @isInteger
     public static final String STORM_EXHIBITOR_RETRY_INTERVAL_CEILING="storm.exhibitor.retry.intervalceiling.millis";
-    public static final Object STORM_EXHIBITOR_RETRY_INTERVAL_CEILING_SCHEMA = ConfigValidation.IntegerValidator;
 
     /**
      * The id assigned to a running topology. The id is the storm name with a unique nonce appended.

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -153,6 +153,19 @@ public class Config extends HashMap<String, Object> {
     public static final String STORM_ZOOKEEPER_PORT = "storm.zookeeper.port";
 
     /**
+     * A list of hosts of Exhibitor servers used to discover/maintain connection to ZooKeeper cluster.
+     * Any configured ZooKeeper servers will be used for the curator/exhibitor backup connection string.
+     */
+    public static final String STORM_EXHIBITOR_SERVERS = "storm.exhibitor.servers";
+    public static final Object STORM_EXHIBITOR_SERVERS_SCHEMA = ConfigValidation.StringsValidator;
+
+    /**
+     * The port Storm will use to connect to each of the exhibitor servers.
+     */
+    public static final String STORM_EXHIBITOR_PORT = "storm.exhibitor.port";
+    public static final Object STORM_EXHIBITOR_PORT_SCHEMA = ConfigValidation.IntegerValidator;
+
+    /**
      * A directory on the local filesystem used by Storm for any local
      * filesystem usage it needs. The directory must exist and the Storm daemons must
      * have permission to read/write from this location.
@@ -341,6 +354,36 @@ public class Config extends HashMap<String, Object> {
      */
     @isString
     public static final String STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD="storm.zookeeper.topology.auth.payload";
+
+    /*
+     * How often to poll Exhibitor cluster in millis.
+     */
+    public static final String STORM_EXHIBITOR_URIPATH="storm.exhibitor.poll.uripath";
+    public static final Object STORM_EXHIBITOR_URIPATH_SCHEMA = String.class;
+
+    /**
+     * How often to poll Exhibitor cluster in millis.
+     */
+    public static final String STORM_EXHIBITOR_POLL="storm.exhibitor.poll.millis";
+    public static final Object STORM_EXHIBITOR_POLL_SCHEMA = ConfigValidation.IntegerValidator;
+
+    /**
+     * The number of times to retry an Exhibitor operation.
+     */
+    public static final String STORM_EXHIBITOR_RETRY_TIMES="storm.exhibitor.retry.times";
+    public static final Object STORM_EXHIBITOR_RETRY_TIMES_SCHEMA = ConfigValidation.IntegerValidator;
+
+    /**
+     * The interval between retries of an Exhibitor operation.
+     */
+    public static final String STORM_EXHIBITOR_RETRY_INTERVAL="storm.exhibitor.retry.interval";
+    public static final Object STORM_EXHIBITOR_RETRY_INTERVAL_SCHEMA = ConfigValidation.IntegerValidator;
+
+    /**
+     * The ceiling of the interval between retries of an Exhibitor operation.
+     */
+    public static final String STORM_EXHIBITOR_RETRY_INTERVAL_CEILING="storm.exhibitor.retry.intervalceiling.millis";
+    public static final Object STORM_EXHIBITOR_RETRY_INTERVAL_CEILING_SCHEMA = ConfigValidation.IntegerValidator;
 
     /**
      * The id assigned to a running topology. The id is the storm name with a unique nonce appended.

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -35,6 +35,25 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.input.ClassLoaderObjectInputStream;
 import org.apache.commons.lang.StringUtils;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.*;
+
+import org.apache.curator.ensemble.exhibitor.DefaultExhibitorRestClient;
+import org.apache.curator.ensemble.exhibitor.ExhibitorEnsembleProvider;
+import org.apache.curator.ensemble.exhibitor.Exhibitors;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.thrift.TBase;
@@ -621,6 +640,22 @@ public class Utils {
         throw new IllegalArgumentException("Could not find component with id " + id);
     }
 
+    public static List<String> getStrings(final Object o) {
+        if (o == null) {
+            return Collections.emptyList();
+        } else if (o instanceof String) {
+            return new ArrayList<String>() {{ add((String) o); }};
+        } else if (o instanceof Collection) {
+            List<String> answer = new ArrayList<String>();
+            for (Object v : (Collection) o) {
+                answer.add(v.toString());
+            }
+            return answer;
+        } else {
+            throw new IllegalArgumentException("Don't know how to convert to string list");
+        }
+    }
+
     public static Integer getInt(Object o) {
         Integer result = getInt(o, null);
         if (null == result) {
@@ -982,12 +1017,33 @@ public class Utils {
         return builder.build();
     }
 
-    protected static void setupBuilder(CuratorFrameworkFactory.Builder builder, String zkStr, Map conf, ZookeeperAuthInfo auth)
+    protected static void setupBuilder(CuratorFrameworkFactory.Builder builder, final String zkStr, Map conf, ZookeeperAuthInfo auth)
     {
-        builder.connectString(zkStr)
-                .connectionTimeoutMs(Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT)))
-                .sessionTimeoutMs(Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT)))
-                .retryPolicy(new StormBoundedExponentialBackoffRetry(
+        List<String> exhibitorServers = getStrings(conf.get(Config.STORM_EXHIBITOR_SERVERS));
+        if (!exhibitorServers.isEmpty()) {
+            // use exhibitor servers
+            builder.ensembleProvider(new ExhibitorEnsembleProvider(
+                new Exhibitors(exhibitorServers, Utils.getInt(conf.get(Config.STORM_EXHIBITOR_PORT), 8080),
+                    new Exhibitors.BackupConnectionStringProvider() {
+                        @Override
+                        public String getBackupConnectionString() throws Exception {
+                            // use zk servers as backup if they exist
+                            return zkStr;
+                        }}),
+                new DefaultExhibitorRestClient(),
+                (String) Utils.get(conf, Config.STORM_EXHIBITOR_URIPATH, "/exhibitor/v1/cluster/list"),
+                Utils.getInt(conf.get(Config.STORM_EXHIBITOR_POLL)),
+                new StormBoundedExponentialBackoffRetry(
+                    Utils.getInt(conf.get(Config.STORM_EXHIBITOR_RETRY_INTERVAL)),
+                    Utils.getInt(conf.get(Config.STORM_EXHIBITOR_RETRY_INTERVAL_CEILING)),
+                    Utils.getInt(conf.get(Config.STORM_EXHIBITOR_RETRY_TIMES)))));
+        } else {
+            builder.connectString(zkStr);
+        }
+        builder
+            .connectionTimeoutMs(Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT)))
+            .sessionTimeoutMs(Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT)))
+            .retryPolicy(new StormBoundedExponentialBackoffRetry(
                         Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_RETRY_INTERVAL)),
                         Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_RETRY_INTERVAL_CEILING)),
                         Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_RETRY_TIMES))));

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -61,8 +61,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,6 +69,35 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.Collection;
+import java.util.Collections;
+
+import backtype.storm.serialization.DefaultSerializationDelegate;
+import backtype.storm.serialization.SerializationDelegate;
+import org.apache.curator.ensemble.exhibitor.DefaultExhibitorRestClient;
+import org.apache.curator.ensemble.exhibitor.ExhibitorEnsembleProvider;
+import org.apache.curator.ensemble.exhibitor.Exhibitors;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.commons.lang.StringUtils;
+import org.apache.thrift.TException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Id;
+import org.json.simple.JSONValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+import backtype.storm.Config;
+import backtype.storm.generated.ComponentCommon;
+import backtype.storm.generated.ComponentObject;
+import backtype.storm.generated.StormTopology;
+import backtype.storm.generated.AuthorizationException;
+
+import clojure.lang.IFn;
+import clojure.lang.RT;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -634,7 +634,7 @@ public class Utils {
 
     public static List<String> getStrings(final Object o) {
         if (o == null) {
-            return Collections.emptyList();
+            return new ArrayList<String>();
         } else if (o instanceof String) {
             return new ArrayList<String>() {{ add((String) o); }};
         } else if (o instanceof Collection) {

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -49,7 +49,17 @@ import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.Collection;
+import java.util.Collections;
 
 import org.apache.curator.ensemble.exhibitor.DefaultExhibitorRestClient;
 import org.apache.curator.ensemble.exhibitor.ExhibitorEnsembleProvider;


### PR DESCRIPTION
This introduces optional exhibitor configuration properties to storm config--the options parallel the zookeeper options where relevant:

   storm.exhibitor.servers:
      - "localhost"
   storm.exhibitor.port: 8080
   storm.exhibitor.poll.millis: 1000
   storm.exhibitor.retry.times: 5
   storm.exhibitor.retry.interval: 1000
   storm.exhibitor.retry.intervalceiling.millis: 30000

If exhibitor.servers are not provided, the behavior of storm is identical to prior. If exhibitor.servers are provided then the curator connection uses exhibitor, using any configured zookeeper.servers for the curator-exhibitor backup connection string.

I've tested this locally, will be deploying this patch in coming weeks in my own production environment/s.