### PR TITLE
[STORM-477]  Add warning for invalid JAVA_HOME

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -85,6 +85,9 @@ CONFFILE = ""
 JAR_JVM_OPTS = shlex.split(os.getenv('STORM_JAR_JVM_OPTS', ''))
 JAVA_HOME = os.getenv('JAVA_HOME', None)
 JAVA_CMD = 'java' if not JAVA_HOME else os.path.join(JAVA_HOME, 'bin', 'java')
+if JAVA_HOME and not os.path.exists(JAVA_CMD):
+    print "ERROR:  JAVA_HOME is invalid.  Could not find bin/java at %s." % JAVA_HOME
+    sys.exit(1)
 STORM_EXT_CLASSPATH = os.getenv('STORM_EXT_CLASSPATH', None)
 STORM_EXT_CLASSPATH_DAEMON = os.getenv('STORM_EXT_CLASSPATH_DAEMON', None)
 


### PR DESCRIPTION
This adds a check in the python script to ensure that JAVA_HOME points to an installation of storm, and prints an error message if it is not properly set.