### PR TITLE
STORM-707: Client (Netty): improve logging to help troubleshooting connection woes

### DIFF
--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
@@ -487,8 +487,10 @@ public class Client extends ConnectionWithStatus implements IStatefulObject {
 
     private synchronized void closeChannelAndReconnect(Channel channel) {
         if (channel != null) {
+            LOG.info("closing channel {} to {}", channel.toString(), dstAddressPrefixedName);
             channel.close();
             if (channelRef.compareAndSet(channel, null)) {
+                LOG.info("triggering reconnect to {}", dstAddressPrefixedName);
                 connect(NO_DELAY_MS);
             }
         }

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
@@ -246,10 +246,12 @@ public class Client extends ConnectionWithStatus implements IStatefulObject {
     private synchronized void connect(long delayMs) {
         try {
             if (closing) {
+                LOG.info("not connecting to {} because this client is being closed", dstAddressPrefixedName);
                 return;
             }
 
             if (connectionEstablished(channelRef.get())) {
+                LOG.info("not connecting to {} because the connection is already established", dstAddressPrefixedName);
                 return;
             }
 


### PR DESCRIPTION
These logging statements are not on a hot path, and `INFO` is the default log level of Storm.  These logging statements are filling a gap that facilitates understanding connection woes in a Storm cluster (cf. our work on STORM-329).