### PR TITLE
[STORM-789] Send more topology context to Multi-Lang components via initial handshake

### DIFF
--- a/docs/documentation/Multilang-protocol.md
+++ b/docs/documentation/Multilang-protocol.md
@@ -49,7 +49,7 @@ STDIN and STDOUT.
 
 The initial handshake is the same for both types of shell components:
 
-* STDIN: Setup info. This is a JSON object with the Storm configuration, Topology context, and a PID directory, like this:
+* STDIN: Setup info. This is a JSON object with the Storm configuration, a PID directory, and a topology context, like this:
 
 ```
 {
@@ -57,21 +57,47 @@ The initial handshake is the same for both types of shell components:
         "topology.message.timeout.secs": 3,
         // etc
     },
+    "pidDir": "...",
     "context": {
         "task->component": {
             "1": "example-spout",
             "2": "__acker",
-            "3": "example-bolt"
+            "3": "example-bolt1",
+            "4": "example-bolt2"
         },
-        "taskid": 3
-    },
-    "pidDir": "..."
+        "taskid": 3,
+        // Everything below this line is only available in Storm 0.11.0+
+        "componentid": "example-bolt"
+        "stream->target->grouping": {
+        	"default": {
+        		"example-bolt2": {
+        			"type": "SHUFFLE"}}},
+        "streams": ["default"],
+ 		"stream->outputfields": {"default": ["word"]},
+	    "source->stream->grouping": {
+	    	"example-spout": {
+	    		"default": {
+	    			"type": "FIELDS",
+	    			"fields": ["word"]
+	    		}
+	    	}
+	    }
+	}
 }
 ```
 
 Your script should create an empty file named with its PID in this directory. e.g.
 the PID is 1234, so an empty file named 1234 is created in the directory. This
 file lets the supervisor know the PID so it can shutdown the process later on.
+
+As of Storm 0.11.0, the context sent by Storm to shell components has been
+enhanced substantially to include all aspects of the topology context available
+to JVM components.  One key addition is the ability to determine a shell
+component's source and targets (i.e., inputs and outputs) in the topology via
+the `stream->target->grouping` and `source->stream->grouping` dictionaries.  At
+the innermost level of these nested dictionaries, groupings are represented as
+a dictionary that minimally has a `type` key, but can also have a `fields` key
+to specify which fields are involved in a `FIELDS` grouping.
 
 * STDOUT: Your PID, in a JSON object, like `{"pid": 1234}`. The shell component will log the PID to its log.
 
@@ -222,30 +248,35 @@ A "log" will log a message in the worker log. It looks like:
 * Note that, as of version 0.7.1, there is no longer any need for a
   shell bolt to 'sync'.
 
-### Handling Heartbeat (0.9.3 and later)
+### Handling Heartbeats (0.9.3 and later)
 
-ShellSpout/ShellBolt has been introduced from [STORM-513](https://issues.apache.org/jira/browse/STORM-513) to prevent hanging/zombie subprocess.
+As of Storm 0.9.3, heartbeats have been between ShellSpout/ShellBolt and their
+multi-lang subprocesses to detect hanging/zombie subprocesses.  Any libraries
+for interfacing with Storm via multi-lang must take the following actions
+regarding hearbeats:
 
-* Spout
+#### Spout
 
-Shell spouts are synchronous, and subprocess always send 'sync' at the end of next() so you don't need to take care of.
-One thing you have to take care of is, don't let subprocess sleep too much from next(), especially keep it less to worker timeout.
+Shell spouts are synchronous, so subprocesses always send `sync` commands at the
+end of `next()`,  so you should not have to do much to support heartbeats for
+spouts.  That said, you must not let subprocesses sleep more than the worker
+timeout during `next()`.
 
-* Bolt
+#### Bolt
 
-Shell bolts are asynchronous, so ShellBolt will send heartbeat tuple periodically.
-Heartbeat tuple looks like:
+Shell bolts are asynchronous, so a ShellBolt will send heartbeat tuples to its
+subprocess periodically.  Heartbeat tuple looks like:
 
 ```
 {
 	"id": "-6955786537413359385",
 	"comp": "1",
-	// heartbeat tuple
 	"stream": "__heartbeat",
-	// it's system task id
+	// this shell bolt's system task id
 	"task": -1,
 	"tuple": []
 }
 ```
 
-When subprocess receives heartbeat tuple, it should send 'sync' to ShellBolt.
+When subprocess receives heartbeat tuple, it must send a `sync` command back to
+ShellBolt.

--- a/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
+++ b/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
@@ -145,25 +145,25 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
         return getComponentId(_taskId);
     }
 
-    /**
-     * Gets the declared output fields for the specified stream id for the component
-     * this task is a part of.
-     */
-    public Fields getThisOutputFields(String streamId) {
-        return getComponentOutputFields(getThisComponentId(), streamId);
-    }
+	/**
+	 * Gets the declared output fields for the specified stream id for the
+	 * component this task is a part of.
+	 */
+	public Fields getThisOutputFields(String streamId) {
+		return getComponentOutputFields(getThisComponentId(), streamId);
+	}
 
-    /**
-     * Gets the declared output fields for the specified stream id for the component
-     * this task is a part of.
-     */
-    public Map<String, List<String>> getThisOutputFieldsForStreams() {
-    	Map<String, List<String>> streamToFields = new HashMap<String, List<String>>();
-    	for (String stream : this.getThisStreams()) {
-    		streamToFields.put(stream, this.getThisOutputFields(stream).toList());
-    	}
-    	return streamToFields;
-    }
+	/**
+	 * Gets the declared output fields for the specified stream id for the
+	 * component this task is a part of.
+	 */
+	public Map<String, List<String>> getThisOutputFieldsForStreams() {
+		Map<String, List<String>> streamToFields = new HashMap<String, List<String>>();
+		for (String stream : this.getThisStreams()) {
+			streamToFields.put(stream, this.getThisOutputFields(stream).toList());
+		}
+		return streamToFields;
+	}
 
     /**
      * Gets the set of streams declared for the component of this task.
@@ -231,13 +231,14 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
         return _hooks;
     }
 
-    public Object groupingToJSONableObject(Grouping grouping) {
-    	if (grouping.is_set_fields()) {
-    		return grouping.get_fields();
-    	} else {
-    		return grouping.getSetField().toString();
-    	}
-    }
+	private static Map<String, Object> groupingToJSONableMap(Grouping grouping) {
+		Map groupingMap = new HashMap<String, Object>();
+		groupingMap.put("type", grouping.getSetField().toString());
+		if (grouping.is_set_fields()) {
+			groupingMap.put("fields", grouping.get_fields());
+		}
+		return groupingMap;
+	}
     
     @Override
     public String toJSONString() {
@@ -254,7 +255,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
         for (Map.Entry<String, Map<String, Grouping>> entry : this.getThisTargets().entrySet()) {
         	Map stringTargetMap = new HashMap<String, Object>();
         	for (Map.Entry<String, Grouping> innerEntry : entry.getValue().entrySet()) {
-        		stringTargetMap.put(innerEntry.getKey(), groupingToJSONableObject(innerEntry.getValue()));
+        		stringTargetMap.put(innerEntry.getKey(), groupingToJSONableMap(innerEntry.getValue()));
         	}
         	stringTargets.put(entry.getKey(), stringTargetMap);
         }
@@ -268,7 +269,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
         		stringSourceMap = new HashMap<String, Object>();
         		stringSources.put(gid.get_componentId(), stringSourceMap);
         	}
-        	stringSourceMap.put(gid.get_streamId(), groupingToJSONableObject(entry.getValue()));        	
+        	stringSourceMap.put(gid.get_streamId(), groupingToJSONableMap(entry.getValue()));        	
         }
         obj.put("source->stream->grouping", stringSources);
         return JSONValue.toJSONString(obj);

--- a/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
+++ b/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
@@ -260,12 +260,17 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
         }
         obj.put("stream->target->grouping", stringTargets);
         // Convert sources to a JSON serializable format
-        Map<String, String> stringSources = new HashMap<String, String>();
+        Map<String, Map<String, Object>> stringSources = new HashMap<String, Map<String, Object>>();
         for (Map.Entry<GlobalStreamId, Grouping> entry : this.getThisSources().entrySet()) {
-        	Map stringSourceMap = new HashMap<String, Object>();
-        	stringSourceMap.put(entry.getKey().toString(), groupingToJSONableObject(entry.getValue()));
+        	GlobalStreamId gid = entry.getKey();
+        	Map<String, Object> stringSourceMap = stringSources.get(gid.get_componentId());
+        	if (stringSourceMap == null) {
+        		stringSourceMap = new HashMap<String, Object>();
+        		stringSources.put(gid.get_componentId(), stringSourceMap);
+        	}
+        	stringSourceMap.put(gid.get_streamId(), groupingToJSONableObject(entry.getValue()));        	
         }
-        obj.put("sources->grouping", stringSources);
+        obj.put("source->stream->grouping", stringSources);
         return JSONValue.toJSONString(obj);
     }
 

--- a/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
+++ b/storm-core/src/jvm/backtype/storm/task/TopologyContext.java
@@ -55,7 +55,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
     private Map<Integer,Map<Integer, Map<String, IMetric>>> _registeredMetrics;
     private clojure.lang.Atom _openOrPrepareWasCalled;
 
-    
+
     public TopologyContext(StormTopology topology, Map stormConf,
             Map<Integer, String> taskToComponent, Map<String, List<Integer>> componentToSortedTasks,
             Map<String, Map<String, Fields>> componentToStreamToFields,
@@ -75,7 +75,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
     /**
      * All state from all subscribed state spouts streams will be synced with
      * the provided object.
-     * 
+     *
      * <p>It is recommended that your ISubscribedState object is kept as an instance
      * variable of this object. The recommended usage of this method is as follows:</p>
      *
@@ -129,7 +129,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
 
     /**
      * Gets the task id of this task.
-     * 
+     *
      * @return the task id
      */
     public int getThisTaskId() {
@@ -154,6 +154,18 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
     }
 
     /**
+     * Gets the declared output fields for the specified stream id for the component
+     * this task is a part of.
+     */
+    public Map<String, List<String>> getThisOutputFieldsForStreams() {
+    	Map<String, List<String>> streamToFields = new HashMap<String, List<String>>();
+    	for (String stream : this.getThisStreams()) {
+    		streamToFields.put(stream, this.getThisOutputFields(stream).toList());
+    	}
+    	return streamToFields;
+    }
+
+    /**
      * Gets the set of streams declared for the component of this task.
      */
     public Set<String> getThisStreams() {
@@ -175,10 +187,10 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
         }
         throw new RuntimeException("Fatal: could not find this task id in this component");
     }
-    
+
     /**
      * Gets the declared inputs to this component.
-     * 
+     *
      * @return A map from subscribed component/stream to the grouping subscribed with.
      */
     public Map<GlobalStreamId, Grouping> getThisSources() {
@@ -193,11 +205,11 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
     public Map<String, Map<String, Grouping>> getThisTargets() {
         return getTargets(getThisComponentId());
     }
-    
+
     public void setTaskData(String name, Object data) {
         _taskData.put(name, data);
     }
-    
+
     public Object getTaskData(String name) {
         return _taskData.get(name);
     }
@@ -205,18 +217,26 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
     public void setExecutorData(String name, Object data) {
         _executorData.put(name, data);
     }
-    
+
     public Object getExecutorData(String name) {
         return _executorData.get(name);
-    }    
-    
+    }
+
     public void addTaskHook(ITaskHook hook) {
         hook.prepare(_stormConf, this);
         _hooks.add(hook);
     }
-    
+
     public Collection<ITaskHook> getHooks() {
         return _hooks;
+    }
+
+    public Object groupingToJSONableObject(Grouping grouping) {
+    	if (grouping.is_set_fields()) {
+    		return grouping.get_fields();
+    	} else {
+    		return grouping.getSetField().toString();
+    	}
     }
     
     @Override
@@ -224,13 +244,33 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
         Map obj = new HashMap();
         obj.put("task->component", this.getTaskToComponent());
         obj.put("taskid", this.getThisTaskId());
-        // TODO: jsonify StormTopology
-        // at the minimum should send source info
+        obj.put("componentid", this.getThisComponentId());
+        List<String> streamList = new ArrayList<String>();
+        streamList.addAll(this.getThisStreams());
+        obj.put("streams", streamList);
+        obj.put("stream->outputfields", this.getThisOutputFieldsForStreams());
+        // Convert targets to a JSON serializable format
+        Map<String, Map> stringTargets = new HashMap<String, Map>();
+        for (Map.Entry<String, Map<String, Grouping>> entry : this.getThisTargets().entrySet()) {
+        	Map stringTargetMap = new HashMap<String, Object>();
+        	for (Map.Entry<String, Grouping> innerEntry : entry.getValue().entrySet()) {
+        		stringTargetMap.put(innerEntry.getKey(), groupingToJSONableObject(innerEntry.getValue()));
+        	}
+        	stringTargets.put(entry.getKey(), stringTargetMap);
+        }
+        obj.put("stream->target->grouping", stringTargets);
+        // Convert sources to a JSON serializable format
+        Map<String, String> stringSources = new HashMap<String, String>();
+        for (Map.Entry<GlobalStreamId, Grouping> entry : this.getThisSources().entrySet()) {
+        	Map stringSourceMap = new HashMap<String, Object>();
+        	stringSourceMap.put(entry.getKey().toString(), groupingToJSONableObject(entry.getValue()));
+        }
+        obj.put("sources->grouping", stringSources);
         return JSONValue.toJSONString(obj);
     }
 
     /*
-     * Register a IMetric instance. 
+     * Register a IMetric instance.
      * Storm will then call getValueAndReset on the metric every timeBucketSizeInSecs
      * and the returned value is sent to all metrics consumers.
      * You must call this during IBolt::prepare or ISpout::open.
@@ -238,7 +278,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
      */
     public <T extends IMetric> T registerMetric(String name, T metric, int timeBucketSizeInSecs) {
         if((Boolean)_openOrPrepareWasCalled.deref() == true) {
-            throw new RuntimeException("TopologyContext.registerMetric can only be called from within overridden " + 
+            throw new RuntimeException("TopologyContext.registerMetric can only be called from within overridden " +
                                        "IBolt::prepare() or ISpout::open() method.");
         }
 
@@ -250,7 +290,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
             throw new IllegalArgumentException("TopologyContext.registerMetric can only be called with timeBucketSizeInSecs " +
                                                "greater than or equal to 1 second.");
         }
-        
+
         if (getRegisteredMetricByName(name) != null) {
             throw new RuntimeException("The same metric name `" + name + "` was registered twice." );
         }
@@ -278,7 +318,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
     /**
      * Get component's metric from registered metrics by name.
      * Notice: Normally, one component can only register one metric name once.
-     *         But now registerMetric has a bug(https://issues.apache.org/jira/browse/STORM-254) 
+     *         But now registerMetric has a bug(https://issues.apache.org/jira/browse/STORM-254)
      *         cause the same metric name can register twice.
      *         So we just return the first metric we meet.
      */
@@ -291,14 +331,14 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
                 metric = nameToMetric.get(name);
                 if (metric != null) {
                     //we just return the first metric we meet
-                    break;  
+                    break;
                 }
             }
-        } 
-        
+        }
+
         return metric;
-    }   
- 
+    }
+
     /*
      * Convinience method for registering ReducedMetric.
      */


### PR DESCRIPTION
This PR adds the following keys to the "context" JSON dictionary sent to multi-lang tasks as part of their handshake with ShellBolt/ShellSpout:

-  `componentid`: the component ID for this task, so you no longer have to look it up in `task->component` by `taskid`
-  `streams`: a list of all of the streams for this task
-  `stream->outputfields`:  a mapping from stream names to output fields for that stream
-  `stream->target->grouping`: a mapping from stream names to the targets for this task to the kind of grouping they use.
-  `source->stream->grouping`:  a mapping from the component IDs of the sources to their streams to their groupings.

Note on groupings:  groupings are represented as a dictionary containing a required `type` key (e.g., `"SHUFFLE"`) and an optional `fields` key (for fields groupings).