### PR TITLE
[STORM-703] With hash key option for RedisMapState, only get values for keys in batch

### DIFF
--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisMapState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisMapState.java
@@ -223,8 +223,10 @@ public class RedisMapState<T> implements IBackingMap<T> {
         if (keys.size() == 0) {
             return Collections.emptyList();
         }
+
+        String[] stringKeys = buildKeys(keys);
+
         if (Strings.isNullOrEmpty(this.options.hkey)) {
-            String[] stringKeys = buildKeys(keys);
             Jedis jedis = null;
             try {
                 jedis = jedisPool.getResource();
@@ -239,8 +241,7 @@ public class RedisMapState<T> implements IBackingMap<T> {
             Jedis jedis = null;
             try {
                 jedis = jedisPool.getResource();
-                Map<String, String> keyValue = jedis.hgetAll(this.options.hkey);
-                List<String> values = buildValuesFromMap(keys, keyValue);
+                List<String> values = jedis.hmget(this.options.hkey, stringKeys);
                 return deserializeValues(keys, values);
             } finally {
                 if (jedis != null) {
@@ -248,16 +249,6 @@ public class RedisMapState<T> implements IBackingMap<T> {
                 }
             }
         }
-    }
-
-    private List<String> buildValuesFromMap(List<List<Object>> keys, Map<String, String> keyValue) {
-        List<String> values = new ArrayList<String>(keys.size());
-        for (List<Object> key : keys) {
-            String strKey = keyFactory.build(key);
-            String value = keyValue.get(strKey);
-            values.add(value);
-        }
-        return values;
     }
 
     private List<T> deserializeValues(List<List<Object>> keys, List<String> values) {
@@ -303,7 +294,7 @@ public class RedisMapState<T> implements IBackingMap<T> {
                 for (int i = 0; i < keys.size(); i++) {
                     String val = new String(serializer.serialize(vals.get(i)));
                     keyValues.put(keyFactory.build(keys.get(i)), val);
-                }               
+                }
                 jedis.hmset(this.options.hkey, keyValues);
 
             } finally {


### PR DESCRIPTION
This commit fixes a bug whereby if the state updater is constructed with a hash key (ie, the state will be stored as a key in a redis hash, versus as a key in the top-level redis space), each call to multiGet would request the entire hash and iterate to extract only the values in the hash relevant to the batch.

This can cause an inordinate amount of network traffic (and actually caused our interfaces to fall over) for states with either a moderately high cardinality or large values. Instead, the call to Redis should be an hmget (hash multiget) that takes the hash key as its first argument and an array of strings as the keys to fetch from that key, thereby retrieving only the requested values.

The change also deprecates and removes buildValuesFromMap.