### PR TITLE
STORM-694: java.lang.ClassNotFoundException: backtype.storm.daemon.common.SupervisorInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
  * STORM-683: Make false in a conf really evaluate to false in clojure.
  * STORM-685: wrong output in log when committed offset is too far behind latest offset
  * STORM-688: update Util to compile under JDK8
+ * STORM-687: Storm UI does not display up to date information despite refreshes in IE
 
 ## 0.9.3-rc2
  * STORM-558: change "swap!" to "reset!" to fix assignment-versions in supervisor


### PR DESCRIPTION
Exception in thread "main" java.lang.ClassNotFoundException: backtype.storm.daemon.common.SupervisorInfo, compiling:(supervisor.clj:16:1)
