### PR TITLE
[STORM-767] Add repository declaration for pentaho-aggdesigner

### DIFF
--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -123,6 +123,14 @@
       <scope>compile</scope>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>spring-releases</id>
+      <url>http://repo.springsource.org/libs-release-remote/</url>
+    </repository>
+  </repositories>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Building `storm-hive` fails due to unresolved dependencies. It is necessary to add a reference to springsource repository.

```
[ERROR] Failed to execute goal on project storm-hive: Could not resolve dependencies for project org.apache.storm:storm-hive:jar:0.11.0-SNAPSHOT: 
Could not find artifact org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.3-jhyde in repo.jenkins-ci.org (http://repo.jenkins-ci.org/public/) -> [Help 1]
```