### PR TITLE
Update "get-task-object" function, change the type of first param "topology" from ^TopologyContext to ^StormTopology.(JIRA [STORM-554])

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/task.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/task.clj
@@ -18,7 +18,7 @@
   (:use [backtype.storm bootstrap])
   (:import [backtype.storm.hooks ITaskHook])
   (:import [backtype.storm.tuple Tuple])
-  (:import [backtype.storm.generated SpoutSpec Bolt StateSpoutSpec])
+  (:import [backtype.storm.generated SpoutSpec Bolt StateSpoutSpec StormTopology])
   (:import [backtype.storm.hooks.info SpoutAckInfo SpoutFailInfo
             EmitInfo BoltFailInfo BoltAckInfo])
   (:require [backtype.storm [tuple :as tuple]])

--- a/storm-core/src/clj/backtype/storm/daemon/task.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/task.clj
@@ -61,7 +61,7 @@
     (:topology worker))
    tid))
 
-(defn- get-task-object [^TopologyContext topology component-id]
+(defn- get-task-object [^StormTopology topology component-id]
   (let [spouts (.get_spouts topology)
         bolts (.get_bolts topology)
         state-spouts (.get_state_spouts topology)


### PR DESCRIPTION
Update "get-task-object" function, change the type of first param "topology" from ^TopologyContext to ^StormTopology. the "get-task-object" function in task.clj,the type of first param "topology" should be ^StormTopology not ^TopologyContext.

the "get-task-object" is called by "mk-task-data" function in task.clj, "mk-task-data" is defined as following:

(defn mk-task-data [executor-data task-id]
  (recursive-map
    :executor-data executor-data
    :task-id task-id
    :system-context (system-topology-context (:worker executor-data) executor-data task-id)
    :user-context (user-topology-context (:worker executor-data) executor-data task-id)
    :builtin-metrics (builtin-metrics/make-data (:type executor-data))
    :tasks-fn (mk-tasks-fn <>)
    :object (get-task-object (.getRawTopology ^TopologyContext (:system-context <>)) (:component-id executor-data))))

(:system-context <>) return TopologyContext instance, TopologyContext extends GeneralTopologyContext, the TopologyContext instance has StormTopology _topology. “getRawTopology” method of TopologyContext must return StormTopology _topology. (.getRawTopology ^TopologyContext (:system-context <>) return StormTopology instance not TopologyContext instance. so the type of param topology is StormTopology not TopologyContext.

at the same time, "get-task-object" call "get_spouts" and "get_bolts" of the param topology. you can find the "get_spouts" and "get_bolts" function are only defined in StormTopology, and StormTopology is not a subclass of TopologyContext. so i think the type of param topology is StormTopology not TopologyContext.