### PR TITLE
[STORM-696] Single Namespace Test Launching

### DIFF
--- a/dev-tools/test-ns.py
+++ b/dev-tools/test-ns.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from subprocess import Popen, PIPE
+import sys
+import os
+
+os.chdir("storm-core")
+
+ns = sys.argv[1]
+pipe = Popen(["mvn", "clojure:repl"], stdin=PIPE)
+
+pipe.stdin.write("(do (use 'clojure.test) (require '%s :reload-all) (run-tests '%s))\n" % (ns, ns))
+pipe.stdin.write("\n")
+pipe.stdin.close()
+pipe.wait()
+
+os.chdir("..")


### PR DESCRIPTION
Adding test-ns.py

test-ns.py accepts a single argument, the name of a test namespace to run. Run it from the storm project root.
```
~/storm $ dev-tools/test-ns.py backtype.storm.config-test

...

Ran 11 tests containing 52 assertions.
0 failures, 0 errors.
{:type :summary, :fail 0, :error 0, :pass 52, :test 11}
user=> Bye for now!
```