### PR TITLE
STORM-711: modifying all connectors to use collector.reportError instead...

### DIFF
--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/HBaseBolt.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/HBaseBolt.java
@@ -62,7 +62,7 @@ public class HBaseBolt  extends AbstractHBaseBolt {
         try {
             this.hBaseClient.batchMutate(mutations);
         } catch(Exception e){
-            LOG.warn("Failing tuple. Error writing rowKey " + rowKey, e);
+            this.collector.reportError(e);
             this.collector.fail(tuple);
             return;
         }

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/HBaseLookupBolt.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/HBaseLookupBolt.java
@@ -67,11 +67,11 @@ public class HBaseLookupBolt extends AbstractHBaseBolt {
         try {
             Result result = hBaseClient.batchGet(Lists.newArrayList(get))[0];
             for(Values values : rowToTupleMapper.toValues(tuple, result)) {
-                this.collector.emit(values);
+                this.collector.emit(tuple, values);
             }
             this.collector.ack(tuple);
         } catch (Exception e) {
-            LOG.warn("Could not perform Lookup for rowKey =" + rowKey + " from Hbase.", e);
+            this.collector.reportError(e);
             this.collector.fail(tuple);
         }
     }

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/state/HBaseState.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/state/HBaseState.java
@@ -141,7 +141,7 @@ public class HBaseState implements State {
         try {
             hBaseClient.batchMutate(mutations);
         } catch (Exception e) {
-            LOG.warn("Batch write failed but some requests might have succeeded. Triggering replay.", e);
+            collector.reportError(e);
             throw new FailedException(e);
         }
     }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/HdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/HdfsBolt.java
@@ -112,7 +112,7 @@ public class HdfsBolt extends AbstractHdfsBolt{
                 this.rotationPolicy.reset();
             }
         } catch (IOException e) {
-            LOG.warn("write/sync failed.", e);
+            this.collector.reportError(e);
             this.collector.fail(tuple);
         }
     }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileBolt.java
@@ -123,7 +123,7 @@ public class SequenceFileBolt extends AbstractHdfsBolt {
                 this.rotationPolicy.reset();
             }
         } catch (IOException e) {
-            LOG.warn("write/sync failed.", e);
+            this.collector.reportError(e);
             this.collector.fail(tuple);
         }
 


### PR DESCRIPTION
... of logging and use tuple anchoring when emitting a tuple.