### PR TITLE
STORM-786: KafkaBolt should ack tick tuples

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/bolt/KafkaBolt.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/bolt/KafkaBolt.java
@@ -91,6 +91,7 @@ public class KafkaBolt<K, V> extends BaseRichBolt {
     @Override
     public void execute(Tuple input) {
         if (TupleUtils.isTick(input)) {
+          collector.ack(input);
           return; // Do not try to send ticks to Kafka
         }
 


### PR DESCRIPTION
[STORM-512](https://issues.apache.org/jira/browse/STORM-512) (KafkaBolt doesn't handle ticks properly) adds special-casing of tick tuples. What is missing in the patch is that the input tuple, when it is a tick tuple, should be properly acked like normal tuples.