### PR TITLE
[STORM-625] Don't leak netty clients when worker moves or reuse netty client.

### DIFF
--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
@@ -510,7 +510,7 @@ public class Client extends ConnectionWithStatus implements IStatefulObject {
     public void close() {
         if (!closing) {
             LOG.info("closing Netty Client {}", dstAddressPrefixedName);
-            context.removeClient(this);
+            context.removeClient(dstAddress.getHostName(),dstAddress.getPort());
             context = null;
             // Set closing to true to prevent any further reconnection attempts.
             closing = true;


### PR DESCRIPTION
- Adding tracking of netty connection by key and reuse whenever client is available.
- Fix included original changes from #455.