### PR TITLE
[STORM-787]: test-ns should announce test failures with 'BUILD FAILURE'

### DIFF
--- a/dev-tools/test-ns.py
+++ b/dev-tools/test-ns.py
@@ -9,9 +9,26 @@ os.chdir("storm-core")
 ns = sys.argv[1]
 pipe = Popen(["mvn", "clojure:repl"], stdin=PIPE)
 
-pipe.stdin.write("(do (use 'clojure.test) (require '%s :reload-all) (run-tests '%s))\n" % (ns, ns))
+
+pipe.stdin.write("""
+(do
+  (use 'clojure.test)
+  (require '%s :reload-all)
+  (let [results (run-tests '%s)]
+    (println results)
+    (if (or
+         (> (:fail results) 0)
+         (> (:error results) 0))
+      (System/exit 1)
+      (System/exit 0))))
+""" % (ns, ns))
+
+
+
 pipe.stdin.write("\n")
 pipe.stdin.close()
 pipe.wait()
 
 os.chdir("..")
+
+sys.exit(pipe.returncode)


### PR DESCRIPTION
Slightly more complicated clojure.
The only thing really changing here is that it checks the values for the `:fail` and `:error` keys in the return value of `run-tests`

In case of error, `System.exit(1)`. 
In the python, propagate the exit code.