### PR TITLE
STORM-761: An option for new/updated Redis keys to expire in RedisMapState

### DIFF
--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterMapState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterMapState.java
@@ -72,7 +72,7 @@ public class RedisClusterMapState<T> implements IBackingMap<T> {
     public static class Options<T> implements Serializable {
         public int localCacheSize = 1000;
         public String globalKey = "$REDIS-MAP-STATE-GLOBAL";
-        KeyFactory keyFactory = null;
+        public KeyFactory keyFactory = null;
         public Serializer<T> serializer = null;
         public String hkey = null;
     }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisMapState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisMapState.java
@@ -72,7 +72,7 @@ public class RedisMapState<T> implements IBackingMap<T> {
     public static class Options<T> implements Serializable {
         public int localCacheSize = 1000;
         public String globalKey = "$REDIS-MAP-STATE-GLOBAL";
-        KeyFactory keyFactory = null;
+        public KeyFactory keyFactory = null;
         public Serializer<T> serializer = null;
         public String hkey = null;
     }


### PR DESCRIPTION
This is much the same as the mechanism already available via `RedisStateUpdater` for `RedisState` instances.  Users can now set `expireIntervalSec` in their `RedisMapState.Options` instance, to set an expiry timeout on each Redis key updated by the state.