### PR TITLE
[STORM-796] Add support for "error" command in ShellSpout

### DIFF
--- a/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -154,6 +154,8 @@ public class ShellSpout implements ISpout {
                     return;
                 } else if (command.equals("log")) {
                     handleLog(shellMsg);
+                } else if (command.equals("error")) {
+                    handleError(shellMsg.getMsg());
                 } else if (command.equals("emit")) {
                     String stream = shellMsg.getStream();
                     Long task = shellMsg.getTask();
@@ -204,6 +206,10 @@ public class ShellSpout implements ISpout {
                 LOG.info(msg);
                 break;
         }
+    }
+
+    private void handleError(String msg) {
+        _collector.reportError(new Exception("Shell Process Exception: " + msg));
     }
 
     @Override


### PR DESCRIPTION
Addresses JIRA issue [STORM-796](https://issues.apache.org/jira/browse/STORM-796). 

The symptoms a multi-lang user will see here is that if their Spout throws an error and their multi-lang implementation sends an "error" command up to the ShellSpout, the ShellSpout will respond saying that it doesn't recognize the "error" command, and thus it will crash (while swallowing the exception thrown by the underlying multi-lang component).

ShellBolt already supports the error command, and ShellSpout already has a way of reporting errors -- so this was just a matter of adding similar logic to the ShellSpout.
