### PR TITLE
STORM-691 Add basic lookup / persist bolts

### DIFF
--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
@@ -20,10 +20,10 @@ package org.apache.storm.redis.bolt;
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.base.BaseRichBolt;
-import org.apache.storm.redis.util.config.JedisClusterConfig;
-import org.apache.storm.redis.util.config.JedisPoolConfig;
-import org.apache.storm.redis.util.container.JedisCommandsContainerBuilder;
-import org.apache.storm.redis.util.container.JedisCommandsInstanceContainer;
+import org.apache.storm.redis.common.config.JedisClusterConfig;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
+import org.apache.storm.redis.common.container.JedisCommandsContainerBuilder;
+import org.apache.storm.redis.common.container.JedisCommandsInstanceContainer;
 import redis.clients.jedis.JedisCommands;
 
 import java.util.Map;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisLookupBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisLookupBolt.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.redis.bolt;
+
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.tuple.Values;
+import org.apache.storm.redis.common.mapper.RedisDataTypeDescription;
+import org.apache.storm.redis.common.mapper.RedisLookupMapper;
+import org.apache.storm.redis.common.config.JedisClusterConfig;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
+import redis.clients.jedis.JedisCommands;
+
+import java.util.List;
+
+public class RedisLookupBolt extends AbstractRedisBolt {
+    private final RedisLookupMapper lookupMapper;
+    private final RedisDataTypeDescription.RedisDataType dataType;
+    private final String additionalKey;
+
+    public RedisLookupBolt(JedisPoolConfig config, RedisLookupMapper lookupMapper) {
+        super(config);
+
+        this.lookupMapper = lookupMapper;
+
+        RedisDataTypeDescription dataTypeDescription = lookupMapper.getDataTypeDescription();
+        this.dataType = dataTypeDescription.getDataType();
+        this.additionalKey = dataTypeDescription.getAdditionalKey();
+    }
+
+    public RedisLookupBolt(JedisClusterConfig config, RedisLookupMapper lookupMapper) {
+        super(config);
+
+        this.lookupMapper = lookupMapper;
+
+        RedisDataTypeDescription dataTypeDescription = lookupMapper.getDataTypeDescription();
+        this.dataType = dataTypeDescription.getDataType();
+        this.additionalKey = dataTypeDescription.getAdditionalKey();
+    }
+
+    @Override
+    public void execute(Tuple input) {
+        String key = lookupMapper.getKeyFromTuple(input);
+        Object lookupValue = null;
+
+        JedisCommands jedisCommand = null;
+        try {
+            jedisCommand = getInstance();
+
+            switch (dataType) {
+                case STRING:
+                    lookupValue = jedisCommand.get(key);
+                    break;
+
+                case LIST:
+                    lookupValue = jedisCommand.lpop(key);
+                    break;
+
+                case HASH:
+                    lookupValue = jedisCommand.hget(additionalKey, key);
+                    break;
+
+                case SET:
+                    lookupValue = jedisCommand.scard(key);
+                    break;
+
+                case SORTED_SET:
+                    lookupValue = jedisCommand.zscore(additionalKey, key);
+                    break;
+
+                case HYPER_LOG_LOG:
+                    lookupValue = jedisCommand.pfcount(key);
+                    break;
+            }
+
+            List<Values> values = lookupMapper.toTuple(input, lookupValue);
+            for (Values value : values) {
+                collector.emit(input, value);
+            }
+
+            collector.ack(input);
+        } catch (Exception e) {
+            this.collector.reportError(e);
+            this.collector.fail(input);
+        } finally {
+            returnInstance(jedisCommand);
+        }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        lookupMapper.declareOutputFields(declarer);
+    }
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisLookupBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisLookupBolt.java
@@ -86,6 +86,9 @@ public class RedisLookupBolt extends AbstractRedisBolt {
                 case HYPER_LOG_LOG:
                     lookupValue = jedisCommand.pfcount(key);
                     break;
+
+                default:
+                    throw new IllegalArgumentException("Cannot process such data type: " + dataType);
             }
 
             List<Values> values = lookupMapper.toTuple(input, lookupValue);

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisStoreBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisStoreBolt.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.redis.bolt;
+
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.tuple.Tuple;
+import org.apache.storm.redis.common.config.JedisClusterConfig;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
+import org.apache.storm.redis.common.mapper.RedisDataTypeDescription;
+import org.apache.storm.redis.common.mapper.RedisStoreMapper;
+import redis.clients.jedis.JedisCommands;
+
+public class RedisStoreBolt extends AbstractRedisBolt {
+    private final RedisStoreMapper storeMapper;
+    private final RedisDataTypeDescription.RedisDataType dataType;
+    private final String additionalKey;
+
+    public RedisStoreBolt(JedisPoolConfig config, RedisStoreMapper storeMapper) {
+        super(config);
+        this.storeMapper = storeMapper;
+
+        RedisDataTypeDescription dataTypeDescription = storeMapper.getDataTypeDescription();
+        this.dataType = dataTypeDescription.getDataType();
+        this.additionalKey = dataTypeDescription.getAdditionalKey();
+    }
+
+    public RedisStoreBolt(JedisClusterConfig config, RedisStoreMapper storeMapper) {
+        super(config);
+        this.storeMapper = storeMapper;
+
+        RedisDataTypeDescription dataTypeDescription = storeMapper.getDataTypeDescription();
+        this.dataType = dataTypeDescription.getDataType();
+        this.additionalKey = dataTypeDescription.getAdditionalKey();
+    }
+
+    @Override
+    public void execute(Tuple input) {
+        String key = storeMapper.getKeyFromTuple(input);
+        String value = storeMapper.getValueFromTuple(input);
+
+        JedisCommands jedisCommand = null;
+        try {
+            jedisCommand = getInstance();
+
+            switch (dataType) {
+                case STRING:
+                    jedisCommand.set(key, value);
+                    break;
+
+                case LIST:
+                    jedisCommand.rpush(key, value);
+                    break;
+
+                case HASH:
+                    jedisCommand.hset(additionalKey, key, value);
+                    break;
+
+                case SET:
+                    jedisCommand.sadd(key, value);
+                    break;
+
+                case SORTED_SET:
+                    jedisCommand.zadd(additionalKey, Double.valueOf(value), key);
+
+                case HYPER_LOG_LOG:
+                    jedisCommand.pfadd(key, value);
+                    break;
+            }
+
+            collector.ack(input);
+        } catch (Exception e) {
+            this.collector.reportError(e);
+            this.collector.fail(input);
+        } finally {
+            returnInstance(jedisCommand);
+        }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+    }
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisStoreBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisStoreBolt.java
@@ -80,6 +80,9 @@ public class RedisStoreBolt extends AbstractRedisBolt {
                 case HYPER_LOG_LOG:
                     jedisCommand.pfadd(key, value);
                     break;
+
+                default:
+                    throw new IllegalArgumentException("Cannot process such data type: " + dataType);
             }
 
             collector.ack(input);

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisClusterConfig.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisClusterConfig.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.redis.util.config;
+package org.apache.storm.redis.common.config;
 
 import com.google.common.base.Preconditions;
 import redis.clients.jedis.HostAndPort;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisPoolConfig.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisPoolConfig.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.redis.util.config;
+package org.apache.storm.redis.common.config;
 
 import redis.clients.jedis.Protocol;
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisClusterContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisClusterContainer.java
@@ -15,51 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.redis.util.container;
+package org.apache.storm.redis.common.container;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisCommands;
-import redis.clients.jedis.JedisPool;
 
 import java.io.Closeable;
-import java.io.IOException;
 
-public class JedisContainer implements JedisCommandsInstanceContainer, Closeable {
-    private static final Logger LOG = LoggerFactory.getLogger(JedisContainer.class);
+public class JedisClusterContainer implements JedisCommandsInstanceContainer, Closeable {
 
-    private JedisPool jedisPool;
+    private JedisCluster jedisCluster;
 
-    public JedisContainer(JedisPool jedisPool) {
-        this.jedisPool = jedisPool;
+    public JedisClusterContainer(JedisCluster jedisCluster) {
+        this.jedisCluster = jedisCluster;
     }
 
     @Override
     public JedisCommands getInstance() {
-        return jedisPool.getResource();
+        return this.jedisCluster;
     }
 
     @Override
     public void returnInstance(JedisCommands jedisCommands) {
-        if (jedisCommands == null) {
-            return;
-        }
-
-        try {
-            ((Closeable) jedisCommands).close();
-        } catch (IOException e) {
-            LOG.warn("Failed to close (return) instance to pool");
-            try {
-                jedisPool.returnBrokenResource((Jedis) jedisCommands);
-            } catch (Exception e2) {
-                LOG.error("Failed to discard instance from pool");
-            }
-        }
+        // do nothing
     }
 
     @Override
     public void close() {
-        jedisPool.close();
+        this.jedisCluster.close();
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsContainerBuilder.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsContainerBuilder.java
@@ -15,10 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.redis.util.container;
+package org.apache.storm.redis.common.container;
 
-import org.apache.storm.redis.util.config.JedisClusterConfig;
-import org.apache.storm.redis.util.config.JedisPoolConfig;
+import org.apache.storm.redis.common.config.JedisClusterConfig;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsInstanceContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsInstanceContainer.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.redis.util.container;
+package org.apache.storm.redis.common.container;
 
 import redis.clients.jedis.JedisCommands;
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisDataTypeDescription.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisDataTypeDescription.java
@@ -1,0 +1,33 @@
+package org.apache.storm.redis.common.mapper;
+
+import java.io.Serializable;
+
+public class RedisDataTypeDescription implements Serializable {
+    public enum RedisDataType { STRING, HASH, LIST, SET, SORTED_SET, HYPER_LOG_LOG }
+
+    private RedisDataType dataType;
+    private String additionalKey;
+
+    public RedisDataTypeDescription(RedisDataType dataType) {
+        this(dataType, null);
+    }
+
+    public RedisDataTypeDescription(RedisDataType dataType, String additionalKey) {
+        this.dataType = dataType;
+        this.additionalKey = additionalKey;
+
+        if (dataType == RedisDataType.HASH || dataType == RedisDataType.SORTED_SET) {
+            if (additionalKey == null) {
+                throw new IllegalArgumentException("Hash and Sorted Set should have additional key");
+            }
+        }
+    }
+
+    public RedisDataType getDataType() {
+        return dataType;
+    }
+
+    public String getAdditionalKey() {
+        return additionalKey;
+    }
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisDataTypeDescription.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisDataTypeDescription.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.storm.redis.common.mapper;
 
 import java.io.Serializable;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisLookupMapper.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisLookupMapper.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.redis.common.mapper;
+
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.tuple.ITuple;
+import backtype.storm.tuple.Values;
+
+import java.util.List;
+
+public interface RedisLookupMapper extends TupleMapper, RedisMapper {
+    /**
+     * Converts return value from Redis to a list of storm values that can be emitted.
+     * @param input the input tuple.
+     * @param value Redis query response value. Can be String, Boolean, Long regarding of data type.
+     * @return a List of storm values that can be emitted. Each item in list is emitted as an output tuple.
+     */
+    public List<Values> toTuple(ITuple input, Object value);
+
+    /**
+     * declare what are the fields that this code will output.
+     * @param declarer
+     */
+    void declareOutputFields(OutputFieldsDeclarer declarer);
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisMapper.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisMapper.java
@@ -1,0 +1,5 @@
+package org.apache.storm.redis.common.mapper;
+
+public interface RedisMapper {
+    public RedisDataTypeDescription getDataTypeDescription();
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisMapper.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisMapper.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.storm.redis.common.mapper;
 
 public interface RedisMapper {

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisStoreMapper.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/RedisStoreMapper.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.redis.common.mapper;
+
+public interface RedisStoreMapper extends TupleMapper, RedisMapper {
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/TupleMapper.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/mapper/TupleMapper.java
@@ -15,13 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.redis.trident.mapper;
+package org.apache.storm.redis.common.mapper;
 
-import storm.trident.tuple.TridentTuple;
+import backtype.storm.tuple.ITuple;
 
 import java.io.Serializable;
 
-public interface TridentTupleMapper extends Serializable {
-    public String getKeyFromTridentTuple(TridentTuple tuple);
-    public String getValueFromTridentTuple(TridentTuple tuple);
+public interface TupleMapper extends Serializable {
+    public String getKeyFromTuple(ITuple tuple);
+    public String getValueFromTuple(ITuple tuple);
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterMapState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterMapState.java
@@ -23,7 +23,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.storm.redis.util.config.JedisClusterConfig;
+import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.JedisCluster;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterState.java
@@ -18,7 +18,7 @@
 package org.apache.storm.redis.trident.state;
 
 import backtype.storm.task.IMetricsContext;
-import org.apache.storm.redis.util.config.JedisClusterConfig;
+import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.JedisCluster;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterStateQuerier.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterStateQuerier.java
@@ -19,7 +19,7 @@ package org.apache.storm.redis.trident.state;
 
 import backtype.storm.tuple.Values;
 import com.google.common.collect.Lists;
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.JedisCluster;
@@ -33,9 +33,9 @@ public class RedisClusterStateQuerier extends BaseQueryFunction<RedisClusterStat
     private static final Logger logger = LoggerFactory.getLogger(RedisClusterState.class);
 
     private final String redisKeyPrefix;
-    private final TridentTupleMapper tupleMapper;
+    private final TupleMapper tupleMapper;
 
-    public RedisClusterStateQuerier(String redisKeyPrefix, TridentTupleMapper tupleMapper) {
+    public RedisClusterStateQuerier(String redisKeyPrefix, TupleMapper tupleMapper) {
         this.redisKeyPrefix = redisKeyPrefix;
         this.tupleMapper = tupleMapper;
     }
@@ -52,7 +52,7 @@ public class RedisClusterStateQuerier extends BaseQueryFunction<RedisClusterStat
 
 
             for (TridentTuple input : inputs) {
-                String key = this.tupleMapper.getKeyFromTridentTuple(input);
+                String key = this.tupleMapper.getKeyFromTuple(input);
                 if (redisKeyPrefix != null && redisKeyPrefix.length() > 0) {
                     key = redisKeyPrefix + key;
                 }
@@ -72,7 +72,7 @@ public class RedisClusterStateQuerier extends BaseQueryFunction<RedisClusterStat
 
     @Override
     public void execute(TridentTuple tuple, String s, TridentCollector collector) {
-        String key = this.tupleMapper.getKeyFromTridentTuple(tuple);
+        String key = this.tupleMapper.getKeyFromTuple(tuple);
         collector.emit(new Values(key, s));
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterStateUpdater.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterStateUpdater.java
@@ -17,7 +17,7 @@
  */
 package org.apache.storm.redis.trident.state;
 
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.JedisCluster;
@@ -31,10 +31,10 @@ public class RedisClusterStateUpdater extends BaseStateUpdater<RedisClusterState
     private static final Logger logger = LoggerFactory.getLogger(RedisClusterState.class);
 
     private final String redisKeyPrefix;
-    private final TridentTupleMapper tupleMapper;
+    private final TupleMapper tupleMapper;
     private final int expireIntervalSec;
 
-    public RedisClusterStateUpdater(String redisKeyPrefix, TridentTupleMapper tupleMapper, int expireIntervalSec) {
+    public RedisClusterStateUpdater(String redisKeyPrefix, TupleMapper tupleMapper, int expireIntervalSec) {
         this.redisKeyPrefix = redisKeyPrefix;
         this.tupleMapper = tupleMapper;
         if (expireIntervalSec > 0) {
@@ -52,12 +52,12 @@ public class RedisClusterStateUpdater extends BaseStateUpdater<RedisClusterState
         try {
             jedisCluster = redisClusterState.getJedisCluster();
             for (TridentTuple input : inputs) {
-                String key = this.tupleMapper.getKeyFromTridentTuple(input);
+                String key = this.tupleMapper.getKeyFromTuple(input);
                 String redisKey = key;
                 if (redisKeyPrefix != null && redisKeyPrefix.length() > 0) {
                     redisKey = redisKeyPrefix + redisKey;
                 }
-                String value = this.tupleMapper.getValueFromTridentTuple(input);
+                String value = this.tupleMapper.getValueFromTuple(input);
 
                 logger.debug("update key[" + key + "] redisKey[" + redisKey + "] value[" + value + "]");
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisMapState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisMapState.java
@@ -22,7 +22,7 @@ import backtype.storm.tuple.Values;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import org.apache.storm.redis.util.config.JedisPoolConfig;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisState.java
@@ -18,7 +18,7 @@
 package org.apache.storm.redis.trident.state;
 
 import backtype.storm.task.IMetricsContext;
-import org.apache.storm.redis.util.config.JedisPoolConfig;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisStateQuerier.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisStateQuerier.java
@@ -19,7 +19,7 @@ package org.apache.storm.redis.trident.state;
 
 import backtype.storm.tuple.Values;
 import com.google.common.collect.Lists;
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
@@ -33,9 +33,9 @@ public class RedisStateQuerier extends BaseQueryFunction<RedisState, String> {
     private static final Logger logger = LoggerFactory.getLogger(RedisState.class);
 
     private final String redisKeyPrefix;
-    private final TridentTupleMapper tupleMapper;
+    private final TupleMapper tupleMapper;
 
-    public RedisStateQuerier(String redisKeyPrefix, TridentTupleMapper tupleMapper) {
+    public RedisStateQuerier(String redisKeyPrefix, TupleMapper tupleMapper) {
         this.redisKeyPrefix = redisKeyPrefix;
         this.tupleMapper = tupleMapper;
     }
@@ -44,7 +44,7 @@ public class RedisStateQuerier extends BaseQueryFunction<RedisState, String> {
     public List<String> batchRetrieve(RedisState redisState, List<TridentTuple> inputs) {
         List<String> keys = Lists.newArrayList();
         for (TridentTuple input : inputs) {
-            String key = this.tupleMapper.getKeyFromTridentTuple(input);
+            String key = this.tupleMapper.getKeyFromTuple(input);
             if (redisKeyPrefix != null && redisKeyPrefix.length() > 0) {
                 key = redisKeyPrefix + key;
             }
@@ -64,7 +64,7 @@ public class RedisStateQuerier extends BaseQueryFunction<RedisState, String> {
 
     @Override
     public void execute(TridentTuple tuple, String s, TridentCollector collector) {
-        String key = this.tupleMapper.getKeyFromTridentTuple(tuple);
+        String key = this.tupleMapper.getKeyFromTuple(tuple);
         collector.emit(new Values(key, s));
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisStateSetCountQuerier.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisStateSetCountQuerier.java
@@ -18,7 +18,7 @@
 package org.apache.storm.redis.trident.state;
 
 import backtype.storm.tuple.Values;
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
@@ -33,9 +33,9 @@ public class RedisStateSetCountQuerier extends BaseQueryFunction<RedisState, Lon
     private static final Logger logger = LoggerFactory.getLogger(RedisState.class);
 
     private final String redisKeyPrefix;
-    private final TridentTupleMapper tupleMapper;
+    private final TupleMapper tupleMapper;
 
-    public RedisStateSetCountQuerier(String redisKeyPrefix, TridentTupleMapper tupleMapper) {
+    public RedisStateSetCountQuerier(String redisKeyPrefix, TupleMapper tupleMapper) {
         this.redisKeyPrefix = redisKeyPrefix;
         this.tupleMapper = tupleMapper;
     }
@@ -48,7 +48,7 @@ public class RedisStateSetCountQuerier extends BaseQueryFunction<RedisState, Lon
         try {
             jedis = redisState.getJedis();
             for (TridentTuple input : inputs) {
-                String key = this.tupleMapper.getKeyFromTridentTuple(input);
+                String key = this.tupleMapper.getKeyFromTuple(input);
                 if (redisKeyPrefix != null && redisKeyPrefix.length() > 0) {
                     key = redisKeyPrefix + key;
                 }
@@ -68,7 +68,7 @@ public class RedisStateSetCountQuerier extends BaseQueryFunction<RedisState, Lon
 
     @Override
     public void execute(TridentTuple tuple, Long s, TridentCollector collector) {
-        String key = this.tupleMapper.getKeyFromTridentTuple(tuple);
+        String key = this.tupleMapper.getKeyFromTuple(tuple);
         collector.emit(new Values(key, s));
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisStateSetUpdater.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisStateSetUpdater.java
@@ -18,7 +18,7 @@
 package org.apache.storm.redis.trident.state;
 
 import backtype.storm.tuple.Values;
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
@@ -32,10 +32,10 @@ public class RedisStateSetUpdater extends BaseStateUpdater<RedisState> {
     private static final Logger logger = LoggerFactory.getLogger(RedisState.class);
 
     private final String redisKeyPrefix;
-    private final TridentTupleMapper tupleMapper;
+    private final TupleMapper tupleMapper;
     private final int expireIntervalSec;
 
-    public RedisStateSetUpdater(String redisKeyPrefix, TridentTupleMapper tupleMapper, int expireIntervalSec) {
+    public RedisStateSetUpdater(String redisKeyPrefix, TupleMapper tupleMapper, int expireIntervalSec) {
         this.redisKeyPrefix = redisKeyPrefix;
         this.tupleMapper = tupleMapper;
         if (expireIntervalSec > 0) {
@@ -53,12 +53,12 @@ public class RedisStateSetUpdater extends BaseStateUpdater<RedisState> {
         try {
             jedis = redisState.getJedis();
             for (TridentTuple input : inputs) {
-                String key = this.tupleMapper.getKeyFromTridentTuple(input);
+                String key = this.tupleMapper.getKeyFromTuple(input);
                 String redisKey = key;
                 if (redisKeyPrefix != null && redisKeyPrefix.length() > 0) {
                     redisKey = redisKeyPrefix + redisKey;
                 }
-                String value = this.tupleMapper.getValueFromTridentTuple(input);
+                String value = this.tupleMapper.getValueFromTuple(input);
 
                 logger.debug("update key[" + key + "] redisKey[" + redisKey + "] value[" + value + "]");
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisStateUpdater.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisStateUpdater.java
@@ -17,7 +17,7 @@
  */
 package org.apache.storm.redis.trident.state;
 
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
@@ -31,10 +31,10 @@ public class RedisStateUpdater extends BaseStateUpdater<RedisState> {
     private static final Logger logger = LoggerFactory.getLogger(RedisState.class);
 
     private final String redisKeyPrefix;
-    private final TridentTupleMapper tupleMapper;
+    private final TupleMapper tupleMapper;
     private final int expireIntervalSec;
 
-    public RedisStateUpdater(String redisKeyPrefix, TridentTupleMapper tupleMapper, int expireIntervalSec) {
+    public RedisStateUpdater(String redisKeyPrefix, TupleMapper tupleMapper, int expireIntervalSec) {
         this.redisKeyPrefix = redisKeyPrefix;
         this.tupleMapper = tupleMapper;
         if (expireIntervalSec > 0) {
@@ -51,12 +51,12 @@ public class RedisStateUpdater extends BaseStateUpdater<RedisState> {
         try {
             jedis = redisState.getJedis();
             for (TridentTuple input : inputs) {
-                String key = this.tupleMapper.getKeyFromTridentTuple(input);
+                String key = this.tupleMapper.getKeyFromTuple(input);
                 String redisKey = key;
                 if (redisKeyPrefix != null && redisKeyPrefix.length() > 0) {
                     redisKey = redisKeyPrefix + redisKey;
                 }
-                String value = this.tupleMapper.getValueFromTridentTuple(input);
+                String value = this.tupleMapper.getValueFromTuple(input);
 
                 logger.debug("update key[" + key + "] redisKey[" + redisKey + "] value[" + value + "]");
 

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/topology/WordCounter.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/topology/WordCounter.java
@@ -23,23 +23,32 @@ import backtype.storm.topology.IBasicBolt;
 import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Tuple;
+import backtype.storm.tuple.Values;
+import com.google.common.collect.Maps;
 
 import java.util.Map;
 
 import static backtype.storm.utils.Utils.tuple;
 
 public class WordCounter implements IBasicBolt {
-
+    private Map<String, Integer> wordCounter = Maps.newHashMap();
 
     @SuppressWarnings("rawtypes")
     public void prepare(Map stormConf, TopologyContext context) {
     }
 
-    /*
-     * Just output the word value with a count of 1.
-     */
     public void execute(Tuple input, BasicOutputCollector collector) {
-        collector.emit(tuple(input.getValues().get(0), 1));
+        String word = input.getStringByField("word");
+        int count;
+        if (wordCounter.containsKey(word)) {
+            count = wordCounter.get(word) + 1;
+            wordCounter.put(word, wordCounter.get(word) + 1);
+        } else {
+            count = 1;
+        }
+
+        wordCounter.put(word, count);
+        collector.emit(new Values(word, String.valueOf(count)));
     }
 
     public void cleanup() {

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTridentRedis.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTridentRedis.java
@@ -23,15 +23,14 @@ import backtype.storm.StormSubmitter;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.apache.storm.redis.trident.state.RedisState;
 import org.apache.storm.redis.trident.state.RedisStateQuerier;
 import org.apache.storm.redis.trident.state.RedisStateUpdater;
-import org.apache.storm.redis.util.config.JedisPoolConfig;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
 import storm.trident.Stream;
 import storm.trident.TridentState;
 import storm.trident.TridentTopology;
-import storm.trident.state.StateFactory;
 import storm.trident.testing.FixedBatchSpout;
 
 public class WordCountTridentRedis {
@@ -48,7 +47,7 @@ public class WordCountTridentRedis {
         JedisPoolConfig poolConfig = new JedisPoolConfig.Builder()
                                         .setHost(redisHost).setPort(redisPort)
                                         .build();
-        TridentTupleMapper tupleMapper = new WordCountTupleMapper();
+        TupleMapper tupleMapper = new WordCountTupleMapper();
         RedisState.Factory factory = new RedisState.Factory(poolConfig);
 
         TridentTopology topology = new TridentTopology();

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTridentRedisCluster.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTridentRedisCluster.java
@@ -23,11 +23,11 @@ import backtype.storm.StormSubmitter;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.apache.storm.redis.trident.state.RedisClusterState;
 import org.apache.storm.redis.trident.state.RedisClusterStateQuerier;
 import org.apache.storm.redis.trident.state.RedisClusterStateUpdater;
-import org.apache.storm.redis.util.config.JedisClusterConfig;
+import org.apache.storm.redis.common.config.JedisClusterConfig;
 import storm.trident.Stream;
 import storm.trident.TridentState;
 import storm.trident.TridentTopology;
@@ -55,7 +55,7 @@ public class WordCountTridentRedisCluster {
         }
         JedisClusterConfig clusterConfig = new JedisClusterConfig.Builder().setNodes(nodes)
                                         .build();
-        TridentTupleMapper tupleMapper = new WordCountTupleMapper();
+        TupleMapper tupleMapper = new WordCountTupleMapper();
         RedisClusterState.Factory factory = new RedisClusterState.Factory(clusterConfig);
 
         TridentTopology topology = new TridentTopology();

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTridentRedisClusterMap.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTridentRedisClusterMap.java
@@ -23,11 +23,9 @@ import backtype.storm.StormSubmitter;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.apache.storm.redis.trident.state.RedisClusterMapState;
-import org.apache.storm.redis.trident.state.RedisClusterStateUpdater;
-import org.apache.storm.redis.trident.state.RedisStateQuerier;
-import org.apache.storm.redis.util.config.JedisClusterConfig;
+import org.apache.storm.redis.common.config.JedisClusterConfig;
 import storm.trident.Stream;
 import storm.trident.TridentState;
 import storm.trident.TridentTopology;
@@ -58,7 +56,7 @@ public class WordCountTridentRedisClusterMap {
         }
         JedisClusterConfig clusterConfig = new JedisClusterConfig.Builder().setNodes(nodes)
                                         .build();
-        TridentTupleMapper tupleMapper = new WordCountTupleMapper();
+        TupleMapper tupleMapper = new WordCountTupleMapper();
         StateFactory factory = RedisClusterMapState.transactional(clusterConfig);
 
         TridentTopology topology = new TridentTopology();

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTridentRedisMap.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTridentRedisMap.java
@@ -23,12 +23,9 @@ import backtype.storm.StormSubmitter;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 import org.apache.storm.redis.trident.state.RedisMapState;
-import org.apache.storm.redis.trident.state.RedisState;
-import org.apache.storm.redis.trident.state.RedisStateQuerier;
-import org.apache.storm.redis.trident.state.RedisStateUpdater;
-import org.apache.storm.redis.util.config.JedisPoolConfig;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
 import storm.trident.Stream;
 import storm.trident.TridentState;
 import storm.trident.TridentTopology;
@@ -51,7 +48,7 @@ public class WordCountTridentRedisMap {
         JedisPoolConfig poolConfig = new JedisPoolConfig.Builder()
                                         .setHost(redisHost).setPort(redisPort)
                                         .build();
-        TridentTupleMapper tupleMapper = new WordCountTupleMapper();
+        TupleMapper tupleMapper = new WordCountTupleMapper();
         StateFactory factory = RedisMapState.transactional(poolConfig);
 
         TridentTopology topology = new TridentTopology();

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTupleMapper.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/trident/WordCountTupleMapper.java
@@ -1,16 +1,16 @@
 package org.apache.storm.redis.trident;
 
-import org.apache.storm.redis.trident.mapper.TridentTupleMapper;
-import storm.trident.tuple.TridentTuple;
+import backtype.storm.tuple.ITuple;
+import org.apache.storm.redis.common.mapper.TupleMapper;
 
-public class WordCountTupleMapper implements TridentTupleMapper {
+public class WordCountTupleMapper implements TupleMapper {
     @Override
-    public String getKeyFromTridentTuple(TridentTuple tuple) {
+    public String getKeyFromTuple(ITuple tuple) {
         return tuple.getString(0);
     }
 
     @Override
-    public String getValueFromTridentTuple(TridentTuple tuple) {
+    public String getValueFromTuple(ITuple tuple) {
         return tuple.getInteger(1).toString();
     }
 }


### PR DESCRIPTION
* Add Basic lookup / persist Bolts
  * support data types : string, list, hash, set, sorted set, hyperloglog
* rename util package to common

 Type | Read | Write
-------- | ------- | ------
STRING | GET (key) | SET (key, value)
HASH | HGET (key, field) | HSET (key, field, value)
LIST | LPOP (key) | RPUSH (key, value)
SET | SCARD (key) | SADD (key, member)
SORTED SET | ZSCORE (key, member) | ZADD (key, score, member)
HLL (HyperLogLog) | PFCOUNT (key) | PFADD (key, element)
