### PR TITLE
[STORM-728] Put emitted and transferred stats under correct columns

### DIFF
--- a/storm-core/src/ui/public/templates/component-page-template.html
+++ b/storm-core/src/ui/public/templates/component-page-template.html
@@ -91,8 +91,8 @@
       {{#spoutSummary}}
       <tr>
         <td><a href="/component.html?id={{encodedId}}&topology_id={{encodedTopologyId}}&window={{window}}">{{windowPretty}}</a></td>
-        <td>{{transferred}}</td>
         <td>{{emitted}}</td>
+        <td>{{transferred}}</td>
         <td>{{completeLatency}}</td>
         <td>{{acked}}</td>
         <td>{{failed}}</td>


### PR DESCRIPTION
The column headers were consistent with other UI tables, so I swapped the data.