### PR TITLE
[STORM-756] ShellBolt can delay sending tuples on demand from subprocess

### DIFF
--- a/examples/storm-starter/multilang/resources/storm.py
+++ b/examples/storm-starter/multilang/resources/storm.py
@@ -70,6 +70,9 @@ def readCommand():
             msg = readMsg()
         return msg
 
+def getPendingQueueSize():
+    return len(pending_commands)
+
 def readTuple():
     cmd = readCommand()
     return Tuple(cmd["id"], cmd["comp"], cmd["stream"], cmd["task"], cmd["tuple"])
@@ -155,6 +158,9 @@ def logError(msg):
 
 def rpcMetrics(name, params):
     sendMsgToParent({"command": "metrics", "name": name, "params": params})
+
+def delay(sec):
+    sendMsgToParent({"command": "delay", "msg": sec})
 
 def initComponent():
     setupInfo = readMsg()

--- a/examples/storm-starter/multilang/resources/storm.rb
+++ b/examples/storm-starter/multilang/resources/storm.rb
@@ -63,6 +63,10 @@ module Storm
           end
     end
 
+    def get_pending_queue_size
+      Storm::Protocol.pending_commands.length
+    end
+
     def send_msg_to_parent(msg)
       puts msg.to_json
       puts "end"
@@ -118,6 +122,10 @@ module Storm
 
     def fail(tup)
       send_msg_to_parent :command => :fail, :id => tup.id
+    end
+
+    def delay(sec)
+      send_msg_to_parent :command => :delay, :msg => sec.to_s
     end
 
     def reportError(msg)

--- a/storm-core/src/dev/resources/storm.py
+++ b/storm-core/src/dev/resources/storm.py
@@ -70,6 +70,9 @@ def readCommand():
             msg = readMsg()
         return msg
 
+def getPendingQueueSize():
+    return len(pending_commands)
+
 def readTuple():
     cmd = readCommand()
     return Tuple(cmd["id"], cmd["comp"], cmd["stream"], cmd["task"], cmd["tuple"])
@@ -155,6 +158,9 @@ def logError(msg):
 
 def rpcMetrics(name, params):
     sendMsgToParent({"command": "metrics", "name": name, "params": params})
+
+def delay(sec):
+    sendMsgToParent({"command": "delay", "msg": sec})
 
 def initComponent():
     setupInfo = readMsg()

--- a/storm-core/src/dev/resources/storm.rb
+++ b/storm-core/src/dev/resources/storm.rb
@@ -63,6 +63,10 @@ module Storm
           end
     end
 
+    def get_pending_queue_size
+      Storm::Protocol.pending_commands.length
+    end
+
     def send_msg_to_parent(msg)
       puts msg.to_json
       puts "end"
@@ -118,6 +122,10 @@ module Storm
 
     def fail(tup)
       send_msg_to_parent :command => :fail, :id => tup.id
+    end
+
+    def delay(sec)
+      send_msg_to_parent :command => :delay, :msg => sec.to_s
     end
 
     def reportError(msg)

--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -29,12 +29,14 @@ import backtype.storm.tuple.Tuple;
 import backtype.storm.utils.ShellProcess;
 import clojure.lang.RT;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -89,6 +91,7 @@ public class ShellBolt implements IBolt {
     private ScheduledExecutorService heartBeatExecutorService;
     private AtomicLong lastHeartbeatTimestamp = new AtomicLong();
     private AtomicBoolean sendHeartbeatFlag = new AtomicBoolean(false);
+    private AtomicInteger delaySeconds = new AtomicInteger(0);
 
     public ShellBolt(ShellComponent component) {
         this(component.get_execution_command(), component.get_script());
@@ -268,6 +271,16 @@ public class ShellBolt implements IBolt {
         }       
     }
 
+    private void handleDelay(ShellMsg shellMsg) {
+        try {
+            Integer seconds = Integer.valueOf(shellMsg.getMsg());
+            int newDelaySeconds = delaySeconds.addAndGet(seconds);
+            LOG.info("Delay requested from subprocess, new delay seconds : " + newDelaySeconds);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private void setHeartbeat() {
         lastHeartbeatTimestamp.set(System.currentTimeMillis());
     }
@@ -307,8 +320,6 @@ public class ShellBolt implements IBolt {
 
             sendHeartbeatFlag.compareAndSet(false, true);
         }
-
-
     }
 
     private class BoltReaderRunnable implements Runnable {
@@ -335,6 +346,8 @@ public class ShellBolt implements IBolt {
                         handleEmit(shellMsg);
                     } else if (command.equals("metrics")) {
                         handleMetrics(shellMsg);
+                    } else if (command.equals("delay")) {
+                        handleDelay(shellMsg);
                     }
                 } catch (InterruptedException e) {
                 } catch (Throwable t) {
@@ -342,6 +355,7 @@ public class ShellBolt implements IBolt {
                 }
             }
         }
+
     }
 
     private class BoltWriterRunnable implements Runnable {
@@ -354,6 +368,15 @@ public class ShellBolt implements IBolt {
                         String genId = Long.toString(_rand.nextLong());
                         _process.writeBoltMsg(createHeartbeatBoltMessage(genId));
                         sendHeartbeatFlag.compareAndSet(true, false);
+                    }
+
+                    // If any delayed seconds left, sleep 1 sec and decrement
+                    // We cannot sleep more than 1 sec because of heartbeat
+                    int delay = delaySeconds.get();
+                    if (delay > 0) {
+                        LOG.debug("delay seconds left, sleep... sec: " + delay);
+                        Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+                        delaySeconds.decrementAndGet();
                     }
 
                     Object write = _pendingWrites.poll(1, SECONDS);

--- a/storm-core/src/multilang/py/storm.py
+++ b/storm-core/src/multilang/py/storm.py
@@ -70,6 +70,9 @@ def readCommand():
             msg = readMsg()
         return msg
 
+def getPendingQueueSize():
+    return len(pending_commands)
+
 def readTuple():
     cmd = readCommand()
     return Tuple(cmd["id"], cmd["comp"], cmd["stream"], cmd["task"], cmd["tuple"])
@@ -155,6 +158,9 @@ def logError(msg):
 
 def rpcMetrics(name, params):
     sendMsgToParent({"command": "metrics", "name": name, "params": params})
+
+def delay(sec):
+    sendMsgToParent({"command": "delay", "msg": sec})
 
 def initComponent():
     setupInfo = readMsg()

--- a/storm-core/src/multilang/rb/storm.rb
+++ b/storm-core/src/multilang/rb/storm.rb
@@ -63,6 +63,10 @@ module Storm
           end
     end
 
+    def get_pending_queue_size
+      Storm::Protocol.pending_commands.length
+    end
+
     def send_msg_to_parent(msg)
       puts msg.to_json
       puts "end"
@@ -118,6 +122,10 @@ module Storm
 
     def fail(tup)
       send_msg_to_parent :command => :fail, :id => tup.id
+    end
+
+    def delay(sec)
+      send_msg_to_parent :command => :delay, :msg => sec.to_s
     end
 
     def reportError(msg)


### PR DESCRIPTION
Please refer https://issues.apache.org/jira/browse/STORM-756 to see more details.

* introduce new multilang protocol: delay [seconds]
  * command: "delay", msg: "seconds(number format)"
  * python: storm.delay(seconds)
  * ruby: Storm::Protocol.delay(seconds)
* expose pending queue size to let users check and request delay
  * python: storm.getPendingQueueSize()
  * ruby: Storm::Protocol.get_pending_queue_size()