### PR TITLE
[STORM-756] ShellBolt can delay sending tuples on demand from subprocess

### DIFF
--- a/storm-multilang/python/src/main/resources/resources/storm.py
+++ b/storm-multilang/python/src/main/resources/resources/storm.py
@@ -70,6 +70,9 @@ def readCommand():
             msg = readMsg()
         return msg
 
+def getPendingQueueSize():
+    return len(pending_commands)
+
 def readTuple():
     cmd = readCommand()
     return Tuple(cmd["id"], cmd["comp"], cmd["stream"], cmd["task"], cmd["tuple"])
@@ -155,6 +158,9 @@ def logError(msg):
 
 def rpcMetrics(name, params):
     sendMsgToParent({"command": "metrics", "name": name, "params": params})
+
+def delay(sec):
+    sendMsgToParent({"command": "delay", "msg": sec})
 
 def initComponent():
     setupInfo = readMsg()

--- a/storm-multilang/ruby/src/main/resources/resources/storm.rb
+++ b/storm-multilang/ruby/src/main/resources/resources/storm.rb
@@ -63,10 +63,18 @@ module Storm
           end
     end
 
+    def get_pending_queue_size
+      Storm::Protocol.pending_commands.length
+    end
+    
     def send_msg_to_parent(msg)
       puts msg.to_json
       puts "end"
       STDOUT.flush
+    end
+
+    def delay(sec)
+      send_msg_to_parent :command => :delay, :msg => sec.to_s
     end
 
     def sync


### PR DESCRIPTION
Please refer https://issues.apache.org/jira/browse/STORM-756 to see more details.

* introduce new multilang protocol: delay [seconds]
  * command: "delay", msg: "seconds(number format)"
  * python: storm.delay(seconds)
  * ruby: Storm::Protocol.delay(seconds)
* expose pending queue size to let users check and request delay
  * python: storm.getPendingQueueSize()
  * ruby: Storm::Protocol.get_pending_queue_size()