### PR TITLE
[STORM-746] Skip ack init when there are no output tasks

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -526,7 +526,8 @@
                                                                         out-tuple
                                                                         overflow-buffer)
                                                            ))
-                                         (if rooted?
+                                         (if (and rooted?
+                                                  (seq out-ids)) ;; not empty
                                            (do
                                              (.put pending root-id [task-id
                                                                     message-id

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -527,7 +527,7 @@
                                                                         overflow-buffer)
                                                            ))
                                          (if (and rooted?
-                                                  (seq out-ids)) ;; not empty
+                                                  (not (.isEmpty out-ids)))
                                            (do
                                              (.put pending root-id [task-id
                                                                     message-id


### PR DESCRIPTION
See [STORM-746](https://issues.apache.org/jira/browse/STORM-746) for the description.