### PR TITLE
stormjar.jar on classpath first in supervisor workers

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -669,9 +669,9 @@
           topo-classpath (if-let [cp (storm-conf TOPOLOGY-CLASSPATH)]
                            [cp]
                            [])
-          classpath (-> (current-classpath)
-                        (add-to-classpath [stormjar])
-                        (add-to-classpath topo-classpath))
+          classpath (-> stormjar 
+                        (add-to-classpath [(current-classpath)])
+                        (add-to-classpath topo-classpath) )
           top-gc-opts (storm-conf TOPOLOGY-WORKER-GC-CHILDOPTS)
           gc-opts (substitute-childopts (if top-gc-opts top-gc-opts (conf WORKER-GC-CHILDOPTS)) worker-id storm-id port)
           user (storm-conf TOPOLOGY-SUBMITTER-USER)

--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -251,7 +251,7 @@
     (let [mock-port "42"
           mock-storm-id "fake-storm-id"
           mock-worker-id "fake-worker-id"
-          mock-cp (str file-path-separator "base" class-path-separator file-path-separator "stormjar.jar")
+          mock-cp (str file-path-separator "stormjar.jar" class-path-separator file-path-separator "base")
           exp-args-fn (fn [opts topo-opts classpath]
                        (concat [(supervisor/java-cmd) "-server"]
                                opts


### PR DESCRIPTION
If stormjar.jar is first on the classpath for the supervisor workers,
libraries AOT-compiled and provided by Storm for Storm UI will take
a backseat to libraries the user provides.