### PR TITLE
[STORM-729] Include Executors (Window Hint) if the component is of Bolt type

### DIFF
--- a/storm-core/src/ui/public/templates/component-page-template.html
+++ b/storm-core/src/ui/public/templates/component-page-template.html
@@ -375,7 +375,7 @@
   </table>
 </script>
 <script id="bolt-executor-template" type="text/html">
-  <h2>Executors</h2>
+  <h2>Executors ({{windowHint}})</h2>
   <table class="table table-striped compact" id="bolt-executor-table">
     <thead>
       <tr>


### PR DESCRIPTION
This was missing only from the Bolt case.