### PR TITLE
STORM-694: java.lang.ClassNotFoundException: backtype.storm.daemon.common.SupervisorInfo

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -18,7 +18,6 @@
   (:import [backtype.storm.scheduler ISupervisor]
            [backtype.storm.utils LocalState Time Utils]
            [backtype.storm.daemon Shutdownable]
-           [backtype.storm.daemon.common SupervisorInfo]
            [backtype.storm Constants]
            [java.net JarURLConnection]
            [java.net URI]
@@ -506,14 +505,14 @@
         heartbeat-fn (fn [] (.supervisor-heartbeat!
                                (:storm-cluster-state supervisor)
                                (:supervisor-id supervisor)
-                               (SupervisorInfo. (current-time-secs)
-                                                (:my-hostname supervisor)
-                                                (:assignment-id supervisor)
-                                                (keys @(:curr-assignment supervisor))
-                                                ;; used ports
-                                                (.getMetadata isupervisor)
-                                                (conf SUPERVISOR-SCHEDULER-META)
-                                                ((:uptime supervisor)))))]
+                               (->SupervisorInfo (current-time-secs)
+                                                 (:my-hostname supervisor)
+                                                 (:assignment-id supervisor)
+                                                 (keys @(:curr-assignment supervisor))
+                                                 ;; used ports
+                                                 (.getMetadata isupervisor)
+                                                 (conf SUPERVISOR-SCHEDULER-META)
+                                                 ((:uptime supervisor)))))]
     (heartbeat-fn)
     ;; should synchronize supervisor so it doesn't launch anything after being down (optimization)
     (schedule-recurring (:heartbeat-timer supervisor)


### PR DESCRIPTION
Storm fails to compile sometimes because of bad imports. 

The import of SupervisorInfo in this file depends on compilation order to succeed. Removing it and using the clojure constructor for SupervisorInfo fixes the issue.