### PR TITLE
UserGroupInformation should use the same config with UserProvider

### DIFF
--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/security/HBaseSecurityUtil.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/security/HBaseSecurityUtil.java
@@ -46,6 +46,7 @@ public class HBaseSecurityUtil {
         if (conf.get(TOPOLOGY_AUTO_CREDENTIALS) == null ||
                 !(((List) conf.get(TOPOLOGY_AUTO_CREDENTIALS)).contains(AutoHBase.class.getName()))) {
             LOG.info("Logging in using keytab as AutoHBase is not specified for " + TOPOLOGY_AUTO_CREDENTIALS);
+            UserGroupInformation.setConfiguration(hbaseConfig); // need krb5.conf configuration
             if (UserGroupInformation.isSecurityEnabled()) {
                 String keytab = (String) conf.get(STORM_KEYTAB_FILE_KEY);
                 if (keytab != null) {


### PR DESCRIPTION
As the title,  if UserGroupInformation is not set with the hbaseConfig, UserGroupInformation with initialize conf with new Configuration(), and this is not the conf used for UserProvider, and this will wrong behavior: I have set hadoop.security.authentication to kerberos in hbase-site.xml, but without this fix, UserGroupInformation.isSecurityEnabled() will always return false.

With UserGroupInformation.setConfiguration you need krb5 configuration, either default value or through System.setProperty("java.security.krb5.conf", krbPath);