### PR TITLE
STORM-680: storm-kafka fails to compile with JDK 1.6

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManager.java
@@ -156,7 +156,7 @@ public class ExponentialBackoffMsgRetryManager implements FailedMsgRetryManager 
 
         @Override
         public int compare(MessageRetryRecord record1, MessageRetryRecord record2) {
-            return Long.compare(record1.retryTimeUTC, record2.retryTimeUTC);
+            return Long.valueOf(record1.retryTimeUTC).compareTo(record2.retryTimeUTC);
         }
 
         @Override


### PR DESCRIPTION
Replaced Long.compare() method of JDK 7 with compareTo() method of JDK 6.