### PR TITLE
[STORM-712] Storm daemons shutdown if OutOfMemoryError occurs in any thread 

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/drpc.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/drpc.clj
@@ -240,4 +240,5 @@
         (.serve handler-server)))))
 
 (defn -main []
+  (setup-default-uncaught-exception-handler)
   (launch-server!))

--- a/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
@@ -377,5 +377,6 @@ Note that if anything goes wrong, this will throw an Error and exit."
 (defn -main []
   (let [conf (read-storm-config)
         log-root (log-root-dir (conf LOGVIEWER-APPENDER-NAME))]
+    (setup-default-uncaught-exception-handler)
     (start-log-cleaner! conf log-root)
     (start-logviewer! conf log-root)))

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -1414,4 +1414,5 @@
     ))
 
 (defn -main []
+  (setup-default-uncaught-exception-handler)
   (-launch (standalone-nimbus)))

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -800,4 +800,5 @@
         ))))
 
 (defn -main []
+  (setup-default-uncaught-exception-handler)
   (-launch (standalone-supervisor)))

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -544,6 +544,7 @@
 
 (defn -main [storm-id assignment-id port-str worker-id]  
   (let [conf (read-storm-config)]
+    (setup-default-uncaught-exception-handler)
     (validate-distributed-mode! conf)
     (let [worker (mk-worker conf nil storm-id assignment-id (Integer/parseInt port-str) worker-id)]
       (add-shutdown-hook-with-force-kill-in-1-sec #(.shutdown worker)))))

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -1031,3 +1031,12 @@
 
 (defn hashmap-to-persistent [^HashMap m]
   (zipmap (.keySet m) (.values m)))
+
+(defn setup-default-uncaught-exception-handler
+  "Set a default uncaught exception handler to handle exceptions not caught in other threads."
+  []
+  (Thread/setDefaultUncaughtExceptionHandler
+    (proxy [Thread$UncaughtExceptionHandler] []
+      (uncaughtException [thread thrown]
+        (Utils/handleUncaughtException thrown)))))
+

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -1038,5 +1038,10 @@
   (Thread/setDefaultUncaughtExceptionHandler
     (proxy [Thread$UncaughtExceptionHandler] []
       (uncaughtException [thread thrown]
-        (Utils/handleUncaughtException thrown)))))
+        (try
+          (Utils/handleUncaughtException thrown)
+          (catch Error err
+            (do
+              (log-error err "Received error in main thread.. terminating server...")
+              (.exit (Runtime/getRuntime) -2))))))))
 

--- a/storm-core/src/jvm/backtype/storm/drpc/DRPCSpout.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/DRPCSpout.java
@@ -28,6 +28,7 @@ import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.topology.base.BaseRichSpout;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
+import backtype.storm.utils.ExtendedThreadPoolExecutor;
 import backtype.storm.utils.ServiceRegistry;
 import backtype.storm.utils.Utils;
 import java.util.ArrayList;
@@ -40,6 +41,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.Callable;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.thrift.TException;
@@ -129,7 +134,9 @@ public class DRPCSpout extends BaseRichSpout {
     public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
         _collector = collector;
         if(_local_drpc_id==null) {
-            _backround = Executors.newCachedThreadPool();
+            _backround = new ExtendedThreadPoolExecutor(0, Integer.MAX_VALUE,
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>());
             _futures = new LinkedList<Future<Void>>();
 
             int numTasks = context.getComponentTasks(context.getThisComponentId()).size();

--- a/storm-core/src/jvm/backtype/storm/drpc/DRPCSpout.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/DRPCSpout.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.Callable;
 import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;

--- a/storm-core/src/jvm/backtype/storm/security/auth/SaslTransportPlugin.java
+++ b/storm-core/src/jvm/backtype/storm/security/auth/SaslTransportPlugin.java
@@ -84,12 +84,11 @@ public abstract class SaslTransportPlugin implements ITransportPlugin {
         }
         BlockingQueue workQueue = new SynchronousQueue();
         if (queueSize != null) {
-          workQueue = new ArrayBlockingQueue(queueSize);
+            workQueue = new ArrayBlockingQueue(queueSize);
         }
         ThreadPoolExecutor executorService = new ExtendedThreadPoolExecutor(numWorkerThreads, numWorkerThreads,
-        60, TimeUnit.SECONDS, workQueue);
+            60, TimeUnit.SECONDS, workQueue);
         server_args.executorService(executorService);
-
         return new TThreadPoolServer(server_args);
     }
 

--- a/storm-core/src/jvm/backtype/storm/utils/ExtendedThreadPoolExecutor.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ExtendedThreadPoolExecutor.java
@@ -1,0 +1,47 @@
+package backtype.storm.utils;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class ExtendedThreadPoolExecutor extends ThreadPoolExecutor{
+
+  public ExtendedThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue) {
+    super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+  }
+
+  public ExtendedThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory) {
+    super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+  }
+
+  public ExtendedThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue, RejectedExecutionHandler handler) {
+    super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
+  }
+
+  public ExtendedThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
+    super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
+  }
+
+  protected void afterExecute(Runnable r, Throwable t) {
+    super.afterExecute(r, t);
+    if (t == null && r instanceof Future<?>) {
+      try {
+        Object result = ((Future<?>) r).get();
+      } catch (CancellationException ce) {
+        t = ce;
+      } catch (ExecutionException ee) {
+        t = ee.getCause();
+
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt(); // ignore/reset
+      }
+    }
+    Utils.handleUncaughtException(t);
+  }
+
+}

--- a/storm-core/src/jvm/backtype/storm/utils/ExtendedThreadPoolExecutor.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ExtendedThreadPoolExecutor.java
@@ -1,5 +1,23 @@
 package backtype.storm.utils;
 
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -27,6 +45,7 @@ public class ExtendedThreadPoolExecutor extends ThreadPoolExecutor{
     super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
   }
 
+  @Override
   protected void afterExecute(Runnable r, Throwable t) {
     super.afterExecute(r, t);
     if (t == null && r instanceof Future<?>) {
@@ -36,12 +55,11 @@ public class ExtendedThreadPoolExecutor extends ThreadPoolExecutor{
         t = ce;
       } catch (ExecutionException ee) {
         t = ee.getCause();
-
       } catch (InterruptedException ie) {
-        Thread.currentThread().interrupt(); // ignore/reset
+        // If future got interrupted exception, we want to main parent thread itself.
+        Thread.currentThread().interrupt();
       }
     }
     Utils.handleUncaughtException(t);
   }
-
 }

--- a/storm-core/src/jvm/backtype/storm/utils/ExtendedThreadPoolExecutor.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ExtendedThreadPoolExecutor.java
@@ -56,7 +56,7 @@ public class ExtendedThreadPoolExecutor extends ThreadPoolExecutor{
       } catch (ExecutionException ee) {
         t = ee.getCause();
       } catch (InterruptedException ie) {
-        // If future got interrupted exception, we want to main parent thread itself.
+        // If future got interrupted exception, we want to interrupt parent thread itself.
         Thread.currentThread().interrupt();
       }
     }

--- a/storm-core/src/jvm/backtype/storm/utils/ExtendedThreadPoolExecutor.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ExtendedThreadPoolExecutor.java
@@ -60,6 +60,8 @@ public class ExtendedThreadPoolExecutor extends ThreadPoolExecutor{
         Thread.currentThread().interrupt();
       }
     }
-    Utils.handleUncaughtException(t);
+    if (t != null) {
+      Utils.handleUncaughtException(t);
+    }
   }
 }

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -533,4 +533,15 @@ public class Utils {
         delegate.prepare(stormConf);
         return delegate;
     }
+
+  public static void handleUncaughtException(Throwable t) {
+    if(t!= null && t instanceof OutOfMemoryError) {
+      try {
+        System.err.println("Halting due to Out Of Memory Error..." + Thread.currentThread().getName());
+      } catch (Throwable err) {
+             //Again we done want to exit because of logging issues.
+      }
+      Runtime.getRuntime().halt(-1);
+    }
+  }
 }

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -534,13 +534,15 @@ public class Utils {
         return delegate;
     }
 
-  public static void handleUncaughtException(Throwable t) {
-    if(t!= null && t instanceof OutOfMemoryError) {
-      try {
-        System.err.println("Halting due to Out Of Memory Error..." + Thread.currentThread().getName());
-      } catch (Throwable err) {
+    public static void handleUncaughtException(Throwable t) {
+      if(t!= null && t instanceof OutOfMemoryError) {
+         try {
+             System.err.println("Halting due to Out Of Memory Error..." + Thread.currentThread().getName());
+         } catch (Throwable err) {
              //Again we done want to exit because of logging issues.
+         }
+         Runtime.getRuntime().halt(-1);
       }
-      Runtime.getRuntime().halt(-1);
     }
 }
+

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -543,5 +543,4 @@ public class Utils {
       }
       Runtime.getRuntime().halt(-1);
     }
-  }
 }

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -547,8 +547,6 @@ public class Utils {
         //Running in daemon mode, we would pass Error to calling thread.
         throw (Error) t;
       }
-    } else {
-      LOG.error("Thread threw an Exception.", t);
     }
   }
 }

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -534,15 +534,22 @@ public class Utils {
         return delegate;
     }
 
-    public static void handleUncaughtException(Throwable t) {
-      if(t!= null && t instanceof OutOfMemoryError) {
-         try {
-             System.err.println("Halting due to Out Of Memory Error..." + Thread.currentThread().getName());
-         } catch (Throwable err) {
-             //Again we done want to exit because of logging issues.
-         }
-         Runtime.getRuntime().halt(-1);
+  public static void handleUncaughtException(Throwable t) {
+    if (t != null && t instanceof Error) {
+      if (t instanceof OutOfMemoryError) {
+        try {
+          System.err.println("Halting due to Out Of Memory Error..." + Thread.currentThread().getName());
+        } catch (Throwable err) {
+          //Again we don't want to exit because of logging issues.
+        }
+        Runtime.getRuntime().halt(-1);
+      } else {
+        //Running in daemon mode, we would pass Error to calling thread.
+        throw (Error) t;
       }
+    } else {
+      LOG.error("Thread threw an Exception.", t);
     }
+  }
 }
 


### PR DESCRIPTION
- Creating `ExtendedThreadPoolExecutor` to pass uncaughtExceptions as part of `afterExecute`
- All daemon main threads set `uncaughtExceptionHandler`.