### PR TITLE
[STORM-768] Support JDK 8 compile and runtime.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -654,8 +654,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
- [x] Unittests (exclude storm-hive)
- [x] nimbus server
- [x] supervisor server
- [x] drpc server
- [x] Topology submit and running (storm.starter.ExclamationTopology)

storm-hive unittest fails even if we use JDK 1.7. It might not be due to JDK 1.8.
It looks fine to support JDK 1.8 here. 