### PR TITLE
[STORM-745] fix storm.cmd to evaluate 'shift' correctly with 'storm jar'

### DIFF
--- a/bin/storm.cmd
+++ b/bin/storm.cmd
@@ -70,11 +70,11 @@
     set CLASSPATH=%CLASSPATH%;%2
     set CLASS=%3
     set args=%4
-    shift
+    goto start
     :start
+    shift
     if [%4] == [] goto done
     set args=%args% %4
-    shift
     goto start
 
     :done


### PR DESCRIPTION
Please refer https://issues.apache.org/jira/browse/STORM-745 to see more details.

The problem is, shift doesn't evaluated before calling goto.
I found the hint from http://ss64.com/nt/shift.html.

The SHIFT command will not work within parenthesis/brackets, so place all your command line arguments in variables before running any FOR commands or other bracketed expressions. Or use the CALL syntax as explained in this forum thread.

Just calling goto first resolves it.