### PR TITLE
STORM-790 Log "task is null" instead of let worker died when task is null in transfer-fn

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -133,8 +133,10 @@
                     (when (not (.get remoteMap node+port))
                       (.put remoteMap node+port (ArrayList.)))
                     (let [remote (.get remoteMap node+port)]
-                      (.add remote (TaskMessage. task (.serialize serializer tuple)))
-                     )))) 
+                      (if (not-nil? task)
+                        (.add remote (TaskMessage. task (.serialize serializer tuple)))
+                        (log-warn "Can't transfer tuple - task value is null. tuple information: " tuple))
+                     ))))
                 (local-transfer local)
                 (disruptor/publish transfer-queue remoteMap)
               ))]

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -135,7 +135,7 @@
                     (let [remote (.get remoteMap node+port)]
                       (if (not-nil? task)
                         (.add remote (TaskMessage. task (.serialize serializer tuple)))
-                        (log-warn "Can't transfer tuple - task value is null. tuple information: " tuple))
+                        (log-warn "Can't transfer tuple - task value is null. tuple type: " (type tuple) " and information: " tuple))
                      ))))
                 (local-transfer local)
                 (disruptor/publish transfer-queue remoteMap)

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -135,7 +135,7 @@
                     (let [remote (.get remoteMap node+port)]
                       (if (not-nil? task)
                         (.add remote (TaskMessage. task (.serialize serializer tuple)))
-                        (log-warn "Can't transfer tuple - task value is null. tuple type: " (type tuple) " and information: " tuple))
+                        (log-warn "Can't transfer tuple - task value is nil. tuple type: " (pr-str (type tuple)) " and information: " (pr-str tuple)))
                      ))))
                 (local-transfer local)
                 (disruptor/publish transfer-queue remoteMap)


### PR DESCRIPTION
When task is null in transfer-fn, creating TaskMessage leads NPE.

Please refer https://issues.apache.org/jira/browse/STORM-770 and https://issues.apache.org/jira/browse/STORM-790.

Thanks!
