### PR TITLE
[STORM-436] Clean up ns declarations

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -239,7 +239,7 @@ The following commands must be run from the top-level directory.
     # Build the code but skip the tests
     $ mvn clean install -DskipTests=true
 
-In case you modified `storm.thrift`, you have to regenerate thrift code as java and python code before compiling whole project.
+In case you modified `storm.thrift`, you have to regenerate thrift code as java and python code before compiling whole project. You will need to install thrift 7 from http://archive.apache.org/dist/thrift/ before running this code.
 
 ```sh
 cd storm-core/src

--- a/examples/storm-starter/src/clj/storm/starter/clj/word_count.clj
+++ b/examples/storm-starter/src/clj/storm/starter/clj/word_count.clj
@@ -14,8 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.starter.clj.word-count
-  (:import [backtype.storm StormSubmitter LocalCluster])
   (:use [backtype.storm clojure config])
+  (:import [backtype.storm StormSubmitter LocalCluster])
   (:gen-class))
 
 (defspout sentence-spout ["sentence"]
@@ -27,7 +27,7 @@
     (spout
      (nextTuple []
        (Thread/sleep 100)
-       (emit-spout! collector [(rand-nth sentences)])         
+       (emit-spout! collector [(rand-nth sentences)])
        )
      (ack [id]
         ;; You only need to define this method for reliable spouts

--- a/examples/storm-starter/src/clj/storm/starter/clj/word_count.clj
+++ b/examples/storm-starter/src/clj/storm/starter/clj/word_count.clj
@@ -14,7 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.starter.clj.word-count
-  (:use [backtype.storm clojure config])
+  (:require [backtype.storm.clojure :refer :all]
+        [backtype.storm.config :refer :all])
   (:import [backtype.storm StormSubmitter LocalCluster])
   (:gen-class))
 

--- a/storm-core/src/clj/backtype/storm/LocalCluster.clj
+++ b/storm-core/src/clj/backtype/storm/LocalCluster.clj
@@ -15,7 +15,8 @@
 ;; limitations under the License.
 
 (ns backtype.storm.LocalCluster
-  (:use [backtype.storm testing config])
+  (:require [backtype.storm.testing :as testing]
+            [backtype.storm.config :as c])
   (:import [java.util Map])
   (:gen-class
     :init init
@@ -25,26 +26,26 @@
 
 (defn -init
   ([]
-   (let [ret (mk-local-storm-cluster
+   (let [ret (testing/mk-local-storm-cluster
                :daemon-conf
-               {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true})]
+               {c/TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true})]
      [[] ret]))
   ([^String zk-host ^Long zk-port]
-   (let [ret (mk-local-storm-cluster :daemon-conf {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true
-                                                     STORM-ZOOKEEPER-SERVERS (list zk-host)
-                                                     STORM-ZOOKEEPER-PORT zk-port})]
+   (let [ret (testing/mk-local-storm-cluster :daemon-conf {c/TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true
+                                                     c/STORM-ZOOKEEPER-SERVERS (list zk-host)
+                                                     c/STORM-ZOOKEEPER-PORT zk-port})]
      [[] ret]))
   ([^Map stateMap]
    [[] stateMap]))
 
 (defn -submitTopology
   [this name conf topology]
-  (submit-local-topology
+  (testing/submit-local-topology
     (:nimbus (. this state)) name conf topology))
 
 (defn -submitTopologyWithOpts
   [this name conf topology submit-opts]
-  (submit-local-topology-with-opts
+  (testing/submit-local-topology-with-opts
     (:nimbus (. this state)) name conf topology submit-opts))
 
 (defn -uploadNewCredentials
@@ -53,7 +54,7 @@
 
 (defn -shutdown
   [this]
-  (kill-local-storm-cluster (. this state)))
+  (testing/kill-local-storm-cluster (. this state)))
 
 (defn -killTopology
   [this name]

--- a/storm-core/src/clj/backtype/storm/LocalDRPC.clj
+++ b/storm-core/src/clj/backtype/storm/LocalDRPC.clj
@@ -15,8 +15,8 @@
 ;; limitations under the License.
 
 (ns backtype.storm.LocalDRPC
-  (:require [backtype.storm.daemon [drpc :as drpc]])
   (:use [backtype.storm config util])
+  (:require [backtype.storm.daemon [drpc :as drpc]])
   (:import [backtype.storm.utils InprocMessaging ServiceRegistry])
   (:gen-class
    :init init

--- a/storm-core/src/clj/backtype/storm/LocalDRPC.clj
+++ b/storm-core/src/clj/backtype/storm/LocalDRPC.clj
@@ -15,9 +15,9 @@
 ;; limitations under the License.
 
 (ns backtype.storm.LocalDRPC
-  (:use [backtype.storm config util])
-  (:require [backtype.storm.daemon [drpc :as drpc]])
-  (:import [backtype.storm.utils InprocMessaging ServiceRegistry])
+  (:require [backtype.storm.daemon [drpc :as drpc]]
+            [backtype.storm.config :as c])
+  (:import [backtype.storm.utils ServiceRegistry])
   (:gen-class
    :init init
    :implements [backtype.storm.ILocalDRPC]
@@ -25,7 +25,7 @@
    :state state ))
 
 (defn -init []
-  (let [handler (drpc/service-handler (read-storm-config))
+  (let [handler (drpc/service-handler (c/read-storm-config))
         id (ServiceRegistry/registerService handler)
         ]
     [[] {:service-id id :handler handler}]

--- a/storm-core/src/clj/backtype/storm/MockAutoCred.clj
+++ b/storm-core/src/clj/backtype/storm/MockAutoCred.clj
@@ -16,7 +16,6 @@
 
 ;;mock implementation of INimbusCredentialPlugin,IAutoCredentials and ICredentialsRenewer for testing only.
 (ns backtype.storm.MockAutoCred
-  (:use [backtype.storm testing config])
   (:import [backtype.storm.security.INimbusCredentialPlugin]
            [backtype.storm.security.auth   ICredentialsRenewer])
   (:gen-class

--- a/storm-core/src/clj/backtype/storm/clojure.clj
+++ b/storm-core/src/clj/backtype/storm/clojure.clj
@@ -16,15 +16,15 @@
 
 (ns backtype.storm.clojure
   (:use [backtype.storm util])
-  (:import [backtype.storm StormSubmitter])
-  (:import [backtype.storm.generated StreamInfo])
-  (:import [backtype.storm.tuple Tuple])
-  (:import [backtype.storm.task OutputCollector IBolt TopologyContext])
-  (:import [backtype.storm.spout SpoutOutputCollector ISpout])
-  (:import [backtype.storm.utils Utils])
-  (:import [backtype.storm.clojure ClojureBolt ClojureSpout])
-  (:import [java.util List])
-  (:require [backtype.storm [thrift :as thrift]]))
+  (:require [backtype.storm [thrift :as thrift]])
+  (:import [backtype.storm StormSubmitter]
+           [backtype.storm.generated StreamInfo]
+           [backtype.storm.tuple Tuple]
+           [backtype.storm.task OutputCollector IBolt TopologyContext]
+           [backtype.storm.spout SpoutOutputCollector ISpout]
+           [backtype.storm.utils Utils]
+           [backtype.storm.clojure ClojureBolt ClojureSpout]
+           [java.util List]))
 
 (defn direct-stream [fields]
   (StreamInfo. fields true))

--- a/storm-core/src/clj/backtype/storm/clojure.clj
+++ b/storm-core/src/clj/backtype/storm/clojure.clj
@@ -15,8 +15,8 @@
 ;; limitations under the License.
 
 (ns backtype.storm.clojure
-  (:use [backtype.storm util])
-  (:require [backtype.storm [thrift :as thrift]])
+  (:require [backtype.storm [thrift :as thrift]]
+            [backtype.storm.util :as util :refer [defnk defalias]])
   (:import [backtype.storm StormSubmitter]
            [backtype.storm.generated StreamInfo]
            [backtype.storm.tuple Tuple]
@@ -155,14 +155,14 @@
 
 (defnk emit-bolt! [collector values
                    :stream Utils/DEFAULT_STREAM_ID :anchor []]
-  (let [^List anchor (collectify anchor)
+  (let [^List anchor (util/collectify anchor)
         values (tuple-values values collector stream) ]
     (.emit ^OutputCollector (:output-collector collector) stream anchor values)
     ))
 
 (defnk emit-direct-bolt! [collector task values
                           :stream Utils/DEFAULT_STREAM_ID :anchor []]
-  (let [^List anchor (collectify anchor)
+  (let [^List anchor (util/collectify anchor)
         values (tuple-values values collector stream) ]
     (.emitDirect ^OutputCollector (:output-collector collector) task stream anchor values)
     ))

--- a/storm-core/src/clj/backtype/storm/cluster.clj
+++ b/storm-core/src/clj/backtype/storm/cluster.clj
@@ -15,15 +15,15 @@
 ;; limitations under the License.
 
 (ns backtype.storm.cluster
-  (:use [backtype.storm util log config converter])
   (:require [backtype.storm [zookeeper :as zk]]
-            [backtype.storm.daemon [common :as common]])
-  (:import [org.apache.zookeeper.data Stat ACL Id]
+            [backtype.storm.util :as util :refer [defnk]]
+            [backtype.storm.log :refer [log-warn log-warn-error]]
+            [backtype.storm.converter :as converter]
+            [backtype.storm.config :as c])
+  (:import [org.apache.zookeeper.data ACL Id]
            [backtype.storm.generated SupervisorInfo Assignment StormBase ClusterWorkerHeartbeat ErrorInfo Credentials]
-           [java.io Serializable]
-           [org.apache.zookeeper KeeperException KeeperException$NoNodeException ZooDefs ZooDefs$Ids ZooDefs$Perms]
+           [org.apache.zookeeper KeeperException KeeperException$NoNodeException ZooDefs$Ids ZooDefs$Perms]
            [backtype.storm.utils Utils]
-           [java.security MessageDigest]
            [org.apache.zookeeper.server.auth DigestAuthenticationProvider]))
 
 (defprotocol ClusterState
@@ -44,23 +44,23 @@
 
 (defn mk-topo-only-acls
   [topo-conf]
-  (let [payload (.get topo-conf STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD)]
+  (let [payload (.get topo-conf c/STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD)]
     (when (Utils/isZkAuthenticationConfiguredTopology topo-conf)
       [(first ZooDefs$Ids/CREATOR_ALL_ACL)
        (ACL. ZooDefs$Perms/READ (Id. "digest" (DigestAuthenticationProvider/generateDigest payload)))])))
 
 (defnk mk-distributed-cluster-state
   [conf :auth-conf nil :acls nil]
-  (let [zk (zk/mk-client conf (conf STORM-ZOOKEEPER-SERVERS) (conf STORM-ZOOKEEPER-PORT) :auth-conf auth-conf)]
-    (zk/mkdirs zk (conf STORM-ZOOKEEPER-ROOT) acls)
+  (let [zk (zk/mk-client conf (conf c/STORM-ZOOKEEPER-SERVERS) (conf c/STORM-ZOOKEEPER-PORT) :auth-conf auth-conf)]
+    (zk/mkdirs zk (conf c/STORM-ZOOKEEPER-ROOT) acls)
     (.close zk))
   (let [callbacks (atom {})
         active (atom true)
         zk (zk/mk-client conf
-                         (conf STORM-ZOOKEEPER-SERVERS)
-                         (conf STORM-ZOOKEEPER-PORT)
+                         (conf c/STORM-ZOOKEEPER-SERVERS)
+                         (conf c/STORM-ZOOKEEPER-PORT)
                          :auth-conf auth-conf
-                         :root (conf STORM-ZOOKEEPER-ROOT)
+                         :root (conf c/STORM-ZOOKEEPER-ROOT)
                          :watcher (fn [state type path]
                                     (when @active
                                       (when-not (= :connected state)
@@ -73,7 +73,7 @@
 
      (register
        [this callback]
-       (let [id (uuid)]
+       (let [id (util/uuid)]
          (swap! callbacks assoc id callback)
          id))
 
@@ -83,9 +83,9 @@
 
      (set-ephemeral-node
        [this path data acls]
-       (zk/mkdirs zk (parent-path path) acls)
+       (zk/mkdirs zk (util/parent-path path) acls)
        (if (zk/exists zk path false)
-         (try-cause
+         (util/try-cause
            (zk/set-data zk path data) ; should verify that it's ephemeral
            (catch KeeperException$NoNodeException e
              (log-warn-error e "Ephemeral node disappeared between checking for existing and setting data")
@@ -102,7 +102,7 @@
        (if (zk/exists zk path false)
          (zk/set-data zk path data)
          (do
-           (zk/mkdirs zk (parent-path path) acls)
+           (zk/mkdirs zk (util/parent-path path) acls)
            (zk/create-node zk path data :persistent acls))))
 
      (delete-node
@@ -210,7 +210,7 @@
 
 (defn error-path
   [storm-id component-id]
-  (str (error-storm-root storm-id) "/" (url-encode component-id)))
+  (str (error-storm-root storm-id) "/" (util/url-encode component-id)))
 
 (def last-error-path-seg "last-error")
 
@@ -218,7 +218,7 @@
   [storm-id component-id]
   (str (error-storm-root storm-id)
        "/"
-       (url-encode component-id)
+       (util/url-encode component-id)
        "-"
        last-error-path-seg))
 
@@ -280,7 +280,7 @@
         state-id (register
                   cluster-state
                   (fn [type path]
-                    (let [[subtree & args] (tokenize-path path)]
+                    (let [[subtree & args] (util/tokenize-path path)]
                       (condp = subtree
                          ASSIGNMENTS-ROOT (if (empty? args)
                                              (issue-callback! assignments-callback)
@@ -292,7 +292,7 @@
                          STORMS-ROOT (issue-map-callback! storm-base-callback (first args))
                          CREDENTIALS-ROOT (issue-map-callback! credentials-callback (first args))
                          ;; this should never happen
-                         (exit-process! 30 "Unknown callback for subtree " subtree args)))))]
+                         (util/exit-process! 30 "Unknown callback for subtree " subtree args)))))]
     (doseq [p [ASSIGNMENTS-SUBTREE STORMS-SUBTREE SUPERVISORS-SUBTREE WORKERBEATS-SUBTREE ERRORS-SUBTREE]]
       (mkdirs cluster-state p acls))
     (reify
@@ -302,28 +302,28 @@
         [this callback]
         (when callback
           (reset! assignments-callback callback))
-        (get-children cluster-state ASSIGNMENTS-SUBTREE (not-nil? callback)))
+        (get-children cluster-state ASSIGNMENTS-SUBTREE (util/not-nil? callback)))
 
       (assignment-info
         [this storm-id callback]
         (when callback
           (swap! assignment-info-callback assoc storm-id callback))
-        (clojurify-assignment (maybe-deserialize (get-data cluster-state (assignment-path storm-id) (not-nil? callback)) Assignment)))
+        (converter/clojurify-assignment (maybe-deserialize (get-data cluster-state (assignment-path storm-id) (util/not-nil? callback)) Assignment)))
 
       (assignment-info-with-version
         [this storm-id callback]
         (when callback
           (swap! assignment-info-with-version-callback assoc storm-id callback))
         (let [{data :data version :version}
-              (get-data-with-version cluster-state (assignment-path storm-id) (not-nil? callback))]
-        {:data (clojurify-assignment (maybe-deserialize data Assignment))
+              (get-data-with-version cluster-state (assignment-path storm-id) (util/not-nil? callback))]
+        {:data (converter/clojurify-assignment (maybe-deserialize data Assignment))
          :version version}))
 
       (assignment-version
         [this storm-id callback]
         (when callback
           (swap! assignment-version-callback assoc storm-id callback))
-        (get-version cluster-state (assignment-path storm-id) (not-nil? callback)))
+        (get-version cluster-state (assignment-path storm-id) (util/not-nil? callback)))
 
       (active-storms
         [this]
@@ -343,7 +343,7 @@
           (if worker-hb
             (-> worker-hb
               (maybe-deserialize ClusterWorkerHeartbeat)
-              clojurify-zk-worker-hb))))
+              converter/clojurify-zk-worker-hb))))
 
 
       (executor-beats
@@ -352,7 +352,7 @@
         ;; long dead worker with a skewed clock overrides all the timestamps. By only checking heartbeats
         ;; with an assigned node+port, and only reading executors from that heartbeat that are actually assigned,
         ;; we avoid situations like that
-        (let [node+port->executors (reverse-map executor->node+port)
+        (let [node+port->executors (util/reverse-map executor->node+port)
               all-heartbeats (for [[[node port] executors] node+port->executors]
                                (->> (get-worker-heartbeat this storm-id node port)
                                     (convert-executor-beats executors)
@@ -363,15 +363,15 @@
         [this callback]
         (when callback
           (reset! supervisors-callback callback))
-        (get-children cluster-state SUPERVISORS-SUBTREE (not-nil? callback)))
+        (get-children cluster-state SUPERVISORS-SUBTREE (util/not-nil? callback)))
 
       (supervisor-info
         [this supervisor-id]
-        (clojurify-supervisor-info (maybe-deserialize (get-data cluster-state (supervisor-path supervisor-id) false) SupervisorInfo)))
+        (converter/clojurify-supervisor-info (maybe-deserialize (get-data cluster-state (supervisor-path supervisor-id) false) SupervisorInfo)))
 
       (worker-heartbeat!
         [this storm-id node port info]
-        (let [thrift-worker-hb (thriftify-zk-worker-hb info)]
+        (let [thrift-worker-hb (converter/thriftify-zk-worker-hb info)]
           (if thrift-worker-hb
             (set-data cluster-state (workerbeat-path storm-id node port) (Utils/serialize thrift-worker-hb) acls))))
 
@@ -385,37 +385,37 @@
 
       (teardown-heartbeats!
         [this storm-id]
-        (try-cause
+        (util/try-cause
           (delete-node cluster-state (workerbeat-storm-root storm-id))
           (catch KeeperException e
             (log-warn-error e "Could not teardown heartbeats for " storm-id))))
 
       (teardown-topology-errors!
         [this storm-id]
-        (try-cause
+        (util/try-cause
           (delete-node cluster-state (error-storm-root storm-id))
           (catch KeeperException e
             (log-warn-error e "Could not teardown errors for " storm-id))))
 
       (supervisor-heartbeat!
         [this supervisor-id info]
-        (let [thrift-supervisor-info (thriftify-supervisor-info info)]
+        (let [thrift-supervisor-info (converter/thriftify-supervisor-info info)]
           (set-ephemeral-node cluster-state (supervisor-path supervisor-id) (Utils/serialize thrift-supervisor-info) acls)))
 
       (activate-storm!
         [this storm-id storm-base]
-        (let [thrift-storm-base (thriftify-storm-base storm-base)]
+        (let [thrift-storm-base (converter/thriftify-storm-base storm-base)]
           (set-data cluster-state (storm-path storm-id) (Utils/serialize thrift-storm-base) acls)))
 
       (update-storm!
         [this storm-id new-elems]
         (let [base (storm-base this storm-id nil)
               executors (:component->executors base)
-              new-elems (update new-elems :component->executors (partial merge executors))]
+              new-elems (util/update new-elems :component->executors (partial merge executors))]
           (set-data cluster-state (storm-path storm-id)
                     (-> base
                         (merge new-elems)
-                        thriftify-storm-base
+                        converter/thriftify-storm-base
                         Utils/serialize)
                     acls)))
 
@@ -423,7 +423,7 @@
         [this storm-id callback]
         (when callback
           (swap! storm-base-callback assoc storm-id callback))
-        (clojurify-storm-base (maybe-deserialize (get-data cluster-state (storm-path storm-id) (not-nil? callback)) StormBase)))
+        (converter/clojurify-storm-base (maybe-deserialize (get-data cluster-state (storm-path storm-id) (util/not-nil? callback)) StormBase)))
 
       (remove-storm-base!
         [this storm-id]
@@ -431,7 +431,7 @@
 
       (set-assignment!
         [this storm-id info]
-        (let [thrift-assignment (thriftify-assignment info)]
+        (let [thrift-assignment (converter/thriftify-assignment info)]
           (set-data cluster-state (assignment-path storm-id) (Utils/serialize thrift-assignment) acls)))
 
       (remove-storm!
@@ -444,20 +444,23 @@
          [this storm-id creds topo-conf]
          (let [topo-acls (mk-topo-only-acls topo-conf)
                path (credentials-path storm-id)
-               thriftified-creds (thriftify-credentials creds)]
+               thriftified-creds (converter/thriftify-credentials creds)]
            (set-data cluster-state path (Utils/serialize thriftified-creds) topo-acls)))
 
       (credentials
         [this storm-id callback]
         (when callback
           (swap! credentials-callback assoc storm-id callback))
-        (clojurify-crdentials (maybe-deserialize (get-data cluster-state (credentials-path storm-id) (not-nil? callback)) Credentials)))
+        (converter/clojurify-crdentials (maybe-deserialize (get-data cluster-state (credentials-path storm-id) (util/not-nil? callback)) Credentials)))
 
       (report-error
          [this storm-id component-id node port error]
          (let [path (error-path storm-id component-id)
                last-error-path (last-error-path storm-id component-id)
-               data (thriftify-error {:time-secs (current-time-secs) :error (stringify-error error) :host node :port port})
+               data (converter/thriftify-error {:time-secs (util/current-time-secs)
+                                      :error (util/stringify-error error)
+                                      :host node
+                                      :port port})
                _ (mkdirs cluster-state path acls)
                ser-data (Utils/serialize data)
                _ (mkdirs cluster-state path acls)
@@ -474,15 +477,15 @@
          [this storm-id component-id]
          (let [path (error-path storm-id component-id)
                errors (if (exists-node? cluster-state path false)
-                        (dofor [c (get-children cluster-state path false)]
+                        (util/dofor [c (get-children cluster-state path false)]
                           (if-let [data (-> (get-data cluster-state
                                                       (str path "/" c)
                                                       false)
                                           (maybe-deserialize ErrorInfo)
-                                          clojurify-error)]
+                                          converter/clojurify-error)]
                             (map->TaskError data)))
                         ())]
-           (->> (filter not-nil? errors)
+           (->> (filter util/not-nil? errors)
                 (sort-by (comp - :time-secs)))))
 
       (last-error
@@ -491,7 +494,7 @@
           (if (exists-node? cluster-state path false)
             (if-let [data (-> (get-data cluster-state path false)
                               (maybe-deserialize ErrorInfo)
-                              clojurify-error)]
+                              converter/clojurify-error)]
               (map->TaskError data)))))
 
       (disconnect

--- a/storm-core/src/clj/backtype/storm/cluster.clj
+++ b/storm-core/src/clj/backtype/storm/cluster.clj
@@ -15,16 +15,16 @@
 ;; limitations under the License.
 
 (ns backtype.storm.cluster
+  (:use [backtype.storm util log config converter])
+  (:require [backtype.storm [zookeeper :as zk]]
+            [backtype.storm.daemon [common :as common]])
   (:import [org.apache.zookeeper.data Stat ACL Id]
            [backtype.storm.generated SupervisorInfo Assignment StormBase ClusterWorkerHeartbeat ErrorInfo Credentials]
-           [java.io Serializable])
-  (:import [org.apache.zookeeper KeeperException KeeperException$NoNodeException ZooDefs ZooDefs$Ids ZooDefs$Perms])
-  (:import [backtype.storm.utils Utils])
-  (:import [java.security MessageDigest])
-  (:import [org.apache.zookeeper.server.auth DigestAuthenticationProvider])
-  (:use [backtype.storm util log config converter])
-  (:require [backtype.storm [zookeeper :as zk]])
-  (:require [backtype.storm.daemon [common :as common]]))
+           [java.io Serializable]
+           [org.apache.zookeeper KeeperException KeeperException$NoNodeException ZooDefs ZooDefs$Ids ZooDefs$Perms]
+           [backtype.storm.utils Utils]
+           [java.security MessageDigest]
+           [org.apache.zookeeper.server.auth DigestAuthenticationProvider]))
 
 (defprotocol ClusterState
   (set-ephemeral-node [this path data acls])
@@ -117,7 +117,7 @@
        [this path watch?]
        (zk/get-data-with-version zk path watch?))
 
-     (get-version 
+     (get-version
        [this path watch?]
        (zk/get-version zk path watch?))
 
@@ -310,16 +310,16 @@
           (swap! assignment-info-callback assoc storm-id callback))
         (clojurify-assignment (maybe-deserialize (get-data cluster-state (assignment-path storm-id) (not-nil? callback)) Assignment)))
 
-      (assignment-info-with-version 
+      (assignment-info-with-version
         [this storm-id callback]
         (when callback
           (swap! assignment-info-with-version-callback assoc storm-id callback))
-        (let [{data :data version :version} 
+        (let [{data :data version :version}
               (get-data-with-version cluster-state (assignment-path storm-id) (not-nil? callback))]
         {:data (clojurify-assignment (maybe-deserialize data Assignment))
          :version version}))
 
-      (assignment-version 
+      (assignment-version
         [this storm-id callback]
         (when callback
           (swap! assignment-version-callback assoc storm-id callback))
@@ -493,7 +493,7 @@
                               (maybe-deserialize ErrorInfo)
                               clojurify-error)]
               (map->TaskError data)))))
-      
+
       (disconnect
          [this]
         (unregister cluster-state state-id)

--- a/storm-core/src/clj/backtype/storm/command/activate.clj
+++ b/storm-core/src/clj/backtype/storm/command/activate.clj
@@ -14,11 +14,11 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.activate
-    (:require [backtype.storm.thrift :as t]
-      [backtype.storm.log :as log])
-    (:gen-class))
+  (:require [backtype.storm.thrift :as thrift]
+            [backtype.storm.log :refer [log-message]])
+  (:gen-class))
 
 (defn -main [name]
-  (t/with-configured-nimbus-connection nimbus
+  (thrift/with-configured-nimbus-connection nimbus
     (.activate nimbus name)
-    (log/log-message "Activated topology: " name)))
+    (log-message "Activated topology: " name)))

--- a/storm-core/src/clj/backtype/storm/command/activate.clj
+++ b/storm-core/src/clj/backtype/storm/command/activate.clj
@@ -14,11 +14,11 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.activate
-  (:use [backtype.storm thrift log])
-  (:gen-class))
+    (:require [backtype.storm.thrift :as t]
+      [backtype.storm.log :as log])
+    (:gen-class))
 
-(defn -main [name] 
-  (with-configured-nimbus-connection nimbus
+(defn -main [name]
+  (t/with-configured-nimbus-connection nimbus
     (.activate nimbus name)
-    (log-message "Activated topology: " name)
-    ))
+    (log/log-message "Activated topology: " name)))

--- a/storm-core/src/clj/backtype/storm/command/config_value.clj
+++ b/storm-core/src/clj/backtype/storm/command/config_value.clj
@@ -14,11 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.config-value
-  (:use [backtype.storm config log])
+  (:require [backtype.storm.config :as config]
+            [backtype.storm.log :as log])
   (:gen-class))
 
-
 (defn -main [^String name]
-  (let [conf (read-storm-config)]
-    (println "VALUE:" (conf name))
-    ))
+  (let [conf (config/read-storm-config)]
+    (log/log-message "VALUE:" (conf name))))

--- a/storm-core/src/clj/backtype/storm/command/config_value.clj
+++ b/storm-core/src/clj/backtype/storm/command/config_value.clj
@@ -15,9 +15,9 @@
 ;; limitations under the License.
 (ns backtype.storm.command.config-value
   (:require [backtype.storm.config :as config]
-            [backtype.storm.log :as log])
+            [backtype.storm.log :refer [log-message]])
   (:gen-class))
 
 (defn -main [^String name]
   (let [conf (config/read-storm-config)]
-    (log/log-message "VALUE:" (conf name))))
+    (log-message "VALUE:" (conf name))))

--- a/storm-core/src/clj/backtype/storm/command/deactivate.clj
+++ b/storm-core/src/clj/backtype/storm/command/deactivate.clj
@@ -14,11 +14,11 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.deactivate
-  (:use [backtype.storm thrift log])
+  (:require [backtype.storm.thrift :as thrift]
+            [backtype.storm.log :as log])
   (:gen-class))
 
-(defn -main [name] 
-  (with-configured-nimbus-connection nimbus
+(defn -main [name]
+  (thrift/with-configured-nimbus-connection nimbus
     (.deactivate nimbus name)
-    (log-message "Deactivated topology: " name)
-    ))
+    (log/log-message "Deactivated topology: " name)))

--- a/storm-core/src/clj/backtype/storm/command/deactivate.clj
+++ b/storm-core/src/clj/backtype/storm/command/deactivate.clj
@@ -15,10 +15,10 @@
 ;; limitations under the License.
 (ns backtype.storm.command.deactivate
   (:require [backtype.storm.thrift :as thrift]
-            [backtype.storm.log :as log])
+            [backtype.storm.log :refer [log-message]])
   (:gen-class))
 
 (defn -main [name]
   (thrift/with-configured-nimbus-connection nimbus
     (.deactivate nimbus name)
-    (log/log-message "Deactivated topology: " name)))
+    (log-message "Deactivated topology: " name)))

--- a/storm-core/src/clj/backtype/storm/command/dev_zookeeper.clj
+++ b/storm-core/src/clj/backtype/storm/command/dev_zookeeper.clj
@@ -15,8 +15,8 @@
 ;; limitations under the License.
 (ns backtype.storm.command.dev-zookeeper
   (:require [backtype.storm.zookeeper :as zoo]
-            [backtype.storm.config :as config])
-  (:use [backtype.storm util ])
+            [backtype.storm.config :as config]
+            [backtype.storm.util :refer [rmr]])
   (:gen-class))
 
 (defn -main [& args]

--- a/storm-core/src/clj/backtype/storm/command/dev_zookeeper.clj
+++ b/storm-core/src/clj/backtype/storm/command/dev_zookeeper.clj
@@ -14,13 +14,15 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.dev-zookeeper
-  (:use [backtype.storm zookeeper util config])
+  (:require [backtype.storm.zookeeper :as zoo]
+            [backtype.storm.config :as config])
+  (:use [backtype.storm util ])
   (:gen-class))
 
 (defn -main [& args]
-  (let [conf (read-storm-config)
-        port (conf STORM-ZOOKEEPER-PORT)
-        localpath (conf DEV-ZOOKEEPER-PATH)]
+  (let [conf (config/read-storm-config)
+        port (conf config/STORM-ZOOKEEPER-PORT)
+        localpath (conf config/DEV-ZOOKEEPER-PATH)]
     (rmr localpath)
-    (mk-inprocess-zookeeper localpath :port port)
+    (zoo/mk-inprocess-zookeeper localpath :port port)
     ))

--- a/storm-core/src/clj/backtype/storm/command/kill_topology.clj
+++ b/storm-core/src/clj/backtype/storm/command/kill_topology.clj
@@ -14,8 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.kill-topology
-  (:use [clojure.tools.cli :only [cli]])
-  (:use [backtype.storm thrift config log])
+  (:require [backtype.storm.thrift :as thrift]
+            [clojure.tools.cli :refer [cli]]
+            [backtype.storm.log :as log])
   (:import [backtype.storm.generated KillOptions])
   (:gen-class))
 
@@ -23,7 +24,6 @@
   (let [[{wait :wait} [name] _] (cli args ["-w" "--wait" :default nil :parse-fn #(Integer/parseInt %)])
         opts (KillOptions.)]
     (if wait (.set_wait_secs opts wait))
-    (with-configured-nimbus-connection nimbus
+    (thrift/with-configured-nimbus-connection nimbus
       (.killTopologyWithOpts nimbus name opts)
-      (log-message "Killed topology: " name)
-      )))
+      (log/log-message "Killed topology: " name))))

--- a/storm-core/src/clj/backtype/storm/command/kill_topology.clj
+++ b/storm-core/src/clj/backtype/storm/command/kill_topology.clj
@@ -16,7 +16,7 @@
 (ns backtype.storm.command.kill-topology
   (:require [backtype.storm.thrift :as thrift]
             [clojure.tools.cli :refer [cli]]
-            [backtype.storm.log :as log])
+            [backtype.storm.log :refer [log-message]])
   (:import [backtype.storm.generated KillOptions])
   (:gen-class))
 
@@ -26,4 +26,4 @@
     (if wait (.set_wait_secs opts wait))
     (thrift/with-configured-nimbus-connection nimbus
       (.killTopologyWithOpts nimbus name opts)
-      (log/log-message "Killed topology: " name))))
+      (log-message "Killed topology: " name))))

--- a/storm-core/src/clj/backtype/storm/command/list.clj
+++ b/storm-core/src/clj/backtype/storm/command/list.clj
@@ -14,12 +14,13 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.list
-  (:use [backtype.storm thrift log])
+  (:require [backtype.storm.thrift :as thrift])
   (:import [backtype.storm.generated TopologySummary])
   (:gen-class))
 
+;; TODO: replace with logging, replace with a table generator?
 (defn -main []
-  (with-configured-nimbus-connection nimbus
+  (thrift/with-configured-nimbus-connection nimbus
     (let [cluster-info (.getClusterInfo nimbus)
           topologies (.get_topologies cluster-info)
           msg-format "%-20s %-10s %-10s %-12s %-10s"]

--- a/storm-core/src/clj/backtype/storm/command/monitor.clj
+++ b/storm-core/src/clj/backtype/storm/command/monitor.clj
@@ -14,11 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.monitor
-  (:use [clojure.tools.cli :only [cli]])
-  (:use [backtype.storm.thrift :only [with-configured-nimbus-connection]])
+  (:require [clojure.tools.cli :refer [cli]]
+            [backtype.storm.thrift :as thrift])
   (:import [backtype.storm.utils Monitor])
-  (:gen-class)
- )
+  (:gen-class))
 
 (defn -main [& args]
   (let [[{interval :interval component :component stream :stream watch :watch} [name] _]
@@ -32,6 +31,5 @@
     (if component (.set_component mon component))
     (if stream (.set_stream mon stream))
     (if watch (.set_watch mon watch))
-    (with-configured-nimbus-connection nimbus
-      (.metrics mon nimbus)
-      )))
+    (thrift/with-configured-nimbus-connection nimbus
+      (.metrics mon nimbus))))

--- a/storm-core/src/clj/backtype/storm/command/rebalance.clj
+++ b/storm-core/src/clj/backtype/storm/command/rebalance.clj
@@ -16,10 +16,9 @@
 (ns backtype.storm.command.rebalance
   (:require [clojure.tools.cli :refer [cli]]
             [backtype.storm.thrift :as thrift]
-            [backtype.storm.log :as log])
+            [backtype.storm.log :refer [log-message]])
   (:import [backtype.storm.generated RebalanceOptions])
   (:gen-class))
-;; TODO: do we need all these gen-class's?
 
 (defn- parse-executor [^String s]
   (let [eq-pos (.lastIndexOf s "=")
@@ -43,4 +42,4 @@
     (if num-workers (.set_num_workers opts num-workers))
     (thrift/with-configured-nimbus-connection nimbus
       (.rebalance nimbus name opts)
-      (log/log-message "Topology " name " is rebalancing"))))
+      (log-message "Topology " name " is rebalancing"))))

--- a/storm-core/src/clj/backtype/storm/command/rebalance.clj
+++ b/storm-core/src/clj/backtype/storm/command/rebalance.clj
@@ -14,19 +14,20 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.rebalance
-  (:use [clojure.tools.cli :only [cli]])
-  (:use [backtype.storm thrift config log])
+  (:require [clojure.tools.cli :refer [cli]]
+            [backtype.storm.thrift :as thrift]
+            [backtype.storm.log :as log])
   (:import [backtype.storm.generated RebalanceOptions])
   (:gen-class))
+;; TODO: do we need all these gen-class's?
 
 (defn- parse-executor [^String s]
   (let [eq-pos (.lastIndexOf s "=")
         name (.substring s 0 eq-pos)
         amt (.substring s (inc eq-pos))]
-    {name (Integer/parseInt amt)}
-    ))
+    {name (Integer/parseInt amt)}))
 
-(defn -main [& args] 
+(defn -main [& args]
   (let [[{wait :wait executor :executor num-workers :num-workers} [name] _]
                   (cli args ["-w" "--wait" :default nil :parse-fn #(Integer/parseInt %)]
                             ["-n" "--num-workers" :default nil :parse-fn #(Integer/parseInt %)]
@@ -40,7 +41,6 @@
     (if wait (.set_wait_secs opts wait))
     (if executor (.set_num_executors opts executor))
     (if num-workers (.set_num_workers opts num-workers))
-    (with-configured-nimbus-connection nimbus
+    (thrift/with-configured-nimbus-connection nimbus
       (.rebalance nimbus name opts)
-      (log-message "Topology " name " is rebalancing")
-      )))
+      (log/log-message "Topology " name " is rebalancing"))))

--- a/storm-core/src/clj/backtype/storm/command/shell_submission.clj
+++ b/storm-core/src/clj/backtype/storm/command/shell_submission.clj
@@ -14,17 +14,17 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.shell-submission
+  (:require [clojure.string :as str]
+            [backtype.storm.config :as config]
+            [backtype.storm.util :as util])
   (:import [backtype.storm StormSubmitter])
-  (:use [backtype.storm thrift util config log])
-  (:require [clojure.string :as str])
   (:gen-class))
 
 
 (defn -main [^String tmpjarpath & args]
-  (let [conf (read-storm-config)
-        host (conf NIMBUS-HOST)
-        port (conf NIMBUS-THRIFT-PORT)
+  (let [conf (config/read-storm-config)
+        host (conf config/NIMBUS-HOST)
+        port (conf config/NIMBUS-THRIFT-PORT)
         jarpath (StormSubmitter/submitJar conf tmpjarpath)
         args (concat args [host port jarpath])]
-    (exec-command! (str/join " " args))
-    ))
+    (util/exec-command! (str/join " " args))))

--- a/storm-core/src/clj/backtype/storm/command/upload_credentials.clj
+++ b/storm-core/src/clj/backtype/storm/command/upload_credentials.clj
@@ -14,22 +14,24 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.command.upload-credentials
-  (:use [clojure.tools.cli :only [cli]])
-  (:use [backtype.storm log util])
-  (:import [backtype.storm StormSubmitter])
-  (:import [java.util Properties])
-  (:import [java.io FileReader])
+  (:require [clojure.tools.cli :refer [cli]]
+            [backtype.storm.util :as util]
+            [backtype.storm.log :as log])
+  (:import [backtype.storm StormSubmitter]
+           [java.util Properties]
+           [java.io FileReader])
   (:gen-class))
 
 (defn read-map [file-name]
   (let [props (Properties. )
         _ (.load props (FileReader. file-name))]
-    (clojurify-structure props)))
+    (util/clojurify-structure props)))
 
 (defn -main [& args]
   (let [[{cred-file :file} [name & rawCreds]] (cli args ["-f" "--file" :default nil])
-        _ (when (and rawCreds (not (even? (.size rawCreds)))) (throw (RuntimeException.  "Need an even number of arguments to make a map")))
+        _ (when (and rawCreds (not (even? (.size rawCreds)))) ;; TODO: is the (and rawCreds needed here?
+            (throw (RuntimeException.  "Need an even number of arguments to make a map")))
         mapping (if rawCreds (apply assoc {} rawCreds) {})
         file-mapping (if (nil? cred-file) {} (read-map cred-file))]
       (StormSubmitter/pushCredentials name {} (merge file-mapping mapping))
-      (log-message "Uploaded new creds to topology: " name)))
+      (log/log-message "Uploaded new creds to topology: " name)))

--- a/storm-core/src/clj/backtype/storm/command/upload_credentials.clj
+++ b/storm-core/src/clj/backtype/storm/command/upload_credentials.clj
@@ -16,7 +16,7 @@
 (ns backtype.storm.command.upload-credentials
   (:require [clojure.tools.cli :refer [cli]]
             [backtype.storm.util :as util]
-            [backtype.storm.log :as log])
+            [backtype.storm.log :refer [log-message]])
   (:import [backtype.storm StormSubmitter]
            [java.util Properties]
            [java.io FileReader])
@@ -34,4 +34,4 @@
         mapping (if rawCreds (apply assoc {} rawCreds) {})
         file-mapping (if (nil? cred-file) {} (read-map cred-file))]
       (StormSubmitter/pushCredentials name {} (merge file-mapping mapping))
-      (log/log-message "Uploaded new creds to topology: " name)))
+      (log-message "Uploaded new creds to topology: " name)))

--- a/storm-core/src/clj/backtype/storm/config.clj
+++ b/storm-core/src/clj/backtype/storm/config.clj
@@ -20,7 +20,8 @@
   (:import [backtype.storm Config ConfigValidation$FieldValidator])
   (:import [backtype.storm.utils Utils LocalState])
   (:import [org.apache.commons.io FileUtils])
-  (:require [clojure [string :as str]])
+  (:require [clojure.string :as str]
+            [backtype.storm.util :as util])
   (:use [backtype.storm log util]))
 
 (def RESOURCES-SUBDIR "resources")
@@ -36,7 +37,7 @@
       `(def ~(symbol new-name) (. Config ~(symbol name))))))
 
 (def ALL-CONFIGS
-  (dofor [f (seq (.getFields Config))]
+  (util/dofor [f (seq (.getFields Config))]
          (.get f nil)))
 
 (defmulti get-FieldValidator class-selector)
@@ -236,7 +237,7 @@
     nil
     )))
 
-  
+
 (defn set-worker-user! [conf worker-id user]
   (log-message "SET worker-user " worker-id " " user)
   (let [file (worker-user-file conf worker-id)]

--- a/storm-core/src/clj/backtype/storm/config.clj
+++ b/storm-core/src/clj/backtype/storm/config.clj
@@ -15,14 +15,14 @@
 ;; limitations under the License.
 
 (ns backtype.storm.config
-  (:import [java.io FileReader File IOException]
-           [backtype.storm.generated StormTopology])
-  (:import [backtype.storm Config ConfigValidation$FieldValidator])
-  (:import [backtype.storm.utils Utils LocalState])
-  (:import [org.apache.commons.io FileUtils])
+  (:use [backtype.storm log util])
   (:require [clojure.string :as str]
             [backtype.storm.util :as util])
-  (:use [backtype.storm log util]))
+  (:import [java.io FileReader File IOException]
+           [backtype.storm.generated StormTopology]
+           [backtype.storm Config ConfigValidation$FieldValidator]
+           [backtype.storm.utils Utils LocalState]
+           [org.apache.commons.io FileUtils]))
 
 (def RESOURCES-SUBDIR "resources")
 

--- a/storm-core/src/clj/backtype/storm/converter.clj
+++ b/storm-core/src/clj/backtype/storm/converter.clj
@@ -2,7 +2,7 @@
   (:import [backtype.storm.generated SupervisorInfo NodeInfo Assignment
             StormBase TopologyStatus ClusterWorkerHeartbeat ExecutorInfo ErrorInfo Credentials RebalanceOptions KillOptions TopologyActionOptions])
   (:use [backtype.storm util stats log])
-  (:require [backtype.storm.daemon [common :as common]]))
+  (:require [backtype.storm.daemon.common :as common]))
 
 (defn thriftify-supervisor-info [supervisor-info]
   (doto (SupervisorInfo.)

--- a/storm-core/src/clj/backtype/storm/converter.clj
+++ b/storm-core/src/clj/backtype/storm/converter.clj
@@ -1,8 +1,9 @@
 (ns backtype.storm.converter
-  (:import [backtype.storm.generated SupervisorInfo NodeInfo Assignment
-            StormBase TopologyStatus ClusterWorkerHeartbeat ExecutorInfo ErrorInfo Credentials RebalanceOptions KillOptions TopologyActionOptions])
   (:use [backtype.storm util stats log])
-  (:require [backtype.storm.daemon.common :as common]))
+  (:require [backtype.storm.daemon.common :as common])
+  (:import [backtype.storm.generated SupervisorInfo NodeInfo Assignment
+                                     StormBase TopologyStatus ClusterWorkerHeartbeat ExecutorInfo ErrorInfo
+                                     Credentials RebalanceOptions KillOptions TopologyActionOptions]))
 
 (defn thriftify-supervisor-info [supervisor-info]
   (doto (SupervisorInfo.)

--- a/storm-core/src/clj/backtype/storm/daemon/builtin_metrics.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/builtin_metrics.clj
@@ -14,11 +14,11 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.daemon.builtin-metrics
-  (:import [backtype.storm.metric.api MultiCountMetric MultiReducedMetric MeanReducer StateMetric IMetric IStatefulObject])
-  (:import [backtype.storm Config])
-  (:use [backtype.storm.stats :only [stats-rate]]))
+  (:import [backtype.storm.metric.api MultiCountMetric MultiReducedMetric MeanReducer StateMetric IMetric IStatefulObject]
+           [backtype.storm Config])
+  (:require [backtype.storm.stats :refer [stats-rate]]))
 
-(defrecord BuiltinSpoutMetrics [^MultiCountMetric ack-count                                
+(defrecord BuiltinSpoutMetrics [^MultiCountMetric ack-count
                                 ^MultiReducedMetric complete-latency
                                 ^MultiCountMetric fail-count
                                 ^MultiCountMetric emit-count
@@ -63,25 +63,25 @@
         (into {}
           (map
             (fn [[node+port ^IStatefulObject connection]] [node+port (.getState connection)])
-            (filter 
+            (filter
               (fn [[node+port connection]] (instance? IStatefulObject connection))
               @node+port->socket-ref)))))
     (int (get storm-conf Config/TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS))))
- 
+
 (defn register-queue-metrics [queues storm-conf topology-context]
   (doseq [[qname q] queues]
     (.registerMetric topology-context (str "__" (name qname)) (StateMetric. q)
                      (int (get storm-conf Config/TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS)))))
 
-(defn spout-acked-tuple! [^BuiltinSpoutMetrics m stats stream latency-ms]  
+(defn spout-acked-tuple! [^BuiltinSpoutMetrics m stats stream latency-ms]
   (-> m .ack-count (.scope stream) (.incrBy (stats-rate stats)))
   (-> m .complete-latency (.scope stream) (.update latency-ms)))
 
-(defn spout-failed-tuple! [^BuiltinSpoutMetrics m stats stream]  
+(defn spout-failed-tuple! [^BuiltinSpoutMetrics m stats stream]
   (-> m .fail-count (.scope stream) (.incrBy (stats-rate stats))))
 
 (defn bolt-execute-tuple! [^BuiltinBoltMetrics m stats comp-id stream latency-ms]
-  (let [scope (str comp-id ":" stream)]    
+  (let [scope (str comp-id ":" stream)]
     (-> m .execute-count (.scope scope) (.incrBy (stats-rate stats)))
     (-> m .execute-latency (.scope scope) (.update latency-ms))))
 
@@ -91,7 +91,7 @@
     (-> m .process-latency (.scope scope) (.update latency-ms))))
 
 (defn bolt-failed-tuple! [^BuiltinBoltMetrics m stats comp-id stream]
-  (let [scope (str comp-id ":" stream)]    
+  (let [scope (str comp-id ":" stream)]
     (-> m .fail-count (.scope scope) (.incrBy (stats-rate stats)))))
 
 (defn emitted-tuple! [m stats stream]

--- a/storm-core/src/clj/backtype/storm/daemon/builtin_metrics.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/builtin_metrics.clj
@@ -14,9 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.daemon.builtin-metrics
+  (:require [backtype.storm.stats :refer [stats-rate]])
   (:import [backtype.storm.metric.api MultiCountMetric MultiReducedMetric MeanReducer StateMetric IMetric IStatefulObject]
-           [backtype.storm Config])
-  (:require [backtype.storm.stats :refer [stats-rate]]))
+           [backtype.storm Config]))
 
 (defrecord BuiltinSpoutMetrics [^MultiCountMetric ack-count
                                 ^MultiReducedMetric complete-latency

--- a/storm-core/src/clj/backtype/storm/daemon/common.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/common.clj
@@ -20,8 +20,7 @@
             [backtype.storm.config :as config]
             [backtype.storm.log :refer [log-error log-debug]]
             [backtype.storm.util :as util])
-  (:import [backtype.storm.generated StormTopology
-                                     InvalidTopologyException GlobalStreamId]
+  (:import [backtype.storm.generated StormTopology InvalidTopologyException GlobalStreamId]
            [backtype.storm.utils Utils]
            [backtype.storm.task WorkerTopologyContext]
            [backtype.storm Constants]

--- a/storm-core/src/clj/backtype/storm/daemon/drpc.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/drpc.clj
@@ -15,22 +15,22 @@
 ;; limitations under the License.
 
 (ns backtype.storm.daemon.drpc
-  (:import [backtype.storm.security.auth AuthUtils ThriftServer ThriftConnectionType ReqContext])
-  (:import [backtype.storm.security.auth.authorizer DRPCAuthorizerBase])
-  (:import [backtype.storm.generated DistributedRPC DistributedRPC$Iface DistributedRPC$Processor
-            DRPCRequest DRPCExecutionException DistributedRPCInvocations DistributedRPCInvocations$Iface
-            DistributedRPCInvocations$Processor])
-  (:import [java.util.concurrent Semaphore ConcurrentLinkedQueue
-            ThreadPoolExecutor ArrayBlockingQueue TimeUnit])
-  (:import [backtype.storm.daemon Shutdownable])
-  (:import [java.net InetAddress])
-  (:import [backtype.storm.generated AuthorizationException])
-  (:use [backtype.storm config log util])
-  (:use [backtype.storm.daemon common])
-  (:use [backtype.storm.ui helpers])
-  (:use compojure.core)
-  (:use ring.middleware.reload)
-  (:require [compojure.handler :as handler])
+  (:require [backtype.storm.util :as util]
+            [backtype.storm.ui.helpers :as helpers]
+            [backtype.storm.config :as config]
+            [backtype.storm.daemon.common :as common]
+            [backtype.storm.log :refer [log-debug log-warn log-message]]
+            [ring.middleware.reload :as reload]
+            [compojure.core :refer [routes POST GET]])
+  (:import [backtype.storm.security.auth AuthUtils ThriftServer ThriftConnectionType ReqContext]
+           [backtype.storm.security.auth.authorizer DRPCAuthorizerBase]
+           [backtype.storm.generated DistributedRPC$Iface DistributedRPC$Processor
+                                     DRPCRequest DRPCExecutionException DistributedRPCInvocations$Iface
+                                     DistributedRPCInvocations$Processor]
+           [java.util.concurrent Semaphore ConcurrentLinkedQueue]
+           [backtype.storm.daemon Shutdownable]
+           [java.net InetAddress]
+           [backtype.storm.generated AuthorizationException])
   (:gen-class))
 
 (defn timeout-check-secs [] 5)
@@ -58,7 +58,7 @@
 
 ;; TODO: change this to use TimeCacheMap
 (defn service-handler [conf]
-  (let [drpc-acl-handler (mk-authorization-handler (conf DRPC-AUTHORIZER) conf)
+  (let [drpc-acl-handler (common/mk-authorization-handler (conf config/DRPC-AUTHORIZER) conf)
         ctr (atom 0)
         id->sem (atom {})
         id->result (atom {})
@@ -71,11 +71,11 @@
                   (swap! id->function dissoc id)
                   (swap! id->request dissoc id)
                   (swap! id->start dissoc id))
-        my-ip (.getHostAddress (InetAddress/getLocalHost))
-        clear-thread (async-loop
+        my-ip (.getHostAddress (InetAddress/getLocalHost))  ;; TODO: is this needed?
+        clear-thread (util/async-loop
                        (fn []
                          (doseq [[id start] @id->start]
-                           (when (> (time-delta start) (conf DRPC-REQUEST-TIMEOUT-SECS))
+                           (when (> (util/time-delta start) (conf config/DRPC-REQUEST-TIMEOUT-SECS))
                              (when-let [sem (@id->sem id)]
                                (.remove (acquire-queue request-queues (@id->function id)) (@id->request id))
                                (log-warn "Timeout DRPC request id: " id " start at " start)
@@ -93,7 +93,7 @@
               ^Semaphore sem (Semaphore. 0)
               req (DRPCRequest. args id)
               ^ConcurrentLinkedQueue queue (acquire-queue request-queues function)]
-          (swap! id->start assoc id (current-time-secs))
+          (swap! id->start assoc id (util/current-time-secs))
           (swap! id->sem assoc id sem)
           (swap! id->function assoc id function)
           (swap! id->request assoc id req)
@@ -188,16 +188,16 @@
             (.populateContext http-creds-handler (ReqContext/context)
                               servlet-request))
           (.execute handler func "")))
-    (wrap-reload '[backtype.storm.daemon.drpc])
+    (reload/wrap-reload '[backtype.storm.daemon.drpc])
     handle-request))
 
 (defn launch-server!
   ([]
-    (let [conf (read-storm-config)
-          worker-threads (int (conf DRPC-WORKER-THREADS))
-          queue-size (int (conf DRPC-QUEUE-SIZE))
-          drpc-http-port (int (conf DRPC-HTTP-PORT))
-          drpc-port (int (conf DRPC-PORT))
+    (let [conf (config/read-storm-config)
+          worker-threads (int (conf config/DRPC-WORKER-THREADS))
+          queue-size (int (conf config/DRPC-QUEUE-SIZE))
+          drpc-http-port (int (conf config/DRPC-HTTP-PORT))
+          drpc-port (int (conf config/DRPC-PORT))
           drpc-service-handler (service-handler conf)
           ;; requests and returns need to be on separate thread pools, since calls to
           ;; "execute" don't unblock until other thrift methods are called. So if
@@ -211,32 +211,32 @@
                           (DistributedRPCInvocations$Processor. drpc-service-handler)
                           ThriftConnectionType/DRPC_INVOCATIONS)
           http-creds-handler (AuthUtils/GetDrpcHttpCredentialsPlugin conf)]
-      (add-shutdown-hook-with-force-kill-in-1-sec (fn []
+      (util/add-shutdown-hook-with-force-kill-in-1-sec (fn []
                                                     (if handler-server (.stop handler-server))
                                                     (.stop invoke-server)))
       (log-message "Starting Distributed RPC servers...")
       (future (.serve invoke-server))
       (when (> drpc-http-port 0)
         (let [app (webapp drpc-service-handler http-creds-handler)
-              filter-class (conf DRPC-HTTP-FILTER)
-              filter-params (conf DRPC-HTTP-FILTER-PARAMS)
+              filter-class (conf config/DRPC-HTTP-FILTER)
+              filter-params (conf config/DRPC-HTTP-FILTER-PARAMS)
               filters-confs [{:filter-class filter-class
                               :filter-params filter-params}]
-              https-port (int (conf DRPC-HTTPS-PORT))
-              https-ks-path (conf DRPC-HTTPS-KEYSTORE-PATH)
-              https-ks-password (conf DRPC-HTTPS-KEYSTORE-PASSWORD)
-              https-ks-type (conf DRPC-HTTPS-KEYSTORE-TYPE)
-              https-key-password (conf DRPC-HTTPS-KEY-PASSWORD)
-              https-ts-path (conf DRPC-HTTPS-TRUSTSTORE-PATH)
-              https-ts-password (conf DRPC-HTTPS-TRUSTSTORE-PASSWORD)
-              https-ts-type (conf DRPC-HTTPS-TRUSTSTORE-TYPE)
-              https-want-client-auth (conf DRPC-HTTPS-WANT-CLIENT-AUTH)
-              https-need-client-auth (conf DRPC-HTTPS-NEED-CLIENT-AUTH)]
+              https-port (int (conf config/DRPC-HTTPS-PORT))
+              https-ks-path (conf config/DRPC-HTTPS-KEYSTORE-PATH)
+              https-ks-password (conf config/DRPC-HTTPS-KEYSTORE-PASSWORD)
+              https-ks-type (conf config/DRPC-HTTPS-KEYSTORE-TYPE)
+              https-key-password (conf config/DRPC-HTTPS-KEY-PASSWORD)
+              https-ts-path (conf config/DRPC-HTTPS-TRUSTSTORE-PATH)
+              https-ts-password (conf config/DRPC-HTTPS-TRUSTSTORE-PASSWORD)
+              https-ts-type (conf config/DRPC-HTTPS-TRUSTSTORE-TYPE)
+              https-want-client-auth (conf config/DRPC-HTTPS-WANT-CLIENT-AUTH)
+              https-need-client-auth (conf config/DRPC-HTTPS-NEED-CLIENT-AUTH)]
 
-          (storm-run-jetty
+          (helpers/storm-run-jetty
            {:port drpc-http-port
             :configurator (fn [server]
-                            (config-ssl server
+                            (helpers/config-ssl server
                                         https-port
                                         https-ks-path
                                         https-ks-password
@@ -247,10 +247,10 @@
                                         https-ts-type
                                         https-need-client-auth
                                         https-want-client-auth)
-                            (config-filter server app filters-confs))})))
+                            (helpers/config-filter server app filters-confs))})))
       (when handler-server
         (.serve handler-server)))))
 
 (defn -main []
-  (setup-default-uncaught-exception-handler)
+  (util/setup-default-uncaught-exception-handler)
   (launch-server!))

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -14,32 +14,31 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.daemon.executor
-  (:use [backtype.storm.daemon common])
-  (:import [backtype.storm.generated Grouping]
-           [java.io Serializable])
   (:use [backtype.storm util config log timer stats])
-  (:import [java.util List Random HashMap ArrayList LinkedList Map])
-  (:import [backtype.storm ICredentialsListener])
-  (:import [backtype.storm.hooks ITaskHook])
-  (:import [backtype.storm.tuple Tuple Fields TupleImpl MessageId])
-  (:import [backtype.storm.spout ISpoutWaitStrategy ISpout SpoutOutputCollector ISpoutOutputCollector])
-  (:import [backtype.storm.hooks.info SpoutAckInfo SpoutFailInfo
-            EmitInfo BoltFailInfo BoltAckInfo BoltExecuteInfo])
-  (:import [backtype.storm.grouping CustomStreamGrouping])
-  (:import [backtype.storm.task WorkerTopologyContext IBolt OutputCollector IOutputCollector])
-  (:import [backtype.storm.generated GlobalStreamId])
-  (:import [backtype.storm.utils Utils MutableObject RotatingMap RotatingMap$ExpiredCallback MutableLong Time])
-  (:import [com.lmax.disruptor InsufficientCapacityException])
-  (:import [backtype.storm.serialization KryoTupleSerializer KryoTupleDeserializer])
-  (:import [backtype.storm.daemon Shutdownable])
-  (:import [backtype.storm.metric.api IMetric IMetricsConsumer$TaskInfo IMetricsConsumer$DataPoint StateMetric])
-  (:import [backtype.storm Config Constants])
-  (:import [java.util.concurrent ConcurrentLinkedQueue])
   (:require [backtype.storm [tuple :as tuple] [thrift :as thrift]
-             [cluster :as cluster] [disruptor :as disruptor] [stats :as stats]])
-  (:require [backtype.storm.daemon [task :as task]])
-  (:require [backtype.storm.daemon.builtin-metrics :as builtin-metrics])
-  (:require [clojure.set :as set]))
+             [cluster :as cluster] [disruptor :as disruptor] [stats :as stats]]
+            [backtype.storm.daemon.task :as task]
+            [backtype.storm.daemon.builtin-metrics :as builtin-metrics]
+            [clojure.set :as set]
+            [backtype.storm.util :as util]
+            [backtype.storm.daemon.common :as common]
+            [backtype.storm.config :as config])
+  (:import [java.io Serializable]
+           [java.util List Random HashMap ArrayList Map]
+           [backtype.storm ICredentialsListener]
+           [backtype.storm.tuple Tuple Fields TupleImpl MessageId]
+           [backtype.storm.spout ISpoutWaitStrategy ISpout SpoutOutputCollector ISpoutOutputCollector]
+           [backtype.storm.hooks.info SpoutAckInfo SpoutFailInfo BoltFailInfo BoltAckInfo BoltExecuteInfo]
+           [backtype.storm.grouping CustomStreamGrouping]
+           [backtype.storm.task WorkerTopologyContext IBolt OutputCollector IOutputCollector]
+           [backtype.storm.generated GlobalStreamId]
+           [backtype.storm.utils Utils MutableObject RotatingMap RotatingMap$ExpiredCallback MutableLong Time]
+           [com.lmax.disruptor InsufficientCapacityException]
+           [backtype.storm.serialization KryoTupleSerializer KryoTupleDeserializer]
+           [backtype.storm.daemon Shutdownable]
+           [backtype.storm.metric.api IMetric IMetricsConsumer$TaskInfo IMetricsConsumer$DataPoint]
+           [backtype.storm Constants]
+           [java.util.concurrent ConcurrentLinkedQueue]))
 
 (defn- mk-fields-grouper [^Fields out-fields ^Fields group-fields ^List target-tasks]
   (let [num-tasks (count target-tasks)
@@ -104,7 +103,7 @@
 
 (defn- outbound-groupings [^WorkerTopologyContext worker-context this-component-id stream-id out-fields component->grouping]
   (->> component->grouping
-       (filter-key #(-> worker-context
+       (util/filter-key #(-> worker-context
                         (.getComponentTasks %)
                         count
                         pos?))
@@ -193,6 +192,7 @@
                               (.getThisWorkerPort (:worker-context executor)) error)
         ))))
 
+;; TODO: replace (= true with (true?
 ;; in its own function so that it can be mocked out by tracked topologies
 (defn mk-executor-transfer-fn [batch-transfer->worker storm-conf]
   (fn this
@@ -215,8 +215,8 @@
       )))
 
 (defn mk-executor-data [worker executor-id]
-  (let [worker-context (worker-context worker)
-        task-ids (executor-id->tasks executor-id)
+  (let [worker-context (common/worker-context worker)
+        task-ids (common/executor-id->tasks executor-id)
         component-id (.getComponentId worker-context (first task-ids))
         storm-conf (normalized-component-conf (:storm-conf worker) worker-context component-id)
         executor-type (executor-type worker-context component-id)
@@ -242,7 +242,7 @@
      :batch-transfer-queue batch-transfer->worker
      :transfer-fn (mk-executor-transfer-fn batch-transfer->worker storm-conf)
      :suicide-fn (:suicide-fn worker)
-     :storm-cluster-state (cluster/mk-storm-cluster-state (:cluster-state worker) 
+     :storm-cluster-state (cluster/mk-storm-cluster-state (:cluster-state worker)
                                                           :acls (Utils/getWorkerACL storm-conf))
      :type executor-type
      ;; TODO: should refactor this to be part of the executor specific map (spout or bolt with :common field)
@@ -284,8 +284,8 @@
   (let [{:keys [storm-conf receive-queue worker-context interval->task->metric-registry]} executor-data
         distinct-time-bucket-intervals (keys interval->task->metric-registry)]
     (doseq [interval distinct-time-bucket-intervals]
-      (schedule-recurring 
-       (:user-timer (:worker executor-data)) 
+      (schedule-recurring
+       (:user-timer (:worker executor-data))
        interval
        interval
        (fn []
@@ -321,7 +321,7 @@
         receive-queue (:receive-queue executor-data)
         context (:worker-context executor-data)]
     (when tick-time-secs
-      (if (or (system-id? (:component-id executor-data))
+      (if (or (common/system-id? (:component-id executor-data))
               (and (= false (storm-conf TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS))
                    (= :spout (:type executor-data))))
         (log-message "Timeouts disabled for executor " (:component-id executor-data) ":" (:executor-id executor-data))
@@ -347,13 +347,13 @@
         report-error-and-die (:report-error-and-die executor-data)
         component-id (:component-id executor-data)
 
-        ;; starting the batch-transfer->worker ensures that anything publishing to that queue 
+        ;; starting the batch-transfer->worker ensures that anything publishing to that queue
         ;; doesn't block (because it's a single threaded queue and the caching/consumer started
         ;; trick isn't thread-safe)
         system-threads [(start-batch-transfer->worker-handler! worker executor-data)]
         handlers (with-error-reaction report-error-and-die
                    (mk-threads executor-data task-datas initial-credentials))
-        threads (concat handlers system-threads)]    
+        threads (concat handlers system-threads)]
     (setup-ticks! worker executor-data)
 
     (log-message "Finished loading executor " component-id ":" (pr-str executor-id))
@@ -380,7 +380,7 @@
         (doseq [t threads]
           (.interrupt t)
           (.join t))
-        
+
         (doseq [user-context (map :user-context (vals task-datas))]
           (doseq [hook (.getHooks user-context)]
             (.cleanup hook)))
@@ -401,7 +401,7 @@
     (.fail spout msg-id)
     (task/apply-hooks (:user-context task-data) .spoutFail (SpoutFailInfo. msg-id task-id time-delta))
     (when time-delta
-      (builtin-metrics/spout-failed-tuple! (:builtin-metrics task-data) (:stats executor-data) (:stream tuple-info))      
+      (builtin-metrics/spout-failed-tuple! (:builtin-metrics task-data) (:stats executor-data) (:stream tuple-info))
       (stats/spout-failed-tuple! (:stats executor-data) (:stream tuple-info) time-delta))))
 
 (defn- ack-spout-msg [executor-data task-data msg-id tuple-info time-delta id]
@@ -423,7 +423,7 @@
         ]
     (disruptor/clojure-handler
       (fn [tuple-batch sequence-id end-of-batch?]
-        (fast-list-iter [[task-id msg] tuple-batch]
+        (util/fast-list-iter [[task-id msg] tuple-batch]
           (let [^TupleImpl tuple (if (instance? Tuple msg) msg (.deserialize deserializer msg))]
             (when debug? (log-message "Processing received message FOR " task-id " TUPLE: " tuple))
             (if task-id
@@ -448,11 +448,11 @@
   (let [{:keys [storm-conf component-id worker-context transfer-fn report-error sampler open-or-prepare-was-called?]} executor-data
         ^ISpoutWaitStrategy spout-wait-strategy (init-spout-wait-strategy storm-conf)
         max-spout-pending (executor-max-spout-pending storm-conf (count task-datas))
-        ^Integer max-spout-pending (if max-spout-pending (int max-spout-pending))        
-        last-active (atom false)        
+        ^Integer max-spout-pending (if max-spout-pending (int max-spout-pending))
+        last-active (atom false)
         spouts (ArrayList. (map :object (vals task-datas)))
         rand (Random. (Utils/secureRandomLong))
-        
+
         pending (RotatingMap.
                  2 ;; microoptimize for performance of .size method
                  (reify RotatingMap$ExpiredCallback
@@ -465,7 +465,7 @@
                             (condp = stream-id
                               Constants/SYSTEM_TICK_STREAM_ID (.rotate pending)
                               Constants/METRICS_TICK_STREAM_ID (metrics-tick executor-data (get task-datas task-id) tuple)
-                              Constants/CREDENTIALS_CHANGED_STREAM_ID 
+                              Constants/CREDENTIALS_CHANGED_STREAM_ID
                                 (let [task-data (get task-datas task-id)
                                       spout-obj (:object task-data)]
                                   (when (instance? ICredentialsListener spout-obj)
@@ -477,34 +477,34 @@
                                     (throw-runtime "Fatal error, mismatched task ids: " task-id " " stored-task-id))
                                   (let [time-delta (if start-time-ms (time-delta-ms start-time-ms))]
                                     (condp = stream-id
-                                      ACKER-ACK-STREAM-ID (ack-spout-msg executor-data (get task-datas task-id)
+                                      common/ACKER-ACK-STREAM-ID (ack-spout-msg executor-data (get task-datas task-id)
                                                                          spout-id tuple-finished-info time-delta id)
-                                      ACKER-FAIL-STREAM-ID (fail-spout-msg executor-data (get task-datas task-id)
+                                      common/ACKER-FAIL-STREAM-ID (fail-spout-msg executor-data (get task-datas task-id)
                                                                            spout-id tuple-finished-info time-delta "FAIL-STREAM" id)
                                       )))
                                 ;; TODO: on failure, emit tuple to failure stream
                                 ))))
         receive-queue (:receive-queue executor-data)
         event-handler (mk-task-receiver executor-data tuple-action-fn)
-        has-ackers? (has-ackers? storm-conf)
+        has-ackers? (common/has-ackers? storm-conf)
         emitted-count (MutableLong. 0)
         empty-emit-streak (MutableLong. 0)
-        
+
         ;; the overflow buffer is used to ensure that spouts never block when emitting
         ;; this ensures that the spout can always clear the incoming buffer (acks and fails), which
         ;; prevents deadlock from occuring across the topology (e.g. Spout -> Bolt -> Acker -> Spout, and all
         ;; buffers filled up)
         ;; when the overflow buffer is full, spouts stop calling nextTuple until it's able to clear the overflow buffer
-        ;; this limits the size of the overflow buffer to however many tuples a spout emits in one call of nextTuple, 
+        ;; this limits the size of the overflow buffer to however many tuples a spout emits in one call of nextTuple,
         ;; preventing memory issues
         overflow-buffer (ConcurrentLinkedQueue.)]
-   
-    [(async-loop
+
+    [(util/async-loop
       (fn []
         ;; If topology was started in inactive state, don't call (.open spout) until it's activated first.
         (while (not @(:storm-active-atom executor-data))
           (Thread/sleep 100))
-        
+
         (log-message "Opening spout " component-id ":" (keys task-datas))
         (doseq [[task-id task-data] task-datas
                 :let [^ISpout spout-obj (:object task-data)
@@ -538,7 +538,7 @@
                                                                     {:stream out-stream-id :values values}
                                                                     (if (sampler) (System/currentTimeMillis))])
                                              (task/send-unanchored task-data
-                                                                   ACKER-INIT-STREAM-ID
+                                                                   common/ACKER-INIT-STREAM-ID
                                                                    [root-id (bit-xor-vals out-ids) task-id]
                                                                    overflow-buffer))
                                            (when message-id
@@ -568,15 +568,15 @@
                     (reportError [this error]
                       (report-error error)
                       )))))
-        (reset! open-or-prepare-was-called? true) 
+        (reset! open-or-prepare-was-called? true)
         (log-message "Opened spout " component-id ":" (keys task-datas))
         (setup-metrics! executor-data)
-        
+
         (disruptor/consumer-started! (:receive-queue executor-data))
         (fn []
           ;; This design requires that spouts be non-blocking
           (disruptor/consume-batch receive-queue event-handler)
-          
+
           ;; try to clear the overflow-buffer
           (try-cause
             (while (not (.isEmpty overflow-buffer))
@@ -585,7 +585,7 @@
                 (.poll overflow-buffer)))
           (catch InsufficientCapacityException e
             ))
-          
+
           (let [active? @(:storm-active-atom executor-data)
                 curr-count (.get emitted-count)]
             (if (and (.isEmpty overflow-buffer)
@@ -597,7 +597,7 @@
                     (reset! last-active true)
                     (log-message "Activating spout " component-id ":" (keys task-datas))
                     (fast-list-iter [^ISpout spout spouts] (.activate spout)))
-               
+
                   (fast-list-iter [^ISpout spout spouts] (.nextTuple spout)))
                 (do
                   (when @last-active
@@ -610,7 +610,7 @@
               (do (.increment empty-emit-streak)
                   (.emptyEmit spout-wait-strategy (.get empty-emit-streak)))
               (.set empty-emit-streak 0)
-              ))           
+              ))
           0))
       :kill-fn (:report-error-and-die executor-data)
       :factory? true
@@ -620,7 +620,7 @@
   (let [ms (.getProcessSampleStartTime tuple)]
     (if ms
       (time-delta-ms ms))))
-      
+
 (defn- tuple-execute-time-delta! [^TupleImpl tuple]
   (let [ms (.getExecuteSampleStartTime tuple)]
     (if ms
@@ -651,12 +651,12 @@
                           ;; TODO: for state sync, need to check if tuple comes from state spout. if so, update state
                           ;; TODO: how to handle incremental updates as well as synchronizations at same time
                           ;; TODO: need to version tuples somehow
-                          
+
                           ;;(log-debug "Received tuple " tuple " at task " task-id)
                           ;; need to do it this way to avoid reflection
                           (let [stream-id (.getSourceStreamId tuple)]
                             (condp = stream-id
-                              Constants/CREDENTIALS_CHANGED_STREAM_ID 
+                              Constants/CREDENTIALS_CHANGED_STREAM_ID
                                 (let [task-data (get task-datas task-id)
                                       bolt-obj (:object task-data)]
                                   (when (instance? ICredentialsListener bolt-obj)
@@ -676,12 +676,12 @@
                                 (let [delta (tuple-execute-time-delta! tuple)]
                                   (when (= true (storm-conf TOPOLOGY-DEBUG))
                                     (log-message "Execute done TUPLE " tuple " TASK: " task-id " DELTA: " delta))
- 
+
                                   (task/apply-hooks user-context .boltExecute (BoltExecuteInfo. tuple task-id delta))
                                   (when delta
                                     (builtin-metrics/bolt-execute-tuple! (:builtin-metrics task-data)
                                                                          executor-stats
-                                                                         (.getSourceComponent tuple)                                                      
+                                                                         (.getSourceComponent tuple)
                                                                          (.getSourceStreamId tuple)
                                                                          delta)
                                     (stats/bolt-execute-tuple! executor-stats
@@ -697,15 +697,15 @@
         ;; the overflow buffer is might gradually fill degrading the performance gradually
         ;; eventually running out of memory, but at least prevent live-locks/deadlocks.
         overflow-buffer (if (storm-conf TOPOLOGY-BOLTS-OUTGOING-OVERFLOW-BUFFER-ENABLE) (ConcurrentLinkedQueue.) nil)]
-    
+
     ;; TODO: can get any SubscribedState objects out of the context now
 
-    [(async-loop
+    [(util/async-loop
       (fn []
         ;; If topology was started in inactive state, don't call prepare bolt until it's activated first.
-        (while (not @(:storm-active-atom executor-data))          
+        (while (not @(:storm-active-atom executor-data))
           (Thread/sleep 100))
-        
+
         (log-message "Preparing bolt " component-id ":" (keys task-datas))
         (doseq [[task-id task-data] task-datas
                 :let [^IBolt bolt-obj (:object task-data)
@@ -734,7 +734,7 @@
                                                                    overflow-buffer)))
                                     (or out-tasks [])))]]
           (builtin-metrics/register-all (:builtin-metrics task-data) storm-conf user-context)
-          (when (instance? ICredentialsListener bolt-obj) (.setCredentials bolt-obj initial-credentials)) 
+          (when (instance? ICredentialsListener bolt-obj) (.setCredentials bolt-obj initial-credentials))
           (if (= component-id Constants/SYSTEM_COMPONENT_ID)
             (do
               (builtin-metrics/register-queue-metrics {:sendqueue (:batch-transfer-queue executor-data)
@@ -760,20 +760,20 @@
                        (^void ack [this ^Tuple tuple]
                          (let [^TupleImpl tuple tuple
                                ack-val (.getAckVal tuple)]
-                           (fast-map-iter [[root id] (.. tuple getMessageId getAnchorsToIds)]
+                           (util/fast-map-iter [[root id] (.. tuple getMessageId getAnchorsToIds)]
                                           (task/send-unanchored task-data
-                                                                ACKER-ACK-STREAM-ID
+                                                                common/ACKER-ACK-STREAM-ID
                                                                 [root (bit-xor id ack-val)] overflow-buffer)
                                           ))
                          (let [delta (tuple-time-delta! tuple)
-                               debug? (= true (storm-conf TOPOLOGY-DEBUG))]
-                           (when debug? 
+                               debug? (= true (storm-conf config/TOPOLOGY-DEBUG))]
+                           (when debug?
                              (log-message "BOLT ack TASK: " task-id " TIME: " delta " TUPLE: " tuple))
                            (task/apply-hooks user-context .boltAck (BoltAckInfo. tuple task-id delta))
                            (when delta
                              (builtin-metrics/bolt-acked-tuple! (:builtin-metrics task-data)
                                                                 executor-stats
-                                                                (.getSourceComponent tuple)                                                      
+                                                                (.getSourceComponent tuple)
                                                                 (.getSourceStreamId tuple)
                                                                 delta)
                              (stats/bolt-acked-tuple! executor-stats
@@ -783,17 +783,17 @@
                        (^void fail [this ^Tuple tuple]
                          (fast-list-iter [root (.. tuple getMessageId getAnchors)]
                                          (task/send-unanchored task-data
-                                                               ACKER-FAIL-STREAM-ID
+                                                               common/ACKER-FAIL-STREAM-ID
                                                                [root] overflow-buffer))
                          (let [delta (tuple-time-delta! tuple)
                                debug? (= true (storm-conf TOPOLOGY-DEBUG))]
-                           (when debug? 
+                           (when debug?
                              (log-message "BOLT fail TASK: " task-id " TIME: " delta " TUPLE: " tuple))
                            (task/apply-hooks user-context .boltFail (BoltFailInfo. tuple task-id delta))
                            (when delta
                              (builtin-metrics/bolt-failed-tuple! (:builtin-metrics task-data)
                                                                  executor-stats
-                                                                 (.getSourceComponent tuple)                                                      
+                                                                 (.getSourceComponent tuple)
                                                                  (.getSourceStreamId tuple))
                              (stats/bolt-failed-tuple! executor-stats
                                                        (.getSourceComponent tuple)
@@ -802,14 +802,14 @@
                        (reportError [this error]
                          (report-error error)
                          )))))
-        (reset! open-or-prepare-was-called? true)        
+        (reset! open-or-prepare-was-called? true)
         (log-message "Prepared bolt " component-id ":" (keys task-datas))
         (setup-metrics! executor-data)
 
         (let [receive-queue (:receive-queue executor-data)
               event-handler (mk-task-receiver executor-data tuple-action-fn)]
           (disruptor/consumer-started! receive-queue)
-          (fn []            
+          (fn []
             (disruptor/consume-batch-when-available receive-queue event-handler)
             ;; try to clear the overflow-buffer
             (try-cause

--- a/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
@@ -14,30 +14,28 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.daemon.logviewer
-  (:use compojure.core)
-  (:use [clojure.set :only [difference intersection]])
-  (:use [clojure.string :only [blank?]])
-  (:use [hiccup core page-helpers])
-  (:use [backtype.storm config util log timer])
-  (:use [backtype.storm.ui helpers])
-  (:import [org.slf4j LoggerFactory])
-  (:import [ch.qos.logback.classic Logger])
-  (:import [ch.qos.logback.core FileAppender])
-  (:import [java.io File FileFilter FileInputStream])
-  (:import [org.yaml.snakeyaml Yaml]
-           [org.yaml.snakeyaml.constructor SafeConstructor])
-  (:import [backtype.storm.ui InvalidRequestException]
-           [backtype.storm.security.auth AuthUtils])
+  (:use [hiccup core page-helpers]
+        [backtype.storm config util log timer]
+        [backtype.storm.ui helpers])
   (:require [compojure.route :as route]
             [compojure.handler :as handler]
             [ring.middleware.keyword-params]
-            [ring.util.response :as resp])
-  (:require [backtype.storm.daemon common [supervisor :as supervisor]])
-  (:import [java.io File FileFilter])
-  (:require [compojure.route :as route]
+            [ring.util.response :as resp]
+            [backtype.storm.daemon common [supervisor :as supervisor]]
+            [compojure.route :as route]
             [compojure.handler :as handler]
             [ring.util.response :as resp]
-            [clojure.string :as string])
+            [clojure.string :as string]
+            [clojure.set :refer [difference intersection]]
+            [clojure.string :refer [blank?]]
+            [compojure.core :refer [defroutes GET POST]])
+  (:import [org.slf4j LoggerFactory]
+           [ch.qos.logback.classic Logger]
+           [ch.qos.logback.core FileAppender]
+           [java.io File FileFilter FileInputStream]
+           [java.io File FileFilter]
+           [backtype.storm.ui InvalidRequestException]
+           [backtype.storm.security.auth AuthUtils])
   (:gen-class))
 
 (def ^:dynamic *STORM-CONF* (read-storm-config))
@@ -219,7 +217,7 @@ Note that if anything goes wrong, this will throw an Error and exit."
 (defnk to-btn-link
   "Create a link that is formatted like a button"
   [url text :enabled true]
-  [:a {:href (java.net.URI. url) 
+  [:a {:href (java.net.URI. url)
        :class (str "btn btn-default " (if enabled "enabled" "disabled"))} text])
 
 (defn pager-links [fname start length file-size]
@@ -247,7 +245,7 @@ Note that if anything goes wrong, this will throw an Error and exit."
                            :start (min (max 0 (- file-size length))
                                        (+ start length))
                            :length length})
-                        "Next" :enabled (> next-start start))])]])) 
+                        "Next" :enabled (> next-start start))])]]))
 
 (defn- download-link [fname]
   [[:p (link-to (url-format "/download/%s" fname) "Download Full Log")]])

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -14,8 +14,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.daemon.supervisor
-  (:use
-        [backtype.storm.daemon common])
   (:require [backtype.storm.daemon [worker :as worker]]
             [backtype.storm [process-simulator :as psim] [cluster :as cluster] [event :as event]]
             [clojure.set :as set]
@@ -24,6 +22,7 @@
             [backtype.storm.log :refer [log-debug log-warn log-message log-warn-error log-error]]
             [backtype.storm.local-state :as ls]
             [backtype.storm.config :as c]
+            [backtype.storm.daemon.common :as common :refer [defserverfn]]
             [clojure.string :as string])
   (:import [java.io IOException]
            [backtype.storm.scheduler ISupervisor]
@@ -507,7 +506,7 @@
         heartbeat-fn (fn [] (.supervisor-heartbeat!
                                (:storm-cluster-state supervisor)
                                (:supervisor-id supervisor)
-                               (->SupervisorInfo (util/current-time-secs)
+                               (common/->SupervisorInfo (util/current-time-secs)
                                                  (:my-hostname supervisor)
                                                  (:assignment-id supervisor)
                                                  (keys @(:curr-assignment supervisor))
@@ -552,7 +551,7 @@
          (doseq [id ids]
            (shutdown-worker supervisor id)
            )))
-     DaemonCommon
+     common/DaemonCommon
      (waiting? [this]
        (or (not @(:active supervisor))
            (and
@@ -772,7 +771,7 @@
 
 (defn -launch [supervisor]
   (let [conf (c/read-storm-config)]
-    (validate-distributed-mode! conf)
+    (common/validate-distributed-mode! conf)
     (let [supervisor (mk-supervisor conf nil supervisor)]
       (util/add-shutdown-hook-with-force-kill-in-1-sec #(.shutdown supervisor)))))
 

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -14,29 +14,33 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.daemon.supervisor
-  (:import [java.io OutputStreamWriter BufferedWriter IOException])
-  (:import [backtype.storm.scheduler ISupervisor]
+  (:use
+        [backtype.storm.daemon common])
+  (:require [backtype.storm.daemon [worker :as worker]]
+            [backtype.storm [process-simulator :as psim] [cluster :as cluster] [event :as event]]
+            [clojure.set :as set]
+            [backtype.storm.util :as util :refer [defnk]]
+            [backtype.storm.timer :as timer]
+            [backtype.storm.log :refer [log-debug log-warn log-message log-warn-error log-error]]
+            [backtype.storm.local-state :as ls]
+            [backtype.storm.config :as c]
+            [clojure.string :as string])
+  (:import [java.io IOException]
+           [backtype.storm.scheduler ISupervisor]
            [backtype.storm.utils LocalState Time Utils]
            [backtype.storm.daemon Shutdownable]
            [backtype.storm Constants]
-           [java.net JarURLConnection]
            [java.net URI]
            [org.apache.commons.io FileUtils]
-           [java.io File])
-  (:use [backtype.storm config util log timer local-state])
-  (:import [backtype.storm.utils VersionInfo])
-  (:use [backtype.storm.daemon common])
-  (:require [backtype.storm.daemon [worker :as worker]]
-            [backtype.storm [process-simulator :as psim] [cluster :as cluster] [event :as event]]
-            [clojure.set :as set])
-  (:import [org.apache.zookeeper data.ACL ZooDefs$Ids ZooDefs$Perms])
-  (:import [org.yaml.snakeyaml Yaml]
-           [org.yaml.snakeyaml.constructor SafeConstructor])
+           [java.io File]
+           [backtype.storm.utils VersionInfo]
+           [org.apache.zookeeper data.ACL ZooDefs$Ids ZooDefs$Perms]
+           [org.yaml.snakeyaml Yaml])
   (:gen-class
     :methods [^{:static true} [launch [backtype.storm.scheduler.ISupervisor] void]]))
 
-(defmulti download-storm-code cluster-mode)
-(defmulti launch-worker (fn [supervisor & _] (cluster-mode (:conf supervisor))))
+(defmulti download-storm-code c/cluster-mode)
+(defmulti launch-worker (fn [supervisor & _] (c/cluster-mode (:conf supervisor))))
 
 (defprotocol SupervisorDaemon
   (get-id [this])
@@ -48,7 +52,7 @@
   (let [storm-ids (.assignments storm-cluster-state callback)]
     (let [new-assignments
           (->>
-           (dofor [sid storm-ids]
+           (util/dofor [sid storm-ids]
                   (let [recorded-version (:version (get assignment-versions sid))]
                     (if-let [assignment-version (.assignment-version storm-cluster-state sid callback)]
                       (if (= assignment-version recorded-version)
@@ -56,7 +60,7 @@
                         {sid (.assignment-info-with-version storm-cluster-state sid callback)})
                       {sid nil})))
            (apply merge)
-           (filter-val not-nil?))]
+           (util/filter-val util/not-nil?))]
 
       {:assignments (into {} (for [[k v] new-assignments] [k (:data v)]))
        :versions new-assignments})))
@@ -73,14 +77,14 @@
     (into {} (for [[port executors] port-executors]
                ;; need to cast to int b/c it might be a long (due to how yaml parses things)
                ;; doall is to avoid serialization/deserialization problems with lazy seqs
-               [(Integer. port) (mk-local-assignment storm-id (doall executors))]
+               [(Integer. port) (ls/mk-local-assignment storm-id (doall executors))]
                ))))
 
 (defn- read-assignments
   "Returns map from port to struct containing :storm-id and :executors"
   ([assignments-snapshot assignment-id]
-     (->> (dofor [sid (keys assignments-snapshot)] (read-my-executors assignments-snapshot sid assignment-id))
-          (apply merge-with (fn [& ignored] (throw-runtime "Should not have multiple topologies assigned to one port")))))
+     (->> (util/dofor [sid (keys assignments-snapshot)] (read-my-executors assignments-snapshot sid assignment-id))
+          (apply merge-with (fn [& ignored] (util/throw-runtime "Should not have multiple topologies assigned to one port")))))
   ([assignments-snapshot assignment-id existing-assignment retries]
      (try (let [assignments (read-assignments assignments-snapshot assignment-id)]
             (reset! retries 0)
@@ -92,30 +96,30 @@
 
 (defn- read-storm-code-locations
   [assignments-snapshot]
-  (map-val :master-code-dir assignments-snapshot))
+  (util/map-val :master-code-dir assignments-snapshot))
 
 (defn- read-downloaded-storm-ids [conf]
-  (map #(url-decode %) (read-dir-contents (supervisor-stormdist-root conf)))
+  (map #(util/url-decode %) (util/read-dir-contents (c/supervisor-stormdist-root conf)))
   )
 
 (defn read-worker-heartbeat [conf id]
-  (let [local-state (worker-state conf id)]
+  (let [local-state (c/worker-state conf id)]
     (try
-      (ls-worker-heartbeat local-state)
+      (ls/ls-worker-heartbeat local-state)
       (catch Exception e
         (log-warn e "Failed to read local heartbeat for workerId : " id ",Ignoring exception.")
         nil))))
 
 
 (defn my-worker-ids [conf]
-  (read-dir-contents (worker-root conf)))
+  (util/read-dir-contents (c/worker-root conf)))
 
 (defn read-worker-heartbeats
   "Returns map from worker id to heartbeat"
   [conf]
   (let [ids (my-worker-ids conf)]
     (into {}
-      (dofor [id ids]
+      (util/dofor [id ids]
         [id (read-worker-heartbeat conf id)]))
     ))
 
@@ -137,7 +141,7 @@
 
 (defn is-worker-hb-timed-out? [now hb conf]
   (> (- now (:time-secs hb))
-     (conf SUPERVISOR-WORKER-TIMEOUT-SECS)))
+     (conf c/SUPERVISOR-WORKER-TIMEOUT-SECS)))
 
 (defn read-allocated-workers
   "Returns map from worker id to worker heartbeat. if the heartbeat is nil, then the worker is dead (timed out or never wrote heartbeat)"
@@ -145,10 +149,10 @@
   (let [conf (:conf supervisor)
         ^LocalState local-state (:local-state supervisor)
         id->heartbeat (read-worker-heartbeats conf)
-        approved-ids (set (keys (ls-approved-workers local-state)))]
+        approved-ids (set (keys (ls/ls-approved-workers local-state)))]
     (into
      {}
-     (dofor [[id hb] id->heartbeat]
+     (util/dofor [[id hb] id->heartbeat]
             (let [state (cond
                          (not hb)
                            :not-started
@@ -169,48 +173,48 @@
      )))
 
 (defn- wait-for-worker-launch [conf id start-time]
-  (let [state (worker-state conf id)]
+  (let [state (c/worker-state conf id)]
     (loop []
-      (let [hb (ls-worker-heartbeat state)]
+      (let [hb (ls/ls-worker-heartbeat state)]
         (when (and
                (not hb)
                (<
-                (- (current-time-secs) start-time)
-                (conf SUPERVISOR-WORKER-START-TIMEOUT-SECS)
+                (- (util/current-time-secs) start-time)
+                (conf c/SUPERVISOR-WORKER-START-TIMEOUT-SECS)
                 ))
           (log-message id " still hasn't started")
           (Time/sleep 500)
           (recur)
           )))
-    (when-not (ls-worker-heartbeat state)
+    (when-not (ls/ls-worker-heartbeat state)
       (log-message "Worker " id " failed to start")
       )))
 
 (defn- wait-for-workers-launch [conf ids]
-  (let [start-time (current-time-secs)]
+  (let [start-time (util/current-time-secs)]
     (doseq [id ids]
       (wait-for-worker-launch conf id start-time))
     ))
 
 (defn generate-supervisor-id []
-  (uuid))
+  (util/uuid))
 
 (defnk worker-launcher [conf user args :environment {} :log-prefix nil :exit-code-callback nil]
   (let [_ (when (clojure.string/blank? user)
             (throw (java.lang.IllegalArgumentException.
                      "User cannot be blank when calling worker-launcher.")))
-        wl-initial (conf SUPERVISOR-WORKER-LAUNCHER)
+        wl-initial (conf c/SUPERVISOR-WORKER-LAUNCHER)
         storm-home (System/getProperty "storm.home")
         wl (if wl-initial wl-initial (str storm-home "/bin/worker-launcher"))
         command (concat [wl user] args)]
     (log-message "Running as user:" user " command:" (pr-str command))
-    (launch-process command :environment environment :log-prefix log-prefix :exit-code-callback exit-code-callback)
+    (util/launch-process command :environment environment :log-prefix log-prefix :exit-code-callback exit-code-callback)
   ))
 
 (defnk worker-launcher-and-wait [conf user args :environment {} :log-prefix nil]
   (let [process (worker-launcher conf user args :environment environment)]
     (if log-prefix
-      (read-and-log-stream log-prefix (.getInputStream process)))
+      (util/read-and-log-stream log-prefix (.getInputStream process)))
       (try
         (.waitFor process)
       (catch InterruptedException e
@@ -225,21 +229,21 @@
                             user
                             ["rmr" path]
                             :log-prefix (str "rmr " id))
-  (if (exists-file? path)
+  (if (util/exists-file? path)
     (throw (RuntimeException. (str path " was not deleted")))))
 
 (defn try-cleanup-worker [conf id user]
   (try
-    (if (.exists (File. (worker-root conf id)))
+    (if (.exists (File. (c/worker-root conf id)))
       (do
-        (if (conf SUPERVISOR-RUN-WORKER-AS-USER)
-          (rmr-as-user conf id user (worker-root conf id))
+        (if (conf c/SUPERVISOR-RUN-WORKER-AS-USER)
+          (rmr-as-user conf id user (c/worker-root conf id))
           (do
-            (rmr (worker-heartbeats-root conf id))
+            (util/rmr (c/worker-heartbeats-root conf id))
             ;; this avoids a race condition with worker or subprocess writing pid around same time
-            (rmpath (worker-pids-root conf id))
-            (rmpath (worker-root conf id))))
-        (remove-worker-user! conf id)
+            (util/rmpath (c/worker-pids-root conf id))
+            (util/rmpath (c/worker-root conf id))))
+        (c/remove-worker-user! conf id)
         (remove-dead-worker id)
       ))
   (catch IOException e
@@ -253,28 +257,28 @@
 (defn shutdown-worker [supervisor id]
   (log-message "Shutting down " (:supervisor-id supervisor) ":" id)
   (let [conf (:conf supervisor)
-        pids (read-dir-contents (worker-pids-root conf id))
+        pids (util/read-dir-contents (c/worker-pids-root conf id))
         thread-pid (@(:worker-thread-pids-atom supervisor) id)
-        shutdown-sleep-secs (conf SUPERVISOR-WORKER-SHUTDOWN-SLEEP-SECS)
-        as-user (conf SUPERVISOR-RUN-WORKER-AS-USER)
-        user (get-worker-user conf id)]
+        shutdown-sleep-secs (conf c/SUPERVISOR-WORKER-SHUTDOWN-SLEEP-SECS)
+        as-user (conf c/SUPERVISOR-RUN-WORKER-AS-USER)
+        user (c/get-worker-user conf id)]
     (when thread-pid
       (psim/kill-process thread-pid))
     (doseq [pid pids]
       (if as-user
         (worker-launcher-and-wait conf user ["signal" pid "9"] :log-prefix (str "kill -15 " pid))
-        (kill-process-with-sig-term pid)))
-    (when-not (empty? pids)  
+        (util/kill-process-with-sig-term pid)))
+    (when-not (empty? pids)
       (log-message "Sleep " shutdown-sleep-secs " seconds for execution of cleanup threads on worker.")
-      (sleep-secs shutdown-sleep-secs))
+      (util/sleep-secs shutdown-sleep-secs))
     (doseq [pid pids]
       (if as-user
         (worker-launcher-and-wait conf user ["signal" pid "9"] :log-prefix (str "kill -9 " pid))
-        (force-kill-process pid))
+        (util/force-kill-process pid))
       (if as-user
-        (rmr-as-user conf id user (worker-pid-path conf id pid))
+        (rmr-as-user conf id user (c/worker-pid-path conf id pid))
         (try
-          (rmpath (worker-pid-path conf id pid))
+          (util/rmpath (c/worker-pid-path conf id pid))
           (catch Exception e)))) ;; on windows, the supervisor may still holds the lock on the worker directory
     (try-cleanup-worker conf id user))
   (log-message "Shut down " (:supervisor-id supervisor) ":" id))
@@ -288,25 +292,25 @@
    :shared-context shared-context
    :isupervisor isupervisor
    :active (atom true)
-   :uptime (uptime-computer)
+   :uptime (util/uptime-computer)
    :version (str (VersionInfo/getVersion))
    :worker-thread-pids-atom (atom {})
    :storm-cluster-state (cluster/mk-storm-cluster-state conf :acls (when
                                                                      (Utils/isZkAuthenticationConfiguredStormServer
                                                                        conf)
                                                                      SUPERVISOR-ZK-ACLS))
-   :local-state (supervisor-state conf)
+   :local-state (c/supervisor-state conf)
    :supervisor-id (.getSupervisorId isupervisor)
    :assignment-id (.getAssignmentId isupervisor)
-   :my-hostname (hostname conf)
+   :my-hostname (util/hostname conf)
    :curr-assignment (atom nil) ;; used for reporting used ports when heartbeating
-   :heartbeat-timer (mk-timer :kill-fn (fn [t]
+   :heartbeat-timer (timer/mk-timer :kill-fn (fn [t]
                                (log-error t "Error when processing event")
-                               (exit-process! 20 "Error when processing an event")
+                               (util/exit-process! 20 "Error when processing an event")
                                ))
-   :event-timer (mk-timer :kill-fn (fn [t]
+   :event-timer (timer/mk-timer :kill-fn (fn [t]
                                          (log-error t "Error when processing event")
-                                         (exit-process! 20 "Error when processing an event")
+                                         (util/exit-process! 20 "Error when processing an event")
                                          ))
    :assignment-versions (atom {})
    :sync-retry (atom 0)
@@ -318,18 +322,18 @@
         download-lock (:download-lock supervisor)
         ^LocalState local-state (:local-state supervisor)
         storm-cluster-state (:storm-cluster-state supervisor)
-        assigned-executors (defaulted (ls-local-assignments local-state) {})
-        now (current-time-secs)
+        assigned-executors (util/defaulted (ls/ls-local-assignments local-state) {})
+        now (util/current-time-secs)
         allocated (read-allocated-workers supervisor assigned-executors now)
-        keepers (filter-val
+        keepers (util/filter-val
                  (fn [[state _]] (= state :valid))
                  allocated)
         keep-ports (set (for [[id [_ hb]] keepers] (:port hb)))
-        reassign-executors (select-keys-pred (complement keep-ports) assigned-executors)
+        reassign-executors (util/select-keys-pred (complement keep-ports) assigned-executors)
         new-worker-ids (into
                         {}
                         (for [port (keys reassign-executors)]
-                          [port (uuid)]))
+                          [port (util/uuid)]))
         ]
     ;; 1. to kill are those in allocated that are dead or disallowed
     ;; 2. kill the ones that should be dead
@@ -354,11 +358,11 @@
         (shutdown-worker supervisor id)
         ))
     (doseq [id (vals new-worker-ids)]
-      (local-mkdirs (worker-pids-root conf id))
-      (local-mkdirs (worker-heartbeats-root conf id)))
-    (ls-approved-workers! local-state
+      (util/local-mkdirs (c/worker-pids-root conf id))
+      (util/local-mkdirs (c/worker-heartbeats-root conf id)))
+    (ls/ls-approved-workers! local-state
           (merge
-           (select-keys (ls-approved-workers local-state)
+           (select-keys (ls/ls-approved-workers local-state)
                         (keys keepers))
            (zipmap (vals new-worker-ids) (keys new-worker-ids))
            ))
@@ -368,19 +372,19 @@
       (let [downloaded-storm-ids (set (read-downloaded-storm-ids conf))
             storm-id (:storm-id assignment)
             cached-assignment-info @(:assignment-versions supervisor)
-            assignment-info (if (and (not-nil? cached-assignment-info) (contains? cached-assignment-info storm-id ))
+            assignment-info (if (and (util/not-nil? cached-assignment-info) (contains? cached-assignment-info storm-id ))
                               (get cached-assignment-info storm-id)
                               (.assignment-info-with-version storm-cluster-state storm-id nil))
 	    storm-code-map (read-storm-code-locations assignment-info)
             master-code-dir (if (contains? storm-code-map :data) (storm-code-map :data))
-            stormroot (supervisor-stormdist-root conf storm-id)]
+            stormroot (c/supervisor-stormdist-root conf storm-id)]
         (if-not (or (contains? downloaded-storm-ids storm-id) (.exists (File. stormroot)) (nil? master-code-dir))
           (download-storm-code conf storm-id master-code-dir download-lock))
         ))
 
     (wait-for-workers-launch
      conf
-     (dofor [[port assignment] reassign-executors]
+     (util/dofor [[port assignment] reassign-executors]
             (let [id (new-worker-ids port)]
               (try
                 (log-message "Launching worker with assignment "
@@ -414,10 +418,10 @@
 (defn shutdown-disallowed-workers [supervisor]
   (let [conf (:conf supervisor)
         ^LocalState local-state (:local-state supervisor)
-        assigned-executors (defaulted (ls-local-assignments local-state) {})
-        now (current-time-secs)
+        assigned-executors (util/defaulted (ls/ls-local-assignments local-state) {})
+        now (util/current-time-secs)
         allocated (read-allocated-workers supervisor assigned-executors now)
-        disallowed (keys (filter-val
+        disallowed (keys (util/filter-val
                                   (fn [[state _]] (= state :disallowed))
                                   allocated))]
     (log-debug "Allocated workers " allocated)
@@ -440,13 +444,13 @@
                                                                   assignment-versions)
           storm-code-map (read-storm-code-locations assignments-snapshot)
           downloaded-storm-ids (set (read-downloaded-storm-ids conf))
-          existing-assignment (ls-local-assignments local-state)
+          existing-assignment (ls/ls-local-assignments local-state)
           all-assignment (read-assignments assignments-snapshot
                                            (:assignment-id supervisor)
                                            existing-assignment
                                            (:sync-retry supervisor))
           new-assignment (->> all-assignment
-                              (filter-key #(.confirmAssigned isupervisor %)))
+                              (util/filter-key #(.confirmAssigned isupervisor %)))
           assigned-storm-ids (assigned-storm-ids-from-port-assignments new-assignment)
           ]
       (log-debug "Synchronizing supervisor")
@@ -470,7 +474,7 @@
                                 (set (keys new-assignment)))]
         (.killedWorker isupervisor (int p)))
       (.assigned isupervisor (keys new-assignment))
-      (ls-local-assignments! local-state
+      (ls/ls-local-assignments! local-state
             new-assignment)
       (reset! (:assignment-versions supervisor) versions)
       (reset! (:curr-assignment supervisor) new-assignment)
@@ -478,13 +482,13 @@
       ;; important that this happens after setting the local assignment so that
       ;; synchronize-supervisor doesn't try to launch workers for which the
       ;; resources don't exist
-      (if on-windows? (shutdown-disallowed-workers supervisor))
+      (if util/on-windows? (shutdown-disallowed-workers supervisor))
       (doseq [storm-id downloaded-storm-ids]
         (when-not (assigned-storm-ids storm-id)
           (log-message "Removing code for storm id "
                        storm-id)
           (try
-            (rmr (supervisor-stormdist-root conf storm-id))
+            (util/rmr (c/supervisor-stormdist-root conf storm-id))
             (catch Exception e (log-message (.getMessage e))))
           ))
       (.add processes-event-manager sync-processes)
@@ -494,8 +498,8 @@
 ;; another thread launches events to restart any dead processes if necessary
 (defserverfn mk-supervisor [conf shared-context ^ISupervisor isupervisor]
   (log-message "Starting Supervisor with conf " conf)
-  (.prepare isupervisor conf (supervisor-isupervisor-dir conf))
-  (FileUtils/cleanDirectory (File. (supervisor-tmp-dir conf)))
+  (.prepare isupervisor conf (c/supervisor-isupervisor-dir conf))
+  (FileUtils/cleanDirectory (File. (c/supervisor-tmp-dir conf)))
   (let [supervisor (supervisor-data conf shared-context isupervisor)
         [event-manager processes-event-manager :as managers] [(event/event-manager false) (event/event-manager false)]
         sync-processes (partial sync-processes supervisor)
@@ -503,29 +507,29 @@
         heartbeat-fn (fn [] (.supervisor-heartbeat!
                                (:storm-cluster-state supervisor)
                                (:supervisor-id supervisor)
-                               (->SupervisorInfo (current-time-secs)
+                               (->SupervisorInfo (util/current-time-secs)
                                                  (:my-hostname supervisor)
                                                  (:assignment-id supervisor)
                                                  (keys @(:curr-assignment supervisor))
                                                   ;; used ports
                                                  (.getMetadata isupervisor)
-                                                 (conf SUPERVISOR-SCHEDULER-META)
+                                                 (conf c/SUPERVISOR-SCHEDULER-META)
                                                  ((:uptime supervisor))
                                                  (:version supervisor))))]
     (heartbeat-fn)
 
     ;; should synchronize supervisor so it doesn't launch anything after being down (optimization)
-    (schedule-recurring (:heartbeat-timer supervisor)
+    (timer/schedule-recurring (:heartbeat-timer supervisor)
                         0
-                        (conf SUPERVISOR-HEARTBEAT-FREQUENCY-SECS)
+                        (conf c/SUPERVISOR-HEARTBEAT-FREQUENCY-SECS)
                         heartbeat-fn)
-    (when (conf SUPERVISOR-ENABLE)
+    (when (conf c/SUPERVISOR-ENABLE)
       ;; This isn't strictly necessary, but it doesn't hurt and ensures that the machine stays up
       ;; to date even if callbacks don't all work exactly right
-      (schedule-recurring (:event-timer supervisor) 0 10 (fn [] (.add event-manager synchronize-supervisor)))
-      (schedule-recurring (:event-timer supervisor)
+      (timer/schedule-recurring (:event-timer supervisor) 0 10 (fn [] (.add event-manager synchronize-supervisor)))
+      (timer/schedule-recurring (:event-timer supervisor)
                           0
-                          (conf SUPERVISOR-MONITOR-FREQUENCY-SECS)
+                          (conf c/SUPERVISOR-MONITOR-FREQUENCY-SECS)
                           (fn [] (.add processes-event-manager sync-processes))))
     (log-message "Starting supervisor with id " (:supervisor-id supervisor) " at host " (:my-hostname supervisor))
     (reify
@@ -533,8 +537,8 @@
      (shutdown [this]
                (log-message "Shutting down supervisor " (:supervisor-id supervisor))
                (reset! (:active supervisor) false)
-               (cancel-timer (:heartbeat-timer supervisor))
-               (cancel-timer (:event-timer supervisor))
+               (timer/cancel-timer (:heartbeat-timer supervisor))
+               (timer/cancel-timer (:event-timer supervisor))
                (.shutdown event-manager)
                (.shutdown processes-event-manager)
                (.disconnect (:storm-cluster-state supervisor)))
@@ -552,8 +556,8 @@
      (waiting? [this]
        (or (not @(:active supervisor))
            (and
-            (timer-waiting? (:heartbeat-timer supervisor))
-            (timer-waiting? (:event-timer supervisor))
+            (timer/timer-waiting? (:heartbeat-timer supervisor))
+            (timer/timer-waiting? (:event-timer supervisor))
             (every? (memfn waiting?) managers)))
            ))))
 
@@ -562,15 +566,15 @@
   )
 
 (defn setup-storm-code-dir [conf storm-conf dir]
- (if (conf SUPERVISOR-RUN-WORKER-AS-USER)
-  (worker-launcher-and-wait conf (storm-conf TOPOLOGY-SUBMITTER-USER) ["code-dir" dir] :log-prefix (str "setup conf for " dir))))
+ (if (conf c/SUPERVISOR-RUN-WORKER-AS-USER)
+  (worker-launcher-and-wait conf (storm-conf c/TOPOLOGY-SUBMITTER-USER) ["code-dir" dir] :log-prefix (str "setup conf for " dir))))
 
 ;; distributed implementation
 (defmethod download-storm-code
     :distributed [conf storm-id master-code-dir download-lock]
     ;; Downloading to permanent location is atomic
-    (let [tmproot (str (supervisor-tmp-dir conf) file-path-separator (uuid))
-          stormroot (supervisor-stormdist-root conf storm-id)]
+    (let [tmproot (str (c/supervisor-tmp-dir conf) util/file-path-separator (util/uuid))
+          stormroot (c/supervisor-stormdist-root conf storm-id)]
       (locking download-lock
             (log-message "Downloading code for storm id "
                          storm-id
@@ -578,14 +582,14 @@
                          master-code-dir)
             (FileUtils/forceMkdir (File. tmproot))
 
-            (Utils/downloadFromMaster conf (master-stormjar-path master-code-dir) (supervisor-stormjar-path tmproot))
-            (Utils/downloadFromMaster conf (master-stormcode-path master-code-dir) (supervisor-stormcode-path tmproot))
-            (Utils/downloadFromMaster conf (master-stormconf-path master-code-dir) (supervisor-stormconf-path tmproot))
-            (extract-dir-from-jar (supervisor-stormjar-path tmproot) RESOURCES-SUBDIR tmproot)
+            (Utils/downloadFromMaster conf (c/master-stormjar-path master-code-dir) (c/supervisor-stormjar-path tmproot))
+            (Utils/downloadFromMaster conf (c/master-stormcode-path master-code-dir) (c/supervisor-stormcode-path tmproot))
+            (Utils/downloadFromMaster conf (c/master-stormconf-path master-code-dir) (c/supervisor-stormconf-path tmproot))
+            (util/extract-dir-from-jar (c/supervisor-stormjar-path tmproot) c/RESOURCES-SUBDIR tmproot)
             (if-not (.exists (File. stormroot))
               (FileUtils/moveDirectory (File. tmproot) (File. stormroot))
               (FileUtils/deleteDirectory (File. tmproot)))
-            (setup-storm-code-dir conf (read-supervisor-storm-conf conf storm-id) stormroot)
+            (setup-storm-code-dir conf (c/read-supervisor-storm-conf conf storm-id) stormroot)
             (log-message "Finished downloading code for storm id "
                          storm-id
                          " from "
@@ -593,10 +597,10 @@
       ))
 
 (defn write-log-metadata-to-yaml-file! [storm-id port data conf]
-  (let [file (get-log-metadata-file storm-id port)]
+  (let [file (util/get-log-metadata-file storm-id port)]
     ;;run worker as user needs the directory to have special permissions
     ;; or it is insecure
-    (when (and (not (conf SUPERVISOR-RUN-WORKER-AS-USER))
+    (when (and (not (conf c/SUPERVISOR-RUN-WORKER-AS-USER)) ;; TODO: This can be reoriented
                (not (.exists (.getParentFile file))))
       (.mkdirs (.getParentFile file)))
     (let [writer (java.io.FileWriter. file)
@@ -607,24 +611,24 @@
           (.close writer))))))
 
 (defn write-log-metadata! [storm-conf user worker-id storm-id port conf]
-  (let [data {TOPOLOGY-SUBMITTER-USER user
+  (let [data {c/TOPOLOGY-SUBMITTER-USER user
               "worker-id" worker-id
-              LOGS-GROUPS (sort (distinct (remove nil?
+              c/LOGS-GROUPS (sort (distinct (remove nil?
                                            (concat
-                                             (storm-conf LOGS-GROUPS)
-                                             (storm-conf TOPOLOGY-GROUPS)))))
-              LOGS-USERS (sort (distinct (remove nil?
+                                             (storm-conf c/LOGS-GROUPS)
+                                             (storm-conf c/TOPOLOGY-GROUPS)))))
+              c/LOGS-USERS (sort (distinct (remove nil?
                                            (concat
-                                             (storm-conf LOGS-USERS)
-                                             (storm-conf TOPOLOGY-USERS)))))}]
+                                             (storm-conf c/LOGS-USERS)
+                                             (storm-conf c/TOPOLOGY-USERS)))))}]
     (write-log-metadata-to-yaml-file! storm-id port data conf)))
 
 (defn jlp [stormroot conf]
-  (let [resource-root (str stormroot File/separator RESOURCES-SUBDIR)
+  (let [resource-root (str stormroot File/separator c/RESOURCES-SUBDIR)
         os (clojure.string/replace (System/getProperty "os.name") #"\s+" "_")
         arch (System/getProperty "os.arch")
         arch-resource-root (str resource-root File/separator os "-" arch)]
-    (str arch-resource-root File/pathSeparator resource-root File/pathSeparator (conf JAVA-LIBRARY-PATH))))
+    (str arch-resource-root File/pathSeparator resource-root File/pathSeparator (conf c/JAVA-LIBRARY-PATH))))
 
 (defn substitute-childopts
   "Generates runtime childopts by replacing keys with topology-id, worker-id, port"
@@ -640,46 +644,46 @@
     (cond
       (nil? value) nil
       (list? value) (map sub-fn value)
-      :else (-> value sub-fn (clojure.string/split #"\s+")))))
+      :else (-> value sub-fn (string/split #"\s+")))))
 
 (defn java-cmd []
   (let [java-home (.get (System/getenv) "JAVA_HOME")]
     (if (nil? java-home)
       "java"
-      (str java-home file-path-separator "bin" file-path-separator "java")
+      (str java-home util/file-path-separator "bin" util/file-path-separator "java")
       )))
 
 
 (defmethod launch-worker
     :distributed [supervisor storm-id port worker-id]
     (let [conf (:conf supervisor)
-          run-worker-as-user (conf SUPERVISOR-RUN-WORKER-AS-USER)
+          run-worker-as-user (conf c/SUPERVISOR-RUN-WORKER-AS-USER)
           storm-home (System/getProperty "storm.home")
           storm-options (System/getProperty "storm.options")
           storm-conf-file (System/getProperty "storm.conf.file")
-          storm-log-dir (or (System/getProperty "storm.log.dir") (str storm-home file-path-separator "logs"))
-          storm-conf (read-storm-config)
+          storm-log-dir (or (System/getProperty "storm.log.dir") (str storm-home util/file-path-separator "logs"))
+          storm-conf (c/read-storm-config)
           storm-log-conf-dir (storm-conf "storm.logback.conf.dir")
-          storm-logback-conf-dir (or storm-log-conf-dir (str storm-home file-path-separator "logback"))
-          stormroot (supervisor-stormdist-root conf storm-id)
+          storm-logback-conf-dir (or storm-log-conf-dir (str storm-home util/file-path-separator "logback"))
+          stormroot (c/supervisor-stormdist-root conf storm-id)
           jlp (jlp stormroot conf)
-          stormjar (supervisor-stormjar-path stormroot)
-          storm-conf (read-supervisor-storm-conf conf storm-id)
-          topo-classpath (if-let [cp (storm-conf TOPOLOGY-CLASSPATH)]
+          stormjar (c/supervisor-stormjar-path stormroot)
+          storm-conf (c/read-supervisor-storm-conf conf storm-id)
+          topo-classpath (if-let [cp (storm-conf c/TOPOLOGY-CLASSPATH)]
                            [cp]
                            [])
-          classpath (-> (worker-classpath)
-                        (add-to-classpath [stormjar])
-                        (add-to-classpath topo-classpath))
-          top-gc-opts (storm-conf TOPOLOGY-WORKER-GC-CHILDOPTS)
-          gc-opts (substitute-childopts (if top-gc-opts top-gc-opts (conf WORKER-GC-CHILDOPTS)) worker-id storm-id port)
-          user (storm-conf TOPOLOGY-SUBMITTER-USER)
-          logfilename (logs-filename storm-id port)
-          worker-childopts (when-let [s (conf WORKER-CHILDOPTS)]
+          classpath (-> (util/worker-classpath)
+                        (util/add-to-classpath [stormjar])
+                        (util/add-to-classpath topo-classpath))
+          top-gc-opts (storm-conf c/TOPOLOGY-WORKER-GC-CHILDOPTS)
+          gc-opts (substitute-childopts (if top-gc-opts top-gc-opts (conf c/WORKER-GC-CHILDOPTS)) worker-id storm-id port)
+          user (storm-conf c/TOPOLOGY-SUBMITTER-USER)
+          logfilename (util/logs-filename storm-id port)
+          worker-childopts (when-let [s (conf c/WORKER-CHILDOPTS)]
                              (substitute-childopts s worker-id storm-id port))
-          topo-worker-childopts (when-let [s (storm-conf TOPOLOGY-WORKER-CHILDOPTS)]
+          topo-worker-childopts (when-let [s (storm-conf c/TOPOLOGY-WORKER-CHILDOPTS)]
                                   (substitute-childopts s worker-id storm-id port))
-          topology-worker-environment (if-let [env (storm-conf TOPOLOGY-ENVIRONMENT)]
+          topology-worker-environment (if-let [env (storm-conf c/TOPOLOGY-ENVIRONMENT)]
                                         (merge env {"LD_LIBRARY_PATH" jlp})
                                         {"LD_LIBRARY_PATH" jlp})
           command (concat
@@ -693,7 +697,7 @@
                      (str "-Dstorm.conf.file=" storm-conf-file)
                      (str "-Dstorm.options=" storm-options)
                      (str "-Dstorm.log.dir=" storm-log-dir)
-                     (str "-Dlogback.configurationFile=" storm-logback-conf-dir file-path-separator "worker.xml")
+                     (str "-Dlogback.configurationFile=" storm-logback-conf-dir util/file-path-separator "worker.xml")
                      (str "-Dstorm.id=" storm-id)
                      (str "-Dworker.id=" worker-id)
                      (str "-Dworker.port=" port)
@@ -704,47 +708,47 @@
                      port
                      worker-id])
           command (->> command (map str) (filter (complement empty?)))]
-      (log-message "Launching worker with command: " (shell-cmd command))
+      (log-message "Launching worker with command: " (util/shell-cmd command))
       (write-log-metadata! storm-conf user worker-id storm-id port conf)
-      (set-worker-user! conf worker-id user)
+      (c/set-worker-user! conf worker-id user)
       (let [log-prefix (str "Worker Process " worker-id)
            callback (fn [exit-code]
                           (log-message log-prefix " exited with code: " exit-code)
                           (add-dead-worker worker-id))]
         (remove-dead-worker worker-id)
         (if run-worker-as-user
-          (let [worker-dir (worker-root conf worker-id)]
-            (worker-launcher conf user ["worker" worker-dir (write-script worker-dir command :environment topology-worker-environment)] :log-prefix log-prefix :exit-code-callback callback))
-          (launch-process command :environment topology-worker-environment :log-prefix log-prefix :exit-code-callback callback)
+          (let [worker-dir (c/worker-root conf worker-id)]
+            (worker-launcher conf user ["worker" worker-dir (util/write-script worker-dir command :environment topology-worker-environment)] :log-prefix log-prefix :exit-code-callback callback))
+          (util/launch-process command :environment topology-worker-environment :log-prefix log-prefix :exit-code-callback callback)
       ))))
 
 ;; local implementation
 
 (defn resources-jar []
-  (->> (.split (current-classpath) File/pathSeparator)
+  (->> (.split (util/current-classpath) File/pathSeparator)
        (filter #(.endsWith  % ".jar"))
-       (filter #(zip-contains-dir? % RESOURCES-SUBDIR))
+       (filter #(util/zip-contains-dir? % c/RESOURCES-SUBDIR))
        first ))
 
 (defmethod download-storm-code
     :local [conf storm-id master-code-dir download-lock]
-    (let [stormroot (supervisor-stormdist-root conf storm-id)]
+    (let [stormroot (c/supervisor-stormdist-root conf storm-id)]
       (locking download-lock
             (FileUtils/copyDirectory (File. master-code-dir) (File. stormroot))
             (let [classloader (.getContextClassLoader (Thread/currentThread))
                   resources-jar (resources-jar)
-                  url (.getResource classloader RESOURCES-SUBDIR)
-                  target-dir (str stormroot file-path-separator RESOURCES-SUBDIR)]
+                  url (.getResource classloader c/RESOURCES-SUBDIR)
+                  target-dir (str stormroot util/file-path-separator c/RESOURCES-SUBDIR)]
               (cond
                resources-jar
                (do
                  (log-message "Extracting resources from jar at " resources-jar " to " target-dir)
-                 (extract-dir-from-jar resources-jar RESOURCES-SUBDIR stormroot))
+                 (util/extract-dir-from-jar resources-jar c/RESOURCES-SUBDIR stormroot))
                url
                (do
                  (log-message "Copying resources at " (URI. (str url)) " to " target-dir)
                  (if (= (.getProtocol url) "jar" )
-                   (extract-dir-from-jar (.getFile (.getJarFileURL (.openConnection url))) RESOURCES-SUBDIR stormroot)
+                   (util/extract-dir-from-jar (.getFile (.getJarFileURL (.openConnection url))) c/RESOURCES-SUBDIR stormroot)
                    (FileUtils/copyDirectory (File. (.getPath (URI. (str url)))) (File. target-dir)))
                  )
                )
@@ -754,23 +758,23 @@
 (defmethod launch-worker
     :local [supervisor storm-id port worker-id]
     (let [conf (:conf supervisor)
-          pid (uuid)
+          pid (util/uuid)
           worker (worker/mk-worker conf
                                    (:shared-context supervisor)
                                    storm-id
                                    (:assignment-id supervisor)
                                    port
                                    worker-id)]
-      (set-worker-user! conf worker-id "")
+      (c/set-worker-user! conf worker-id "")
       (psim/register-process pid worker)
       (swap! (:worker-thread-pids-atom supervisor) assoc worker-id pid)
       ))
 
 (defn -launch [supervisor]
-  (let [conf (read-storm-config)]
+  (let [conf (c/read-storm-config)]
     (validate-distributed-mode! conf)
     (let [supervisor (mk-supervisor conf nil supervisor)]
-      (add-shutdown-hook-with-force-kill-in-1-sec #(.shutdown supervisor)))))
+      (util/add-shutdown-hook-with-force-kill-in-1-sec #(.shutdown supervisor)))))
 
 (defn standalone-supervisor []
   (let [conf-atom (atom nil)
@@ -779,16 +783,16 @@
       (prepare [this conf local-dir]
         (reset! conf-atom conf)
         (let [state (LocalState. local-dir)
-              curr-id (if-let [id (ls-supervisor-id state)]
+              curr-id (if-let [id (ls/ls-supervisor-id state)]
                         id
                         (generate-supervisor-id))]
-          (ls-supervisor-id! state curr-id)
+          (ls/ls-supervisor-id! state curr-id)
           (reset! id-atom curr-id))
         )
       (confirmAssigned [this port]
         true)
       (getMetadata [this]
-        (doall (map int (get @conf-atom SUPERVISOR-SLOTS-PORTS))))
+        (doall (map int (get @conf-atom c/SUPERVISOR-SLOTS-PORTS))))
       (getSupervisorId [this]
         @id-atom)
       (getAssignmentId [this]
@@ -799,5 +803,5 @@
         ))))
 
 (defn -main []
-  (setup-default-uncaught-exception-handler)
+  (util/setup-default-uncaught-exception-handler)
   (-launch (standalone-supervisor)))

--- a/storm-core/src/clj/backtype/storm/daemon/task.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/task.clj
@@ -18,8 +18,7 @@
         [backtype.storm config util log])
   (:import [backtype.storm.tuple Tuple TupleImpl]
            [backtype.storm.generated SpoutSpec Bolt StateSpoutSpec StormTopology]
-           [backtype.storm.hooks.info SpoutAckInfo SpoutFailInfo
-                                      EmitInfo BoltFailInfo BoltAckInfo]
+           [backtype.storm.hooks.info EmitInfo]
            [backtype.storm.task TopologyContext ShellBolt WorkerTopologyContext]
            [backtype.storm.utils Utils]
            [backtype.storm.generated ShellComponent JavaObject]

--- a/storm-core/src/clj/backtype/storm/daemon/task.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/task.clj
@@ -14,23 +14,22 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.daemon.task
-  (:use [backtype.storm.daemon common])
-  (:use [backtype.storm config util log])
-  (:import [backtype.storm.hooks ITaskHook])
-  (:import [backtype.storm.tuple Tuple TupleImpl])
-  (:import [backtype.storm.generated SpoutSpec Bolt StateSpoutSpec StormTopology])
-  (:import [backtype.storm.hooks.info SpoutAckInfo SpoutFailInfo
-            EmitInfo BoltFailInfo BoltAckInfo])
-  (:import [backtype.storm.task TopologyContext ShellBolt WorkerTopologyContext])
-  (:import [backtype.storm.utils Utils])
-  (:import [backtype.storm.generated ShellComponent JavaObject])
-  (:import [backtype.storm.spout ShellSpout])
-  (:import [java.util Collection List ArrayList])
+  (:use [backtype.storm.daemon common]
+        [backtype.storm config util log])
+  (:import [backtype.storm.tuple Tuple TupleImpl]
+           [backtype.storm.generated SpoutSpec Bolt StateSpoutSpec StormTopology]
+           [backtype.storm.hooks.info SpoutAckInfo SpoutFailInfo
+                                      EmitInfo BoltFailInfo BoltAckInfo]
+           [backtype.storm.task TopologyContext ShellBolt WorkerTopologyContext]
+           [backtype.storm.utils Utils]
+           [backtype.storm.generated ShellComponent JavaObject]
+           [backtype.storm.spout ShellSpout]
+           [java.util Collection List ArrayList])
   (:require [backtype.storm
              [tuple :as tuple]
              [thrift :as thrift]
-             [stats :as stats]])
-  (:require [backtype.storm.daemon.builtin-metrics :as builtin-metrics]))
+             [stats :as stats]]
+            [backtype.storm.daemon.builtin-metrics :as builtin-metrics]))
 
 (defn mk-topology-context-builder [worker executor-data topology]
   (let [conf (:conf worker)]
@@ -134,7 +133,7 @@
         user-context (:user-context task-data)
         executor-stats (:stats executor-data)
         debug? (= true (storm-conf TOPOLOGY-DEBUG))]
-        
+
     (fn ([^Integer out-task-id ^String stream ^List values]
           (when debug?
             (log-message "Emitting direct: " out-task-id "; " component-id " " stream " " values))
@@ -143,7 +142,7 @@
                 grouping (get component->grouping target-component)
                 out-task-id (if grouping out-task-id)]
             (when (and (not-nil? grouping) (not= :direct grouping))
-              (throw (IllegalArgumentException. "Cannot emitDirect to a task expecting a regular grouping")))                          
+              (throw (IllegalArgumentException. "Cannot emitDirect to a task expecting a regular grouping")))
             (apply-hooks user-context .emit (EmitInfo. values stream task-id [out-task-id]))
             (when (emit-sampler)
               (builtin-metrics/emitted-tuple! (:builtin-metrics task-data) executor-stats stream)
@@ -169,7 +168,7 @@
              (apply-hooks user-context .emit (EmitInfo. values stream task-id out-tasks))
              (when (emit-sampler)
                (stats/emitted-tuple! executor-stats stream)
-               (builtin-metrics/emitted-tuple! (:builtin-metrics task-data) executor-stats stream)              
+               (builtin-metrics/emitted-tuple! (:builtin-metrics task-data) executor-stats stream)
                (stats/transferred-tuples! executor-stats stream (count out-tasks))
                (builtin-metrics/transferred-tuple! (:builtin-metrics task-data) executor-stats stream (count out-tasks)))
              out-tasks)))

--- a/storm-core/src/clj/backtype/storm/disruptor.clj
+++ b/storm-core/src/clj/backtype/storm/disruptor.clj
@@ -15,14 +15,12 @@
 ;; limitations under the License.
 
 (ns backtype.storm.disruptor
-  (:import [backtype.storm.utils DisruptorQueue])
-  (:import [com.lmax.disruptor MultiThreadedClaimStrategy SingleThreadedClaimStrategy
-            BlockingWaitStrategy SleepingWaitStrategy YieldingWaitStrategy
-            BusySpinWaitStrategy])
-  (:require [clojure [string :as str]])
-  (:require [clojure [set :as set]])
-  (:use [clojure walk])
-  (:use [backtype.storm util log]))
+  (:use [clojure walk]
+        [backtype.storm util log])
+  (:import [backtype.storm.utils DisruptorQueue]
+           [com.lmax.disruptor MultiThreadedClaimStrategy SingleThreadedClaimStrategy
+                               BlockingWaitStrategy SleepingWaitStrategy YieldingWaitStrategy
+                               BusySpinWaitStrategy]))
 
 (def CLAIM-STRATEGY
   {:multi-threaded (fn [size] (MultiThreadedClaimStrategy. (int size)))

--- a/storm-core/src/clj/backtype/storm/disruptor.clj
+++ b/storm-core/src/clj/backtype/storm/disruptor.clj
@@ -15,8 +15,7 @@
 ;; limitations under the License.
 
 (ns backtype.storm.disruptor
-  (:use [clojure walk]
-        [backtype.storm util log])
+  (:require [backtype.storm.util :as util :refer [defnk]])
   (:import [backtype.storm.utils DisruptorQueue]
            [com.lmax.disruptor MultiThreadedClaimStrategy SingleThreadedClaimStrategy
                                BlockingWaitStrategy SleepingWaitStrategy YieldingWaitStrategy
@@ -36,7 +35,7 @@
   [spec]
   (if (keyword? spec)
     ((WAIT-STRATEGY spec))
-    (-> (str spec) new-instance)))
+    (-> (str spec) util/new-instance)))
 
 ;; :block strategy requires using a timeout on waitFor (implemented in DisruptorQueue), as sometimes the consumer stays blocked even when there's an item on the queue.
 ;; This would manifest itself in Trident when doing 1 batch at a time processing, and the ack_init message
@@ -87,8 +86,8 @@
 
 (defnk consume-loop*
   [^DisruptorQueue queue handler
-   :kill-fn (fn [error] (exit-process! 1 "Async loop died!"))]
-  (let [ret (async-loop
+   :kill-fn (fn [error] (util/exit-process! 1 "Async loop died!"))]
+  (let [ret (util/async-loop
               (fn [] (consume-batch-when-available queue handler) 0)
               :kill-fn kill-fn
               :thread-name (.getName queue))]

--- a/storm-core/src/clj/backtype/storm/event.clj
+++ b/storm-core/src/clj/backtype/storm/event.clj
@@ -16,9 +16,9 @@
 
 (ns backtype.storm.event
   (:use [backtype.storm log util])
-  (:import [backtype.storm.utils Time Utils])
-  (:import [java.io InterruptedIOException])
-  (:import [java.util.concurrent LinkedBlockingQueue TimeUnit]))
+  (:import [backtype.storm.utils Time Utils]
+           [java.io InterruptedIOException]
+           [java.util.concurrent LinkedBlockingQueue TimeUnit]))
 
 (defprotocol EventManager
   (add [this event-fn])

--- a/storm-core/src/clj/backtype/storm/event.clj
+++ b/storm-core/src/clj/backtype/storm/event.clj
@@ -15,10 +15,11 @@
 ;; limitations under the License.
 
 (ns backtype.storm.event
-  (:use [backtype.storm log util])
-  (:import [backtype.storm.utils Time Utils]
+  (:require [backtype.storm.log :refer [log-message log-error]]
+            [backtype.storm.util :as util])
+  (:import [backtype.storm.utils Time]
            [java.io InterruptedIOException]
-           [java.util.concurrent LinkedBlockingQueue TimeUnit]))
+           [java.util.concurrent LinkedBlockingQueue]))
 
 (defprotocol EventManager
   (add [this event-fn])
@@ -34,7 +35,7 @@
         running (atom true)
         runner (Thread.
                  (fn []
-                   (try-cause
+                   (util/try-cause
                      (while @running
                        (let [r (.take queue)]
                          (r)
@@ -45,7 +46,7 @@
                        (log-message "Event manager interrupted"))
                      (catch Throwable t
                        (log-error t "Error when processing event")
-                       (exit-process! 20 "Error when processing an event")))))]
+                       (util/exit-process! 20 "Error when processing an event")))))]
     (.setDaemon runner daemon?)
     (.start runner)
     (reify

--- a/storm-core/src/clj/backtype/storm/local_state.clj
+++ b/storm-core/src/clj/backtype/storm/local_state.clj
@@ -14,10 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.local-state
-  (:use [backtype.storm log util])
-  (:import [backtype.storm.generated StormTopology
-                                     InvalidTopologyException GlobalStreamId
-                                     LSSupervisorId LSApprovedWorkers
+  (:require [backtype.storm.util :as util])
+  (:import [backtype.storm.generated LSSupervisorId LSApprovedWorkers
                                      LSSupervisorAssignments LocalAssignment
                                      ExecutorInfo LSWorkerHeartbeat]
            [backtype.storm.utils LocalState]))
@@ -74,14 +72,14 @@
 
 (defn ls-local-assignments!
   [^LocalState local-state assignments]
-    (let [local-assignment-map (map-val ->LocalAssignment assignments)]
+    (let [local-assignment-map (util/map-val ->LocalAssignment assignments)]
     (.put local-state LS-LOCAL-ASSIGNMENTS
           (LSSupervisorAssignments. local-assignment-map))))
 
 (defn ls-local-assignments
   [^LocalState local-state]
     (if-let [thrift-local-assignments (.get local-state LS-LOCAL-ASSIGNMENTS)]
-      (map-val
+      (util/map-val
         ->local-assignment
         (.get_assignments thrift-local-assignments))))
 

--- a/storm-core/src/clj/backtype/storm/local_state.clj
+++ b/storm-core/src/clj/backtype/storm/local_state.clj
@@ -16,11 +16,11 @@
 (ns backtype.storm.local-state
   (:use [backtype.storm log util])
   (:import [backtype.storm.generated StormTopology
-            InvalidTopologyException GlobalStreamId
-            LSSupervisorId LSApprovedWorkers
-            LSSupervisorAssignments LocalAssignment
-            ExecutorInfo LSWorkerHeartbeat])
-  (:import [backtype.storm.utils LocalState]))
+                                     InvalidTopologyException GlobalStreamId
+                                     LSSupervisorId LSApprovedWorkers
+                                     LSSupervisorAssignments LocalAssignment
+                                     ExecutorInfo LSWorkerHeartbeat]
+           [backtype.storm.utils LocalState]))
 
 (def LS-WORKER-HEARTBEAT "worker-heartbeat")
 (def LS-ID "supervisor-id")
@@ -54,8 +54,8 @@
 
 (defn ->executor-list
   [executors]
-  (into [] 
-    (for [exec-info executors] 
+  (into []
+    (for [exec-info executors]
       [(.get_task_start exec-info) (.get_task_end exec-info)])))
 
 (defn ->LocalAssignment
@@ -75,7 +75,7 @@
 (defn ls-local-assignments!
   [^LocalState local-state assignments]
     (let [local-assignment-map (map-val ->LocalAssignment assignments)]
-    (.put local-state LS-LOCAL-ASSIGNMENTS 
+    (.put local-state LS-LOCAL-ASSIGNMENTS
           (LSSupervisorAssignments. local-assignment-map))))
 
 (defn ls-local-assignments
@@ -89,7 +89,7 @@
   [^LocalState local-state time-secs storm-id executors port]
   (.put local-state LS-WORKER-HEARTBEAT (LSWorkerHeartbeat. time-secs storm-id (->ExecutorInfo-list executors) port) false))
 
-(defn ls-worker-heartbeat 
+(defn ls-worker-heartbeat
   [^LocalState local-state]
   (if-let [worker-hb (.get local-state LS-WORKER-HEARTBEAT)]
     {:time-secs (.get_time_secs worker-hb)

--- a/storm-core/src/clj/backtype/storm/log.clj
+++ b/storm-core/src/clj/backtype/storm/log.clj
@@ -15,7 +15,7 @@
 ;; limitations under the License.
 
 (ns backtype.storm.log
-  (:require [clojure.tools [logging :as log]]))
+  (:require [clojure.tools.logging :as log]))
 
 (defmacro log-message
   [& args]

--- a/storm-core/src/clj/backtype/storm/messaging/loader.clj
+++ b/storm-core/src/clj/backtype/storm/messaging/loader.clj
@@ -14,9 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.messaging.loader
-  (:use [backtype.storm util log])
   (:require [backtype.storm.messaging [local :as local]]
-            [backtype.storm [disruptor :as disruptor]])
+            [backtype.storm [disruptor :as disruptor]]
+            [backtype.storm.log :refer [log-message]]
+            [backtype.storm.util :as util :refer [defnk]])
   (:import [java.util ArrayList Iterator]
            [backtype.storm.messaging IContext IConnection TaskMessage]
            [backtype.storm.utils DisruptorQueue MutableObject]))
@@ -25,7 +26,7 @@
   (local/mk-context))
 
 (defn- mk-receive-thread [storm-id port transfer-local-fn  daemon kill-fn priority socket max-buffer-size thread-id]
-    (async-loop
+    (util/async-loop
        (fn []
          (log-message "Starting receive-thread: [stormId: " storm-id ", port: " port ", thread-id: " thread-id  " ]")
          (fn []
@@ -65,7 +66,7 @@
    :kill-fn (fn [t] (System/exit 1))
    :priority Thread/NORM_PRIORITY]
   (let [max-buffer-size (int max-buffer-size)
-        local-hostname (memoized-local-hostname)
+        local-hostname (util/memoized-local-hostname)
         thread-count (if receiver-thread-count receiver-thread-count 1)
         vthreads (mk-receive-threads storm-id port transfer-local-fn daemon kill-fn priority socket max-buffer-size thread-count)]
     (fn []

--- a/storm-core/src/clj/backtype/storm/messaging/local.clj
+++ b/storm-core/src/clj/backtype/storm/messaging/local.clj
@@ -16,10 +16,10 @@
 (ns backtype.storm.messaging.local
   (:refer-clojure :exclude [send])
   (:use [backtype.storm log])
-  (:import [backtype.storm.messaging IContext IConnection TaskMessage])
-  (:import [java.util.concurrent LinkedBlockingQueue])
-  (:import [java.util Map Iterator])
-  (:import [java.util Iterator ArrayList])
+  (:import [backtype.storm.messaging IContext IConnection TaskMessage]
+           [java.util.concurrent LinkedBlockingQueue]
+           [java.util Map Iterator]
+           [java.util Iterator ArrayList])
   (:gen-class))
 
 (defn add-queue! [queues-map lock storm-id port]
@@ -37,7 +37,7 @@
     (let [ret (ArrayList.)
           msg (if (= flags 1) (.poll queue) (.take queue))]
       (if msg
-        (do 
+        (do
           (.add ret msg)
           (.iterator ret))
         nil)))
@@ -47,7 +47,7 @@
       ))
   (^void send [this ^Iterator iter]
     (let [send-queue (add-queue! queues-map lock storm-id port)]
-      (while (.hasNext iter) 
+      (while (.hasNext iter)
          (.put send-queue (.next iter)))
       ))
   (^void close [this]
@@ -67,7 +67,7 @@
   (^void term [this]
     ))
 
-(defn mk-context [] 
+(defn mk-context []
   (let [context  (LocalContext. nil nil)]
     (.prepare ^IContext context nil)
     context))

--- a/storm-core/src/clj/backtype/storm/messaging/local.clj
+++ b/storm-core/src/clj/backtype/storm/messaging/local.clj
@@ -15,7 +15,6 @@
 ;; limitations under the License.
 (ns backtype.storm.messaging.local
   (:refer-clojure :exclude [send])
-  (:use [backtype.storm log])
   (:import [backtype.storm.messaging IContext IConnection TaskMessage]
            [java.util.concurrent LinkedBlockingQueue]
            [java.util Map Iterator]

--- a/storm-core/src/clj/backtype/storm/process_simulator.clj
+++ b/storm-core/src/clj/backtype/storm/process_simulator.clj
@@ -15,9 +15,10 @@
 ;; limitations under the License.
 
 (ns backtype.storm.process-simulator
-  (:use [backtype.storm log util]))
+  (:require [backtype.storm.log :refer [log-message]]
+            [backtype.storm.util :as util]))
 
-(def pid-counter (mk-counter))
+(def pid-counter (util/mk-counter))
 
 (def process-map (atom {}))
 

--- a/storm-core/src/clj/backtype/storm/scheduler/DefaultScheduler.clj
+++ b/storm-core/src/clj/backtype/storm/scheduler/DefaultScheduler.clj
@@ -14,8 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.scheduler.DefaultScheduler
-  (:use [backtype.storm util config])
-  (:require [backtype.storm.scheduler.EvenScheduler :as EvenScheduler])
+  (:require [backtype.storm.scheduler.EvenScheduler :as EvenScheduler]
+            [backtype.storm.util :as util])
   (:import [backtype.storm.scheduler IScheduler Topologies
             Cluster TopologyDetails WorkerSlot SchedulerAssignment
             EvenScheduler ExecutorDetails])
@@ -25,7 +25,7 @@
 (defn- bad-slots [existing-slots num-executors num-workers]
   (if (= 0 num-workers)
     '()
-    (let [distribution (atom (integer-divided num-executors num-workers))
+    (let [distribution (atom (util/integer-divided num-executors num-workers))
           keepers (atom {})]
       (doseq [[node+port executor-list] existing-slots :let [executor-count (count executor-list)]]
         (when (pos? (get @distribution executor-count 0))
@@ -66,7 +66,7 @@
                   can-reassign-slots (slots-can-reassign cluster (keys alive-assigned))
                   total-slots-to-use (min (.getNumWorkers topology)
                                           (+ (count can-reassign-slots) (count available-slots)))
-                  bad-slots (if (or (> total-slots-to-use (count alive-assigned)) 
+                  bad-slots (if (or (> total-slots-to-use (count alive-assigned))
                                     (not= alive-executors all-executors))
                                 (bad-slots alive-assigned (count all-executors) total-slots-to-use)
                                 [])]]

--- a/storm-core/src/clj/backtype/storm/scheduler/IsolationScheduler.clj
+++ b/storm-core/src/clj/backtype/storm/scheduler/IsolationScheduler.clj
@@ -16,14 +16,14 @@
 (ns backtype.storm.scheduler.IsolationScheduler
   (:use [backtype.storm util config log])
   (:require [backtype.storm.scheduler.DefaultScheduler :as DefaultScheduler])
-  (:import [java.util HashSet Set List LinkedList ArrayList Map HashMap])
-  (:import [backtype.storm.scheduler IScheduler Topologies
-            Cluster TopologyDetails WorkerSlot SchedulerAssignment
-            EvenScheduler ExecutorDetails])
+  (:import [java.util HashSet Set List LinkedList ArrayList Map HashMap]
+           [backtype.storm.scheduler IScheduler Topologies
+                                     Cluster TopologyDetails WorkerSlot SchedulerAssignment
+                                     EvenScheduler ExecutorDetails])
   (:gen-class
     :init init
     :constructors {[] []}
-    :state state 
+    :state state
     :implements [backtype.storm.scheduler.IScheduler]))
 
 (defn -init []
@@ -155,7 +155,7 @@
 ;; run default scheduler on isolated topologies that didn't have enough slots + non-isolated topologies on remaining machines
 ;; set blacklist to what it was initially
 (defn -schedule [this ^Topologies topologies ^Cluster cluster]
-  (let [conf (container-get (.state this))        
+  (let [conf (container-get (.state this))
         orig-blacklist (HashSet. (.getBlacklistedHosts cluster))
         iso-topologies (isolated-topologies conf (.getTopologies topologies))
         iso-ids-set (->> iso-topologies (map #(.getId ^TopologyDetails %)) set)
@@ -180,7 +180,7 @@
               (.freeSlot cluster slot)
               ))
           )))
-    
+
     (let [host->used-slots (host->used-slots cluster)
           ^LinkedList sorted-assignable-hosts (host-assignable-slots cluster)]
       ;; TODO: can improve things further by ordering topologies in terms of who needs the least workers
@@ -196,7 +196,7 @@
               (.assign cluster slot top-id executors-set))
             (.blacklistHost cluster host))
           )))
-    
+
     (let [failed-iso-topologies (->> topology-worker-specs
                                   (mapcat (fn [[top-id worker-specs]]
                                     (if-not (empty? worker-specs) [top-id])

--- a/storm-core/src/clj/backtype/storm/scheduler/IsolationScheduler.clj
+++ b/storm-core/src/clj/backtype/storm/scheduler/IsolationScheduler.clj
@@ -14,8 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.scheduler.IsolationScheduler
-  (:use [backtype.storm util config log])
-  (:require [backtype.storm.scheduler.DefaultScheduler :as DefaultScheduler])
+  (:require [backtype.storm.scheduler.DefaultScheduler :as DefaultScheduler]
+            [backtype.storm.log :refer [log-warn]]
+            [backtype.storm.util :as util]
+            [backtype.storm.config :as c])
   (:import [java.util HashSet Set List LinkedList ArrayList Map HashMap]
            [backtype.storm.scheduler IScheduler Topologies
                                      Cluster TopologyDetails WorkerSlot SchedulerAssignment
@@ -27,27 +29,27 @@
     :implements [backtype.storm.scheduler.IScheduler]))
 
 (defn -init []
-  [[] (container)])
+  [[] (util/container)])
 
 (defn -prepare [this conf]
-  (container-set! (.state this) conf))
+  (util/container-set! (.state this) conf))
 
 (defn- compute-worker-specs "Returns mutable set of sets of executors"
   [^TopologyDetails details]
   (->> (.getExecutorToComponent details)
-       reverse-map
+       util/reverse-map
        (map second)
        (apply concat)
-       (map vector (repeat-seq (range (.getNumWorkers details))))
+       (map vector (util/repeat-seq (range (.getNumWorkers details))))
        (group-by first)
-       (map-val #(map second %))
+       (util/map-val #(map second %))
        vals
        (map set)
        (HashSet.)
        ))
 
 (defn isolated-topologies [conf topologies]
-  (let [tset (-> conf (get ISOLATION-SCHEDULER-MACHINES) keys set)]
+  (let [tset (-> conf (get c/ISOLATION-SCHEDULER-MACHINES) keys set)]
     (filter (fn [^TopologyDetails t] (contains? tset (.getName t))) topologies)
     ))
 
@@ -58,10 +60,10 @@
        (apply merge)))
 
 (defn machine-distribution [conf ^TopologyDetails topology]
-  (let [name->machines (get conf ISOLATION-SCHEDULER-MACHINES)
+  (let [name->machines (get conf c/ISOLATION-SCHEDULER-MACHINES)
         machines (get name->machines (.getName topology))
         workers (.getNumWorkers topology)]
-    (-> (integer-divided workers machines)
+    (-> (util/integer-divided workers machines)
         (dissoc 0)
         (HashMap.)
         )))
@@ -75,7 +77,7 @@
   (letfn [(to-slot-specs [^SchedulerAssignment ass]
             (->> ass
                  .getExecutorToSlot
-                 reverse-map
+                 util/reverse-map
                  (map (fn [[slot executors]]
                         [slot (.getTopologyId ass) (set executors)]))))]
   (->> cluster
@@ -93,7 +95,7 @@
 
 ;; returns list of list of slots, reverse sorted by number of slots
 (defn- host-assignable-slots [^Cluster cluster]
-  (-<> cluster
+  (util/-<> cluster
        .getAssignableSlots
        (group-by #(.getHost cluster (.getNodeId ^WorkerSlot %)) <>)
        (dissoc <> nil)
@@ -155,7 +157,7 @@
 ;; run default scheduler on isolated topologies that didn't have enough slots + non-isolated topologies on remaining machines
 ;; set blacklist to what it was initially
 (defn -schedule [this ^Topologies topologies ^Cluster cluster]
-  (let [conf (container-get (.state this))
+  (let [conf (util/container-get (.state this))
         orig-blacklist (HashSet. (.getBlacklistedHosts cluster))
         iso-topologies (isolated-topologies conf (.getTopologies topologies))
         iso-ids-set (->> iso-topologies (map #(.getId ^TopologyDetails %)) set)
@@ -203,7 +205,7 @@
                                     )))]
       (if (empty? failed-iso-topologies)
         ;; run default scheduler on non-isolated topologies
-        (-<> topology-worker-specs
+        (util/-<> topology-worker-specs
              allocated-topologies
              (leftover-topologies topologies <>)
              (DefaultScheduler/default-schedule <> cluster))

--- a/storm-core/src/clj/backtype/storm/stats.clj
+++ b/storm-core/src/clj/backtype/storm/stats.clj
@@ -15,12 +15,12 @@
 ;; limitations under the License.
 
 (ns backtype.storm.stats
+  (:use [backtype.storm util log]
+        [clojure.math.numeric-tower :only [ceil]])
   (:import [backtype.storm.generated Nimbus Nimbus$Processor Nimbus$Iface StormTopology ShellComponent
             NotAliveException AlreadyAliveException InvalidTopologyException GlobalStreamId
             ClusterSummary TopologyInfo TopologySummary ExecutorSummary ExecutorStats ExecutorSpecificStats
-            SpoutStats BoltStats ErrorInfo SupervisorSummary])
-  (:use [backtype.storm util log])
-  (:use [clojure.math.numeric-tower :only [ceil]]))
+            SpoutStats BoltStats ErrorInfo SupervisorSummary]))
 
 ;;TODO: consider replacing this with some sort of RRD
 

--- a/storm-core/src/clj/backtype/storm/stats.clj
+++ b/storm-core/src/clj/backtype/storm/stats.clj
@@ -15,12 +15,9 @@
 ;; limitations under the License.
 
 (ns backtype.storm.stats
-  (:use [backtype.storm util log]
-        [clojure.math.numeric-tower :only [ceil]])
-  (:import [backtype.storm.generated Nimbus Nimbus$Processor Nimbus$Iface StormTopology ShellComponent
-            NotAliveException AlreadyAliveException InvalidTopologyException GlobalStreamId
-            ClusterSummary TopologyInfo TopologySummary ExecutorSummary ExecutorStats ExecutorSpecificStats
-            SpoutStats BoltStats ErrorInfo SupervisorSummary]))
+  (:require [backtype.storm.util :as util]
+            [clojure.math.numeric-tower :refer [ceil]])
+  (:import [backtype.storm.generated GlobalStreamId ExecutorStats ExecutorSpecificStats SpoutStats BoltStats]))
 
 ;;TODO: consider replacing this with some sort of RRD
 
@@ -53,7 +50,7 @@
 (defn cleanup-rolling-window
   [^RollingWindow rw]
   (let [buckets (:buckets rw)
-        cutoff (- (current-time-secs)
+        cutoff (- (util/current-time-secs)
                   (* (:num-buckets rw)
                      (:bucket-size-secs rw)))
         to-remove (filter #(< % cutoff) (keys buckets))
@@ -67,13 +64,13 @@
 (defrecord RollingWindowSet [updater extractor windows all-time])
 
 (defn rolling-window-set [updater merger extractor num-buckets & bucket-sizes]
-  (RollingWindowSet. updater extractor (dofor [s bucket-sizes] (rolling-window updater merger extractor s num-buckets)) nil)
+  (RollingWindowSet. updater extractor (util/dofor [s bucket-sizes] (rolling-window updater merger extractor s num-buckets)) nil)
   )
 
 (defn update-rolling-window-set
   ([^RollingWindowSet rws & args]
-   (let [now (current-time-secs)
-         new-windows (dofor [w (:windows rws)]
+   (let [now (util/current-time-secs)
+         new-windows (util/dofor [w (:windows rws)]
                             (apply update-rolling-window w now args))]
      (assoc rws
        :windows new-windows
@@ -124,7 +121,7 @@
   (apply merge-with merge-avg vals))
 
 (defn- extract-keyed-avg [vals]
-  (map-val extract-avg vals))
+  (util/map-val extract-avg vals))
 
 (defn- counter-extract [v]
   (if v v {}))
@@ -203,7 +200,7 @@
 
 (defmacro update-executor-stat!
   [stats path & args]
-  (let [path (collectify path)]
+  (let [path (util/collectify path)]
     `(swap! (-> ~stats ~@path) update-rolling-window-set ~@args)))
 
 (defmacro stats-rate
@@ -267,7 +264,7 @@
 
 (defn- value-stats
   [stats fields]
-  (into {} (dofor [f fields]
+  (into {} (util/dofor [f fields]
                   [f (value-rolling-window-set @(f stats))])))
 
 (defn- value-common-stats
@@ -290,7 +287,7 @@
          (value-stats stats SPOUT-FIELDS)
          {:type :spout}))
 
-(defmulti render-stats! class-selector)
+(defmulti render-stats! util/class-selector)
 
 (defmethod render-stats! SpoutExecutorStats
   [stats]
@@ -301,7 +298,7 @@
   (value-bolt-stats! stats))
 
 (defmulti thriftify-specific-stats :type)
-(defmulti clojurify-specific-stats class-selector)
+(defmulti clojurify-specific-stats util/class-selector)
 
 (defn window-set-converter
   ([stats key-fn first-key-fun]

--- a/storm-core/src/clj/backtype/storm/testing.clj
+++ b/storm-core/src/clj/backtype/storm/testing.clj
@@ -15,34 +15,34 @@
 ;; limitations under the License.
 
 (ns backtype.storm.testing
+  (:use [backtype.storm cluster util thrift config log local-state])
   (:require [backtype.storm.daemon
              [nimbus :as nimbus]
              [supervisor :as supervisor]
              [common :as common]
              [worker :as worker]
-             [executor :as executor]])
-  (:require [backtype.storm [process-simulator :as psim]])
-  (:import [org.apache.commons.io FileUtils])
-  (:import [java.io File])
-  (:import [java.util HashMap ArrayList])
-  (:import [java.util.concurrent.atomic AtomicInteger])
-  (:import [java.util.concurrent ConcurrentHashMap])
-  (:import [backtype.storm.utils Time Utils RegisteredGlobalState])
-  (:import [backtype.storm.tuple Fields Tuple TupleImpl])
-  (:import [backtype.storm.task TopologyContext])
-  (:import [backtype.storm.generated GlobalStreamId Bolt KillOptions])
-  (:import [backtype.storm.testing FeederSpout FixedTupleSpout FixedTuple
-            TupleCaptureBolt SpoutTracker BoltTracker NonRichBoltTracker
-            TestWordSpout MemoryTransactionalSpout])
-  (:import [backtype.storm.transactional TransactionalSpoutCoordinator])
-  (:import [backtype.storm.transactional.partitioned PartitionedTransactionalSpoutExecutor])
-  (:import [backtype.storm.tuple Tuple])
-  (:import [backtype.storm.generated StormTopology])
-  (:import [backtype.storm.task TopologyContext])
-  (:require [backtype.storm [zookeeper :as zk]])
-  (:require [backtype.storm.messaging.loader :as msg-loader])
-  (:require [backtype.storm.daemon.acker :as acker])
-  (:use [backtype.storm cluster util thrift config log local-state]))
+             [executor :as executor]]
+            [backtype.storm [process-simulator :as psim]]
+            [backtype.storm [zookeeper :as zk]]
+            [backtype.storm.messaging.loader :as msg-loader]
+            [backtype.storm.daemon.acker :as acker])
+  (:import [org.apache.commons.io FileUtils]
+           [java.io File]
+           [java.util HashMap ArrayList]
+           [java.util.concurrent.atomic AtomicInteger]
+           [java.util.concurrent ConcurrentHashMap]
+           [backtype.storm.utils Time Utils RegisteredGlobalState]
+           [backtype.storm.tuple Fields Tuple TupleImpl]
+           [backtype.storm.task TopologyContext]
+           [backtype.storm.generated GlobalStreamId Bolt KillOptions]
+           [backtype.storm.testing FeederSpout FixedTupleSpout FixedTuple
+                                   TupleCaptureBolt SpoutTracker BoltTracker NonRichBoltTracker
+                                   TestWordSpout MemoryTransactionalSpout]
+           [backtype.storm.transactional TransactionalSpoutCoordinator]
+           [backtype.storm.transactional.partitioned PartitionedTransactionalSpoutExecutor]
+           [backtype.storm.tuple Tuple]
+           [backtype.storm.generated StormTopology]
+           [backtype.storm.task TopologyContext]))
 
 (defn feeder-spout
   [fields]
@@ -610,7 +610,7 @@
           track-id (-> tracked-topology :cluster ::track-id)
           waiting? (fn []
                      (or (not= target (global-amt track-id "spout-emitted"))
-                         (not= (global-amt track-id "transferred")                                 
+                         (not= (global-amt track-id "transferred")
                                (global-amt track-id "processed"))))]
       (while-timeout timeout-ms (waiting?)
                      ;; (println "Spout emitted: " (global-amt track-id "spout-emitted"))

--- a/storm-core/src/clj/backtype/storm/testing4j.clj
+++ b/storm-core/src/clj/backtype/storm/testing4j.clj
@@ -14,15 +14,15 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.testing4j
-  (:import [java.util Map List Collection ArrayList])
-  (:require [backtype.storm [LocalCluster :as LocalCluster]])
-  (:import [backtype.storm Config ILocalCluster LocalCluster])
-  (:import [backtype.storm.generated StormTopology])
-  (:import [backtype.storm.daemon nimbus])
-  (:import [backtype.storm.testing TestJob MockedSources TrackedTopology
-            MkClusterParam CompleteTopologyParam MkTupleParam])
-  (:import [backtype.storm.utils Utils])
   (:use [backtype.storm testing util log])
+  (:require [backtype.storm [LocalCluster :as LocalCluster]])
+  (:import [java.util Map List Collection ArrayList]
+           [backtype.storm Config ILocalCluster LocalCluster]
+           [backtype.storm.generated StormTopology]
+           [backtype.storm.daemon nimbus]
+           [backtype.storm.testing TestJob MockedSources TrackedTopology
+                                   MkClusterParam CompleteTopologyParam MkTupleParam]
+           [backtype.storm.utils Utils])
   (:gen-class
    :name backtype.storm.Testing
    :methods [^:static [completeTopology

--- a/storm-core/src/clj/backtype/storm/testing4j.clj
+++ b/storm-core/src/clj/backtype/storm/testing4j.clj
@@ -14,13 +14,13 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.testing4j
-  (:use [backtype.storm testing util log])
-  (:require [backtype.storm [LocalCluster :as LocalCluster]])
+  (:require [backtype.storm.LocalCluster :as LocalCluster]
+            [backtype.storm.util :as util]
+            [backtype.storm.testing :as testing])
   (:import [java.util Map List Collection ArrayList]
-           [backtype.storm Config ILocalCluster LocalCluster]
+           [backtype.storm ILocalCluster LocalCluster]
            [backtype.storm.generated StormTopology]
-           [backtype.storm.daemon nimbus]
-           [backtype.storm.testing TestJob MockedSources TrackedTopology
+           [backtype.storm.testing TestJob TrackedTopology
                                    MkClusterParam CompleteTopologyParam MkTupleParam]
            [backtype.storm.utils Utils])
   (:gen-class
@@ -58,8 +58,8 @@
           storm-conf (or (.getStormConf completeTopologyParam) {})
           cleanup-state (or (.getCleanupState completeTopologyParam) true)
           topology-name (.getTopologyName completeTopologyParam)
-          timeout-ms (or (.getTimeoutMs completeTopologyParam) TEST-TIMEOUT-MS)]
-      (complete-topology (.getState cluster) topology
+          timeout-ms (or (.getTimeoutMs completeTopologyParam) testing/TEST-TIMEOUT-MS)]
+      (testing/complete-topology (.getState cluster) topology
         :mock-sources mocked-sources
         :storm-conf storm-conf
         :cleanup-state cleanup-state
@@ -71,7 +71,7 @@
 
 (defn -withSimulatedTime
   [^Runnable code]
-  (with-simulated-time
+  (testing/with-simulated-time
     (.run code)))
 
 (defmacro with-cluster
@@ -87,19 +87,19 @@
 
 (defn -withLocalCluster
   ([^MkClusterParam mkClusterParam ^TestJob code]
-     (with-cluster with-local-cluster mkClusterParam code))
+     (with-cluster testing/with-local-cluster mkClusterParam code))
   ([^TestJob code]
      (-withLocalCluster (MkClusterParam.) code)))
 
 (defn -withSimulatedTimeLocalCluster
   ([^MkClusterParam mkClusterParam ^TestJob code]
-     (with-cluster with-simulated-time-local-cluster mkClusterParam code))
+     (with-cluster testing/with-simulated-time-local-cluster mkClusterParam code))
   ([^TestJob code]
      (-withSimulatedTimeLocalCluster (MkClusterParam.) code)))
 
 (defn -withTrackedCluster
   ([^MkClusterParam mkClusterParam ^TestJob code]
-     (with-cluster with-tracked-cluster mkClusterParam code))
+     (with-cluster testing/with-tracked-cluster mkClusterParam code))
   ([^TestJob code]
      (-withTrackedCluster (MkClusterParam.) code)))
 
@@ -123,28 +123,28 @@
 
 (defn -mkTrackedTopology
   [^ILocalCluster trackedCluster ^StormTopology topology]
-  (-> (mk-tracked-topology (.getState trackedCluster) topology)
+  (-> (testing/mk-tracked-topology (.getState trackedCluster) topology)
       (TrackedTopology.)))
 
 (defn -trackedWait
   ([^TrackedTopology trackedTopology ^Integer amt ^Integer timeout-ms]
-   (tracked-wait trackedTopology amt timeout-ms))
+   (testing/tracked-wait trackedTopology amt timeout-ms))
   ([^TrackedTopology trackedTopology ^Integer amt]
-   (tracked-wait trackedTopology amt))
+   (testing/tracked-wait trackedTopology amt))
   ([^TrackedTopology trackedTopology]
    (-trackedWait trackedTopology 1)))
 
 (defn -advanceClusterTime
   ([^ILocalCluster cluster ^Integer secs ^Integer step]
-   (advance-cluster-time (.getState cluster) secs step))
+   (testing/advance-cluster-time (.getState cluster) secs step))
   ([^ILocalCluster cluster ^Integer secs]
    (-advanceClusterTime cluster secs 1)))
 
 (defn- multiseteq
   [^Object obj1 ^Object obj2]
-  (let [obj1 (clojurify-structure obj1)
-        obj2 (clojurify-structure obj2)]
-    (ms= obj1 obj2)))
+  (let [obj1 (util/clojurify-structure obj1)
+        obj2 (util/clojurify-structure obj2)]
+    (testing/ms= obj1 obj2)))
 
 (defn -multiseteq
   [^Collection coll1 ^Collection coll2]
@@ -159,8 +159,8 @@
    (-testTuple values nil))
   ([^List values ^MkTupleParam param]
    (if (nil? param)
-     (test-tuple values)
+     (testing/test-tuple values)
      (let [stream (or (.getStream param) Utils/DEFAULT_STREAM_ID)
            component (or (.getComponent param) "component")
            fields (.getFields param)]
-       (test-tuple values :stream stream :component component :fields fields)))))
+       (testing/test-tuple values :stream stream :component component :fields fields)))))

--- a/storm-core/src/clj/backtype/storm/timer.clj
+++ b/storm-core/src/clj/backtype/storm/timer.clj
@@ -15,10 +15,10 @@
 ;; limitations under the License.
 
 (ns backtype.storm.timer
-  (:import [backtype.storm.utils Time])
-  (:import [java.util PriorityQueue Comparator])
-  (:import [java.util.concurrent Semaphore])
-  (:use [backtype.storm util log]))
+  (:use [backtype.storm util log])
+  (:import [backtype.storm.utils Time]
+           [java.util PriorityQueue Comparator]
+           [java.util.concurrent Semaphore]))
 
 ;; The timer defined in this file is very similar to java.util.Timer, except
 ;; it integrates with Storm's time simulation capabilities. This lets us test

--- a/storm-core/src/clj/backtype/storm/timer.clj
+++ b/storm-core/src/clj/backtype/storm/timer.clj
@@ -15,7 +15,7 @@
 ;; limitations under the License.
 
 (ns backtype.storm.timer
-  (:use [backtype.storm util log])
+  (:require [backtype.storm.util :as util :refer [defnk]])
   (:import [backtype.storm.utils Time]
            [java.util PriorityQueue Comparator]
            [java.util.concurrent Semaphore]))
@@ -41,7 +41,7 @@
                          (while @active
                            (try
                              (let [[time-millis _ _ :as elem] (locking lock (.peek queue))]
-                               (if (and elem (>= (current-time-millis) time-millis))
+                               (if (and elem (>= (util/current-time-millis) time-millis))
                                  ;; It is imperative to not run the function
                                  ;; inside the timer lock. Otherwise, it is
                                  ;; possible to deadlock if the fn deals with
@@ -54,7 +54,7 @@
                                    ;; are scheduled then we will always go
                                    ;; through this branch, sleeping only the
                                    ;; exact necessary amount of time.
-                                   (Time/sleep (- time-millis (current-time-millis)))
+                                   (Time/sleep (- time-millis (util/current-time-millis)))
                                    ;; Otherwise poll to see if any new event
                                    ;; was scheduled. This is, in essence, the
                                    ;; response time for detecting any new event
@@ -64,7 +64,7 @@
                              (catch Throwable t
                                ;; Because the interrupted exception can be
                                ;; wrapped in a RuntimeException.
-                               (when-not (exception-cause? InterruptedException t)
+                               (when-not (util/exception-cause? InterruptedException t)
                                  (kill-fn t)
                                  (reset! active false)
                                  (throw t)))))
@@ -86,10 +86,10 @@
 (defnk schedule
   [timer delay-secs afn :check-active true]
   (when check-active (check-active! timer))
-  (let [id (uuid)
+  (let [id (util/uuid)
         ^PriorityQueue queue (:queue timer)]
     (locking (:lock timer)
-      (.add queue [(+ (current-time-millis) (secs-to-millis-long delay-secs)) afn id]))))
+      (.add queue [(+ (util/current-time-millis) (util/secs-to-millis-long delay-secs)) afn id]))))
 
 (defn schedule-recurring
   [timer delay-secs recur-secs afn]

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -15,33 +15,33 @@
 ;; limitations under the License.
 
 (ns backtype.storm.ui.core
-  (:use compojure.core)
-  (:use [clojure.java.shell :only [sh]])
-  (:use ring.middleware.reload
-        ring.middleware.multipart-params)
-  (:use [ring.middleware.json :only [wrap-json-params]])
-  (:use [hiccup core page-helpers])
-  (:use [backtype.storm config util log])
-  (:use [backtype.storm.ui helpers])
-  (:use [backtype.storm.daemon [common :only [ACKER-COMPONENT-ID ACKER-INIT-STREAM-ID ACKER-ACK-STREAM-ID
-                                              ACKER-FAIL-STREAM-ID system-id? mk-authorization-handler]]])
-  (:use [clojure.string :only [blank? lower-case trim]])
-  (:import [backtype.storm.utils Utils])
-  (:import [backtype.storm.generated ExecutorSpecificStats
-            ExecutorStats ExecutorSummary TopologyInfo SpoutStats BoltStats
-            ErrorInfo ClusterSummary SupervisorSummary TopologySummary
-            Nimbus$Client StormTopology GlobalStreamId RebalanceOptions
-            KillOptions GetInfoOptions NumErrorsChoice])
-  (:import [backtype.storm.security.auth AuthUtils ReqContext])
-  (:import [backtype.storm.generated AuthorizationException])
-  (:import [backtype.storm.security.auth AuthUtils])
-  (:import [backtype.storm.utils VersionInfo])
-  (:import [java.io File])
+  (:use compojure.core
+        [clojure.java.shell :only [sh]]
+        ring.middleware.reload
+        ring.middleware.multipart-params
+        [ring.middleware.json :only [wrap-json-params]]
+        [hiccup core page-helpers]
+        [backtype.storm config util log]
+        [backtype.storm.ui helpers]
+        [backtype.storm.daemon [common :only [ACKER-COMPONENT-ID ACKER-INIT-STREAM-ID ACKER-ACK-STREAM-ID
+                                              ACKER-FAIL-STREAM-ID system-id? mk-authorization-handler]]]
+        [clojure.string :only [blank? lower-case trim]])
   (:require [compojure.route :as route]
             [compojure.handler :as handler]
             [ring.util.response :as resp]
             [backtype.storm [thrift :as thrift]])
-  (:import [org.apache.commons.lang StringEscapeUtils])
+  (:import [backtype.storm.utils Utils]
+           [backtype.storm.generated ExecutorSpecificStats
+                                     ExecutorStats ExecutorSummary TopologyInfo SpoutStats BoltStats
+                                     ErrorInfo ClusterSummary SupervisorSummary TopologySummary
+                                     Nimbus$Client StormTopology GlobalStreamId RebalanceOptions
+                                     KillOptions GetInfoOptions NumErrorsChoice]
+           [backtype.storm.security.auth AuthUtils ReqContext]
+           [backtype.storm.generated AuthorizationException]
+           [backtype.storm.security.auth AuthUtils]
+           [backtype.storm.utils VersionInfo]
+           [java.io File]
+           [org.apache.commons.lang StringEscapeUtils])
   (:gen-class))
 
 (def ^:dynamic *STORM-CONF* (read-storm-config))

--- a/storm-core/src/clj/backtype/storm/ui/helpers.clj
+++ b/storm-core/src/clj/backtype/storm/ui/helpers.clj
@@ -14,17 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.ui.helpers
-  (:use compojure.core
-        [hiccup core page-helpers]
-        [clojure
-         [string :only [blank? join]]
-         [walk :only [keywordize-keys]]]
-        [backtype.storm config log]
-        [backtype.storm.util :only [clojurify-structure uuid defnk url-encode not-nil?]]
-        [clj-time coerce format])
-  (:require [ring.util servlet]
-            [compojure.route :as route]
-            [compojure.handler :as handler])
+  (:require [clojure.string :as str]
+            [backtype.storm.util :as util :refer [defnk]]
+            [hiccup.core :as core :refer [defelem]]
+            [ring.util.servlet])
   (:import [backtype.storm.generated ExecutorInfo ExecutorSummary]
            [java.util EnumSet]
            [org.eclipse.jetty.server Server]
@@ -70,7 +63,7 @@
                  (str val suffix))
                dividers
                ))]
-    (join " " (reverse strs))
+    (str/join " " (reverse strs))
     ))
 
 (defn pretty-uptime-sec [secs]
@@ -116,7 +109,7 @@
 
 (defn url-format [fmt & args]
   (String/format fmt
-    (to-array (map #(url-encode (str %)) args))))
+    (to-array (map #(util/url-encode (str %)) args))))
 
 (defn to-tasks [^ExecutorInfo e]
   (let [start (.get_task_start e)
@@ -134,7 +127,7 @@
   (str "[" (.get_task_start e) "-" (.get_task_end e) "]"))
 
 (defn unauthorized-user-html [user]
-  [[:h2 "User '" (escape-html user) "' is not authorized."]])
+  [[:h2 "User '" (core/escape-html user) "' is not authorized."]])
 
 (defn- mk-ssl-connector [port ks-path ks-password ks-type key-password
                          ts-path ts-password ts-type need-client-auth want-client-auth]
@@ -146,7 +139,7 @@
                             (.setKeyStoreType ks-type)
                             (.setKeyStorePassword ks-password)
                             (.setKeyManagerPassword key-password))]
-    (if (and (not-nil? ts-path) (not-nil? ts-password) (not-nil? ts-type))
+    (if (and (util/not-nil? ts-path) (util/not-nil? ts-password) (util/not-nil? ts-type))
       ((.setTrustStore sslContextFactory ts-path)
        (.setTrustStoreType sslContextFactory ts-type)
        (.setTrustStoreType sslContextFactory ts-password)))
@@ -211,7 +204,7 @@
                     (.addConnector connector)
                     (.setSendDateHeader true))
         https-port (options :https-port)]
-    (if (and (not-nil? https-port) (> https-port 0)) (remove-non-ssl-connectors server))
+    (if (and (util/not-nil? https-port) (> https-port 0)) (remove-non-ssl-connectors server))
     server))
 
 (defn storm-run-jetty

--- a/storm-core/src/clj/backtype/storm/ui/helpers.clj
+++ b/storm-core/src/clj/backtype/storm/ui/helpers.clj
@@ -14,26 +14,26 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.ui.helpers
-  (:use compojure.core)
-  (:use [hiccup core page-helpers])
-  (:use [clojure
+  (:use compojure.core
+        [hiccup core page-helpers]
+        [clojure
          [string :only [blank? join]]
-         [walk :only [keywordize-keys]]])
-  (:use [backtype.storm config log])
-  (:use [backtype.storm.util :only [clojurify-structure uuid defnk url-encode not-nil?]])
-  (:use [clj-time coerce format])
-  (:import [backtype.storm.generated ExecutorInfo ExecutorSummary])
-  (:import [java.util EnumSet])
-  (:import [org.eclipse.jetty.server Server]
+         [walk :only [keywordize-keys]]]
+        [backtype.storm config log]
+        [backtype.storm.util :only [clojurify-structure uuid defnk url-encode not-nil?]]
+        [clj-time coerce format])
+  (:require [ring.util servlet]
+            [compojure.route :as route]
+            [compojure.handler :as handler])
+  (:import [backtype.storm.generated ExecutorInfo ExecutorSummary]
+           [java.util EnumSet]
+           [org.eclipse.jetty.server Server]
            [org.eclipse.jetty.server.nio SelectChannelConnector]
            [org.eclipse.jetty.server.ssl SslSocketConnector]
            [org.eclipse.jetty.servlet ServletHolder FilterMapping]
-	   [org.eclipse.jetty.util.ssl SslContextFactory]
+           [org.eclipse.jetty.util.ssl SslContextFactory]
            [org.eclipse.jetty.server DispatcherType]
-           [org.eclipse.jetty.servlets CrossOriginFilter])
-  (:require [ring.util servlet])
-  (:require [compojure.route :as route]
-            [compojure.handler :as handler]))
+           [org.eclipse.jetty.servlets CrossOriginFilter]))
 
 (defn split-divide [val divider]
   [(Integer. (int (/ val divider))) (mod val divider)]

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -15,23 +15,20 @@
 ;; limitations under the License.
 
 (ns backtype.storm.util
-  (:use [clojure walk]
-        [backtype.storm log])
-  (:require [clojure [string :as str]]
-            [clojure [set :as set]]
+  (:require [clojure.string :as str]
+            [clojure.set :as set]
+            [clojure.walk :as walk]
             [clojure.java.io :as io]
-            [ring.util.codec :as codec])
-  (:import [java.net InetAddress]
+            [ring.util.codec :as codec]
+            [backtype.storm.log :as log :refer [log-debug log-message log-error log-warn]])
+  (:import [backtype.storm Config]
+           [backtype.storm.utils Time Container Utils MutableInt]
+           [java.net InetAddress]
            [java.util Map Map$Entry List ArrayList Collection Iterator HashMap]
-           [java.io FileReader FileNotFoundException]
-           [backtype.storm Config]
-           [backtype.storm.utils Time Container ClojureTimerTask Utils
-                                 MutableObject MutableInt]
            [java.util UUID Random ArrayList List Collections]
            [java.util.zip ZipFile]
            [java.util.concurrent.locks ReentrantReadWriteLock]
-           [java.util.concurrent Semaphore]
-           [java.io File FileOutputStream RandomAccessFile StringWriter
+           [java.io File FileOutputStream FileNotFoundException RandomAccessFile StringWriter
                     PrintWriter BufferedReader InputStreamReader IOException]
            [java.lang.management ManagementFactory]
            [org.apache.commons.exec DefaultExecutor CommandLine]
@@ -244,7 +241,7 @@
 
 (defn clojurify-structure
   [s]
-  (prewalk (fn [x]
+  (walk/prewalk (fn [x]
              (cond (instance? Map x) (into {} x)
                    (instance? List x) (vec x)
                    ;; (Boolean. false) does not evaluate to false in an if.
@@ -856,7 +853,7 @@
   ;;         (java.io.OutputStreamWriter.
   ;;           (log-stream :error "STDIO"))
   ;;         true))
-  (log-capture! "STDIO"))
+  (log/log-capture! "STDIO"))
 
 (defn spy
   [prefix val]

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -250,7 +250,7 @@
                    ;; (Boolean. false) does not evaluate to false in an if.
                    ;; This fixes that.
                    (instance? Boolean x) (boolean x)
-                   true x))
+                   true x))                                 ;; TODO: :else x
            s))
 
 (defmacro with-file-lock
@@ -537,9 +537,9 @@
                (catch InterruptedException e
                  (log-message log-prefix " interrupted.")))
              (exit-code-callback (.exitValue process)))
-           nil)))                    
+           nil)))
       process)))
-   
+
 (defn exists-file?
   [path]
   (.exists (File. path)))
@@ -1014,7 +1014,7 @@
   ([x form & more] `(-<> (-<> ~x ~form) ~@more)))
 
 (def LOG-DIR
-  (.getCanonicalPath 
+  (.getCanonicalPath
                 (clojure.java.io/file (System/getProperty "storm.home") "logs")))
 
 (defn- logs-rootname [storm-id port]

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -15,32 +15,32 @@
 ;; limitations under the License.
 
 (ns backtype.storm.util
-  (:import [java.net InetAddress])
-  (:import [java.util Map Map$Entry List ArrayList Collection Iterator HashMap])
-  (:import [java.io FileReader FileNotFoundException])
-  (:import [backtype.storm Config])
-  (:import [backtype.storm.utils Time Container ClojureTimerTask Utils
-            MutableObject MutableInt])
-  (:import [java.util UUID Random ArrayList List Collections])
-  (:import [java.util.zip ZipFile])
-  (:import [java.util.concurrent.locks ReentrantReadWriteLock])
-  (:import [java.util.concurrent Semaphore])
-  (:import [java.io File FileOutputStream RandomAccessFile StringWriter
-            PrintWriter BufferedReader InputStreamReader IOException])
-  (:import [java.lang.management ManagementFactory])
-  (:import [org.apache.commons.exec DefaultExecutor CommandLine])
-  (:import [org.apache.commons.io FileUtils])
-  (:import [org.apache.commons.exec ExecuteException])
-  (:import [org.json.simple JSONValue])
-  (:import [org.yaml.snakeyaml Yaml]
-           [org.yaml.snakeyaml.constructor SafeConstructor])
-  (:require [clojure [string :as str]])
-  (:import [clojure.lang RT])
-  (:require [clojure [set :as set]])
-  (:require [clojure.java.io :as io])
-  (:use [clojure walk])
-  (:require [ring.util.codec :as codec])
-  (:use [backtype.storm log]))
+  (:use [clojure walk]
+        [backtype.storm log])
+  (:require [clojure [string :as str]]
+            [clojure [set :as set]]
+            [clojure.java.io :as io]
+            [ring.util.codec :as codec])
+  (:import [java.net InetAddress]
+           [java.util Map Map$Entry List ArrayList Collection Iterator HashMap]
+           [java.io FileReader FileNotFoundException]
+           [backtype.storm Config]
+           [backtype.storm.utils Time Container ClojureTimerTask Utils
+                                 MutableObject MutableInt]
+           [java.util UUID Random ArrayList List Collections]
+           [java.util.zip ZipFile]
+           [java.util.concurrent.locks ReentrantReadWriteLock]
+           [java.util.concurrent Semaphore]
+           [java.io File FileOutputStream RandomAccessFile StringWriter
+                    PrintWriter BufferedReader InputStreamReader IOException]
+           [java.lang.management ManagementFactory]
+           [org.apache.commons.exec DefaultExecutor CommandLine]
+           [org.apache.commons.io FileUtils]
+           [org.apache.commons.exec ExecuteException]
+           [org.json.simple JSONValue]
+           [org.yaml.snakeyaml Yaml]
+           [org.yaml.snakeyaml.constructor SafeConstructor]
+           [clojure.lang RT]))
 
 (defn wrap-in-runtime
   "Wraps an exception in a RuntimeException if needed"
@@ -598,11 +598,11 @@
   (let [storm-dir (System/getProperty "storm.home")
         storm-lib-dir (str storm-dir file-path-separator "lib")
         storm-conf-dir (if-let [confdir (System/getenv "STORM_CONF_DIR")]
-                         confdir 
+                         confdir
                          (str storm-dir file-path-separator "conf"))
         storm-extlib-dir (str storm-dir file-path-separator "extlib")
         extcp (System/getenv "STORM_EXT_CLASSPATH")]
-    (if (nil? storm-dir) 
+    (if (nil? storm-dir)
       (current-classpath)
       (str/join class-path-separator
                 (concat (get-full-jars storm-lib-dir) (get-full-jars storm-extlib-dir) [extcp] [storm-conf-dir])))))

--- a/storm-core/src/clj/backtype/storm/zookeeper.clj
+++ b/storm-core/src/clj/backtype/storm/zookeeper.clj
@@ -15,18 +15,18 @@
 ;; limitations under the License.
 
 (ns backtype.storm.zookeeper
-  (:import [org.apache.curator.retry RetryNTimes])
-  (:import [org.apache.curator.framework.api CuratorEvent CuratorEventType CuratorListener UnhandledErrorListener])
-  (:import [org.apache.curator.framework CuratorFramework CuratorFrameworkFactory])
-  (:import [org.apache.zookeeper ZooKeeper Watcher KeeperException$NoNodeException
-            ZooDefs ZooDefs$Ids CreateMode WatchedEvent Watcher$Event Watcher$Event$KeeperState
-            Watcher$Event$EventType KeeperException$NodeExistsException])
-  (:import [org.apache.zookeeper.data Stat])
-  (:import [org.apache.zookeeper.server ZooKeeperServer NIOServerCnxnFactory])
-  (:import [java.net InetSocketAddress BindException])
-  (:import [java.io File])
-  (:import [backtype.storm.utils Utils ZookeeperAuthInfo])
-  (:use [backtype.storm util log config]))
+  (:use [backtype.storm util log config])
+  (:import [org.apache.curator.retry RetryNTimes]
+           [org.apache.curator.framework.api CuratorEvent CuratorEventType CuratorListener UnhandledErrorListener]
+           [org.apache.curator.framework CuratorFramework CuratorFrameworkFactory]
+           [org.apache.zookeeper ZooKeeper Watcher KeeperException$NoNodeException
+                                 ZooDefs ZooDefs$Ids CreateMode WatchedEvent Watcher$Event Watcher$Event$KeeperState
+                                 Watcher$Event$EventType KeeperException$NodeExistsException]
+           [org.apache.zookeeper.data Stat]
+           [org.apache.zookeeper.server ZooKeeperServer NIOServerCnxnFactory]
+           [java.net InetSocketAddress BindException]
+           [java.io File]
+           [backtype.storm.utils Utils ZookeeperAuthInfo]))
 
 (def zk-keeper-states
   {Watcher$Event$KeeperState/Disconnected :disconnected
@@ -134,12 +134,12 @@
         nil )
       (catch Exception e (throw (wrap-in-runtime e))))))
 
-(defn get-data-with-version 
+(defn get-data-with-version
   [^CuratorFramework zk ^String path watch?]
   (let [stats (org.apache.zookeeper.data.Stat. )
         path (normalize-path path)]
     (try-cause
-     (if-let [data 
+     (if-let [data
               (if (exists-node? zk path watch?)
                 (if watch?
                   (.. zk (getData) (watched) (storingStatIn stats) (forPath path))
@@ -150,7 +150,7 @@
        ;; this is fine b/c we still have a watch from the successful exists call
        nil ))))
 
-(defn get-version 
+(defn get-version
 [^CuratorFramework zk ^String path watch?]
   (if-let [stats
            (if watch?

--- a/storm-core/src/clj/storm/trident/testing.clj
+++ b/storm-core/src/clj/storm/trident/testing.clj
@@ -14,14 +14,14 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.trident.testing
-    (:require [backtype.storm.LocalDRPC :as LocalDRPC]
-      [backtype.storm [testing :as t]]
-      [backtype.storm [LocalDRPC]])
-    (:import [storm.trident.testing FeederBatchSpout FeederCommitterBatchSpout MemoryMapState MemoryMapState$Factory TuplifyArgs]
-      [backtype.storm LocalDRPC]
-      [backtype.storm.tuple Fields]
-      [backtype.storm.generated KillOptions])
-    (:use [backtype.storm util]))
+  (:use [backtype.storm util])
+  (:require [backtype.storm.LocalDRPC :as LocalDRPC]
+            [backtype.storm [testing :as t]]
+            [backtype.storm [LocalDRPC]])
+  (:import [storm.trident.testing FeederBatchSpout FeederCommitterBatchSpout MemoryMapState MemoryMapState$Factory TuplifyArgs]
+           [backtype.storm LocalDRPC]
+           [backtype.storm.tuple Fields]
+           [backtype.storm.generated KillOptions]))
 
 (defn local-drpc []
   (LocalDRPC.))

--- a/storm-core/src/clj/storm/trident/testing.clj
+++ b/storm-core/src/clj/storm/trident/testing.clj
@@ -14,10 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.trident.testing
-  (:use [backtype.storm util])
   (:require [backtype.storm.LocalDRPC :as LocalDRPC]
-            [backtype.storm [testing :as t]]
-            [backtype.storm [LocalDRPC]])
+            [backtype.storm.testing :as t]
+            [backtype.storm.util :as util])
   (:import [storm.trident.testing FeederBatchSpout FeederCommitterBatchSpout MemoryMapState MemoryMapState$Factory TuplifyArgs]
            [backtype.storm LocalDRPC]
            [backtype.storm.tuple Fields]
@@ -28,10 +27,10 @@
 
 (defn exec-drpc [^LocalDRPC drpc function-name args]
   (let [res (.execute drpc function-name args)]
-    (from-json res)))
+    (util/from-json res)))
 
 (defn exec-drpc-tuples [^LocalDRPC drpc function-name tuples]
-  (exec-drpc drpc function-name (to-json tuples)))
+  (exec-drpc drpc function-name (util/to-json tuples)))
 
 (defn feeder-spout [fields]
   (FeederBatchSpout. fields))

--- a/storm-core/src/clj/storm/trident/testing.clj
+++ b/storm-core/src/clj/storm/trident/testing.clj
@@ -14,15 +14,14 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.trident.testing
-  (:require [backtype.storm.LocalDRPC :as LocalDRPC])
-  (:import [storm.trident.testing FeederBatchSpout FeederCommitterBatchSpout MemoryMapState MemoryMapState$Factory TuplifyArgs])
-  (:require [backtype.storm [LocalDRPC]])
-  (:import [backtype.storm LocalDRPC])
-  (:import [backtype.storm.tuple Fields])
-  (:import [backtype.storm.generated KillOptions])
-  (:require [backtype.storm [testing :as t]])
-  (:use [backtype.storm util])
-  )
+    (:require [backtype.storm.LocalDRPC :as LocalDRPC]
+      [backtype.storm [testing :as t]]
+      [backtype.storm [LocalDRPC]])
+    (:import [storm.trident.testing FeederBatchSpout FeederCommitterBatchSpout MemoryMapState MemoryMapState$Factory TuplifyArgs]
+      [backtype.storm LocalDRPC]
+      [backtype.storm.tuple Fields]
+      [backtype.storm.generated KillOptions])
+    (:use [backtype.storm util]))
 
 (defn local-drpc []
   (LocalDRPC.))

--- a/storm-core/test/clj/backtype/storm/clojure_test.clj
+++ b/storm-core/test/clj/backtype/storm/clojure_test.clj
@@ -14,12 +14,12 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.clojure-test
-  (:use [clojure test])
+  (:use [clojure test]
+        [backtype.storm testing clojure config]
+        [backtype.storm.daemon common])
+  (:require [backtype.storm.thrift :as thrift])
   (:import [backtype.storm.testing TestWordSpout TestPlannerSpout]
-           [backtype.storm.tuple Fields])
-  (:use [backtype.storm testing clojure config])
-  (:use [backtype.storm.daemon common])
-  (:require [backtype.storm [thrift :as thrift]]))
+           [backtype.storm.tuple Fields]))
 
 
 (defbolt lalala-bolt1 ["word"] [[val :as tuple] collector]
@@ -39,7 +39,7 @@
                 (ack! collector tuple)
                 ))
       )))
-      
+
 (defbolt lalala-bolt3 ["word"] {:prepare true :params [prefix]}
   [conf context collector]
   (let [state (atom nil)]
@@ -79,7 +79,7 @@
 (defbolt punctuator-bolt ["word" "period" "question" "exclamation"]
   [tuple collector]
   (if (= (:word tuple) "bar")
-    (do 
+    (do
       (emit-bolt! collector {:word "bar" :period "bar" :question "bar"
                             "exclamation" "bar"})
       (ack! collector tuple))

--- a/storm-core/test/clj/backtype/storm/cluster_test.clj
+++ b/storm-core/test/clj/backtype/storm/cluster_test.clj
@@ -14,11 +14,13 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.cluster-test
-  (:use [conjure core]
-        [clojure test]
-        [backtype.storm cluster config util testing thrift log])
-  (:require [backtype.storm [zookeeper :as zk]]
-            [conjure.core])
+  (:require [backtype.storm.zookeeper :as zk]
+            [backtype.storm.config :as c]
+            [backtype.storm.cluster :refer :all]
+            [backtype.storm.testing :as testing]
+            [backtype.storm.util :as util :refer [barr]]
+            [conjure.core :as conjure]
+            [clojure.test :refer :all])
   (:import [java.util Arrays]
            [backtype.storm.daemon.common Assignment StormBase SupervisorInfo]
            [org.apache.zookeeper ZooDefs ZooDefs$Ids]
@@ -28,9 +30,9 @@
            [backtype.storm.utils Utils TestUtils ZookeeperAuthInfo]))
 
 (defn mk-config [zk-port]
-  (merge (read-storm-config)
-         {STORM-ZOOKEEPER-PORT zk-port
-          STORM-ZOOKEEPER-SERVERS ["localhost"]}))
+  (merge (c/read-storm-config)
+         {c/STORM-ZOOKEEPER-PORT zk-port
+          c/STORM-ZOOKEEPER-SERVERS ["localhost"]}))
 
 (defn mk-state
   ([zk-port] (let [conf (mk-config zk-port)]
@@ -43,7 +45,7 @@
 (defn mk-storm-state [zk-port] (mk-storm-cluster-state (mk-config zk-port)))
 
 (deftest test-basics
-  (with-inprocess-zookeeper zk-port
+  (testing/with-inprocess-zookeeper zk-port
     (let [state (mk-state zk-port)]
       (.set-data state "/root" (barr 1 2 3) ZooDefs$Ids/OPEN_ACL_UNSAFE)
       (is (Arrays/equals (barr 1 2 3) (.get-data state "/root" false)))
@@ -64,7 +66,7 @@
       )))
 
 (deftest test-multi-state
-  (with-inprocess-zookeeper zk-port
+  (testing/with-inprocess-zookeeper zk-port
     (let [state1 (mk-state zk-port)
           state2 (mk-state zk-port)]
       (.set-data state1 "/root" (barr 1) ZooDefs$Ids/OPEN_ACL_UNSAFE)
@@ -78,7 +80,7 @@
       )))
 
 (deftest test-ephemeral
-  (with-inprocess-zookeeper zk-port
+  (testing/with-inprocess-zookeeper zk-port
     (let [state1 (mk-state zk-port)
           state2 (mk-state zk-port)
           state3 (mk-state zk-port)]
@@ -115,7 +117,7 @@
       ))))
 
 (deftest test-callbacks
-  (with-inprocess-zookeeper zk-port
+  (testing/with-inprocess-zookeeper zk-port
     (let [[state1-last-cb state1-cb] (mk-callback-tester)
           state1 (mk-state zk-port state1-cb)
           [state2-last-cb state2-cb] (mk-callback-tester)
@@ -166,7 +168,7 @@
 
 
 (deftest test-storm-cluster-state-basics
-  (with-inprocess-zookeeper zk-port
+  (testing/with-inprocess-zookeeper zk-port
     (let [state (mk-storm-state zk-port)
           assignment1 (Assignment. "/aaa" {} {[1] ["1" 1001 1]} {})
           assignment2 (Assignment. "/aaa" {} {[2] ["2" 2002]} {})
@@ -217,21 +219,21 @@
 
 
 (deftest test-storm-cluster-state-errors
-  (with-inprocess-zookeeper zk-port
-    (with-simulated-time
+  (testing/with-inprocess-zookeeper zk-port
+    (testing/with-simulated-time
       (let [state (mk-storm-state zk-port)]
-        (.report-error state "a" "1" (local-hostname) 6700 (RuntimeException.))
+        (.report-error state "a" "1" (util/local-hostname) 6700 (RuntimeException.))
         (validate-errors! state "a" "1" ["RuntimeException"])
-        (advance-time-secs! 1)
-        (.report-error state "a" "1" (local-hostname) 6700 (IllegalArgumentException.))
+        (testing/advance-time-secs! 1)
+        (.report-error state "a" "1" (util/local-hostname) 6700 (IllegalArgumentException.))
         (validate-errors! state "a" "1" ["IllegalArgumentException" "RuntimeException"])
         (doseq [i (range 10)]
-          (.report-error state "a" "2" (local-hostname) 6700 (RuntimeException.))
-          (advance-time-secs! 2))
+          (.report-error state "a" "2" (util/local-hostname) 6700 (RuntimeException.))
+          (testing/advance-time-secs! 2))
         (validate-errors! state "a" "2" (repeat 10 "RuntimeException"))
         (doseq [i (range 5)]
-          (.report-error state "a" "2" (local-hostname) 6700 (IllegalArgumentException.))
-          (advance-time-secs! 2))
+          (.report-error state "a" "2" (util/local-hostname) 6700 (IllegalArgumentException.))
+          (testing/advance-time-secs! 2))
         (validate-errors! state "a" "2" (concat (repeat 5 "IllegalArgumentException")
                                                 (repeat 5 "RuntimeException")
                                                 ))
@@ -240,7 +242,7 @@
 
 
 (deftest test-supervisor-state
-  (with-inprocess-zookeeper zk-port
+  (testing/with-inprocess-zookeeper zk-port
     (let [state1 (mk-storm-state zk-port)
           state2 (mk-storm-state zk-port)
           supervisor-info1 (SupervisorInfo. 10 "hostname-1" "id1" [1 2] [] {} 1000 "0.9.2")
@@ -259,24 +261,24 @@
       )))
 
 (deftest test-cluster-authentication
-  (with-inprocess-zookeeper zk-port
+  (testing/with-inprocess-zookeeper zk-port
     (let [builder (Mockito/mock CuratorFrameworkFactory$Builder)
           conf (merge
                 (mk-config zk-port)
-                {STORM-ZOOKEEPER-CONNECTION-TIMEOUT 10
-                 STORM-ZOOKEEPER-SESSION-TIMEOUT 10
-                 STORM-ZOOKEEPER-RETRY-INTERVAL 5
-                 STORM-ZOOKEEPER-RETRY-TIMES 2
-                 STORM-ZOOKEEPER-RETRY-INTERVAL-CEILING 15
-                 STORM-ZOOKEEPER-AUTH-SCHEME "digest"
-                 STORM-ZOOKEEPER-AUTH-PAYLOAD "storm:thisisapoorpassword"})]
+                {c/STORM-ZOOKEEPER-CONNECTION-TIMEOUT 10
+                 c/STORM-ZOOKEEPER-SESSION-TIMEOUT 10
+                 c/STORM-ZOOKEEPER-RETRY-INTERVAL 5
+                 c/STORM-ZOOKEEPER-RETRY-TIMES 2
+                 c/STORM-ZOOKEEPER-RETRY-INTERVAL-CEILING 15
+                 c/STORM-ZOOKEEPER-AUTH-SCHEME "digest"
+                 c/STORM-ZOOKEEPER-AUTH-PAYLOAD "storm:thisisapoorpassword"})]
       (. (Mockito/when (.connectString builder (Mockito/anyString))) (thenReturn builder))
       (. (Mockito/when (.connectionTimeoutMs builder (Mockito/anyInt))) (thenReturn builder))
       (. (Mockito/when (.sessionTimeoutMs builder (Mockito/anyInt))) (thenReturn builder))
       (TestUtils/testSetupBuilder builder (str zk-port "/") conf (ZookeeperAuthInfo. conf))
       (is (nil?
            (try
-             (. (Mockito/verify builder) (authorization "digest" (.getBytes (conf STORM-ZOOKEEPER-AUTH-PAYLOAD))))
+             (. (Mockito/verify builder) (authorization "digest" (.getBytes (conf c/STORM-ZOOKEEPER-AUTH-PAYLOAD))))
              (catch MockitoAssertionError e
                e)))))))
 
@@ -286,14 +288,14 @@
 
 (deftest test-cluster-state-default-acls
   (testing "The default ACLs are empty."
-    (stubbing [zk/mkdirs nil
+    (conjure/stubbing [zk/mkdirs nil
                zk/mk-client (reify CuratorFramework (^void close [this] nil))]
       (mk-distributed-cluster-state {})
-      (verify-call-times-for zk/mkdirs 1)
-      (verify-first-call-args-for-indices zk/mkdirs [2] nil))
-    (stubbing [mk-distributed-cluster-state nil
+      (conjure/verify-call-times-for zk/mkdirs 1)
+      (conjure/verify-first-call-args-for-indices zk/mkdirs [2] nil))
+    (conjure/stubbing [mk-distributed-cluster-state nil
                register nil
                mkdirs nil]
       (mk-storm-cluster-state {})
-      (verify-call-times-for mk-distributed-cluster-state 1)
-      (verify-first-call-args-for-indices mk-distributed-cluster-state [4] nil))))
+      (conjure/verify-call-times-for mk-distributed-cluster-state 1)
+      (conjure/verify-first-call-args-for-indices mk-distributed-cluster-state [4] nil))))

--- a/storm-core/test/clj/backtype/storm/cluster_test.clj
+++ b/storm-core/test/clj/backtype/storm/cluster_test.clj
@@ -14,18 +14,18 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.cluster-test
-  (:import [java.util Arrays])
-  (:import [backtype.storm.daemon.common Assignment StormBase SupervisorInfo])
-  (:import [org.apache.zookeeper ZooDefs ZooDefs$Ids])
-  (:import [org.mockito Mockito])
-  (:import [org.mockito.exceptions.base MockitoAssertionError])
-  (:import [org.apache.curator.framework CuratorFramework CuratorFrameworkFactory CuratorFrameworkFactory$Builder])
-  (:import [backtype.storm.utils Utils TestUtils ZookeeperAuthInfo])
-  (:require [backtype.storm [zookeeper :as zk]])
-  (:require [conjure.core])
-  (:use [conjure core])
-  (:use [clojure test])
-  (:use [backtype.storm cluster config util testing thrift log]))
+  (:use [conjure core]
+        [clojure test]
+        [backtype.storm cluster config util testing thrift log])
+  (:require [backtype.storm [zookeeper :as zk]]
+            [conjure.core])
+  (:import [java.util Arrays]
+           [backtype.storm.daemon.common Assignment StormBase SupervisorInfo]
+           [org.apache.zookeeper ZooDefs ZooDefs$Ids]
+           [org.mockito Mockito]
+           [org.mockito.exceptions.base MockitoAssertionError]
+           [org.apache.curator.framework CuratorFramework CuratorFrameworkFactory CuratorFrameworkFactory$Builder]
+           [backtype.storm.utils Utils TestUtils ZookeeperAuthInfo]))
 
 (defn mk-config [zk-port]
   (merge (read-storm-config)
@@ -181,7 +181,7 @@
       (is (= #{"storm1" "storm3"} (set (.assignments state nil))))
       (is (= assignment2 (.assignment-info state "storm1" nil)))
       (is (= assignment1 (.assignment-info state "storm3" nil)))
-      
+
       (is (= [] (.active-storms state)))
       (.activate-storm! state "storm1" base1)
       (is (= ["storm1"] (.active-storms state)))

--- a/storm-core/test/clj/backtype/storm/config_test.clj
+++ b/storm-core/test/clj/backtype/storm/config_test.clj
@@ -14,21 +14,21 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.config-test
-  (:use [clojure test]
-        [backtype.storm config util])
-  (:import [backtype.storm Config ConfigValidation]
-           [backtype.storm.scheduler TopologyDetails]
+  (:require [backtype.storm.config :as c]
+            [backtype.storm.util :as util]
+            [clojure.test :refer :all])
+  (:import [backtype.storm ConfigValidation]
            [backtype.storm.utils Utils]))
 
 (deftest test-validity
-  (is (Utils/isValidConf {TOPOLOGY-DEBUG true "q" "asasdasd" "aaa" (Integer. "123") "bbb" (Long. "456") "eee" [1 2 (Integer. "3") (Long. "4")]}))
+  (is (Utils/isValidConf {c/TOPOLOGY-DEBUG true "q" "asasdasd" "aaa" (Integer. "123") "bbb" (Long. "456") "eee" [1 2 (Integer. "3") (Long. "4")]}))
   (is (not (Utils/isValidConf {"qqq" (backtype.storm.utils.Utils.)})))
   )
 
 (deftest test-power-of-2-validator
   (let [validator ConfigValidation/PowerOf2Validator]
     (doseq [x [42.42 42 23423423423 -33 -32 -1 -0.00001 0 -0 "Forty-two"]]
-      (is (thrown-cause? java.lang.IllegalArgumentException
+      (is (util/thrown-cause? java.lang.IllegalArgumentException
         (.validateField validator "test" x))))
 
     (doseq [x [64 4294967296 1 nil]]
@@ -45,12 +45,12 @@
                [nil]
                [nil "nil"]
               ]]
-      (is (thrown-cause-with-msg?
+      (is (util/thrown-cause-with-msg?
             java.lang.IllegalArgumentException #"(?i).*each element.*"
         (.validateField validator "test" x))))
 
     (doseq [x ["not a list at all"]]
-      (is (thrown-cause-with-msg?
+      (is (util/thrown-cause-with-msg?
             java.lang.IllegalArgumentException #"(?i).*must be an iterable.*"
         (.validateField validator "test" x))))
 
@@ -68,20 +68,20 @@
   (let [validator ConfigValidation/IntegerValidator]
     (.validateField validator "test" nil)
     (.validateField validator "test" 1000)
-    (is (thrown-cause? java.lang.IllegalArgumentException
+    (is (util/thrown-cause? java.lang.IllegalArgumentException
           (.validateField validator "test" 1.34)))
-    (is (thrown-cause? java.lang.IllegalArgumentException
+    (is (util/thrown-cause? java.lang.IllegalArgumentException
           (.validateField validator "test" (inc Integer/MAX_VALUE))))))
 
 (deftest test-integers-validator
   (let [validator ConfigValidation/IntegersValidator]
     (.validateField validator "test" nil)
     (.validateField validator "test" [1000 0 -1000])
-    (is (thrown-cause? java.lang.IllegalArgumentException
+    (is (util/thrown-cause? java.lang.IllegalArgumentException
           (.validateField validator "test" [0 10 1.34])))
-    (is (thrown-cause? java.lang.IllegalArgumentException
+    (is (util/thrown-cause? java.lang.IllegalArgumentException
           (.validateField validator "test" [0 nil])))
-    (is (thrown-cause? java.lang.IllegalArgumentException
+    (is (util/thrown-cause? java.lang.IllegalArgumentException
           (.validateField validator "test" [-100 (inc Integer/MAX_VALUE)])))))
 
 (deftest test-double-validator
@@ -94,32 +94,32 @@
     (.validateField validator "test" Double/MAX_VALUE)))
 
 (deftest test-topology-workers-is-integer
-  (let [validator (CONFIG-SCHEMA-MAP TOPOLOGY-WORKERS)]
+  (let [validator (c/CONFIG-SCHEMA-MAP c/TOPOLOGY-WORKERS)]
     (.validateField validator "test" 42)
-    (is (thrown-cause? java.lang.IllegalArgumentException
+    (is (util/thrown-cause? java.lang.IllegalArgumentException
       (.validateField validator "test" 3.14159)))))
 
 (deftest test-topology-stats-sample-rate-is-float
-  (let [validator (CONFIG-SCHEMA-MAP TOPOLOGY-STATS-SAMPLE-RATE)]
+  (let [validator (c/CONFIG-SCHEMA-MAP c/TOPOLOGY-STATS-SAMPLE-RATE)]
     (.validateField validator "test" 0.5)
     (.validateField validator "test" 10)
     (.validateField validator "test" Double/MAX_VALUE)))
 
 (deftest test-isolation-scheduler-machines-is-map
-  (let [validator (CONFIG-SCHEMA-MAP ISOLATION-SCHEDULER-MACHINES)]
+  (let [validator (c/CONFIG-SCHEMA-MAP c/ISOLATION-SCHEDULER-MACHINES)]
     (is (nil? (try
                 (.validateField validator "test" {})
                 (catch Exception e e))))
     (is (nil? (try
                 (.validateField validator "test" {"host0" 1 "host1" 2})
                 (catch Exception e e))))
-    (is (thrown-cause? java.lang.IllegalArgumentException
+    (is (util/thrown-cause? java.lang.IllegalArgumentException
       (.validateField validator "test" 42)))))
 
 (deftest test-positive-integer-validator
   (let [validator ConfigValidation/PositiveIntegerValidator]
     (doseq [x [42.42 -32 0 -0 "Forty-two"]]
-      (is (thrown-cause? java.lang.IllegalArgumentException
+      (is (util/thrown-cause? java.lang.IllegalArgumentException
         (.validateField validator "test" x))))
 
     (doseq [x [42 4294967296 1 nil]]
@@ -130,19 +130,19 @@
 (deftest test-worker-childopts-is-string-or-string-list
   (let [pass-cases [nil "some string" ["some" "string" "list"]]]
     (testing "worker.childopts validates"
-      (let [validator (CONFIG-SCHEMA-MAP WORKER-CHILDOPTS)]
+      (let [validator (c/CONFIG-SCHEMA-MAP c/WORKER-CHILDOPTS)]
         (doseq [value pass-cases]
           (is (nil? (try
                       (.validateField validator "test" value)
                       (catch Exception e e)))))
-        (is (thrown-cause? java.lang.IllegalArgumentException
+        (is (util/thrown-cause? java.lang.IllegalArgumentException
           (.validateField validator "test" 42)))))
 
     (testing "topology.worker.childopts validates"
-      (let [validator (CONFIG-SCHEMA-MAP TOPOLOGY-WORKER-CHILDOPTS)]
+      (let [validator (c/CONFIG-SCHEMA-MAP c/TOPOLOGY-WORKER-CHILDOPTS)]
         (doseq [value pass-cases]
           (is (nil? (try
                       (.validateField validator "test" value)
                       (catch Exception e e)))))
-        (is (thrown-cause? java.lang.IllegalArgumentException
+        (is (util/thrown-cause? java.lang.IllegalArgumentException
           (.validateField validator "test" 42)))))))

--- a/storm-core/test/clj/backtype/storm/config_test.clj
+++ b/storm-core/test/clj/backtype/storm/config_test.clj
@@ -14,12 +14,11 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.config-test
-  (:import [backtype.storm Config ConfigValidation])
-  (:import [backtype.storm.scheduler TopologyDetails])
-  (:import [backtype.storm.utils Utils])
-  (:use [clojure test])
-  (:use [backtype.storm config util])
-  )
+  (:use [clojure test]
+        [backtype.storm config util])
+  (:import [backtype.storm Config ConfigValidation]
+           [backtype.storm.scheduler TopologyDetails]
+           [backtype.storm.utils Utils]))
 
 (deftest test-validity
   (is (Utils/isValidConf {TOPOLOGY-DEBUG true "q" "asasdasd" "aaa" (Integer. "123") "bbb" (Long. "456") "eee" [1 2 (Integer. "3") (Long. "4")]}))
@@ -33,7 +32,7 @@
         (.validateField validator "test" x))))
 
     (doseq [x [64 4294967296 1 nil]]
-      (is (nil? (try 
+      (is (nil? (try
                   (.validateField validator "test" x)
                   (catch Exception e e)))))))
 
@@ -61,7 +60,7 @@
                ["42" "64"]
                nil
               ]]
-    (is (nil? (try 
+    (is (nil? (try
                 (.validateField validator "test" x)
                 (catch Exception e e)))))))
 
@@ -108,11 +107,11 @@
 
 (deftest test-isolation-scheduler-machines-is-map
   (let [validator (CONFIG-SCHEMA-MAP ISOLATION-SCHEDULER-MACHINES)]
-    (is (nil? (try 
-                (.validateField validator "test" {}) 
+    (is (nil? (try
+                (.validateField validator "test" {})
                 (catch Exception e e))))
-    (is (nil? (try 
-                (.validateField validator "test" {"host0" 1 "host1" 2}) 
+    (is (nil? (try
+                (.validateField validator "test" {"host0" 1 "host1" 2})
                 (catch Exception e e))))
     (is (thrown-cause? java.lang.IllegalArgumentException
       (.validateField validator "test" 42)))))

--- a/storm-core/test/clj/backtype/storm/drpc_test.clj
+++ b/storm-core/test/clj/backtype/storm/drpc_test.clj
@@ -14,18 +14,17 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.drpc-test
-  (:use [clojure test])
-  (:import [backtype.storm.drpc ReturnResults DRPCSpout
-            LinearDRPCTopologyBuilder])
-  (:import [backtype.storm.topology FailedException])
-  (:import [backtype.storm.coordination CoordinatedBolt$FinishedCallback])
-  (:import [backtype.storm LocalDRPC LocalCluster])
-  (:import [backtype.storm.tuple Fields])
-  (:import [backtype.storm.generated DRPCExecutionException])
-  (:import [java.util.concurrent ConcurrentLinkedQueue])
-  (:use [backtype.storm config testing clojure])
-  (:use [backtype.storm.daemon common drpc])
-  (:use [conjure core]))
+  (:use [clojure test]
+        [backtype.storm config testing clojure]
+        [backtype.storm.daemon common drpc]
+        [conjure core])
+  (:import [backtype.storm.drpc ReturnResults DRPCSpout LinearDRPCTopologyBuilder]
+           [backtype.storm.topology FailedException]
+           [backtype.storm.coordination CoordinatedBolt$FinishedCallback]
+           [backtype.storm LocalDRPC LocalCluster]
+           [backtype.storm.tuple Fields]
+           [backtype.storm.generated DRPCExecutionException]
+           [java.util.concurrent ConcurrentLinkedQueue]))
 
 (defbolt exclamation-bolt ["result" "return-info"] [tuple collector]
   (emit-bolt! collector
@@ -49,8 +48,8 @@
     (is (= "aaa!!!" (.execute drpc "test" "aaa")))
     (is (= "b!!!" (.execute drpc "test" "b")))
     (is (= "c!!!" (.execute drpc "test" "c")))
-    
-    
+
+
     (.shutdown cluster)
     (.shutdown drpc)
     ))
@@ -74,8 +73,8 @@
                      (.createLocalTopology builder drpc))
     (is (= "aaa!!!" (.execute drpc "test" "aaa")))
     (is (= "b!!!" (.execute drpc "test" "b")))
-    (is (= "c!!!" (.execute drpc "test" "c")))  
-    
+    (is (= "c!!!" (.execute drpc "test" "c")))
+
     (.shutdown cluster)
     (.shutdown drpc)
     ))
@@ -144,8 +143,8 @@
     (is (= "100" (.execute drpc "square" "10")))
     (is (= "1" (.execute drpc "square" "1")))
     (is (= "0" (.execute drpc "square" "0")))
-    
-    
+
+
     (.shutdown cluster)
     (.shutdown drpc)
     ))
@@ -210,7 +209,7 @@
                      "fail2"
                      {}
                      (.createLocalTopology builder drpc))
-    
+
     (is (thrown? DRPCExecutionException (.execute drpc "fail2" "2")))
 
     (.shutdown cluster)
@@ -228,7 +227,7 @@
           (.execute drpc-handler "ArbitraryDRPCFunctionName" "")))
         (is (= 0 (.size queue)))))))
 
-(deftest test-drpc-timeout-cleanup 
+(deftest test-drpc-timeout-cleanup
   (let [queue (ConcurrentLinkedQueue.)
         delay-seconds 1
         conf {DRPC-REQUEST-TIMEOUT-SECS delay-seconds}]
@@ -236,6 +235,6 @@
                read-storm-config conf
                timeout-check-secs delay-seconds]
               (let [drpc-handler (service-handler conf)]
-                (is (thrown? DRPCExecutionException 
+                (is (thrown? DRPCExecutionException
                              (.execute drpc-handler "ArbitraryDRPCFunctionName" "no-args")))))))
 

--- a/storm-core/test/clj/backtype/storm/drpc_test.clj
+++ b/storm-core/test/clj/backtype/storm/drpc_test.clj
@@ -14,10 +14,11 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.drpc-test
-  (:use [clojure test]
-        [backtype.storm config testing clojure]
-        [backtype.storm.daemon common drpc]
-        [conjure core])
+  (:require [conjure.core :as conjure]
+            [backtype.storm.config :as c]
+            [backtype.storm.daemon.drpc :refer :all]
+            [backtype.storm.clojure :refer :all]
+            [clojure.test :refer :all])
   (:import [backtype.storm.drpc ReturnResults DRPCSpout LinearDRPCTopologyBuilder]
            [backtype.storm.topology FailedException]
            [backtype.storm.coordination CoordinatedBolt$FinishedCallback]
@@ -219,9 +220,9 @@
 (deftest test-dequeue-req-after-timeout
   (let [queue (ConcurrentLinkedQueue.)
         delay-seconds 2
-        conf {DRPC-REQUEST-TIMEOUT-SECS delay-seconds}]
-    (stubbing [acquire-queue queue
-               read-storm-config conf]
+        conf {c/DRPC-REQUEST-TIMEOUT-SECS delay-seconds}]
+    (conjure/stubbing [acquire-queue queue
+               c/read-storm-config conf]
       (let [drpc-handler (service-handler conf)]
         (is (thrown? DRPCExecutionException
           (.execute drpc-handler "ArbitraryDRPCFunctionName" "")))
@@ -230,9 +231,9 @@
 (deftest test-drpc-timeout-cleanup
   (let [queue (ConcurrentLinkedQueue.)
         delay-seconds 1
-        conf {DRPC-REQUEST-TIMEOUT-SECS delay-seconds}]
-    (stubbing [acquire-queue queue
-               read-storm-config conf
+        conf {c/DRPC-REQUEST-TIMEOUT-SECS delay-seconds}]
+    (conjure/stubbing [acquire-queue queue
+               c/read-storm-config conf
                timeout-check-secs delay-seconds]
               (let [drpc-handler (service-handler conf)]
                 (is (thrown? DRPCExecutionException

--- a/storm-core/test/clj/backtype/storm/fields_test.clj
+++ b/storm-core/test/clj/backtype/storm/fields_test.clj
@@ -15,9 +15,9 @@
 ;; limitations under the License.
 (ns backtype.storm.fields-test
   (:use [clojure test])
-  (:import [backtype.storm.tuple Fields])
-  (:import [java.util List])
-  (:import [java.util Iterator]))
+  (:import [backtype.storm.tuple Fields]
+           [java.util List]
+           [java.util Iterator]))
 
 (deftest test-fields-constructor
   (testing "constructor"

--- a/storm-core/test/clj/backtype/storm/fields_test.clj
+++ b/storm-core/test/clj/backtype/storm/fields_test.clj
@@ -14,7 +14,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.fields-test
-  (:use [clojure test])
+  (:require [clojure.test :refer :all])
   (:import [backtype.storm.tuple Fields]
            [java.util List]
            [java.util Iterator]))

--- a/storm-core/test/clj/backtype/storm/grouping_test.clj
+++ b/storm-core/test/clj/backtype/storm/grouping_test.clj
@@ -14,12 +14,12 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.grouping-test
-  (:use [clojure test])
+  (:use [clojure test]
+        [backtype.storm testing clojure]
+        [backtype.storm.daemon common])
+  (:require [backtype.storm [thrift :as thrift]])
   (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount TestAggregatesCounter NGrouping]
-           [backtype.storm.generated JavaObject JavaObjectArg])
-  (:use [backtype.storm testing clojure])
-  (:use [backtype.storm.daemon common])
-  (:require [backtype.storm [thrift :as thrift]]))
+           [backtype.storm.generated JavaObject JavaObjectArg]))
 
 (deftest test-shuffle
   (with-simulated-time-local-cluster [cluster :supervisors 4]

--- a/storm-core/test/clj/backtype/storm/grouping_test.clj
+++ b/storm-core/test/clj/backtype/storm/grouping_test.clj
@@ -14,21 +14,21 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.grouping-test
-  (:use [clojure test]
-        [backtype.storm testing clojure]
-        [backtype.storm.daemon common])
-  (:require [backtype.storm [thrift :as thrift]])
-  (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount TestAggregatesCounter NGrouping]
+  (:require [backtype.storm.thrift :as thrift]
+            [backtype.storm.testing :as testing]
+            [backtype.storm.clojure :refer :all]
+            [clojure.test :refer :all])
+  (:import [backtype.storm.testing TestWordSpout TestGlobalCount NGrouping]
            [backtype.storm.generated JavaObject JavaObjectArg]))
 
 (deftest test-shuffle
-  (with-simulated-time-local-cluster [cluster :supervisors 4]
+  (testing/with-simulated-time-local-cluster [cluster :supervisors 4]
     (let [topology (thrift/mk-topology
                     {"1" (thrift/mk-spout-spec (TestWordSpout. true) :parallelism-hint 4)}
                     {"2" (thrift/mk-bolt-spec {"1" :shuffle} (TestGlobalCount.)
                                             :parallelism-hint 6)
                      })
-          results (complete-topology cluster
+          results (testing/complete-topology cluster
                                      topology
                                      ;; important for test that
                                      ;; #tuples = multiple of 4 and 6
@@ -46,8 +46,8 @@
                                                          ["a"] ["b"]
                                                        ]}
                                      )]
-      (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
-               (read-tuples results "2")))
+      (is (testing/ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
+               (testing/read-tuples results "2")))
       )))
 
 (defbolt id-bolt ["val"] [tuple collector]
@@ -55,7 +55,7 @@
   (ack! collector tuple))
 
 (deftest test-custom-groupings
-  (with-simulated-time-local-cluster [cluster]
+  (testing/with-simulated-time-local-cluster [cluster]
     (let [topology (topology
                     {"1" (spout-spec (TestWordSpout. true))}
                     {"2" (bolt-spec {"1" (NGrouping. 2)}
@@ -66,14 +66,14 @@
                                   id-bolt
                                   :p 6)
                      })
-          results (complete-topology cluster
+          results (testing/complete-topology cluster
                                      topology
                                      :mock-sources {"1" [["a"]
                                                         ["b"]
                                                         ]}
                                      )]
-      (is (ms= [["a"] ["a"] ["b"] ["b"]]
-               (read-tuples results "2")))
-      (is (ms= [["a"] ["a"] ["a"] ["b"] ["b"] ["b"]]
-               (read-tuples results "3")))
+      (is (testing/ms= [["a"] ["a"] ["b"] ["b"]]
+               (testing/read-tuples results "2")))
+      (is (testing/ms= [["a"] ["a"] ["a"] ["b"] ["b"] ["b"]]
+               (testing/read-tuples results "3")))
       )))

--- a/storm-core/test/clj/backtype/storm/integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/integration_test.clj
@@ -14,16 +14,16 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.integration-test
-  (:use [clojure test])
-  (:import [backtype.storm Config])
-  (:import [backtype.storm.topology TopologyBuilder])
-  (:import [backtype.storm.generated InvalidTopologyException SubmitOptions TopologyInitialStatus])
-  (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount
-            TestAggregatesCounter TestConfBolt AckFailMapTracker AckTracker TestPlannerSpout])
-  (:import [backtype.storm.tuple Fields])
-  (:use [backtype.storm testing config clojure util])
-  (:use [backtype.storm.daemon common])
-  (:require [backtype.storm [thrift :as thrift]]))
+  (:use [clojure test]
+        [backtype.storm testing config clojure util]
+        [backtype.storm.daemon common])
+  (:require [backtype.storm [thrift :as thrift]])
+  (:import [backtype.storm Config]
+           [backtype.storm.topology TopologyBuilder]
+           [backtype.storm.generated InvalidTopologyException SubmitOptions TopologyInitialStatus]
+           [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount
+                                   TestAggregatesCounter TestConfBolt AckFailMapTracker AckTracker TestPlannerSpout]
+           [backtype.storm.tuple Fields]))
 
 (deftest test-basic-topology
   (doseq [zmq-on? [true false]]
@@ -100,7 +100,7 @@
           _ (.setAckFailDelegate feeder tracker)
           topology (thrift/mk-topology
                      {"1" (thrift/mk-spout-spec feeder)}
-                     {"2" (thrift/mk-bolt-spec {"1" :global} ack-every-other)})]      
+                     {"2" (thrift/mk-bolt-spec {"1" :global} ack-every-other)})]
       (submit-local-topology (:nimbus cluster)
                              "timeout-tester"
                              {TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
@@ -258,7 +258,7 @@
       (checker1 1)
       (checker2 1)
       (checker3 1)
-      
+
       )))
 
 (deftest test-ack-branching
@@ -293,7 +293,7 @@
 
 (def bolt-prepared? (atom false))
 (defbolt prepare-tracked-bolt [] {:prepare true}
-  [conf context collector]  
+  [conf context collector]
   (reset! bolt-prepared? true)
   (bolt
    (execute [tuple]
@@ -316,8 +316,8 @@
                      "2" (thrift/mk-spout-spec open-tracked-spout)}
                     {"3" (thrift/mk-bolt-spec {"1" :global} prepare-tracked-bolt)})]
       (reset! bolt-prepared? false)
-      (reset! spout-opened? false)      
-      
+      (reset! spout-opened? false)
+
       (submit-local-topology-with-opts (:nimbus cluster)
         "test"
         {TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
@@ -326,9 +326,9 @@
       (.feed feeder ["a"] 1)
       (advance-cluster-time cluster 9)
       (is (not @bolt-prepared?))
-      (is (not @spout-opened?))        
-      (.activate (:nimbus cluster) "test")              
-      
+      (is (not @spout-opened?))
+      (.activate (:nimbus cluster) "test")
+
       (advance-cluster-time cluster 12)
       (assert-acked tracker 1)
       (is @bolt-prepared?)
@@ -393,7 +393,7 @@
     (spout
      (nextTuple []
        (Thread/sleep 100)
-       (emit-spout! collector [@state] :id 1)         
+       (emit-spout! collector [@state] :id 1)
        )
      (ack [id]
        (swap! state inc))
@@ -407,7 +407,7 @@
      (nextTuple []
        (Thread/sleep 100)
        (swap! state inc)
-       (emit-spout! collector [(str prefix "-" @state)])         
+       (emit-spout! collector [(str prefix "-" @state)])
        )
      )))
 
@@ -440,13 +440,13 @@
                    (TestConfBolt.
                     {TOPOLOGY-KRYO-DECORATORS ["one" "two"]}))
          (.shuffleGrouping "1"))
-     
+
      (bind results
            (complete-topology cluster
                               (.createTopology builder)
                               :storm-conf {TOPOLOGY-KRYO-DECORATORS ["one" "three"]}
                               :mock-sources {"1" [[TOPOLOGY-KRYO-DECORATORS]]}))
-     (is (= {"topology.kryo.decorators" (list "one" "two" "three")}            
+     (is (= {"topology.kryo.decorators" (list "one" "two" "three")}
             (->> (read-tuples results "2")
                  (apply concat)
                  (apply hash-map)))))))
@@ -470,7 +470,7 @@
          (.setMaxTaskParallelism (int 2))
          (.addConfiguration "fake.config2" 987)
          )
-     
+
 
      (bind results
            (complete-topology cluster
@@ -579,19 +579,19 @@
         (tracked-wait tracked 1)
         (is (= 4 (errors-count)))
         (is (.last-error state storm-id "2"))
-        
+
         (advance-time-secs! 5)
         (.feed feeder [2])
         (tracked-wait tracked 1)
         (is (= 4 (errors-count)))
         (is (.last-error state storm-id "2"))
-        
+
         (advance-time-secs! 6)
         (.feed feeder [2])
         (tracked-wait tracked 1)
         (is (= 6 (errors-count)))
         (is (.last-error state storm-id "2"))
-        
+
         (advance-time-secs! 6)
         (.feed feeder [3])
         (tracked-wait tracked 1)

--- a/storm-core/test/clj/backtype/storm/integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/integration_test.clj
@@ -14,12 +14,14 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.integration-test
-  (:use [clojure test]
-        [backtype.storm testing config clojure util]
-        [backtype.storm.daemon common])
-  (:require [backtype.storm [thrift :as thrift]])
-  (:import [backtype.storm Config]
-           [backtype.storm.topology TopologyBuilder]
+  (:require [backtype.storm.config :as c]
+            [backtype.storm.thrift :as thrift]
+            [backtype.storm.daemon.common :as daemon]
+            [backtype.storm.util :as util]
+            [backtype.storm.testing :as testing]
+            [backtype.storm.clojure :refer :all]
+            [clojure.test :refer :all])
+  (:import [backtype.storm.topology TopologyBuilder]
            [backtype.storm.generated InvalidTopologyException SubmitOptions TopologyInitialStatus]
            [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount
                                    TestAggregatesCounter TestConfBolt AckFailMapTracker AckTracker TestPlannerSpout]
@@ -27,26 +29,26 @@
 
 (deftest test-basic-topology
   (doseq [zmq-on? [true false]]
-    (with-simulated-time-local-cluster [cluster :supervisors 4
-                                        :daemon-conf {STORM-LOCAL-MODE-ZMQ zmq-on?}]
+    (testing/with-simulated-time-local-cluster [cluster :supervisors 4
+                                        :daemon-conf {c/STORM-LOCAL-MODE-ZMQ zmq-on?}]
       (let [topology (thrift/mk-topology
                       {"1" (thrift/mk-spout-spec (TestWordSpout. true) :parallelism-hint 3)}
                       {"2" (thrift/mk-bolt-spec {"1" ["word"]} (TestWordCounter.) :parallelism-hint 4)
                        "3" (thrift/mk-bolt-spec {"1" :global} (TestGlobalCount.))
                        "4" (thrift/mk-bolt-spec {"2" :global} (TestAggregatesCounter.))
                        })
-            results (complete-topology cluster
+            results (testing/complete-topology cluster
                                        topology
                                        :mock-sources {"1" [["nathan"] ["bob"] ["joey"] ["nathan"]]}
-                                       :storm-conf {TOPOLOGY-WORKERS 2})]
-        (is (ms= [["nathan"] ["bob"] ["joey"] ["nathan"]]
-                 (read-tuples results "1")))
-        (is (ms= [["nathan" 1] ["nathan" 2] ["bob" 1] ["joey" 1]]
-                 (read-tuples results "2")))
+                                       :storm-conf {c/TOPOLOGY-WORKERS 2})]
+        (is (testing/ms= [["nathan"] ["bob"] ["joey"] ["nathan"]]
+                 (testing/read-tuples results "1")))
+        (is (testing/ms= [["nathan" 1] ["nathan" 2] ["bob" 1] ["joey" 1]]
+                 (testing/read-tuples results "2")))
         (is (= [[1] [2] [3] [4]]
-               (read-tuples results "3")))
+               (testing/read-tuples results "3")))
         (is (= [[1] [2] [3] [4]]
-               (read-tuples results "4")))
+               (testing/read-tuples results "4")))
         ))))
 
 (defbolt emit-task-id ["tid"] {:prepare true}
@@ -59,18 +61,18 @@
         ))))
 
 (deftest test-multi-tasks-per-executor
-  (with-simulated-time-local-cluster [cluster :supervisors 4]
+  (testing/with-simulated-time-local-cluster [cluster :supervisors 4]
     (let [topology (thrift/mk-topology
                     {"1" (thrift/mk-spout-spec (TestWordSpout. true))}
                     {"2" (thrift/mk-bolt-spec {"1" :shuffle} emit-task-id
                       :parallelism-hint 3
-                      :conf {TOPOLOGY-TASKS 6})
+                      :conf {c/TOPOLOGY-TASKS 6})
                      })
-          results (complete-topology cluster
+          results (testing/complete-topology cluster
                                      topology
                                      :mock-sources {"1" [["a"] ["a"] ["a"] ["a"] ["a"] ["a"]]})]
-      (is (ms= [[0] [1] [2] [3] [4] [5]]
-               (read-tuples results "2")))
+      (is (testing/ms= [[0] [1] [2] [3] [4] [5]]
+               (testing/read-tuples results "2")))
       )))
 
 (defbolt ack-every-other {} {:prepare true}
@@ -94,24 +96,24 @@
   (assert-loop #(.isFailed tracker %) ids))
 
 (deftest test-timeout
-  (with-simulated-time-local-cluster [cluster :daemon-conf {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true}]
-    (let [feeder (feeder-spout ["field1"])
+  (testing/with-simulated-time-local-cluster [cluster :daemon-conf {c/TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true}]
+    (let [feeder (testing/feeder-spout ["field1"])
           tracker (AckFailMapTracker.)
           _ (.setAckFailDelegate feeder tracker)
           topology (thrift/mk-topology
                      {"1" (thrift/mk-spout-spec feeder)}
                      {"2" (thrift/mk-bolt-spec {"1" :global} ack-every-other)})]
-      (submit-local-topology (:nimbus cluster)
+      (testing/submit-local-topology (:nimbus cluster)
                              "timeout-tester"
-                             {TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
+                             {c/TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
                              topology)
       (.feed feeder ["a"] 1)
       (.feed feeder ["b"] 2)
       (.feed feeder ["c"] 3)
-      (advance-cluster-time cluster 9)
+      (testing/advance-cluster-time cluster 9)
       (assert-acked tracker 1 3)
       (is (not (.isFailed tracker 2)))
-      (advance-cluster-time cluster 12)
+      (testing/advance-cluster-time cluster 12)
       (assert-failed tracker 2)
       )))
 
@@ -137,15 +139,15 @@
 
 (defn try-complete-wc-topology [cluster topology]
   (try (do
-         (complete-topology cluster
+         (testing/complete-topology cluster
                             topology
                             :mock-sources {"1" [["nathan"] ["bob"] ["joey"] ["nathan"]]}
-                            :storm-conf {TOPOLOGY-WORKERS 2})
+                            :storm-conf {c/TOPOLOGY-WORKERS 2})
          false)
        (catch InvalidTopologyException e true)))
 
 (deftest test-validate-topology-structure
-  (with-simulated-time-local-cluster [cluster :supervisors 4]
+  (testing/with-simulated-time-local-cluster [cluster :supervisors 4]
     (let [any-error1? (try-complete-wc-topology cluster (mk-validate-topology-1))
           any-error2? (try-complete-wc-topology cluster (mk-invalidate-topology-1))
           any-error3? (try-complete-wc-topology cluster (mk-invalidate-topology-2))
@@ -162,22 +164,22 @@
 
 (deftest test-system-stream
   ;; this test works because mocking a spout splits up the tuples evenly among the tasks
-  (with-simulated-time-local-cluster [cluster]
+  (testing/with-simulated-time-local-cluster [cluster]
       (let [topology (thrift/mk-topology
                       {"1" (thrift/mk-spout-spec (TestWordSpout. true) :p 3)}
                       {"2" (thrift/mk-bolt-spec {"1" ["word"] ["1" "__system"] :global} identity-bolt :p 1)
                        })
-            results (complete-topology cluster
+            results (testing/complete-topology cluster
                                        topology
                                        :mock-sources {"1" [["a"] ["b"] ["c"]]}
-                                       :storm-conf {TOPOLOGY-WORKERS 2})]
-        (is (ms= [["a"] ["b"] ["c"] ["startup"] ["startup"] ["startup"]]
-                 (read-tuples results "2")))
+                                       :storm-conf {c/TOPOLOGY-WORKERS 2})]
+        (is (testing/ms= [["a"] ["b"] ["c"] ["startup"] ["startup"] ["startup"]]
+                 (testing/read-tuples results "2")))
         )))
 
 (defn ack-tracking-feeder [fields]
   (let [tracker (AckTracker.)]
-    [(doto (feeder-spout fields)
+    [(doto (testing/feeder-spout fields)
        (.setAckFailDelegate tracker))
      (fn [val]
        (is (= (.getNumAcks tracker) val))
@@ -211,11 +213,11 @@
   (ack! collector tuple))
 
 (deftest test-acking
-  (with-tracked-cluster [cluster]
+  (testing/with-tracked-cluster [cluster]
     (let [[feeder1 checker1] (ack-tracking-feeder ["num"])
           [feeder2 checker2] (ack-tracking-feeder ["num"])
           [feeder3 checker3] (ack-tracking-feeder ["num"])
-          tracked (mk-tracked-topology
+          tracked (testing/mk-tracked-topology
                    cluster
                    (topology
                      {"1" (spout-spec feeder1)
@@ -232,29 +234,29 @@
                       "8" (bolt-spec {"7" :shuffle} (branching-bolt 2))
                       "9" (bolt-spec {"8" :shuffle} ack-bolt)}
                      ))]
-      (submit-local-topology (:nimbus cluster)
+      (testing/submit-local-topology (:nimbus cluster)
                              "acking-test1"
                              {}
                              (:topology tracked))
       (.feed feeder1 [1])
-      (tracked-wait tracked 1)
+      (testing/tracked-wait tracked 1)
       (checker1 0)
       (.feed feeder2 [1])
-      (tracked-wait tracked 1)
+      (testing/tracked-wait tracked 1)
       (checker1 1)
       (checker2 1)
       (.feed feeder1 [1])
-      (tracked-wait tracked 1)
+      (testing/tracked-wait tracked 1)
       (checker1 0)
       (.feed feeder1 [1])
-      (tracked-wait tracked 1)
+      (testing/tracked-wait tracked 1)
       (checker1 1)
       (.feed feeder3 [1])
-      (tracked-wait tracked 1)
+      (testing/tracked-wait tracked 1)
       (checker1 0)
       (checker3 0)
       (.feed feeder2 [1])
-      (tracked-wait tracked 1)
+      (testing/tracked-wait tracked 1)
       (checker1 1)
       (checker2 1)
       (checker3 1)
@@ -262,9 +264,9 @@
       )))
 
 (deftest test-ack-branching
-  (with-tracked-cluster [cluster]
+  (testing/with-tracked-cluster [cluster]
     (let [[feeder checker] (ack-tracking-feeder ["num"])
-          tracked (mk-tracked-topology
+          tracked (testing/mk-tracked-topology
                    cluster
                    (topology
                      {"1" (spout-spec feeder)}
@@ -274,15 +276,15 @@
                             {"2" :shuffle
                              "3" :shuffle}
                              (agg-bolt 4))}))]
-      (submit-local-topology (:nimbus cluster)
+      (testing/submit-local-topology (:nimbus cluster)
                              "test-acking2"
                              {}
                              (:topology tracked))
       (.feed feeder [1])
-      (tracked-wait tracked 1)
+      (testing/tracked-wait tracked 1)
       (checker 0)
       (.feed feeder [1])
-      (tracked-wait tracked 1)
+      (testing/tracked-wait tracked 1)
       (checker 2)
       )))
 
@@ -307,8 +309,8 @@
    (nextTuple [])))
 
 (deftest test-submit-inactive-topology
-  (with-simulated-time-local-cluster [cluster :daemon-conf {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true}]
-    (let [feeder (feeder-spout ["field1"])
+  (testing/with-simulated-time-local-cluster [cluster :daemon-conf {c/TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true}]
+    (let [feeder (testing/feeder-spout ["field1"])
           tracker (AckFailMapTracker.)
           _ (.setAckFailDelegate feeder tracker)
           topology (thrift/mk-topology
@@ -318,42 +320,42 @@
       (reset! bolt-prepared? false)
       (reset! spout-opened? false)
 
-      (submit-local-topology-with-opts (:nimbus cluster)
+      (testing/submit-local-topology-with-opts (:nimbus cluster)
         "test"
-        {TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
+        {c/TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
         topology
         (SubmitOptions. TopologyInitialStatus/INACTIVE))
       (.feed feeder ["a"] 1)
-      (advance-cluster-time cluster 9)
+      (testing/advance-cluster-time cluster 9)
       (is (not @bolt-prepared?))
       (is (not @spout-opened?))
       (.activate (:nimbus cluster) "test")
 
-      (advance-cluster-time cluster 12)
+      (testing/advance-cluster-time cluster 12)
       (assert-acked tracker 1)
       (is @bolt-prepared?)
       (is @spout-opened?))))
 
 (deftest test-acking-self-anchor
-  (with-tracked-cluster [cluster]
+  (testing/with-tracked-cluster [cluster]
     (let [[feeder checker] (ack-tracking-feeder ["num"])
-          tracked (mk-tracked-topology
+          tracked (testing/mk-tracked-topology
                    cluster
                    (topology
                      {"1" (spout-spec feeder)}
                      {"2" (bolt-spec {"1" :shuffle} dup-anchor)
                       "3" (bolt-spec {"2" :shuffle} ack-bolt)}))]
-      (submit-local-topology (:nimbus cluster)
+      (testing/submit-local-topology (:nimbus cluster)
                              "test"
                              {}
                              (:topology tracked))
       (.feed feeder [1])
-      (tracked-wait tracked 1)
+      (testing/tracked-wait tracked 1)
       (checker 1)
       (.feed feeder [1])
       (.feed feeder [1])
       (.feed feeder [1])
-      (tracked-wait tracked 3)
+      (testing/tracked-wait tracked 3)
       (checker 3)
       )))
 
@@ -429,41 +431,41 @@
 ;;       )))
 
 (deftest test-kryo-decorators-config
-  (with-simulated-time-local-cluster [cluster
-                                      :daemon-conf {TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS true
-                                                    TOPOLOGY-KRYO-DECORATORS ["this-is-overriden"]}]
-    (letlocals
+  (testing/with-simulated-time-local-cluster [cluster
+                                      :daemon-conf {c/TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS true
+                                                    c/TOPOLOGY-KRYO-DECORATORS ["this-is-overriden"]}]
+    (util/letlocals
      (bind builder (TopologyBuilder.))
      (.setSpout builder "1" (TestPlannerSpout. (Fields. ["conf"])))
      (-> builder
          (.setBolt "2"
                    (TestConfBolt.
-                    {TOPOLOGY-KRYO-DECORATORS ["one" "two"]}))
+                    {c/TOPOLOGY-KRYO-DECORATORS ["one" "two"]}))
          (.shuffleGrouping "1"))
 
      (bind results
-           (complete-topology cluster
+           (testing/complete-topology cluster
                               (.createTopology builder)
-                              :storm-conf {TOPOLOGY-KRYO-DECORATORS ["one" "three"]}
-                              :mock-sources {"1" [[TOPOLOGY-KRYO-DECORATORS]]}))
+                              :storm-conf {c/TOPOLOGY-KRYO-DECORATORS ["one" "three"]}
+                              :mock-sources {"1" [[c/TOPOLOGY-KRYO-DECORATORS]]}))
      (is (= {"topology.kryo.decorators" (list "one" "two" "three")}
-            (->> (read-tuples results "2")
+            (->> (testing/read-tuples results "2")
                  (apply concat)
                  (apply hash-map)))))))
 
 (deftest test-component-specific-config
-  (with-simulated-time-local-cluster [cluster
-                                      :daemon-conf {TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS true}]
-    (letlocals
+  (testing/with-simulated-time-local-cluster [cluster
+                                      :daemon-conf {c/TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS true}]
+    (util/letlocals
      (bind builder (TopologyBuilder.))
      (.setSpout builder "1" (TestPlannerSpout. (Fields. ["conf"])))
      (-> builder
          (.setBolt "2"
                    (TestConfBolt.
                     {"fake.config" 123
-                     TOPOLOGY-MAX-TASK-PARALLELISM 20
-                     TOPOLOGY-MAX-SPOUT-PENDING 30
-                     TOPOLOGY-KRYO-REGISTER [{"fake.type" "bad.serializer"}
+                     c/TOPOLOGY-MAX-TASK-PARALLELISM 20
+                     c/TOPOLOGY-MAX-SPOUT-PENDING 30
+                     c/TOPOLOGY-KRYO-REGISTER [{"fake.type" "bad.serializer"}
                                              {"fake.type2" "a.serializer"}]
                      }))
          (.shuffleGrouping "1")
@@ -473,23 +475,23 @@
 
 
      (bind results
-           (complete-topology cluster
+           (testing/complete-topology cluster
                               (.createTopology builder)
-                              :storm-conf {TOPOLOGY-KRYO-REGISTER [{"fake.type" "good.serializer" "fake.type3" "a.serializer3"}]}
+                              :storm-conf {c/TOPOLOGY-KRYO-REGISTER [{"fake.type" "good.serializer" "fake.type3" "a.serializer3"}]}
                               :mock-sources {"1" [["fake.config"]
-                                                  [TOPOLOGY-MAX-TASK-PARALLELISM]
-                                                  [TOPOLOGY-MAX-SPOUT-PENDING]
+                                                  [c/TOPOLOGY-MAX-TASK-PARALLELISM]
+                                                  [c/TOPOLOGY-MAX-SPOUT-PENDING]
                                                   ["fake.config2"]
-                                                  [TOPOLOGY-KRYO-REGISTER]
+                                                  [c/TOPOLOGY-KRYO-REGISTER]
                                                   ]}))
      (is (= {"fake.config" 123
              "fake.config2" 987
-             TOPOLOGY-MAX-TASK-PARALLELISM 2
-             TOPOLOGY-MAX-SPOUT-PENDING 30
-             TOPOLOGY-KRYO-REGISTER {"fake.type" "good.serializer"
+             c/TOPOLOGY-MAX-TASK-PARALLELISM 2
+             c/TOPOLOGY-MAX-SPOUT-PENDING 30
+             c/TOPOLOGY-KRYO-REGISTER {"fake.type" "good.serializer"
                                      "fake.type2" "a.serializer"
                                      "fake.type3" "a.serializer3"}}
-            (->> (read-tuples results "2")
+            (->> (testing/read-tuples results "2")
                  (apply concat)
                  (apply hash-map))
             ))
@@ -525,13 +527,13 @@
         ))))
 
 (deftest test-hooks
-  (with-simulated-time-local-cluster [cluster]
+  (testing/with-simulated-time-local-cluster [cluster]
     (let [topology (topology {"1" (spout-spec (TestPlannerSpout. (Fields. ["conf"])))
                               }
                              {"2" (bolt-spec {"1" :shuffle}
                                              hooks-bolt)
                               })
-          results (complete-topology cluster
+          results (testing/complete-topology cluster
                                      topology
                                      :mock-sources {"1" [[1]
                                                          [1]
@@ -542,7 +544,7 @@
               [2 1 0 1]
               [4 1 1 2]
               [6 2 1 3]]
-             (read-tuples results "2")
+             (testing/read-tuples results "2")
              )))))
 
 (defbolt report-errors-bolt {}
@@ -552,49 +554,49 @@
   (ack! collector tuple))
 
 (deftest test-throttled-errors
-  (with-simulated-time
-    (with-tracked-cluster [cluster]
+  (testing/with-simulated-time
+    (testing/with-tracked-cluster [cluster]
       (let [state (:storm-cluster-state cluster)
             [feeder checker] (ack-tracking-feeder ["num"])
-            tracked (mk-tracked-topology
+            tracked (testing/mk-tracked-topology
                      cluster
                      (topology
                        {"1" (spout-spec feeder)}
                        {"2" (bolt-spec {"1" :shuffle} report-errors-bolt)}))
-            _       (submit-local-topology (:nimbus cluster)
+            _       (testing/submit-local-topology (:nimbus cluster)
                                              "test-errors"
-                                             {TOPOLOGY-ERROR-THROTTLE-INTERVAL-SECS 10
-                                              TOPOLOGY-MAX-ERROR-REPORT-PER-INTERVAL 4
-                                              TOPOLOGY-DEBUG true
+                                             {c/TOPOLOGY-ERROR-THROTTLE-INTERVAL-SECS 10
+                                              c/TOPOLOGY-MAX-ERROR-REPORT-PER-INTERVAL 4
+                                              c/TOPOLOGY-DEBUG true
                                               }
                                              (:topology tracked))
-            storm-id (get-storm-id state "test-errors")
+            storm-id (daemon/get-storm-id state "test-errors")
             errors-count (fn [] (count (.errors state storm-id "2")))]
 
         (is (nil? (.last-error state storm-id "2")))
 
         ;; so it launches the topology
-        (advance-cluster-time cluster 2)
+        (testing/advance-cluster-time cluster 2)
         (.feed feeder [6])
-        (tracked-wait tracked 1)
+        (testing/tracked-wait tracked 1)
         (is (= 4 (errors-count)))
         (is (.last-error state storm-id "2"))
 
-        (advance-time-secs! 5)
+        (testing/advance-time-secs! 5)
         (.feed feeder [2])
-        (tracked-wait tracked 1)
+        (testing/tracked-wait tracked 1)
         (is (= 4 (errors-count)))
         (is (.last-error state storm-id "2"))
 
-        (advance-time-secs! 6)
+        (testing/advance-time-secs! 6)
         (.feed feeder [2])
-        (tracked-wait tracked 1)
+        (testing/tracked-wait tracked 1)
         (is (= 6 (errors-count)))
         (is (.last-error state storm-id "2"))
 
-        (advance-time-secs! 6)
+        (testing/advance-time-secs! 6)
         (.feed feeder [3])
-        (tracked-wait tracked 1)
+        (testing/tracked-wait tracked 1)
         (is (= 8 (errors-count)))
         (is (.last-error state storm-id "2"))))))
 

--- a/storm-core/test/clj/backtype/storm/local_state_test.clj
+++ b/storm-core/test/clj/backtype/storm/local_state_test.clj
@@ -14,8 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.local-state-test
-  (:use [clojure test])
-  (:use [backtype.storm testing])
+  (:use [clojure test]
+        [backtype.storm testing])
   (:import [backtype.storm.utils LocalState]
            [backtype.storm.generated GlobalStreamId]
            [org.apache.commons.io FileUtils]

--- a/storm-core/test/clj/backtype/storm/local_state_test.clj
+++ b/storm-core/test/clj/backtype/storm/local_state_test.clj
@@ -14,15 +14,15 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.local-state-test
-  (:use [clojure test]
-        [backtype.storm testing])
+  (:require [backtype.storm.testing :as testing]
+            [clojure.test :refer :all])
   (:import [backtype.storm.utils LocalState]
            [backtype.storm.generated GlobalStreamId]
            [org.apache.commons.io FileUtils]
            [java.io File]))
 
 (deftest test-local-state
-  (with-local-tmp [dir1 dir2]
+  (testing/with-local-tmp [dir1 dir2]
     (let [gs-a (GlobalStreamId. "a" "a")
           gs-b (GlobalStreamId. "b" "b")
           gs-c (GlobalStreamId. "c" "c")
@@ -45,7 +45,7 @@
       (is (= gs-d (.get ls2 "b"))))))
 
 (deftest empty-state
-  (with-local-tmp [dir]
+  (testing/with-local-tmp [dir]
     (let [ls (LocalState. dir)
           gs-a (GlobalStreamId. "a" "a")
           data (FileUtils/openOutputStream (File. dir "12345"))

--- a/storm-core/test/clj/backtype/storm/logviewer_test.clj
+++ b/storm-core/test/clj/backtype/storm/logviewer_test.clj
@@ -14,12 +14,13 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.logviewer-test
-  (:use [backtype.storm config util])
-  (:require [backtype.storm.daemon [logviewer :as logviewer]
-                                   [supervisor :as supervisor]])
-  (:require [conjure.core])
-  (:use [clojure test])
-  (:use [conjure core])
+  (:use [backtype.storm config util]
+        [clojure.test]
+        [conjure.core])
+  (:require [backtype.storm.daemon
+             [logviewer :as logviewer]
+             [supervisor :as supervisor]]
+            [conjure.core])
   (:import [org.mockito Mockito]))
 
 (defmulti mk-mock-File #(:type %))

--- a/storm-core/test/clj/backtype/storm/messaging/netty_integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging/netty_integration_test.clj
@@ -14,20 +14,20 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.messaging.netty-integration-test
-  (:use [clojure test])
-  (:import [backtype.storm.messaging TransportFactory])
-  (:import [backtype.storm.testing TestWordSpout TestGlobalCount])
-  (:use [backtype.storm testing util config])
-  (:require [backtype.storm [thrift :as thrift]]))
+  (:use [backtype.storm testing util config]
+        [clojure test])
+  (:require [backtype.storm [thrift :as thrift]])
+  (:import [backtype.storm.messaging TransportFactory]
+           [backtype.storm.testing TestWordSpout TestGlobalCount]))
 
 (deftest test-integration
   (with-simulated-time-local-cluster [cluster :supervisors 4 :supervisor-slot-port-min 6710
-                                      :daemon-conf {STORM-LOCAL-MODE-ZMQ true 
+                                      :daemon-conf {STORM-LOCAL-MODE-ZMQ true
                                                     STORM-MESSAGING-TRANSPORT  "backtype.storm.messaging.netty.Context"
                                                     STORM-MESSAGING-NETTY-AUTHENTICATION false
                                                     STORM-MESSAGING-NETTY-BUFFER-SIZE 1024000
                                                     STORM-MESSAGING-NETTY-MAX-RETRIES 10
-                                                    STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000 
+                                                    STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
                                                     STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
                                                     STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
                                                     STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1}]

--- a/storm-core/test/clj/backtype/storm/messaging/netty_integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging/netty_integration_test.clj
@@ -14,32 +14,33 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.messaging.netty-integration-test
-  (:use [backtype.storm testing util config]
-        [clojure test])
-  (:require [backtype.storm [thrift :as thrift]])
+  (:require [backtype.storm [thrift :as thrift]]
+            [backtype.storm.testing :as t]
+            [backtype.storm.config :as c]
+            [clojure.test :refer :all])
   (:import [backtype.storm.messaging TransportFactory]
            [backtype.storm.testing TestWordSpout TestGlobalCount]))
 
 (deftest test-integration
-  (with-simulated-time-local-cluster [cluster :supervisors 4 :supervisor-slot-port-min 6710
-                                      :daemon-conf {STORM-LOCAL-MODE-ZMQ true
-                                                    STORM-MESSAGING-TRANSPORT  "backtype.storm.messaging.netty.Context"
-                                                    STORM-MESSAGING-NETTY-AUTHENTICATION false
-                                                    STORM-MESSAGING-NETTY-BUFFER-SIZE 1024000
-                                                    STORM-MESSAGING-NETTY-MAX-RETRIES 10
-                                                    STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
-                                                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
-                                                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
-                                                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1}]
+  (t/with-simulated-time-local-cluster [cluster :supervisors 4 :supervisor-slot-port-min 6710
+                                      :daemon-conf {c/STORM-LOCAL-MODE-ZMQ true
+                                                    c/STORM-MESSAGING-TRANSPORT  "backtype.storm.messaging.netty.Context"
+                                                    c/STORM-MESSAGING-NETTY-AUTHENTICATION false
+                                                    c/STORM-MESSAGING-NETTY-BUFFER-SIZE 1024000
+                                                    c/STORM-MESSAGING-NETTY-MAX-RETRIES 10
+                                                    c/STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
+                                                    c/STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                                                    c/STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                                                    c/STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1}]
     (let [topology (thrift/mk-topology
                      {"1" (thrift/mk-spout-spec (TestWordSpout. true) :parallelism-hint 4)}
                      {"2" (thrift/mk-bolt-spec {"1" :shuffle} (TestGlobalCount.)
                                                :parallelism-hint 6)})
-          results (complete-topology cluster
+          results (t/complete-topology cluster
                                      topology
                                      ;; important for test that
                                      ;; #tuples = multiple of 4 and 6
-                                     :storm-conf {TOPOLOGY-WORKERS 3}
+                                     :storm-conf {c/TOPOLOGY-WORKERS 3}
                                      :mock-sources {"1" [["a"] ["b"]
                                                          ["a"] ["b"]
                                                          ["a"] ["b"]
@@ -54,5 +55,5 @@
                                                          ["a"] ["b"]
                                                          ]}
                                      )]
-      (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
-               (read-tuples results "2"))))))
+      (is (t/ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
+               (t/read-tuples results "2"))))))

--- a/storm-core/test/clj/backtype/storm/messaging/netty_unit_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging/netty_unit_test.clj
@@ -14,11 +14,11 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.messaging.netty-unit-test
-  (:use [clojure test])
-  (:import [backtype.storm.messaging TransportFactory])
-  (:use [backtype.storm testing util config log])
-  (:use [backtype.storm.daemon.worker :only [is-connection-ready]])
-  (:import [java.util ArrayList]))
+  (:use [clojure test]
+        [backtype.storm testing util config log]
+        [backtype.storm.daemon.worker :only [is-connection-ready]])
+  (:import [java.util ArrayList]
+           [backtype.storm.messaging TransportFactory]))
 
 (def port 6700)
 (def task 1)

--- a/storm-core/test/clj/backtype/storm/messaging/netty_unit_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging/netty_unit_test.clj
@@ -14,9 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.messaging.netty-unit-test
-  (:use [clojure test]
-        [backtype.storm testing util config log]
-        [backtype.storm.daemon.worker :only [is-connection-ready]])
+  (:require [backtype.storm.daemon.worker :refer [is-connection-ready]]
+            [backtype.storm.log :refer [log-message]]
+            [backtype.storm.config :as c]
+            [clojure.test :refer :all])
   (:import [java.util ArrayList]
            [backtype.storm.messaging TransportFactory]))
 
@@ -46,14 +47,14 @@
 (deftest test-basic
   (log-message "Should send and receive a basic message")
   (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
-        storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
-                    STORM-MESSAGING-NETTY-AUTHENTICATION false
-                    STORM-MESSAGING-NETTY-BUFFER-SIZE 1024
-                    STORM-MESSAGING-NETTY-MAX-RETRIES 10
-                    STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
-                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
-                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
-                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+        storm-conf {c/STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+                    c/STORM-MESSAGING-NETTY-AUTHENTICATION false
+                    c/STORM-MESSAGING-NETTY-BUFFER-SIZE 1024
+                    c/STORM-MESSAGING-NETTY-MAX-RETRIES 10
+                    c/STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
+                    c/STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                    c/STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    c/STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
                     }
         context (TransportFactory/makeContext storm-conf)
         server (.bind context nil port)
@@ -71,14 +72,14 @@
 (deftest test-large-msg
   (log-message "Should send and receive a large message")
   (let [req_msg (apply str (repeat 2048000 'c'))
-        storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
-                    STORM-MESSAGING-NETTY-AUTHENTICATION false
-                    STORM-MESSAGING-NETTY-BUFFER-SIZE 102400
-                    STORM-MESSAGING-NETTY-MAX-RETRIES 10
-                    STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
-                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
-                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
-                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+        storm-conf {c/STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+                    c/STORM-MESSAGING-NETTY-AUTHENTICATION false
+                    c/STORM-MESSAGING-NETTY-BUFFER-SIZE 102400
+                    c/STORM-MESSAGING-NETTY-MAX-RETRIES 10
+                    c/STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
+                    c/STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                    c/STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    c/STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
                     }
         context (TransportFactory/makeContext storm-conf)
         server (.bind context nil port)
@@ -96,14 +97,14 @@
 
 (deftest test-batch
   (let [num-messages 100000
-        storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
-                    STORM-MESSAGING-NETTY-AUTHENTICATION false
-                    STORM-MESSAGING-NETTY-BUFFER-SIZE 1024000
-                    STORM-MESSAGING-NETTY-MAX-RETRIES 10
-                    STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
-                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
-                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
-                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+        storm-conf {c/STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+                    c/STORM-MESSAGING-NETTY-AUTHENTICATION false
+                    c/STORM-MESSAGING-NETTY-BUFFER-SIZE 1024000
+                    c/STORM-MESSAGING-NETTY-MAX-RETRIES 10
+                    c/STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
+                    c/STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                    c/STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    c/STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
                     }
         _ (log-message "Should send and receive many messages (testing with " num-messages " messages)")
         context (TransportFactory/makeContext storm-conf)

--- a/storm-core/test/clj/backtype/storm/messaging_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging_test.clj
@@ -14,26 +14,26 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.messaging-test
-  (:use [clojure test]
-        [backtype.storm testing config]
-        [backtype.storm.daemon common])
-  (:require [backtype.storm [thrift :as thrift]])
+  (:require [backtype.storm.thrift :as thrift]
+            [backtype.storm.config :as c]
+            [backtype.storm.testing :as testing]
+            [clojure.test :refer :all])
   (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount TestEventLogSpout TestEventOrderCheckBolt]))
 
 (deftest test-local-transport
   (doseq [transport-on? [false true]]
-    (with-simulated-time-local-cluster [cluster :supervisors 1 :ports-per-supervisor 2
-                                        :daemon-conf {TOPOLOGY-WORKERS 2
-                                                      STORM-LOCAL-MODE-ZMQ
+    (testing/with-simulated-time-local-cluster [cluster :supervisors 1 :ports-per-supervisor 2
+                                        :daemon-conf {c/TOPOLOGY-WORKERS 2
+                                                      c/STORM-LOCAL-MODE-ZMQ
                                                       (if transport-on? true false)
-                                                      STORM-MESSAGING-TRANSPORT
+                                                      c/STORM-MESSAGING-TRANSPORT
                                                       "backtype.storm.messaging.netty.Context"}]
       (let [topology (thrift/mk-topology
                        {"1" (thrift/mk-spout-spec (TestWordSpout. true) :parallelism-hint 2)}
                        {"2" (thrift/mk-bolt-spec {"1" :shuffle} (TestGlobalCount.)
                                                  :parallelism-hint 6)
                         })
-            results (complete-topology cluster
+            results (testing/complete-topology cluster
                                        topology
                                        ;; important for test that
                                        ;; #tuples = multiple of 4 and 6
@@ -51,11 +51,11 @@
                                                            ["a"] ["b"]
                                                            ]}
                                        )]
-        (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
-                 (read-tuples results "2")))))))
+        (is (testing/ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
+                 (testing/read-tuples results "2")))))))
 
 (extend-type TestEventLogSpout
-  CompletableSpout
+  testing/CompletableSpout
   (exhausted? [this]
     (-> this .completed))
   (cleanup [this]
@@ -65,12 +65,12 @@
 
 ;; Test Adding more receiver threads won't violate the message delivery order gurantee
 (deftest test-receiver-message-order
-  (with-simulated-time-local-cluster [cluster :supervisors 1 :ports-per-supervisor 2
-                                        :daemon-conf {TOPOLOGY-WORKERS 2
+  (testing/with-simulated-time-local-cluster [cluster :supervisors 1 :ports-per-supervisor 2
+                                        :daemon-conf {c/TOPOLOGY-WORKERS 2
                                                       ;; Configure multiple receiver threads per worker
-                                                      WORKER-RECEIVER-THREAD-COUNT 2
-                                                      STORM-LOCAL-MODE-ZMQ  true
-                                                      STORM-MESSAGING-TRANSPORT
+                                                      c/WORKER-RECEIVER-THREAD-COUNT 2
+                                                      c/STORM-LOCAL-MODE-ZMQ  true
+                                                      c/STORM-MESSAGING-TRANSPORT
                                                       "backtype.storm.messaging.netty.Context"}]
       (let [topology (thrift/mk-topology
 
@@ -82,8 +82,8 @@
                        {"2" (thrift/mk-bolt-spec {"1" ["source"]} (TestEventOrderCheckBolt.)
                                                  :parallelism-hint 4)
                         })
-            results (complete-topology cluster
+            results (testing/complete-topology cluster
                                        topology)]
 
         ;; No error Tuple from Bolt TestEventOrderCheckBolt
-        (is (empty? (read-tuples results "2"))))))
+        (is (empty? (testing/read-tuples results "2"))))))

--- a/storm-core/test/clj/backtype/storm/metrics_test.clj
+++ b/storm-core/test/clj/backtype/storm/metrics_test.clj
@@ -14,20 +14,17 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.metrics-test
-  (:use [clojure test]
+  (:use [clojure.test]
         [backtype.storm testing clojure config]
-        [backtype.storm.daemon common]
-        [backtype.storm.metric testing])
-  (:require [backtype.storm [thrift :as thrift]])
-  (:import [backtype.storm.topology TopologyBuilder]
-           [backtype.storm.generated InvalidTopologyException SubmitOptions TopologyInitialStatus]
-           [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount
-                                   TestAggregatesCounter TestConfBolt AckFailMapTracker PythonShellMetricsBolt PythonShellMetricsSpout]
-           [backtype.storm.task ShellBolt]
-           [backtype.storm.spout ShellSpout]
-           [backtype.storm.metric.api CountMetric IMetricsConsumer$DataPoint IMetricsConsumer$TaskInfo]
-           [backtype.storm.metric.api.rpc CountShellMetric]
-           [backtype.storm.utils Utils]))
+        [backtype.storm.daemon common])
+  (:require [backtype.storm.thrift :as thrift]
+            [backtype.storm.testing :as testing]
+            [backtype.storm.metric.testing :as metric-testing]
+            [backtype.storm.config :as c]
+            [backtype.storm.clojure :refer :all]
+            [clojure.test :refer :all])
+  (:import [backtype.storm.testing AckFailMapTracker PythonShellMetricsBolt PythonShellMetricsSpout]
+           [backtype.storm.metric.api CountMetric]))
 
 (defbolt acking-bolt {} {:prepare true}
   [conf context collector]
@@ -65,17 +62,17 @@
               (.incr mycustommetric)
               (ack! collector tuple)))))
 
-(def metrics-data backtype.storm.metric.testing/buffer)
+(def metrics-data metric-testing/buffer)
 
 (defn wait-for-atleast-N-buckets! [N comp-id metric-name cluster]
-  (while-timeout TEST-TIMEOUT-MS
+  (testing/while-timeout TEST-TIMEOUT-MS
       (let [taskid->buckets (-> @metrics-data (get comp-id) (get metric-name))]
         (or
          (and (not= N 0) (nil? taskid->buckets))
          (not-every? #(<= N %) (map (comp count second) taskid->buckets))))
       ;;(log-message "Waiting for at least " N " timebuckets to appear in FakeMetricsConsumer for component id " comp-id " and metric name " metric-name " metrics " (-> @metrics-data (get comp-id) (get metric-name)))
     (if cluster
-      (advance-cluster-time cluster 1)
+      (testing/advance-cluster-time cluster 1)
       (Thread/sleep 10))))
 
 
@@ -97,7 +94,7 @@
   `(is (not-empty (lookup-bucket-by-comp-id-&-metric-name! ~comp-id ~metric-name))))
 
 (deftest test-custom-metric
-  (with-simulated-time-local-cluster
+  (testing/with-simulated-time-local-cluster
     [cluster :daemon-conf {TOPOLOGY-METRICS-CONSUMER-REGISTER
                            [{"class" "clojure.storm.metric.testing.FakeMetricConsumer"}]
                            "storm.zookeeper.connection.timeout" 30000
@@ -107,49 +104,49 @@
           topology (thrift/mk-topology
                     {"1" (thrift/mk-spout-spec feeder)}
                     {"2" (thrift/mk-bolt-spec {"1" :global} count-acks)})]
-      (submit-local-topology (:nimbus cluster) "metrics-tester" {} topology)
+      (testing/submit-local-topology (:nimbus cluster) "metrics-tester" {} topology)
 
       (.feed feeder ["a"] 1)
-      (advance-cluster-time cluster 6)
+      (testing/advance-cluster-time cluster 6)
       (assert-buckets! "2" "my-custom-metric" [1] cluster)
 
-      (advance-cluster-time cluster 5)
+      (testing/advance-cluster-time cluster 5)
       (assert-buckets! "2" "my-custom-metric" [1 0] cluster)
 
-      (advance-cluster-time cluster 20)
+      (testing/advance-cluster-time cluster 20)
       (assert-buckets! "2" "my-custom-metric" [1 0 0 0 0 0] cluster)
 
       (.feed feeder ["b"] 2)
       (.feed feeder ["c"] 3)
-      (advance-cluster-time cluster 5)
+      (testing/advance-cluster-time cluster 5)
       (assert-buckets! "2" "my-custom-metric" [1 0 0 0 0 0 2] cluster))))
 
 (deftest test-custom-metric-with-multi-tasks
-  (with-simulated-time-local-cluster
-    [cluster :daemon-conf {TOPOLOGY-METRICS-CONSUMER-REGISTER
+  (testing/with-simulated-time-local-cluster
+    [cluster :daemon-conf {c/TOPOLOGY-METRICS-CONSUMER-REGISTER
                            [{"class" "clojure.storm.metric.testing.FakeMetricConsumer"}]
                            "storm.zookeeper.connection.timeout" 30000
                            "storm.zookeeper.session.timeout" 60000
                            }]
-    (let [feeder (feeder-spout ["field1"])
+    (let [feeder (testing/feeder-spout ["field1"])
           topology (thrift/mk-topology
                      {"1" (thrift/mk-spout-spec feeder)}
-                     {"2" (thrift/mk-bolt-spec {"1" :all} count-acks :p 1 :conf {TOPOLOGY-TASKS 2})})]
-      (submit-local-topology (:nimbus cluster) "metrics-tester-with-multitasks" {} topology)
+                     {"2" (thrift/mk-bolt-spec {"1" :all} count-acks :p 1 :conf {c/TOPOLOGY-TASKS 2})})]
+      (testing/submit-local-topology (:nimbus cluster) "metrics-tester-with-multitasks" {} topology)
 
       (.feed feeder ["a"] 1)
-      (advance-cluster-time cluster 6)
+      (testing/advance-cluster-time cluster 6)
       (assert-buckets! "2" "my-custom-metric" [1] cluster)
 
-      (advance-cluster-time cluster 5)
+      (testing/advance-cluster-time cluster 5)
       (assert-buckets! "2" "my-custom-metric" [1 0] cluster)
 
-      (advance-cluster-time cluster 20)
+      (testing/advance-cluster-time cluster 20)
       (assert-buckets! "2" "my-custom-metric" [1 0 0 0 0 0] cluster)
 
       (.feed feeder ["b"] 2)
       (.feed feeder ["c"] 3)
-      (advance-cluster-time cluster 5)
+      (testing/advance-cluster-time cluster 5)
       (assert-buckets! "2" "my-custom-metric" [1 0 0 0 0 0 2] cluster))))
 
 (defn mk-shell-bolt-with-metrics-spec
@@ -159,31 +156,31 @@
          (PythonShellMetricsBolt. command) kwargs)))
 
 (deftest test-custom-metric-with-multilang-py
-  (with-simulated-time-local-cluster
-    [cluster :daemon-conf {TOPOLOGY-METRICS-CONSUMER-REGISTER
+  (testing/with-simulated-time-local-cluster
+    [cluster :daemon-conf {c/TOPOLOGY-METRICS-CONSUMER-REGISTER
                        [{"class" "clojure.storm.metric.testing.FakeMetricConsumer"}]
                        "storm.zookeeper.connection.timeout" 30000
                        "storm.zookeeper.session.timeout" 60000
                        }]
-    (let [feeder (feeder-spout ["field1"])
+    (let [feeder (testing/feeder-spout ["field1"])
           topology (thrift/mk-topology
                      {"1" (thrift/mk-spout-spec feeder)}
                      {"2" (mk-shell-bolt-with-metrics-spec {"1" :global} ["python" "tester_bolt_metrics.py"])})]
-      (submit-local-topology (:nimbus cluster) "shell-metrics-tester" {} topology)
+      (testing/submit-local-topology (:nimbus cluster) "shell-metrics-tester" {} topology)
 
       (.feed feeder ["a"] 1)
-      (advance-cluster-time cluster 6)
+      (testing/advance-cluster-time cluster 6)
       (assert-buckets! "2" "my-custom-shell-metric" [1] cluster)
 
-      (advance-cluster-time cluster 5)
+      (testing/advance-cluster-time cluster 5)
       (assert-buckets! "2" "my-custom-shell-metric" [1 0] cluster)
 
-      (advance-cluster-time cluster 20)
+      (testing/advance-cluster-time cluster 20)
       (assert-buckets! "2" "my-custom-shell-metric" [1 0 0 0 0 0] cluster)
 
       (.feed feeder ["b"] 2)
       (.feed feeder ["c"] 3)
-      (advance-cluster-time cluster 5)
+      (testing/advance-cluster-time cluster 5)
       (assert-buckets! "2" "my-custom-shell-metric" [1 0 0 0 0 0 2] cluster)
       )))
 
@@ -193,42 +190,42 @@
     (apply thrift/mk-spout-spec (PythonShellMetricsSpout. command) kwargs)))
 
 (deftest test-custom-metric-with-spout-multilang-py
-  (with-simulated-time-local-cluster
-    [cluster :daemon-conf {TOPOLOGY-METRICS-CONSUMER-REGISTER
+  (testing/with-simulated-time-local-cluster
+    [cluster :daemon-conf {c/TOPOLOGY-METRICS-CONSUMER-REGISTER
                        [{"class" "clojure.storm.metric.testing.FakeMetricConsumer"}]
                        "storm.zookeeper.connection.timeout" 30000
                        "storm.zookeeper.session.timeout" 60000}]
     (let [topology (thrift/mk-topology
                      {"1" (mk-shell-spout-with-metrics-spec ["python" "tester_spout_metrics.py"])}
                      {"2" (thrift/mk-bolt-spec {"1" :all} count-acks)})]
-      (submit-local-topology (:nimbus cluster) "shell-spout-metrics-tester" {} topology)
+      (testing/submit-local-topology (:nimbus cluster) "shell-spout-metrics-tester" {} topology)
 
-      (advance-cluster-time cluster 7)
+      (testing/advance-cluster-time cluster 7)
       (assert-buckets! "1" "my-custom-shellspout-metric" [2] cluster)
       )))
 
 
 (deftest test-builtin-metrics-1
-  (with-simulated-time-local-cluster
-    [cluster :daemon-conf {TOPOLOGY-METRICS-CONSUMER-REGISTER
+  (testing/with-simulated-time-local-cluster
+    [cluster :daemon-conf {c/TOPOLOGY-METRICS-CONSUMER-REGISTER
                            [{"class" "clojure.storm.metric.testing.FakeMetricConsumer"}]
-                           TOPOLOGY-STATS-SAMPLE-RATE 1.0
-                           TOPOLOGY-BUILTIN-METRICS-BUCKET-SIZE-SECS 60}]
-    (let [feeder (feeder-spout ["field1"])
+                           c/TOPOLOGY-STATS-SAMPLE-RATE 1.0
+                           c/TOPOLOGY-BUILTIN-METRICS-BUCKET-SIZE-SECS 60}]
+    (let [feeder (testing/feeder-spout ["field1"])
           topology (thrift/mk-topology
                     {"myspout" (thrift/mk-spout-spec feeder)}
                     {"mybolt" (thrift/mk-bolt-spec {"myspout" :shuffle} acking-bolt)})]
-      (submit-local-topology (:nimbus cluster) "metrics-tester" {} topology)
+      (testing/submit-local-topology (:nimbus cluster) "metrics-tester" {} topology)
 
       (.feed feeder ["a"] 1)
-      (advance-cluster-time cluster 61)
+      (testing/advance-cluster-time cluster 61)
       (assert-buckets! "myspout" "__ack-count/default" [1] cluster)
       (assert-buckets! "myspout" "__emit-count/default" [1] cluster)
       (assert-buckets! "myspout" "__transfer-count/default" [1] cluster)
       (assert-buckets! "mybolt" "__ack-count/myspout:default" [1] cluster)
       (assert-buckets! "mybolt" "__execute-count/myspout:default" [1] cluster)
 
-      (advance-cluster-time cluster 120)
+      (testing/advance-cluster-time cluster 120)
       (assert-buckets! "myspout" "__ack-count/default" [1 0 0] cluster)
       (assert-buckets! "myspout" "__emit-count/default" [1 0 0] cluster)
       (assert-buckets! "myspout" "__transfer-count/default" [1 0 0] cluster)
@@ -237,7 +234,7 @@
 
       (.feed feeder ["b"] 1)
       (.feed feeder ["c"] 1)
-      (advance-cluster-time cluster 60)
+      (testing/advance-cluster-time cluster 60)
       (assert-buckets! "myspout" "__ack-count/default" [1 0 0 2] cluster)
       (assert-buckets! "myspout" "__emit-count/default" [1 0 0 2] cluster)
       (assert-buckets! "myspout" "__transfer-count/default" [1 0 0 2] cluster)
@@ -246,24 +243,24 @@
 
 
 (deftest test-builtin-metrics-2
-  (with-simulated-time-local-cluster
-    [cluster :daemon-conf {TOPOLOGY-METRICS-CONSUMER-REGISTER
+  (testing/with-simulated-time-local-cluster
+    [cluster :daemon-conf {c/TOPOLOGY-METRICS-CONSUMER-REGISTER
                            [{"class" "clojure.storm.metric.testing.FakeMetricConsumer"}]
-                           TOPOLOGY-STATS-SAMPLE-RATE 1.0
-                           TOPOLOGY-BUILTIN-METRICS-BUCKET-SIZE-SECS 5}]
-    (let [feeder (feeder-spout ["field1"])
+                           c/TOPOLOGY-STATS-SAMPLE-RATE 1.0
+                           c/TOPOLOGY-BUILTIN-METRICS-BUCKET-SIZE-SECS 5}]
+    (let [feeder (testing/feeder-spout ["field1"])
           tracker (AckFailMapTracker.)
           _ (.setAckFailDelegate feeder tracker)
           topology (thrift/mk-topology
                     {"myspout" (thrift/mk-spout-spec feeder)}
                     {"mybolt" (thrift/mk-bolt-spec {"myspout" :shuffle} ack-every-other)})]
-      (submit-local-topology (:nimbus cluster)
+      (testing/submit-local-topology (:nimbus cluster)
                              "metrics-tester"
                              {}
                              topology)
 
       (.feed feeder ["a"] 1)
-      (advance-cluster-time cluster 6)
+      (testing/advance-cluster-time cluster 6)
       (assert-acked tracker 1)
       (assert-buckets! "myspout" "__fail-count/default" [] cluster)
       (assert-buckets! "myspout" "__ack-count/default" [1] cluster)
@@ -273,7 +270,7 @@
       (assert-buckets! "mybolt" "__execute-count/myspout:default" [1] cluster)
 
       (.feed feeder ["b"] 2)
-      (advance-cluster-time cluster 5)
+      (testing/advance-cluster-time cluster 5)
       (assert-buckets! "myspout" "__fail-count/default" [] cluster)
       (assert-buckets! "myspout" "__ack-count/default" [1 0] cluster)
       (assert-buckets! "myspout" "__emit-count/default" [1 1] cluster)
@@ -281,7 +278,7 @@
       (assert-buckets! "mybolt" "__ack-count/myspout:default" [1 0] cluster)
       (assert-buckets! "mybolt" "__execute-count/myspout:default" [1 1] cluster)
 
-      (advance-cluster-time cluster 15)
+      (testing/advance-cluster-time cluster 15)
       (assert-buckets! "myspout" "__ack-count/default" [1 0 0 0 0] cluster)
       (assert-buckets! "myspout" "__emit-count/default" [1 1 0 0 0] cluster)
       (assert-buckets! "myspout" "__transfer-count/default" [1 1 0 0 0] cluster)
@@ -289,7 +286,7 @@
       (assert-buckets! "mybolt" "__execute-count/myspout:default" [1 1 0 0 0] cluster)
 
       (.feed feeder ["c"] 3)
-      (advance-cluster-time cluster 15)
+      (testing/advance-cluster-time cluster 15)
       (assert-buckets! "myspout" "__ack-count/default" [1 0 0 0 0 1 0 0] cluster)
       (assert-buckets! "myspout" "__emit-count/default" [1 1 0 0 0 1 0 0] cluster)
       (assert-buckets! "myspout" "__transfer-count/default" [1 1 0 0 0 1 0 0] cluster)
@@ -297,26 +294,26 @@
       (assert-buckets! "mybolt" "__execute-count/myspout:default" [1 1 0 0 0 1 0 0] cluster))))
 
 (deftest test-builtin-metrics-3
-  (with-simulated-time-local-cluster
-    [cluster :daemon-conf {TOPOLOGY-METRICS-CONSUMER-REGISTER
+  (testing/with-simulated-time-local-cluster
+    [cluster :daemon-conf {c/TOPOLOGY-METRICS-CONSUMER-REGISTER
                            [{"class" "clojure.storm.metric.testing.FakeMetricConsumer"}]
-                           TOPOLOGY-STATS-SAMPLE-RATE 1.0
-                           TOPOLOGY-BUILTIN-METRICS-BUCKET-SIZE-SECS 5
-                           TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true}]
-    (let [feeder (feeder-spout ["field1"])
+                           c/TOPOLOGY-STATS-SAMPLE-RATE 1.0
+                           c/TOPOLOGY-BUILTIN-METRICS-BUCKET-SIZE-SECS 5
+                           c/TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true}]
+    (let [feeder (testing/feeder-spout ["field1"])
           tracker (AckFailMapTracker.)
           _ (.setAckFailDelegate feeder tracker)
           topology (thrift/mk-topology
                     {"myspout" (thrift/mk-spout-spec feeder)}
                     {"mybolt" (thrift/mk-bolt-spec {"myspout" :global} ack-every-other)})]
-      (submit-local-topology (:nimbus cluster)
+      (testing/submit-local-topology (:nimbus cluster)
                              "timeout-tester"
-                             {TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
+                             {c/TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
                              topology)
       (.feed feeder ["a"] 1)
       (.feed feeder ["b"] 2)
       (.feed feeder ["c"] 3)
-      (advance-cluster-time cluster 9)
+      (testing/advance-cluster-time cluster 9)
       (assert-acked tracker 1 3)
       (assert-buckets! "myspout" "__ack-count/default" [2] cluster)
       (assert-buckets! "myspout" "__emit-count/default" [3] cluster)
@@ -325,7 +322,7 @@
       (assert-buckets! "mybolt" "__execute-count/myspout:default" [3] cluster)
 
       (is (not (.isFailed tracker 2)))
-      (advance-cluster-time cluster 30)
+      (testing/advance-cluster-time cluster 30)
       (assert-failed tracker 2)
       (assert-buckets! "myspout" "__fail-count/default" [1] cluster)
       (assert-buckets! "myspout" "__ack-count/default" [2 0 0 0] cluster)
@@ -335,23 +332,23 @@
       (assert-buckets! "mybolt" "__execute-count/myspout:default" [3 0 0 0] cluster))))
 
 (deftest test-system-bolt
-  (with-simulated-time-local-cluster
-    [cluster :daemon-conf {TOPOLOGY-METRICS-CONSUMER-REGISTER
+  (testing/with-simulated-time-local-cluster
+    [cluster :daemon-conf {c/TOPOLOGY-METRICS-CONSUMER-REGISTER
                            [{"class" "clojure.storm.metric.testing.FakeMetricConsumer"}]
-                           TOPOLOGY-BUILTIN-METRICS-BUCKET-SIZE-SECS 60}]
-    (let [feeder (feeder-spout ["field1"])
+                           c/TOPOLOGY-BUILTIN-METRICS-BUCKET-SIZE-SECS 60}]
+    (let [feeder (testing/feeder-spout ["field1"])
           topology (thrift/mk-topology
                     {"1" (thrift/mk-spout-spec feeder)}
                     {})]
-      (submit-local-topology (:nimbus cluster) "metrics-tester" {} topology)
+      (testing/submit-local-topology (:nimbus cluster) "metrics-tester" {} topology)
 
       (.feed feeder ["a"] 1)
-      (advance-cluster-time cluster 70)
+      (testing/advance-cluster-time cluster 70)
       (assert-buckets! "__system" "newWorkerEvent" [1] cluster)
       (assert-metric-data-exists! "__system" "uptimeSecs")
       (assert-metric-data-exists! "__system" "startTimeSecs")
 
-      (advance-cluster-time cluster 180)
+      (testing/advance-cluster-time cluster 180)
       (assert-buckets! "__system" "newWorkerEvent" [1 0 0 0] cluster)
       )))
 

--- a/storm-core/test/clj/backtype/storm/multilang_test.clj
+++ b/storm-core/test/clj/backtype/storm/multilang_test.clj
@@ -14,9 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.multilang-test
-  (:use [clojure test])
-  (:use [backtype.storm testing config])
-  (:use [backtype.storm.daemon common])
+  (:use [clojure test]
+        [backtype.storm testing config]
+        [backtype.storm.daemon common])
   (:require [backtype.storm [thrift :as thrift]]))
 
 ;; (deftest test-multilang-fy

--- a/storm-core/test/clj/backtype/storm/multilang_test.clj
+++ b/storm-core/test/clj/backtype/storm/multilang_test.clj
@@ -14,10 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.multilang-test
-  (:use [clojure test]
-        [backtype.storm testing config]
-        [backtype.storm.daemon common])
-  (:require [backtype.storm [thrift :as thrift]]))
+  (:require [backtype.storm.thrift :as thrift]
+            [backtype.storm.testing :as testing]
+            [backtype.storm.config :as c]
+            [clojure.test :refer :all]))
 
 ;; (deftest test-multilang-fy
 ;;   (with-local-cluster [cluster :supervisors 4]
@@ -38,14 +38,14 @@
 
  (defn test-multilang
        [executor file-extension]
-       (with-local-cluster [cluster :supervisors 4]
+       (testing/with-local-cluster [cluster :supervisors 4]
          (let [nimbus (:nimbus cluster)
                topology (thrift/mk-topology
                   {"1" (thrift/mk-shell-spout-spec [executor (str "tester_spout." file-extension)] ["word"])}
                   {"2" (thrift/mk-shell-bolt-spec {"1" :shuffle} [executor (str "tester_bolt." file-extension)] ["word"] :parallelism-hint 1)})]
-         (submit-local-topology nimbus
+         (testing/submit-local-topology nimbus
                "test"
-               {TOPOLOGY-WORKERS 20 TOPOLOGY-MESSAGE-TIMEOUT-SECS 3 TOPOLOGY-DEBUG true}
+               {c/TOPOLOGY-WORKERS 20 c/TOPOLOGY-MESSAGE-TIMEOUT-SECS 3 c/TOPOLOGY-DEBUG true}
                topology)
        (Thread/sleep 10000)
        (.killTopology nimbus "test")

--- a/storm-core/test/clj/backtype/storm/scheduler/multitenant_scheduler_test.clj
+++ b/storm-core/test/clj/backtype/storm/scheduler/multitenant_scheduler_test.clj
@@ -14,14 +14,14 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.scheduler.multitenant-scheduler-test
-  (:use [clojure test])
-  (:use [backtype.storm config testing log])
+  (:use [clojure test]
+        [backtype.storm config testing log])
   (:require [backtype.storm.daemon [nimbus :as nimbus]])
-  (:import [backtype.storm.generated StormTopology])
-  (:import [backtype.storm.scheduler Cluster SupervisorDetails WorkerSlot ExecutorDetails
-            SchedulerAssignmentImpl Topologies TopologyDetails])
-  (:import [backtype.storm.scheduler.multitenant Node NodePool FreePool DefaultPool
-            IsolatedPool MultitenantScheduler]))
+  (:import [backtype.storm.generated StormTopology]
+           [backtype.storm.scheduler Cluster SupervisorDetails WorkerSlot ExecutorDetails
+                                     SchedulerAssignmentImpl Topologies TopologyDetails]
+           [backtype.storm.scheduler.multitenant Node NodePool FreePool DefaultPool
+                                                 IsolatedPool MultitenantScheduler]))
 
 (defn gen-supervisors [count]
   (into {} (for [id (range count)
@@ -132,7 +132,7 @@
        executor1 (ed 1)
        executor2 (ed 2)
        executor3 (ed 3)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    2
@@ -169,7 +169,7 @@
        executor1 (ed 1)
        executor2 (ed 2)
        executor3 (ed 3)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    5
@@ -208,7 +208,7 @@
        executor3 (ed 3)
        executor4 (ed 4)
        executor5 (ed 5)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    5
@@ -247,7 +247,7 @@
        executor3 (ed 3)
        executor4 (ed 4)
        executor5 (ed 5)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    5
@@ -296,7 +296,7 @@
        executor12 (ed 12)
        executor13 (ed 13)
        executor14 (ed 14)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    2
@@ -375,7 +375,7 @@
        executor2 (ed 2)
        executor3 (ed 3)
        executor4 (ed 4)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"
                     TOPOLOGY-ISOLATED-MACHINES 4}
                    (StormTopology.)
@@ -419,7 +419,7 @@
        executor2 (ed 2)
        executor3 (ed 3)
        executor4 (ed 4)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"
                     TOPOLOGY-ISOLATED-MACHINES 4}
                    (StormTopology.)
@@ -467,7 +467,7 @@
        executor12 (ed 12)
        executor13 (ed 13)
        executor14 (ed 14)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    4
@@ -572,7 +572,7 @@
        executor12 (ed 12)
        executor13 (ed 13)
        executor14 (ed 14)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    4
@@ -628,7 +628,7 @@
 
 (deftest test-multitenant-scheduler
   (let [supers (gen-supervisors 10)
-       topology1 (TopologyDetails. "topology1" 
+       topology1 (TopologyDetails. "topology1"
                    {TOPOLOGY-NAME "topology-name-1"
                     TOPOLOGY-SUBMITTER-USER "userC"}
                    (StormTopology.)

--- a/storm-core/test/clj/backtype/storm/scheduler/multitenant_scheduler_test.clj
+++ b/storm-core/test/clj/backtype/storm/scheduler/multitenant_scheduler_test.clj
@@ -14,9 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.scheduler.multitenant-scheduler-test
-  (:use [clojure test]
-        [backtype.storm config testing log])
-  (:require [backtype.storm.daemon [nimbus :as nimbus]])
+  (:require [backtype.storm.daemon.nimbus :as nimbus]
+            [backtype.storm.log :refer [log-message]]
+            [backtype.storm.config :as c]
+            [clojure.test :refer :all])
   (:import [backtype.storm.generated StormTopology]
            [backtype.storm.scheduler Cluster SupervisorDetails WorkerSlot ExecutorDetails
                                      SchedulerAssignmentImpl Topologies TopologyDetails]
@@ -133,7 +134,7 @@
        executor2 (ed 2)
        executor3 (ed 3)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"}
+                   {c/TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    2
                    {executor1 "spout1"
@@ -170,7 +171,7 @@
        executor2 (ed 2)
        executor3 (ed 3)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"}
+                   {c/TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    5
                    {executor1 "spout1"
@@ -209,7 +210,7 @@
        executor4 (ed 4)
        executor5 (ed 5)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"}
+                   {c/TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    5
                    {executor1 "spout1"
@@ -248,7 +249,7 @@
        executor4 (ed 4)
        executor5 (ed 5)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"}
+                   {c/TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    5
                    {executor1 "spout1"
@@ -297,14 +298,14 @@
        executor13 (ed 13)
        executor14 (ed 14)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"}
+                   {c/TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    2
                    {executor1 "spout1"
                     executor2 "bolt1"
                     executor3 "bolt2"})
        topology2 (TopologyDetails. "topology2"
-                    {TOPOLOGY-NAME "topology-name-2"}
+                    {c/TOPOLOGY-NAME "topology-name-2"}
                     (StormTopology.)
                     4
                     {executor11 "spout11"
@@ -376,8 +377,8 @@
        executor3 (ed 3)
        executor4 (ed 4)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"
-                    TOPOLOGY-ISOLATED-MACHINES 4}
+                   {c/TOPOLOGY-NAME "topology-name-1"
+                    c/TOPOLOGY-ISOLATED-MACHINES 4}
                    (StormTopology.)
                    4
                    {executor1 "spout1"
@@ -420,8 +421,8 @@
        executor3 (ed 3)
        executor4 (ed 4)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"
-                    TOPOLOGY-ISOLATED-MACHINES 4}
+                   {c/TOPOLOGY-NAME "topology-name-1"
+                    c/TOPOLOGY-ISOLATED-MACHINES 4}
                    (StormTopology.)
                    10
                    {executor1 "spout1"
@@ -468,7 +469,7 @@
        executor13 (ed 13)
        executor14 (ed 14)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"}
+                   {c/TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    4
                    {executor1 "spout1"
@@ -476,8 +477,8 @@
                     executor3 "bolt2"
                     executor4 "bolt4"})
        topology2 (TopologyDetails. "topology2"
-                    {TOPOLOGY-NAME "topology-name-2"
-                     TOPOLOGY-ISOLATED-MACHINES 2}
+                    {c/TOPOLOGY-NAME "topology-name-2"
+                     c/TOPOLOGY-ISOLATED-MACHINES 2}
                     (StormTopology.)
                     4
                     {executor11 "spout11"
@@ -573,7 +574,7 @@
        executor13 (ed 13)
        executor14 (ed 14)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"}
+                   {c/TOPOLOGY-NAME "topology-name-1"}
                    (StormTopology.)
                    4
                    {executor1 "spout1"
@@ -581,8 +582,8 @@
                     executor3 "bolt2"
                     executor4 "bolt4"})
        topology2 (TopologyDetails. "topology2"
-                    {TOPOLOGY-NAME "topology-name-2"
-                     TOPOLOGY-ISOLATED-MACHINES 2}
+                    {c/TOPOLOGY-NAME "topology-name-2"
+                     c/TOPOLOGY-ISOLATED-MACHINES 2}
                     (StormTopology.)
                     4
                     {executor11 "spout11"
@@ -629,8 +630,8 @@
 (deftest test-multitenant-scheduler
   (let [supers (gen-supervisors 10)
        topology1 (TopologyDetails. "topology1"
-                   {TOPOLOGY-NAME "topology-name-1"
-                    TOPOLOGY-SUBMITTER-USER "userC"}
+                   {c/TOPOLOGY-NAME "topology-name-1"
+                    c/TOPOLOGY-SUBMITTER-USER "userC"}
                    (StormTopology.)
                    4
                    (mk-ed-map [["spout1" 0 5]
@@ -638,9 +639,9 @@
                                ["bolt2" 10 15]
                                ["bolt3" 15 20]]))
        topology2 (TopologyDetails. "topology2"
-                    {TOPOLOGY-NAME "topology-name-2"
-                     TOPOLOGY-ISOLATED-MACHINES 2
-                     TOPOLOGY-SUBMITTER-USER "userA"}
+                    {c/TOPOLOGY-NAME "topology-name-2"
+                     c/TOPOLOGY-ISOLATED-MACHINES 2
+                     c/TOPOLOGY-SUBMITTER-USER "userA"}
                     (StormTopology.)
                     4
                     (mk-ed-map [["spout11" 0 5]
@@ -648,9 +649,9 @@
                                 ["bolt13" 6 7]
                                 ["bolt14" 7 10]]))
        topology3 (TopologyDetails. "topology3"
-                    {TOPOLOGY-NAME "topology-name-3"
-                     TOPOLOGY-ISOLATED-MACHINES 5
-                     TOPOLOGY-SUBMITTER-USER "userB"}
+                    {c/TOPOLOGY-NAME "topology-name-3"
+                     c/TOPOLOGY-ISOLATED-MACHINES 5
+                     c/TOPOLOGY-SUBMITTER-USER "userB"}
                     (StormTopology.)
                     10
                     (mk-ed-map [["spout21" 0 10]
@@ -660,7 +661,7 @@
        cluster (Cluster. (nimbus/standalone-nimbus) supers {})
        node-map (Node/getAllNodesFrom cluster)
        topologies (Topologies. (to-top-map [topology1 topology2 topology3]))
-       conf {MULTITENANT-SCHEDULER-USER-POOLS {"userA" 5 "userB" 5}}
+       conf {c/MULTITENANT-SCHEDULER-USER-POOLS {"userA" 5 "userB" 5}}
        scheduler (MultitenantScheduler.)]
     (.assign (.get node-map "super0") "topology1" (list (ed 1)) cluster)
     (.assign (.get node-map "super1") "topology2" (list (ed 5)) cluster)
@@ -682,8 +683,8 @@
 (deftest test-force-free-slot-in-bad-state
   (let [supers (gen-supervisors 1)
         topology1 (TopologyDetails. "topology1"
-                                    {TOPOLOGY-NAME "topology-name-1"
-                                     TOPOLOGY-SUBMITTER-USER "userC"}
+                                    {c/TOPOLOGY-NAME "topology-name-1"
+                                     c/TOPOLOGY-SUBMITTER-USER "userC"}
                                     (StormTopology.)
                                     4
                                     (mk-ed-map [["spout1" 0 5]
@@ -699,7 +700,7 @@
         cluster (Cluster. (nimbus/standalone-nimbus) supers existing-assignments)
         node-map (Node/getAllNodesFrom cluster)
         topologies (Topologies. (to-top-map [topology1]))
-        conf {MULTITENANT-SCHEDULER-USER-POOLS {"userA" 5 "userB" 5}}
+        conf {c/MULTITENANT-SCHEDULER-USER-POOLS {"userA" 5 "userB" 5}}
         scheduler (MultitenantScheduler.)]
     (.assign (.get node-map "super0") "topology1" (list (ed 1)) cluster)
     (.prepare scheduler conf)
@@ -719,22 +720,22 @@
   (testing "Assiging same worker slot to different topologies is bad state"
     (let [supers (gen-supervisors 5)
           topology1 (TopologyDetails. "topology1"
-                      {TOPOLOGY-NAME "topology-name-1"
-                       TOPOLOGY-SUBMITTER-USER "userC"}
+                      {c/TOPOLOGY-NAME "topology-name-1"
+                       c/TOPOLOGY-SUBMITTER-USER "userC"}
                       (StormTopology.)
                       1
                       (mk-ed-map [["spout1" 0 1]]))
           topology2 (TopologyDetails. "topology2"
-                      {TOPOLOGY-NAME "topology-name-2"
-                       TOPOLOGY-ISOLATED-MACHINES 2
-                       TOPOLOGY-SUBMITTER-USER "userA"}
+                      {c/TOPOLOGY-NAME "topology-name-2"
+                       c/TOPOLOGY-ISOLATED-MACHINES 2
+                       c/TOPOLOGY-SUBMITTER-USER "userA"}
                       (StormTopology.)
                       1
                       (mk-ed-map [["spout11" 1 2]]))
           topology3 (TopologyDetails. "topology3"
-                      {TOPOLOGY-NAME "topology-name-3"
-                       TOPOLOGY-ISOLATED-MACHINES 1
-                       TOPOLOGY-SUBMITTER-USER "userB"}
+                      {c/TOPOLOGY-NAME "topology-name-3"
+                       c/TOPOLOGY-ISOLATED-MACHINES 1
+                       c/TOPOLOGY-SUBMITTER-USER "userB"}
                       (StormTopology.)
                       1
                       (mk-ed-map [["spout21" 2 3]]))
@@ -743,7 +744,7 @@
                                 "topology3" (SchedulerAssignmentImpl. "topology3" {(ExecutorDetails. 2 2) worker-slot-with-multiple-assignments})}
           cluster (Cluster. (nimbus/standalone-nimbus) supers existing-assignments)
           topologies (Topologies. (to-top-map [topology1 topology2 topology3]))
-          conf {MULTITENANT-SCHEDULER-USER-POOLS {"userA" 2 "userB" 1}}
+          conf {c/MULTITENANT-SCHEDULER-USER-POOLS {"userA" 2 "userB" 1}}
           scheduler (MultitenantScheduler.)]
       (.prepare scheduler conf)
       (.schedule scheduler topologies cluster)
@@ -761,8 +762,8 @@
     (let [supers (gen-supervisors 1)
           port-not-reported-by-supervisor 6
           topology1 (TopologyDetails. "topology1"
-                      {TOPOLOGY-NAME "topology-name-1"
-                       TOPOLOGY-SUBMITTER-USER "userA"}
+                      {c/TOPOLOGY-NAME "topology-name-1"
+                       c/TOPOLOGY-SUBMITTER-USER "userA"}
                       (StormTopology.)
                       1
                       (mk-ed-map [["spout11" 0 1]]))
@@ -787,15 +788,15 @@
           dead-supervisor "super1"
           port-not-reported-by-supervisor 6
           topology1 (TopologyDetails. "topology1"
-                      {TOPOLOGY-NAME "topology-name-1"
-                       TOPOLOGY-SUBMITTER-USER "userA"}
+                      {c/TOPOLOGY-NAME "topology-name-1"
+                       c/TOPOLOGY-SUBMITTER-USER "userA"}
                       (StormTopology.)
                       2
                       (mk-ed-map [["spout11" 0 1]
                                   ["bolt12" 1 2]]))
           topology2 (TopologyDetails. "topology2"
-                      {TOPOLOGY-NAME "topology-name-2"
-                       TOPOLOGY-SUBMITTER-USER "userA"}
+                      {c/TOPOLOGY-NAME "topology-name-2"
+                       c/TOPOLOGY-SUBMITTER-USER "userA"}
                       (StormTopology.)
                       2
                       (mk-ed-map [["spout21" 4 5]

--- a/storm-core/test/clj/backtype/storm/scheduler_test.clj
+++ b/storm-core/test/clj/backtype/storm/scheduler_test.clj
@@ -14,13 +14,13 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.scheduler-test
-  (:use [clojure test])
-  (:use [backtype.storm config testing])
-  (:use [backtype.storm.scheduler EvenScheduler])
+  (:use [clojure test]
+        [backtype.storm config testing]
+        [backtype.storm.scheduler EvenScheduler])
   (:require [backtype.storm.daemon [nimbus :as nimbus]])
-  (:import [backtype.storm.generated StormTopology])
-  (:import [backtype.storm.scheduler Cluster SupervisorDetails WorkerSlot ExecutorDetails
-            SchedulerAssignmentImpl Topologies TopologyDetails]))
+  (:import [backtype.storm.generated StormTopology]
+           [backtype.storm.scheduler Cluster SupervisorDetails WorkerSlot ExecutorDetails
+                                     SchedulerAssignmentImpl Topologies TopologyDetails]))
 
 (defn clojurify-executor->slot [executorToSlot]
   (into {} (for [[executor slot] executorToSlot]
@@ -180,7 +180,7 @@
     (is (= #{1 3 5} (set (.getUsedPorts cluster supervisor1))))
     (is (= #{2 4} (set (.getUsedPorts cluster supervisor2))))
     (is (= #{1 3 5} (set (.getUsedPorts cluster supervisor1))))
-    
+
     ;; test Cluster.getAvailablePorts
     (is (= #{7 9} (set (.getAvailablePorts cluster supervisor1))))
     (is (= #{6 8 10} (set (.getAvailablePorts cluster supervisor2))))

--- a/storm-core/test/clj/backtype/storm/scheduler_test.clj
+++ b/storm-core/test/clj/backtype/storm/scheduler_test.clj
@@ -14,10 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.scheduler-test
-  (:use [clojure test]
-        [backtype.storm config testing]
+  (:use [backtype.storm config testing]
         [backtype.storm.scheduler EvenScheduler])
-  (:require [backtype.storm.daemon [nimbus :as nimbus]])
+  (:require [backtype.storm.daemon [nimbus :as nimbus]]
+            [clojure.test :refer :all])
   (:import [backtype.storm.generated StormTopology]
            [backtype.storm.scheduler Cluster SupervisorDetails WorkerSlot ExecutorDetails
                                      SchedulerAssignmentImpl Topologies TopologyDetails]))

--- a/storm-core/test/clj/backtype/storm/security/auth/AuthUtils_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/AuthUtils_test.clj
@@ -14,7 +14,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.AuthUtils-test
-  (:use [clojure test])
+  (:require [clojure.test :refer :all])
   (:import [backtype.storm.security.auth AuthUtils IAutoCredentials]
            [java.io IOException]
            [javax.security.auth.login AppConfigurationEntry Configuration]

--- a/storm-core/test/clj/backtype/storm/security/auth/AuthUtils_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/AuthUtils_test.clj
@@ -14,11 +14,11 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.AuthUtils-test
-  (:import [backtype.storm.security.auth AuthUtils IAutoCredentials])
-  (:import [java.io IOException])
-  (:import [javax.security.auth.login AppConfigurationEntry Configuration])
-  (:import [org.mockito Mockito])
-  (:use [clojure test]))
+  (:use [clojure test])
+  (:import [backtype.storm.security.auth AuthUtils IAutoCredentials]
+           [java.io IOException]
+           [javax.security.auth.login AppConfigurationEntry Configuration]
+           [org.mockito Mockito]))
 
 (deftest test-throws-on-missing-section
   (is (thrown? IOException

--- a/storm-core/test/clj/backtype/storm/security/auth/DefaultHttpCredentialsPlugin_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/DefaultHttpCredentialsPlugin_test.clj
@@ -1,12 +1,11 @@
 (ns backtype.storm.security.auth.DefaultHttpCredentialsPlugin-test
   (:use [clojure test])
-  (:import [javax.security.auth Subject])
-  (:import [javax.servlet.http HttpServletRequest])
-  (:import [backtype.storm.security.auth SingleUserPrincipal])
-  (:import [org.mockito Mockito])
-  (:import [backtype.storm.security.auth DefaultHttpCredentialsPlugin
-            ReqContext SingleUserPrincipal])
-  )
+  (:import [javax.security.auth Subject]
+           [javax.servlet.http HttpServletRequest]
+           [backtype.storm.security.auth SingleUserPrincipal]
+           [org.mockito Mockito]
+           [backtype.storm.security.auth DefaultHttpCredentialsPlugin
+                                         ReqContext SingleUserPrincipal]))
 
 (deftest test-getUserName
   (let [handler (doto (DefaultHttpCredentialsPlugin.) (.prepare {}))]

--- a/storm-core/test/clj/backtype/storm/security/auth/DefaultHttpCredentialsPlugin_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/DefaultHttpCredentialsPlugin_test.clj
@@ -1,5 +1,5 @@
 (ns backtype.storm.security.auth.DefaultHttpCredentialsPlugin-test
-  (:use [clojure test])
+  (:require [clojure.test :refer :all])
   (:import [javax.security.auth Subject]
            [javax.servlet.http HttpServletRequest]
            [backtype.storm.security.auth SingleUserPrincipal]

--- a/storm-core/test/clj/backtype/storm/security/auth/ReqContext_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/ReqContext_test.clj
@@ -14,7 +14,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.ReqContext-test
-  (:use [clojure test])
+  (:require [clojure.test :refer :all])
   (:import [backtype.storm.security.auth ReqContext]
            [java.net InetAddress]
            [java.security AccessControlContext Principal]

--- a/storm-core/test/clj/backtype/storm/security/auth/ReqContext_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/ReqContext_test.clj
@@ -14,12 +14,11 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.ReqContext-test
-  (:import [backtype.storm.security.auth ReqContext])
-  (:import [java.net InetAddress])
-  (:import [java.security AccessControlContext Principal])
-  (:import [javax.security.auth Subject])
   (:use [clojure test])
-)
+  (:import [backtype.storm.security.auth ReqContext]
+           [java.net InetAddress]
+           [java.security AccessControlContext Principal]
+           [javax.security.auth Subject]))
 
 (def test-subject
   (let [rc (ReqContext/context)

--- a/storm-core/test/clj/backtype/storm/security/auth/SaslTransportPlugin_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/SaslTransportPlugin_test.clj
@@ -15,8 +15,7 @@
 ;; limitations under the License.
 (ns backtype.storm.security.auth.SaslTransportPlugin-test
   (:use [clojure test])
-  (import [backtype.storm.security.auth SaslTransportPlugin$User])
-)
+  (:import [backtype.storm.security.auth SaslTransportPlugin$User]) )
 
 (deftest test-User-name
   (let [nam "Andy"

--- a/storm-core/test/clj/backtype/storm/security/auth/SaslTransportPlugin_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/SaslTransportPlugin_test.clj
@@ -14,7 +14,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.SaslTransportPlugin-test
-  (:use [clojure test])
+  (:require [clojure.test :refer :all])
   (:import [backtype.storm.security.auth SaslTransportPlugin$User]) )
 
 (deftest test-User-name

--- a/storm-core/test/clj/backtype/storm/security/auth/ThriftClient_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/ThriftClient_test.clj
@@ -14,31 +14,32 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.ThriftClient-test
-  (:use [backtype.storm config util]
-        [clojure test])
+  (:require [backtype.storm.util :as util]
+            [backtype.storm.config :as c]
+            [clojure.test :refer :all])
   (:import [backtype.storm.security.auth ThriftClient ThriftConnectionType]
            [org.apache.thrift.transport TTransportException]))
 
 (deftest test-ctor-throws-if-port-invalid
   (let [conf (merge
-              (read-default-config)
-              {STORM-NIMBUS-RETRY-TIMES 0})
+              (c/read-default-config)
+              {c/STORM-NIMBUS-RETRY-TIMES 0})
         timeout (Integer. 30)]
-    (is (thrown-cause? java.lang.IllegalArgumentException
+    (is (util/thrown-cause? java.lang.IllegalArgumentException
       (ThriftClient. conf ThriftConnectionType/DRPC "bogushost" (int -1) timeout)))
-    (is (thrown-cause? java.lang.IllegalArgumentException
+    (is (util/thrown-cause? java.lang.IllegalArgumentException
         (ThriftClient. conf ThriftConnectionType/DRPC "bogushost" (int 0) timeout)))
   )
 )
 
 (deftest test-ctor-throws-if-host-not-set
   (let [conf (merge
-              (read-default-config)
-              {STORM-NIMBUS-RETRY-TIMES 0})
+              (c/read-default-config)
+              {c/STORM-NIMBUS-RETRY-TIMES 0})
         timeout (Integer. 60)]
-    (is (thrown-cause? TTransportException
+    (is (util/thrown-cause? TTransportException
          (ThriftClient. conf ThriftConnectionType/DRPC "" (int 4242) timeout)))
-    (is (thrown-cause? IllegalArgumentException
+    (is (util/thrown-cause? IllegalArgumentException
         (ThriftClient. conf ThriftConnectionType/DRPC nil (int 4242) timeout)))
   )
 )

--- a/storm-core/test/clj/backtype/storm/security/auth/ThriftClient_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/ThriftClient_test.clj
@@ -14,11 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.ThriftClient-test
-  (:use [backtype.storm config util])
-  (:use [clojure test])
-  (:import [backtype.storm.security.auth ThriftClient ThriftConnectionType])
-  (:import [org.apache.thrift.transport TTransportException])
-)
+  (:use [backtype.storm config util]
+        [clojure test])
+  (:import [backtype.storm.security.auth ThriftClient ThriftConnectionType]
+           [org.apache.thrift.transport TTransportException]))
 
 (deftest test-ctor-throws-if-port-invalid
   (let [conf (merge

--- a/storm-core/test/clj/backtype/storm/security/auth/ThriftServer_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/ThriftServer_test.clj
@@ -14,17 +14,17 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.ThriftServer-test
-  (:use [backtype.storm config]
-        [clojure test])
+  (:require [backtype.storm.config :as c]
+            [clojure.test :refer :all])
   (:import [backtype.storm.security.auth ThriftServer ThriftConnectionType]
            [org.apache.thrift.transport TTransportException]))
 
 (deftest test-stop-checks-for-null
-  (let [server (ThriftServer. (read-default-config) nil
+  (let [server (ThriftServer. (c/read-default-config) nil
                               ThriftConnectionType/DRPC)]
     (.stop server)))
 
 (deftest test-isServing-checks-for-null
-  (let [server (ThriftServer. (read-default-config) nil
+  (let [server (ThriftServer. (c/read-default-config) nil
                               ThriftConnectionType/DRPC)]
     (is (not (.isServing server)))))

--- a/storm-core/test/clj/backtype/storm/security/auth/ThriftServer_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/ThriftServer_test.clj
@@ -14,18 +14,17 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.ThriftServer-test
-  (:use [backtype.storm config])
-  (:use [clojure test])
-  (:import [backtype.storm.security.auth ThriftServer ThriftConnectionType])
-  (:import [org.apache.thrift.transport TTransportException])
-)
+  (:use [backtype.storm config]
+        [clojure test])
+  (:import [backtype.storm.security.auth ThriftServer ThriftConnectionType]
+           [org.apache.thrift.transport TTransportException]))
 
 (deftest test-stop-checks-for-null
-  (let [server (ThriftServer. (read-default-config) nil 
+  (let [server (ThriftServer. (read-default-config) nil
                               ThriftConnectionType/DRPC)]
     (.stop server)))
 
 (deftest test-isServing-checks-for-null
-  (let [server (ThriftServer. (read-default-config) nil 
+  (let [server (ThriftServer. (read-default-config) nil
                               ThriftConnectionType/DRPC)]
     (is (not (.isServing server)))))

--- a/storm-core/test/clj/backtype/storm/security/auth/auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/auth_test.clj
@@ -14,27 +14,27 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.auth-test
-  (:use [clojure test])
+  (:use [clojure test]
+        [backtype.storm util config]
+        [backtype.storm.daemon common]
+        [backtype.storm testing])
   (:require [backtype.storm.daemon [nimbus :as nimbus]])
   (:import [org.apache.thrift TException]
            [backtype.storm.security.auth.authorizer ImpersonationAuthorizer]
-           [java.net Inet4Address])
-  (:import [org.apache.thrift.transport TTransportException])
-  (:import [java.nio ByteBuffer])
-  (:import [java.security Principal AccessController])
-  (:import [javax.security.auth Subject])
-  (:import [java.net InetAddress])
-  (:import [backtype.storm Config])
-  (:import [backtype.storm.generated AuthorizationException])
-  (:import [backtype.storm.utils NimbusClient])
-  (:import [backtype.storm.security.auth.authorizer SimpleWhitelistAuthorizer SimpleACLAuthorizer])
-  (:import [backtype.storm.security.auth AuthUtils ThriftServer ThriftClient ShellBasedGroupsMapping 
-            ReqContext SimpleTransportPlugin KerberosPrincipalToLocal ThriftConnectionType])
-  (:use [backtype.storm util config])
-  (:use [backtype.storm.daemon common])
-  (:use [backtype.storm testing])
-  (:import [backtype.storm.generated Nimbus Nimbus$Client Nimbus$Iface StormTopology SubmitOptions
-            KillOptions RebalanceOptions ClusterSummary TopologyInfo Nimbus$Processor]))
+           [java.net Inet4Address]
+           [org.apache.thrift.transport TTransportException]
+           [java.nio ByteBuffer]
+           [java.security Principal AccessController]
+           [javax.security.auth Subject]
+           [java.net InetAddress]
+           [backtype.storm Config]
+           [backtype.storm.generated AuthorizationException]
+           [backtype.storm.utils NimbusClient]
+           [backtype.storm.security.auth.authorizer SimpleWhitelistAuthorizer SimpleACLAuthorizer]
+           [backtype.storm.security.auth AuthUtils ThriftServer ThriftClient ShellBasedGroupsMapping
+                                         ReqContext SimpleTransportPlugin KerberosPrincipalToLocal ThriftConnectionType]
+           [backtype.storm.generated Nimbus Nimbus$Client Nimbus$Iface StormTopology SubmitOptions
+                                     KillOptions RebalanceOptions ClusterSummary TopologyInfo Nimbus$Processor]))
 
 (defn mk-principal [name]
   (reify Principal

--- a/storm-core/test/clj/backtype/storm/security/auth/auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/auth_test.clj
@@ -14,27 +14,27 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.auth-test
-  (:use [clojure test]
-        [backtype.storm util config]
-        [backtype.storm.daemon common]
-        [backtype.storm testing])
-  (:require [backtype.storm.daemon [nimbus :as nimbus]])
-  (:import [org.apache.thrift TException]
-           [backtype.storm.security.auth.authorizer ImpersonationAuthorizer]
-           [java.net Inet4Address]
+  (:use [backtype.storm.config]
+        [backtype.storm.daemon.common]
+        [backtype.storm.testing])
+  (:require [backtype.storm.daemon.nimbus :as nimbus]
+            [backtype.storm.util :as util]
+            [backtype.storm.config :as c]
+            [clojure.test :refer :all])
+  (:import [backtype.storm.security.auth.authorizer ImpersonationAuthorizer]
            [org.apache.thrift.transport TTransportException]
            [java.nio ByteBuffer]
-           [java.security Principal AccessController]
+           [java.security Principal]
            [javax.security.auth Subject]
            [java.net InetAddress]
            [backtype.storm Config]
-           [backtype.storm.generated AuthorizationException]
            [backtype.storm.utils NimbusClient]
            [backtype.storm.security.auth.authorizer SimpleWhitelistAuthorizer SimpleACLAuthorizer]
-           [backtype.storm.security.auth AuthUtils ThriftServer ThriftClient ShellBasedGroupsMapping
-                                         ReqContext SimpleTransportPlugin KerberosPrincipalToLocal ThriftConnectionType]
-           [backtype.storm.generated Nimbus Nimbus$Client Nimbus$Iface StormTopology SubmitOptions
-                                     KillOptions RebalanceOptions ClusterSummary TopologyInfo Nimbus$Processor]))
+           [backtype.storm.security.auth AuthUtils ThriftServer ShellBasedGroupsMapping
+                                         ReqContext KerberosPrincipalToLocal ThriftConnectionType]
+           [backtype.storm.generated Nimbus Nimbus$Iface StormTopology SubmitOptions
+                                     KillOptions RebalanceOptions ClusterSummary TopologyInfo Nimbus$Processor
+                                     AuthorizationException]))
 
 (defn mk-principal [name]
   (reify Principal
@@ -53,14 +53,14 @@
   (let [forced-scheduler (.getForcedScheduler inimbus)]
     {:conf storm-conf
      :inimbus inimbus
-     :authorization-handler (mk-authorization-handler (storm-conf NIMBUS-AUTHORIZER) storm-conf)
+     :authorization-handler (mk-authorization-handler (storm-conf c/NIMBUS-AUTHORIZER) storm-conf)
      :submitted-count (atom 0)
      :storm-cluster-state nil
      :submit-lock (Object.)
      :heartbeats-cache (atom {})
      :downloaders nil
      :uploaders nil
-     :uptime (uptime-computer)
+     :uptime (util/uptime-computer)
      :validator nil
      :timer nil
      :scheduler nil
@@ -73,7 +73,7 @@
        (reify Nimbus$Iface
          (^void submitTopologyWithOpts [this ^String storm-name ^String uploadedJarLocation ^String serializedConf ^StormTopology topology
                                         ^SubmitOptions submitOptions]
-           (if (not (nil? serializedConf)) (swap! topo-conf (fn [prev new] new) (from-json serializedConf)))
+           (if (not (nil? serializedConf)) (swap! topo-conf (fn [prev new] new) (util/from-json serializedConf)))
            (nimbus/check-authorization! nimbus-d storm-name @topo-conf "submitTopology" auth-context))
 
          (^void killTopology [this ^String storm-name]
@@ -122,11 +122,11 @@
 
 
 (defn launch-server [server-port login-cfg aznClass transportPluginClass serverConf]
-  (let [conf1 (merge (read-storm-config)
-                     {NIMBUS-AUTHORIZER aznClass
-                      NIMBUS-HOST "localhost"
-                      NIMBUS-THRIFT-PORT server-port
-                      STORM-THRIFT-TRANSPORT-PLUGIN transportPluginClass})
+  (let [conf1 (merge (c/read-storm-config)
+                     {c/NIMBUS-AUTHORIZER aznClass
+                      c/NIMBUS-HOST "localhost"
+                      c/NIMBUS-THRIFT-PORT server-port
+                      c/STORM-THRIFT-TRANSPORT-PLUGIN transportPluginClass})
         conf2 (if login-cfg (merge conf1 {"java.security.auth.login.config" login-cfg}) conf1)
         conf (if serverConf (merge conf2 serverConf) conf2)
         nimbus (nimbus/standalone-nimbus)
@@ -154,44 +154,44 @@
     (is (= "someone" (.toLocal kptol (mk-principal "someone/host@realm"))))))
 
 (deftest Simple-authentication-test
-  (let [a-port (available-port)]
+  (let [a-port (util/available-port)]
     (with-server [a-port nil nil "backtype.storm.security.auth.SimpleTransportPlugin" nil]
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"})
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"})
             client (NimbusClient. storm-conf "localhost" a-port nimbus-timeout)
             nimbus_client (.getClient client)]
         (.activate nimbus_client "security_auth_test_topology")
         (.close client))
 
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
                                "java.security.auth.login.config" "test/clj/backtype/storm/security/auth/jaas_digest.conf"
-                               STORM-NIMBUS-RETRY-TIMES 0})]
+                               c/STORM-NIMBUS-RETRY-TIMES 0})]
         (testing "(Negative authentication) Server: Simple vs. Client: Digest"
-          (is (thrown-cause?  org.apache.thrift.transport.TTransportException
+          (is (util/thrown-cause?  org.apache.thrift.transport.TTransportException
                               (NimbusClient. storm-conf "localhost" a-port nimbus-timeout))))))))
 
 (deftest negative-whitelist-authorization-test
-  (let [a-port (available-port)]
+  (let [a-port (util/available-port)]
     (with-server [a-port nil
                   "backtype.storm.security.auth.authorizer.SimpleWhitelistAuthorizer"
                   "backtype.storm.testing.SingleUserSimpleTransport" nil]
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.testing.SingleUserSimpleTransport"})
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.testing.SingleUserSimpleTransport"})
             client (NimbusClient. storm-conf "localhost" a-port nimbus-timeout)
             nimbus_client (.getClient client)]
         (testing "(Negative authorization) Authorization plugin should reject client request"
-          (is (thrown-cause? AuthorizationException
+          (is (util/thrown-cause? AuthorizationException
                              (.activate nimbus_client "security_auth_test_topology"))))
         (.close client)))))
 
 (deftest positive-whitelist-authorization-test
-    (let [a-port (available-port)]
+    (let [a-port (util/available-port)]
       (with-server [a-port nil
                     "backtype.storm.security.auth.authorizer.SimpleWhitelistAuthorizer"
                     "backtype.storm.testing.SingleUserSimpleTransport" {SimpleWhitelistAuthorizer/WHITELIST_USERS_CONF ["user"]}]
         (let [storm-conf (merge (read-storm-config)
-                                {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.testing.SingleUserSimpleTransport"})
+                                {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.testing.SingleUserSimpleTransport"})
               client (NimbusClient. storm-conf "localhost" a-port nimbus-timeout)
               nimbus_client (.getClient client)]
           (testing "(Positive authorization) Authorization plugin should accept client request"
@@ -200,8 +200,8 @@
 
 (deftest simple-acl-user-auth-test
   (let [cluster-conf (merge (read-storm-config)
-                       {NIMBUS-ADMINS ["admin"]
-                        NIMBUS-SUPERVISOR-USERS ["supervisor"]})
+                       {c/NIMBUS-ADMINS ["admin"]
+                        c/NIMBUS-SUPERVISOR-USERS ["supervisor"]})
         authorizer (SimpleACLAuthorizer. )
         admin-user (mk-subject "admin")
         supervisor-user (mk-subject "supervisor")
@@ -233,57 +233,57 @@
   (is (= true (.permit authorizer (ReqContext. admin-user) "fileDownload" nil)))
   (is (= true (.permit authorizer (ReqContext. supervisor-user) "fileDownload" nil)))
 
-  (is (= true (.permit authorizer (ReqContext. user-a) "killTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. user-b) "killTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "killTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. supervisor-user) "killTopolgy" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. user-a) "killTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. user-b) "killTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "killTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. supervisor-user) "killTopolgy" {c/TOPOLOGY-USERS ["user-a"]})))
 
-  (is (= true (.permit authorizer (ReqContext. user-a) "uploadNewCredentials" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. user-b) "uploadNewCredentials" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "uploadNewCredentials" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. supervisor-user) "uploadNewCredentials" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. user-a) "uploadNewCredentials" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. user-b) "uploadNewCredentials" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "uploadNewCredentials" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. supervisor-user) "uploadNewCredentials" {c/TOPOLOGY-USERS ["user-a"]})))
 
-  (is (= true (.permit authorizer (ReqContext. user-a) "rebalance" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. user-b) "rebalance" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "rebalance" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. supervisor-user) "rebalance" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. user-a) "rebalance" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. user-b) "rebalance" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "rebalance" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. supervisor-user) "rebalance" {c/TOPOLOGY-USERS ["user-a"]})))
 
-  (is (= true (.permit authorizer (ReqContext. user-a) "activate" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. user-b) "activate" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "activate" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. supervisor-user) "activate" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. user-a) "activate" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. user-b) "activate" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "activate" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. supervisor-user) "activate" {c/TOPOLOGY-USERS ["user-a"]})))
 
-  (is (= true (.permit authorizer (ReqContext. user-a) "deactivate" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. user-b) "deactivate" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "deactivate" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. supervisor-user) "deactivate" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. user-a) "deactivate" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. user-b) "deactivate" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "deactivate" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. supervisor-user) "deactivate" {c/TOPOLOGY-USERS ["user-a"]})))
 
-  (is (= true (.permit authorizer (ReqContext. user-a) "getTopologyConf" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. user-b) "getTopologyConf" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopologyConf" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. supervisor-user) "getTopologyConf" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. user-a) "getTopologyConf" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. user-b) "getTopologyConf" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopologyConf" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. supervisor-user) "getTopologyConf" {c/TOPOLOGY-USERS ["user-a"]})))
 
-  (is (= true (.permit authorizer (ReqContext. user-a) "getTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. user-b) "getTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. supervisor-user) "getTopology" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. user-a) "getTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. user-b) "getTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. supervisor-user) "getTopology" {c/TOPOLOGY-USERS ["user-a"]})))
 
-  (is (= true (.permit authorizer (ReqContext. user-a) "getUserTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. user-b) "getUserTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "getUserTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. supervisor-user) "getUserTopology" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. user-a) "getUserTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. user-b) "getUserTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "getUserTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. supervisor-user) "getUserTopology" {c/TOPOLOGY-USERS ["user-a"]})))
 
-  (is (= true (.permit authorizer (ReqContext. user-a) "getTopologyInfo" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. user-b) "getTopologyInfo" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopologyInfo" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= false (.permit authorizer (ReqContext. supervisor-user) "getTopologyInfo" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. user-a) "getTopologyInfo" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. user-b) "getTopologyInfo" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopologyInfo" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= false (.permit authorizer (ReqContext. supervisor-user) "getTopologyInfo" {c/TOPOLOGY-USERS ["user-a"]})))
 ))
 
 (deftest simple-acl-nimbus-users-auth-test
   (let [cluster-conf (merge (read-storm-config)
-                            {NIMBUS-ADMINS ["admin"]
-                             NIMBUS-SUPERVISOR-USERS ["supervisor"]
-                             NIMBUS-USERS ["user-a"]})
+                            {c/NIMBUS-ADMINS ["admin"]
+                             c/NIMBUS-SUPERVISOR-USERS ["supervisor"]
+                             c/NIMBUS-USERS ["user-a"]})
         authorizer (SimpleACLAuthorizer. )
         admin-user (mk-subject "admin")
         supervisor-user (mk-subject "supervisor")
@@ -306,8 +306,8 @@
 
 (deftest simple-acl-same-user-auth-test
   (let [cluster-conf (merge (read-storm-config)
-                       {NIMBUS-ADMINS ["admin"]
-                        NIMBUS-SUPERVISOR-USERS ["admin"]})
+                       {c/NIMBUS-ADMINS ["admin"]
+                        c/NIMBUS-SUPERVISOR-USERS ["admin"]})
         authorizer (SimpleACLAuthorizer. )
         admin-user (mk-subject "admin")]
   (.prepare authorizer cluster-conf)
@@ -316,25 +316,25 @@
   (is (= true (.permit authorizer (ReqContext. admin-user) "getNimbusConf" nil)))
   (is (= true (.permit authorizer (ReqContext. admin-user) "getClusterInfo" nil)))
   (is (= true (.permit authorizer (ReqContext. admin-user) "fileDownload" nil)))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "killTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "uploadNewCredentials" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "rebalance" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "activate" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "deactivate" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopologyConf" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "getUserTopology" {TOPOLOGY-USERS ["user-a"]})))
-  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopologyInfo" {TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "killTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "uploadNewCredentials" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "rebalance" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "activate" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "deactivate" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopologyConf" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "getUserTopology" {c/TOPOLOGY-USERS ["user-a"]})))
+  (is (= true (.permit authorizer (ReqContext. admin-user) "getTopologyInfo" {c/TOPOLOGY-USERS ["user-a"]})))
 ))
 
 
 (deftest positive-authorization-test
-  (let [a-port (available-port)]
+  (let [a-port (util/available-port)]
     (with-server [a-port nil
                   "backtype.storm.security.auth.authorizer.NoopAuthorizer"
                   "backtype.storm.security.auth.SimpleTransportPlugin" nil]
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"})
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"})
             client (NimbusClient. storm-conf "localhost" a-port nimbus-timeout)
             nimbus_client (.getClient client)]
         (testing "(Positive authorization) Authorization plugin should accept client request"
@@ -342,32 +342,32 @@
         (.close client)))))
 
 (deftest deny-authorization-test
-  (let [a-port (available-port)]
+  (let [a-port (util/available-port)]
     (with-server [a-port nil
                   "backtype.storm.security.auth.authorizer.DenyAuthorizer"
                   "backtype.storm.security.auth.SimpleTransportPlugin" nil]
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
                                Config/NIMBUS_HOST "localhost"
                                Config/NIMBUS_THRIFT_PORT a-port
                                Config/NIMBUS_TASK_TIMEOUT_SECS nimbus-timeout})
             client (NimbusClient/getConfiguredClient storm-conf)
             nimbus_client (.getClient client)]
         (testing "(Negative authorization) Authorization plugin should reject client request"
-          (is (thrown-cause? AuthorizationException
+          (is (util/thrown-cause? AuthorizationException
                              (.activate nimbus_client "security_auth_test_topology"))))
         (.close client)))))
 
 (deftest digest-authentication-test
-  (let [a-port (available-port)]
+  (let [a-port (util/available-port)]
     (with-server [a-port
                   "test/clj/backtype/storm/security/auth/jaas_digest.conf"
                   nil
                   "backtype.storm.security.auth.digest.DigestSaslTransportPlugin" nil]
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
                                "java.security.auth.login.config" "test/clj/backtype/storm/security/auth/jaas_digest.conf"
-                               STORM-NIMBUS-RETRY-TIMES 0})
+                               c/STORM-NIMBUS-RETRY-TIMES 0})
             client (NimbusClient. storm-conf "localhost" a-port nimbus-timeout)
             nimbus_client (.getClient client)]
         (testing "(Positive authentication) valid digest authentication"
@@ -375,51 +375,51 @@
         (.close client))
 
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
-                               STORM-NIMBUS-RETRY-TIMES 0})
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
+                               c/STORM-NIMBUS-RETRY-TIMES 0})
             client (NimbusClient. storm-conf "localhost" a-port nimbus-timeout)
             nimbus_client (.getClient client)]
         (testing "(Negative authentication) Server: Digest vs. Client: Simple"
-          (is (thrown-cause? org.apache.thrift.transport.TTransportException
+          (is (util/thrown-cause? org.apache.thrift.transport.TTransportException
                              (.activate nimbus_client "security_auth_test_topology"))))
         (.close client))
 
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
                                "java.security.auth.login.config" "test/clj/backtype/storm/security/auth/jaas_digest_bad_password.conf"
-                               STORM-NIMBUS-RETRY-TIMES 0})]
+                               c/STORM-NIMBUS-RETRY-TIMES 0})]
         (testing "(Negative authentication) Invalid  password"
-          (is (thrown-cause? TTransportException
+          (is (util/thrown-cause? TTransportException
                              (NimbusClient. storm-conf "localhost" a-port nimbus-timeout)))))
 
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
                                "java.security.auth.login.config" "test/clj/backtype/storm/security/auth/jaas_digest_unknown_user.conf"
-                               STORM-NIMBUS-RETRY-TIMES 0})]
+                               c/STORM-NIMBUS-RETRY-TIMES 0})]
         (testing "(Negative authentication) Unknown user"
-          (is (thrown-cause? TTransportException
+          (is (util/thrown-cause? TTransportException
                              (NimbusClient. storm-conf "localhost" a-port nimbus-timeout)))))
 
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
                                "java.security.auth.login.config" "test/clj/backtype/storm/security/auth/nonexistent.conf"
-                               STORM-NIMBUS-RETRY-TIMES 0})]
+                               c/STORM-NIMBUS-RETRY-TIMES 0})]
         (testing "(Negative authentication) nonexistent configuration file"
-          (is (thrown-cause? RuntimeException
+          (is (util/thrown-cause? RuntimeException
                              (NimbusClient. storm-conf "localhost" a-port nimbus-timeout)))))
 
       (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
                                "java.security.auth.login.config" "test/clj/backtype/storm/security/auth/jaas_digest_missing_client.conf"
-                               STORM-NIMBUS-RETRY-TIMES 0})]
+                               c/STORM-NIMBUS-RETRY-TIMES 0})]
         (testing "(Negative authentication) Missing client"
-          (is (thrown-cause? java.io.IOException
+          (is (util/thrown-cause? java.io.IOException
                              (NimbusClient. storm-conf "localhost" a-port nimbus-timeout))))))))
 
 (deftest test-GetTransportPlugin-throws-RuntimeException
   (let [conf (merge (read-storm-config)
                     {Config/STORM_THRIFT_TRANSPORT_PLUGIN "null.invalid"})]
-    (is (thrown-cause? RuntimeException (AuthUtils/GetTransportPlugin conf nil nil)))))
+    (is (util/thrown-cause? RuntimeException (AuthUtils/GetTransportPlugin conf nil nil)))))
 
 (defn mk-impersonating-req-context [impersonating-user user-being-impersonated remote-address]
   (let [impersonating-principal (mk-principal impersonating-user)

--- a/storm-core/test/clj/backtype/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer_test.clj
@@ -1,11 +1,10 @@
 (ns backtype.storm.security.auth.authorizer.DRPCSimpleACLAuthorizer-test
-  (:use [clojure test])
-  (:import [org.mockito Mockito])
-  (:import [backtype.storm Config])
-  (:import [backtype.storm.security.auth ReqContext SingleUserPrincipal])
-  (:import [backtype.storm.security.auth.authorizer DRPCSimpleACLAuthorizer])
-  (:use [backtype.storm config util])
-  )
+  (:use [clojure test]
+        [backtype.storm config util])
+  (:import [org.mockito Mockito]
+           [backtype.storm Config]
+           [backtype.storm.security.auth ReqContext SingleUserPrincipal]
+           [backtype.storm.security.auth.authorizer DRPCSimpleACLAuthorizer]))
 
 (defn- mk-mock-context [user]
   (let [mock-context (Mockito/mock ReqContext)]

--- a/storm-core/test/clj/backtype/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer_test.clj
@@ -1,8 +1,7 @@
 (ns backtype.storm.security.auth.authorizer.DRPCSimpleACLAuthorizer-test
-  (:use [clojure test]
-        [backtype.storm config util])
+  (:require [backtype.storm.config :as c]
+            [clojure.test :refer :all])
   (:import [org.mockito Mockito]
-           [backtype.storm Config]
            [backtype.storm.security.auth ReqContext SingleUserPrincipal]
            [backtype.storm.security.auth.authorizer DRPCSimpleACLAuthorizer]))
 
@@ -20,13 +19,13 @@
       charlie-context (mk-mock-context "charlie")
       acl-file "drpc-simple-acl-test-scenario.yaml"
       strict-handler (doto (DRPCSimpleACLAuthorizer.)
-                           (.prepare {DRPC-AUTHORIZER-ACL-STRICT true
-                                      DRPC-AUTHORIZER-ACL-FILENAME acl-file
-                                      STORM-PRINCIPAL-TO-LOCAL-PLUGIN "backtype.storm.security.auth.KerberosPrincipalToLocal"}))
+                           (.prepare {c/DRPC-AUTHORIZER-ACL-STRICT true
+                                      c/DRPC-AUTHORIZER-ACL-FILENAME acl-file
+                                      c/STORM-PRINCIPAL-TO-LOCAL-PLUGIN "backtype.storm.security.auth.KerberosPrincipalToLocal"}))
       permissive-handler (doto (DRPCSimpleACLAuthorizer.)
-                               (.prepare {DRPC-AUTHORIZER-ACL-STRICT false
-                                          DRPC-AUTHORIZER-ACL-FILENAME acl-file
-                                          STORM-PRINCIPAL-TO-LOCAL-PLUGIN "backtype.storm.security.auth.KerberosPrincipalToLocal"}))]
+                               (.prepare {c/DRPC-AUTHORIZER-ACL-STRICT false
+                                          c/DRPC-AUTHORIZER-ACL-FILENAME acl-file
+                                          c/STORM-PRINCIPAL-TO-LOCAL-PLUGIN "backtype.storm.security.auth.KerberosPrincipalToLocal"}))]
 
   (deftest test-partial-authorization
     (testing "deny execute to unauthorized user"

--- a/storm-core/test/clj/backtype/storm/security/auth/auto_login_module_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/auto_login_module_test.clj
@@ -14,14 +14,13 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.auto-login-module-test
-  (:use [clojure test])
-  (:use [backtype.storm util])
+  (:use [clojure test]
+        [backtype.storm util])
   (:import [backtype.storm.security.auth.kerberos AutoTGT
-            AutoTGTKrb5LoginModule AutoTGTKrb5LoginModuleTest])
-  (:import [javax.security.auth Subject Subject])
-  (:import [javax.security.auth.kerberos KerberosTicket])
-  (:import [org.mockito Mockito])
-  )
+                                                  AutoTGTKrb5LoginModule AutoTGTKrb5LoginModuleTest]
+           [javax.security.auth Subject Subject]
+           [javax.security.auth.kerberos KerberosTicket]
+           [org.mockito Mockito]))
 
 (deftest login-module-no-subj-no-tgt-test
   (testing "Behavior is correct when there is no Subject or TGT"

--- a/storm-core/test/clj/backtype/storm/security/auth/auto_login_module_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/auto_login_module_test.clj
@@ -14,10 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.auto-login-module-test
-  (:use [clojure test]
-        [backtype.storm util])
-  (:import [backtype.storm.security.auth.kerberos AutoTGT
-                                                  AutoTGTKrb5LoginModule AutoTGTKrb5LoginModuleTest]
+  (:require [backtype.storm.util :as util]
+            [clojure.test :refer :all])
+  (:import [backtype.storm.security.auth.kerberos AutoTGTKrb5LoginModule AutoTGTKrb5LoginModuleTest]
            [javax.security.auth Subject Subject]
            [javax.security.auth.kerberos KerberosTicket]
            [org.mockito Mockito]))
@@ -25,8 +24,7 @@
 (deftest login-module-no-subj-no-tgt-test
   (testing "Behavior is correct when there is no Subject or TGT"
     (let [login-module (AutoTGTKrb5LoginModule.)]
-
-      (is (thrown-cause? javax.security.auth.login.LoginException
+      (is (util/thrown-cause? javax.security.auth.login.LoginException
                          (.login login-module)))
       (is (not (.commit login-module)))
       (is (not (.abort login-module)))
@@ -44,7 +42,7 @@
   (testing "Behavior is correct when there is a Subject and no TGT"
     (let [login-module (AutoTGTKrb5LoginModule.)]
       (.initialize login-module (Subject.) nil nil nil)
-      (is (thrown-cause? javax.security.auth.login.LoginException
+      (is (util/thrown-cause? javax.security.auth.login.LoginException
                          (.login login-module)))
       (is (not (.commit login-module)))
       (is (not (.abort login-module)))
@@ -55,7 +53,7 @@
     (let [login-module (AutoTGTKrb5LoginModuleTest.)]
       (.setKerbTicket login-module (Mockito/mock KerberosTicket))
       (is (.login login-module))
-      (is (thrown-cause? javax.security.auth.login.LoginException
+      (is (util/thrown-cause? javax.security.auth.login.LoginException
                          (.commit login-module)))
 
       (.setKerbTicket login-module (Mockito/mock KerberosTicket))
@@ -69,7 +67,7 @@
       (.initialize login-module readonly-subj nil nil nil)
       (.setKerbTicket login-module (Mockito/mock KerberosTicket))
       (is (.login login-module))
-      (is (thrown-cause? javax.security.auth.login.LoginException
+      (is (util/thrown-cause? javax.security.auth.login.LoginException
                          (.commit login-module)))
 
       (.setKerbTicket login-module (Mockito/mock KerberosTicket))

--- a/storm-core/test/clj/backtype/storm/security/auth/drpc_auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/drpc_auth_test.clj
@@ -14,20 +14,19 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.drpc-auth-test
-  (:use [clojure test])
+  (:use [clojure test]
+        [backtype.storm util config log]
+        [backtype.storm.daemon common]
+        [backtype.storm testing])
   (:require [backtype.storm.daemon [drpc :as drpc]])
-  (:import [backtype.storm.generated AuthorizationException
-            DRPCExecutionException DistributedRPC$Processor
-            DistributedRPCInvocations$Processor])
-  (:import [backtype.storm Config])
-  (:import [backtype.storm.security.auth ReqContext SingleUserPrincipal ThriftServer ThriftConnectionType])
-  (:import [backtype.storm.utils DRPCClient])
-  (:import [backtype.storm.drpc DRPCInvocationsClient])
-  (:import [java.util.concurrent TimeUnit])
-  (:import [javax.security.auth Subject])
-  (:use [backtype.storm util config log])
-  (:use [backtype.storm.daemon common])
-  (:use [backtype.storm testing]))
+  (:import [backtype.storm.generated AuthorizationException DRPCExecutionException DistributedRPC$Processor
+                                     DistributedRPCInvocations$Processor]
+           [backtype.storm Config]
+           [backtype.storm.security.auth ReqContext SingleUserPrincipal ThriftServer ThriftConnectionType]
+           [backtype.storm.utils DRPCClient]
+           [backtype.storm.drpc DRPCInvocationsClient]
+           [java.util.concurrent TimeUnit]
+           [javax.security.auth Subject]))
 
 (def drpc-timeout (Integer. 30))
 

--- a/storm-core/test/clj/backtype/storm/security/auth/nimbus_auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/nimbus_auth_test.clj
@@ -14,16 +14,18 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.nimbus-auth-test
-  (:use [clojure test]
-        [backtype.storm cluster util config log]
-        [backtype.storm.daemon common nimbus]
-        [conjure core])
-  (:require [backtype.storm [testing :as testing]]
+  (:use [backtype.storm cluster]
+        [backtype.storm.daemon common nimbus])
+  (:require [backtype.storm.testing :as t]
             [conjure.core]
             [backtype.storm.daemon [nimbus :as nimbus]]
-            [backtype.storm [zookeeper :as zk]])
-  (:import [java.nio ByteBuffer]
-           [backtype.storm Config]
+            [backtype.storm [zookeeper :as zk]]
+            [backtype.storm.log :refer [log-debug]]
+            [backtype.storm.util :as util]
+            [conjure.core :as conjure]
+            [backtype.storm.config :as c]
+            [clojure.test :refer :all])
+  (:import [backtype.storm Config]
            [backtype.storm.utils NimbusClient]
            [backtype.storm.generated NotAliveException]
            [backtype.storm.security.auth AuthUtils ThriftServer ThriftClient
@@ -34,11 +36,11 @@
 (def nimbus-timeout (Integer. 30))
 
 (defn launch-test-cluster [nimbus-port login-cfg aznClass transportPluginClass]
-  (let [conf {NIMBUS-AUTHORIZER aznClass
-              NIMBUS-THRIFT-PORT nimbus-port
-              STORM-THRIFT-TRANSPORT-PLUGIN transportPluginClass }
+  (let [conf {c/NIMBUS-AUTHORIZER             aznClass
+              c/NIMBUS-THRIFT-PORT            nimbus-port
+              c/STORM-THRIFT-TRANSPORT-PLUGIN transportPluginClass }
         conf (if login-cfg (merge conf {"java.security.auth.login.config" login-cfg}) conf)
-        cluster-map (testing/mk-local-storm-cluster :supervisors 0
+        cluster-map (t/mk-local-storm-cluster :supervisors 0
                                             :ports-per-supervisor 0
                                             :daemon-conf conf)
         nimbus-server (ThriftServer. (:daemon-conf cluster-map)
@@ -46,137 +48,137 @@
                                      ThriftConnectionType/NIMBUS)]
     (.addShutdownHook (Runtime/getRuntime) (Thread. (fn [] (.stop nimbus-server))))
     (.start (Thread. #(.serve nimbus-server)))
-    (testing/wait-for-condition #(.isServing nimbus-server))
+    (t/wait-for-condition #(.isServing nimbus-server))
     [cluster-map nimbus-server]))
 
 (defmacro with-test-cluster [args & body]
   `(let [[cluster-map#  nimbus-server#] (launch-test-cluster  ~@args)]
       ~@body
       (log-debug "Shutdown cluster from macro")
-      (testing/kill-local-storm-cluster cluster-map#)
+      (t/kill-local-storm-cluster cluster-map#)
       (.stop nimbus-server#)))
 
 (deftest Simple-authentication-test
-  (let [port (available-port)]
+  (let [port (util/available-port)]
     (with-test-cluster [port nil nil "backtype.storm.security.auth.SimpleTransportPlugin"]
-      (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
-                               STORM-NIMBUS-RETRY-TIMES 0})
+      (let [storm-conf (merge (c/read-storm-config)
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
+                               c/STORM-NIMBUS-RETRY-TIMES      0})
             client (NimbusClient. storm-conf "localhost" port nimbus-timeout)
             nimbus_client (.getClient client)]
         (testing "(Positive authorization) Simple protocol w/o authentication/authorization enforcement"
-                 (is (thrown-cause? NotAliveException
+                 (is (util/thrown-cause? NotAliveException
                               (.activate nimbus_client "topo-name"))))
         (.close client)))))
 
 (deftest test-noop-authorization-w-simple-transport
-  (let [port (available-port)]
+  (let [port (util/available-port)]
     (with-test-cluster [port nil
                   "backtype.storm.security.auth.authorizer.NoopAuthorizer"
                   "backtype.storm.security.auth.SimpleTransportPlugin"]
-      (let [storm-conf (merge (read-storm-config)
-                               {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
-                                STORM-NIMBUS-RETRY-TIMES 0})
+      (let [storm-conf (merge (c/read-storm-config)
+                               {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
+                                c/STORM-NIMBUS-RETRY-TIMES      0})
             client (NimbusClient. storm-conf "localhost" port nimbus-timeout)
             nimbus_client (.getClient client)]
         (testing "(Positive authorization) Authorization plugin should accept client request"
-                 (is (thrown-cause? NotAliveException
+                 (is (util/thrown-cause? NotAliveException
                               (.activate nimbus_client "topo-name"))))
         (.close client)))))
 
 (deftest test-deny-authorization-w-simple-transport
-  (let [port (available-port)]
+  (let [port (util/available-port)]
     (with-test-cluster [port nil
                   "backtype.storm.security.auth.authorizer.DenyAuthorizer"
                   "backtype.storm.security.auth.SimpleTransportPlugin"]
-      (let [storm-conf (merge (read-storm-config)
-                               {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
+      (let [storm-conf (merge (c/read-storm-config)
+                               {c/STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.SimpleTransportPlugin"
                                Config/NIMBUS_HOST "localhost"
                                Config/NIMBUS_THRIFT_PORT port
-                               STORM-NIMBUS-RETRY-TIMES 0})
+                                c/STORM-NIMBUS-RETRY-TIMES      0})
             client (NimbusClient/getConfiguredClient storm-conf)
             nimbus_client (.getClient client)
             topologyInitialStatus (TopologyInitialStatus/findByValue 2)
             submitOptions (SubmitOptions. topologyInitialStatus)]
-        (is (thrown-cause? AuthorizationException (.submitTopology nimbus_client  "topo-name" nil nil nil)))
-        (is (thrown-cause? AuthorizationException (.submitTopologyWithOpts nimbus_client  "topo-name" nil nil nil submitOptions)))
-        (is (thrown-cause? AuthorizationException (.beginFileUpload nimbus_client)))
-        (is (thrown-cause? AuthorizationException (.uploadChunk nimbus_client nil nil)))
-        (is (thrown-cause? AuthorizationException (.finishFileUpload nimbus_client nil)))
-        (is (thrown-cause? AuthorizationException (.beginFileDownload nimbus_client nil)))
-        (is (thrown-cause? AuthorizationException (.downloadChunk nimbus_client nil)))
-        (is (thrown-cause? AuthorizationException (.getNimbusConf nimbus_client)))
-        (is (thrown-cause? AuthorizationException (.getClusterInfo nimbus_client)))
-        (stubbing [nimbus/check-storm-active! nil
+        (is (util/thrown-cause? AuthorizationException (.submitTopology nimbus_client  "topo-name" nil nil nil)))
+        (is (util/thrown-cause? AuthorizationException (.submitTopologyWithOpts nimbus_client  "topo-name" nil nil nil submitOptions)))
+        (is (util/thrown-cause? AuthorizationException (.beginFileUpload nimbus_client)))
+        (is (util/thrown-cause? AuthorizationException (.uploadChunk nimbus_client nil nil)))
+        (is (util/thrown-cause? AuthorizationException (.finishFileUpload nimbus_client nil)))
+        (is (util/thrown-cause? AuthorizationException (.beginFileDownload nimbus_client nil)))
+        (is (util/thrown-cause? AuthorizationException (.downloadChunk nimbus_client nil)))
+        (is (util/thrown-cause? AuthorizationException (.getNimbusConf nimbus_client)))
+        (is (util/thrown-cause? AuthorizationException (.getClusterInfo nimbus_client)))
+        (conjure/stubbing [nimbus/check-storm-active! nil
                    nimbus/try-read-storm-conf-from-name {}]
-          (is (thrown-cause? AuthorizationException (.killTopology nimbus_client "topo-name")))
-          (is (thrown-cause? AuthorizationException (.killTopologyWithOpts nimbus_client "topo-name" (KillOptions.))))
-          (is (thrown-cause? AuthorizationException (.activate nimbus_client "topo-name")))
-          (is (thrown-cause? AuthorizationException (.deactivate nimbus_client "topo-name")))
-          (is (thrown-cause? AuthorizationException (.rebalance nimbus_client "topo-name" nil)))
+          (is (util/thrown-cause? AuthorizationException (.killTopology nimbus_client "topo-name")))
+          (is (util/thrown-cause? AuthorizationException (.killTopologyWithOpts nimbus_client "topo-name" (KillOptions.))))
+          (is (util/thrown-cause? AuthorizationException (.activate nimbus_client "topo-name")))
+          (is (util/thrown-cause? AuthorizationException (.deactivate nimbus_client "topo-name")))
+          (is (util/thrown-cause? AuthorizationException (.rebalance nimbus_client "topo-name" nil)))
         )
-        (stubbing [nimbus/try-read-storm-conf {}]
-          (is (thrown-cause? AuthorizationException (.getTopologyConf nimbus_client "topo-ID")))
-          (is (thrown-cause? AuthorizationException (.getTopology nimbus_client "topo-ID")))
-          (is (thrown-cause? AuthorizationException (.getUserTopology nimbus_client "topo-ID")))
-          (is (thrown-cause? AuthorizationException (.getTopologyInfo nimbus_client "topo-ID"))))
+        (conjure/stubbing [nimbus/try-read-storm-conf {}]
+          (is (util/thrown-cause? AuthorizationException (.getTopologyConf nimbus_client "topo-ID")))
+          (is (util/thrown-cause? AuthorizationException (.getTopology nimbus_client "topo-ID")))
+          (is (util/thrown-cause? AuthorizationException (.getUserTopology nimbus_client "topo-ID")))
+          (is (util/thrown-cause? AuthorizationException (.getTopologyInfo nimbus_client "topo-ID"))))
         (.close client)))))
 
 (deftest test-noop-authorization-w-sasl-digest
-  (let [port (available-port)]
+  (let [port (util/available-port)]
     (with-test-cluster [port
                   "test/clj/backtype/storm/security/auth/jaas_digest.conf"
                   "backtype.storm.security.auth.authorizer.NoopAuthorizer"
                   "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"]
-      (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
+      (let [storm-conf (merge (c/read-storm-config)
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN   "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
                                "java.security.auth.login.config" "test/clj/backtype/storm/security/auth/jaas_digest.conf"
                                Config/NIMBUS_HOST "localhost"
                                Config/NIMBUS_THRIFT_PORT port
-                               STORM-NIMBUS-RETRY-TIMES 0})
+                               c/STORM-NIMBUS-RETRY-TIMES        0})
             client (NimbusClient/getConfiguredClient storm-conf)
             nimbus_client (.getClient client)]
         (testing "(Positive authorization) Authorization plugin should accept client request"
-                 (is (thrown-cause? NotAliveException
+                 (is (util/thrown-cause? NotAliveException
                               (.activate nimbus_client "topo-name"))))
         (.close client)))))
 
 (deftest test-deny-authorization-w-sasl-digest
-  (let [port (available-port)]
+  (let [port (util/available-port)]
     (with-test-cluster [port
                   "test/clj/backtype/storm/security/auth/jaas_digest.conf"
                   "backtype.storm.security.auth.authorizer.DenyAuthorizer"
                   "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"]
-      (let [storm-conf (merge (read-storm-config)
-                              {STORM-THRIFT-TRANSPORT-PLUGIN "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
+      (let [storm-conf (merge (c/read-storm-config)
+                              {c/STORM-THRIFT-TRANSPORT-PLUGIN   "backtype.storm.security.auth.digest.DigestSaslTransportPlugin"
                                "java.security.auth.login.config" "test/clj/backtype/storm/security/auth/jaas_digest.conf"
                                Config/NIMBUS_HOST "localhost"
                                Config/NIMBUS_THRIFT_PORT port
-                               STORM-NIMBUS-RETRY-TIMES 0})
+                               c/STORM-NIMBUS-RETRY-TIMES        0})
             client (NimbusClient/getConfiguredClient storm-conf)
             nimbus_client (.getClient client)
             topologyInitialStatus (TopologyInitialStatus/findByValue 2)
             submitOptions (SubmitOptions. topologyInitialStatus)]
-        (is (thrown-cause? AuthorizationException (.submitTopology nimbus_client  "topo-name" nil nil nil)))
-        (is (thrown-cause? AuthorizationException (.submitTopologyWithOpts nimbus_client  "topo-name" nil nil nil submitOptions)))
-        (is (thrown-cause? AuthorizationException (.beginFileUpload nimbus_client)))
-        (is (thrown-cause? AuthorizationException (.uploadChunk nimbus_client nil nil)))
-        (is (thrown-cause? AuthorizationException (.finishFileUpload nimbus_client nil)))
-        (is (thrown-cause? AuthorizationException (.beginFileDownload nimbus_client nil)))
-        (is (thrown-cause? AuthorizationException (.downloadChunk nimbus_client nil)))
-        (is (thrown-cause? AuthorizationException (.getNimbusConf nimbus_client)))
-        (is (thrown-cause? AuthorizationException (.getClusterInfo nimbus_client)))
-        (stubbing [nimbus/check-storm-active! nil
+        (is (util/thrown-cause? AuthorizationException (.submitTopology nimbus_client  "topo-name" nil nil nil)))
+        (is (util/thrown-cause? AuthorizationException (.submitTopologyWithOpts nimbus_client  "topo-name" nil nil nil submitOptions)))
+        (is (util/thrown-cause? AuthorizationException (.beginFileUpload nimbus_client)))
+        (is (util/thrown-cause? AuthorizationException (.uploadChunk nimbus_client nil nil)))
+        (is (util/thrown-cause? AuthorizationException (.finishFileUpload nimbus_client nil)))
+        (is (util/thrown-cause? AuthorizationException (.beginFileDownload nimbus_client nil)))
+        (is (util/thrown-cause? AuthorizationException (.downloadChunk nimbus_client nil)))
+        (is (util/thrown-cause? AuthorizationException (.getNimbusConf nimbus_client)))
+        (is (util/thrown-cause? AuthorizationException (.getClusterInfo nimbus_client)))
+        (conjure/stubbing [nimbus/check-storm-active! nil
                    nimbus/try-read-storm-conf-from-name {}]
-          (is (thrown-cause? AuthorizationException (.killTopology nimbus_client "topo-name")))
-          (is (thrown-cause? AuthorizationException (.killTopologyWithOpts nimbus_client "topo-name" (KillOptions.))))
-          (is (thrown-cause? AuthorizationException (.activate nimbus_client "topo-name")))
-          (is (thrown-cause? AuthorizationException (.deactivate nimbus_client "topo-name")))
-          (is (thrown-cause? AuthorizationException (.rebalance nimbus_client "topo-name" nil))))
-        (stubbing [nimbus/try-read-storm-conf {}]
-          (is (thrown-cause? AuthorizationException (.getTopologyConf nimbus_client "topo-ID")))
-          (is (thrown-cause? AuthorizationException (.getTopology nimbus_client "topo-ID")))
-          (is (thrown-cause? AuthorizationException (.getUserTopology nimbus_client "topo-ID")))
-          (is (thrown-cause? AuthorizationException (.getTopologyInfo nimbus_client "topo-ID"))))
+          (is (util/thrown-cause? AuthorizationException (.killTopology nimbus_client "topo-name")))
+          (is (util/thrown-cause? AuthorizationException (.killTopologyWithOpts nimbus_client "topo-name" (KillOptions.))))
+          (is (util/thrown-cause? AuthorizationException (.activate nimbus_client "topo-name")))
+          (is (util/thrown-cause? AuthorizationException (.deactivate nimbus_client "topo-name")))
+          (is (util/thrown-cause? AuthorizationException (.rebalance nimbus_client "topo-name" nil))))
+        (conjure/stubbing [nimbus/try-read-storm-conf {}]
+          (is (util/thrown-cause? AuthorizationException (.getTopologyConf nimbus_client "topo-ID")))
+          (is (util/thrown-cause? AuthorizationException (.getTopology nimbus_client "topo-ID")))
+          (is (util/thrown-cause? AuthorizationException (.getUserTopology nimbus_client "topo-ID")))
+          (is (util/thrown-cause? AuthorizationException (.getTopologyInfo nimbus_client "topo-ID"))))
         (.close client)))))
 

--- a/storm-core/test/clj/backtype/storm/security/auth/nimbus_auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/nimbus_auth_test.clj
@@ -14,27 +14,27 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.auth.nimbus-auth-test
-  (:use [clojure test])
-  (:require [backtype.storm [testing :as testing]])
-  (:require [backtype.storm.daemon [nimbus :as nimbus]])
-  (:require [backtype.storm [zookeeper :as zk]])
-  (:import [java.nio ByteBuffer])
-  (:import [backtype.storm Config])
-  (:import [backtype.storm.utils NimbusClient])
-  (:import [backtype.storm.generated NotAliveException])
-  (:import [backtype.storm.security.auth AuthUtils ThriftServer ThriftClient 
-                                         ReqContext ThriftConnectionType])
-  (:use [backtype.storm cluster util config log])
-  (:use [backtype.storm.daemon common nimbus])
-  (:import [backtype.storm.generated Nimbus Nimbus$Client Nimbus$Processor 
-            AuthorizationException SubmitOptions TopologyInitialStatus KillOptions])
-  (:require [conjure.core])
-  (:use [conjure core]))
+  (:use [clojure test]
+        [backtype.storm cluster util config log]
+        [backtype.storm.daemon common nimbus]
+        [conjure core])
+  (:require [backtype.storm [testing :as testing]]
+            [conjure.core]
+            [backtype.storm.daemon [nimbus :as nimbus]]
+            [backtype.storm [zookeeper :as zk]])
+  (:import [java.nio ByteBuffer]
+           [backtype.storm Config]
+           [backtype.storm.utils NimbusClient]
+           [backtype.storm.generated NotAliveException]
+           [backtype.storm.security.auth AuthUtils ThriftServer ThriftClient
+                                         ReqContext ThriftConnectionType]
+           [backtype.storm.generated Nimbus Nimbus$Client Nimbus$Processor
+                                     AuthorizationException SubmitOptions TopologyInitialStatus KillOptions]))
 
 (def nimbus-timeout (Integer. 30))
 
-(defn launch-test-cluster [nimbus-port login-cfg aznClass transportPluginClass] 
-  (let [conf {NIMBUS-AUTHORIZER aznClass 
+(defn launch-test-cluster [nimbus-port login-cfg aznClass transportPluginClass]
+  (let [conf {NIMBUS-AUTHORIZER aznClass
               NIMBUS-THRIFT-PORT nimbus-port
               STORM-THRIFT-TRANSPORT-PLUGIN transportPluginClass }
         conf (if login-cfg (merge conf {"java.security.auth.login.config" login-cfg}) conf)
@@ -42,7 +42,7 @@
                                             :ports-per-supervisor 0
                                             :daemon-conf conf)
         nimbus-server (ThriftServer. (:daemon-conf cluster-map)
-                                     (Nimbus$Processor. (:nimbus cluster-map)) 
+                                     (Nimbus$Processor. (:nimbus cluster-map))
                                      ThriftConnectionType/NIMBUS)]
     (.addShutdownHook (Runtime/getRuntime) (Thread. (fn [] (.stop nimbus-server))))
     (.start (Thread. #(.serve nimbus-server)))
@@ -56,7 +56,7 @@
       (testing/kill-local-storm-cluster cluster-map#)
       (.stop nimbus-server#)))
 
-(deftest Simple-authentication-test 
+(deftest Simple-authentication-test
   (let [port (available-port)]
     (with-test-cluster [port nil nil "backtype.storm.security.auth.SimpleTransportPlugin"]
       (let [storm-conf (merge (read-storm-config)
@@ -68,7 +68,7 @@
                  (is (thrown-cause? NotAliveException
                               (.activate nimbus_client "topo-name"))))
         (.close client)))))
-  
+
 (deftest test-noop-authorization-w-simple-transport
   (let [port (available-port)]
     (with-test-cluster [port nil

--- a/storm-core/test/clj/backtype/storm/security/serialization/BlowfishTupleSerializer_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/serialization/BlowfishTupleSerializer_test.clj
@@ -16,14 +16,11 @@
 (ns backtype.storm.security.serialization.BlowfishTupleSerializer-test
   (:use [clojure test]
         [backtype.storm.util :only (exception-cause?)]
-        [clojure.string :only (join split)]
-  )
+        [clojure.string :only (join split)])
   (:import [backtype.storm.security.serialization BlowfishTupleSerializer]
            [backtype.storm.utils ListDelegate]
            [com.esotericsoftware.kryo Kryo]
-           [com.esotericsoftware.kryo.io Input Output]
-  )
-)
+           [com.esotericsoftware.kryo.io Input Output]) )
 
 (deftest test-constructor-throws-on-null-key
   (is (thrown? RuntimeException (new BlowfishTupleSerializer nil {}))
@@ -66,10 +63,10 @@
     (-> delegate (.addAll strlist))
     (-> writer-bts (.write kryo output delegate))
     (.setBuffer input (.getBuffer output))
-    (is 
+    (is
       (=
         test-text
-        (join " " (map (fn [e] (str e)) 
+        (join " " (map (fn [e] (str e))
           (-> reader-bts (.read kryo input ListDelegate) (.toArray))))
       )
       "Reads a string encrypted by another instance with a shared key"

--- a/storm-core/test/clj/backtype/storm/security/serialization/BlowfishTupleSerializer_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/serialization/BlowfishTupleSerializer_test.clj
@@ -14,9 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.security.serialization.BlowfishTupleSerializer-test
-  (:use [clojure test]
-        [backtype.storm.util :only (exception-cause?)]
-        [clojure.string :only (join split)])
+  (:require [backtype.storm.util :refer [exception-cause?]]
+            [clojure.string :refer [join split]]
+            [clojure.test :refer :all])
   (:import [backtype.storm.security.serialization BlowfishTupleSerializer]
            [backtype.storm.utils ListDelegate]
            [com.esotericsoftware.kryo Kryo]

--- a/storm-core/test/clj/backtype/storm/serialization/SerializationFactory_test.clj
+++ b/storm-core/test/clj/backtype/storm/serialization/SerializationFactory_test.clj
@@ -14,8 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.serialization.SerializationFactory-test
-  (:use [backtype.storm config]
-        [clojure test])
+  (:require [backtype.storm.config :as c]
+            [clojure.test :refer :all])
   (:import [backtype.storm Config]
            [backtype.storm.security.serialization BlowfishTupleSerializer]
            [backtype.storm.serialization SerializationFactory]
@@ -23,7 +23,7 @@
 
 
 (deftest test-registers-default-when-not-in-conf
-  (let [conf (read-default-config)
+  (let [conf (c/read-default-config)
         klass-name (get conf Config/TOPOLOGY_TUPLE_SERIALIZER)
         configured-class (Class/forName klass-name)
         kryo (SerializationFactory/getKryo conf)]
@@ -32,7 +32,7 @@
 )
 
 (deftest test-throws-runtimeexception-when-no-such-class
-  (let [conf (merge (read-default-config)
+  (let [conf (merge (c/read-default-config)
           {Config/TOPOLOGY_TUPLE_SERIALIZER "null.this.class.does.not.exist"})]
     (is (thrown? RuntimeException
       (SerializationFactory/getKryo conf)))
@@ -44,7 +44,7 @@
         (String. "backtype.storm.security.serialization.BlowfishTupleSerializer")
         serializer-class (Class/forName arbitrary-class-name)
         arbitrary-key "0123456789abcdef"
-        conf (merge (read-default-config)
+        conf (merge (c/read-default-config)
           {Config/TOPOLOGY_TUPLE_SERIALIZER arbitrary-class-name
            BlowfishTupleSerializer/SECRET_KEY arbitrary-key})
         kryo (SerializationFactory/getKryo conf)]

--- a/storm-core/test/clj/backtype/storm/serialization/SerializationFactory_test.clj
+++ b/storm-core/test/clj/backtype/storm/serialization/SerializationFactory_test.clj
@@ -14,13 +14,12 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.serialization.SerializationFactory-test
-  (:import [backtype.storm Config])
-  (:import [backtype.storm.security.serialization BlowfishTupleSerializer])
-  (:import [backtype.storm.serialization SerializationFactory])
-  (:import [backtype.storm.utils ListDelegate])
-  (:use [backtype.storm config])
-  (:use [clojure test])
-)
+  (:use [backtype.storm config]
+        [clojure test])
+  (:import [backtype.storm Config]
+           [backtype.storm.security.serialization BlowfishTupleSerializer]
+           [backtype.storm.serialization SerializationFactory]
+           [backtype.storm.utils ListDelegate]))
 
 
 (deftest test-registers-default-when-not-in-conf

--- a/storm-core/test/clj/backtype/storm/serialization_test.clj
+++ b/storm-core/test/clj/backtype/storm/serialization_test.clj
@@ -14,13 +14,12 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.serialization-test
-  (:use [clojure test])
+  (:use [clojure test]
+        [backtype.storm util config])
   (:import [backtype.storm.serialization KryoTupleSerializer KryoTupleDeserializer
-            KryoValuesSerializer KryoValuesDeserializer])
-  (:import [backtype.storm.testing TestSerObject TestKryoDecorator])
-  (:import [backtype.storm ConfigValidation])
-  (:use [backtype.storm util config])
-  )
+                                         KryoValuesSerializer KryoValuesDeserializer]
+           [backtype.storm.testing TestSerObject TestKryoDecorator]
+           [backtype.storm ConfigValidation]))
 
 
 (defn mk-conf [extra]
@@ -72,7 +71,7 @@
    (bind obj (TestSerObject. 1 2))
    (is (thrown? Exception
                 (roundtrip [obj] {TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))
-   
+
    (is (= [obj] (roundtrip [obj] {TOPOLOGY-KRYO-DECORATORS ["backtype.storm.testing.TestKryoDecorator"]
                                   TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))))
 

--- a/storm-core/test/clj/backtype/storm/serialization_test.clj
+++ b/storm-core/test/clj/backtype/storm/serialization_test.clj
@@ -14,8 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.serialization-test
-  (:use [clojure test]
-        [backtype.storm util config])
+  (:require [backtype.storm.util :as util]
+            [backtype.storm.config :as c]
+            [clojure.test :refer :all])
   (:import [backtype.storm.serialization KryoTupleSerializer KryoTupleDeserializer
                                          KryoValuesSerializer KryoValuesDeserializer]
            [backtype.storm.testing TestSerObject TestKryoDecorator]
@@ -23,7 +24,7 @@
 
 
 (defn mk-conf [extra]
-  (merge (read-default-config) extra))
+  (merge (c/read-default-config) extra))
 
 (defn serialize [vals conf]
   (let [serializer (KryoValuesSerializer. (mk-conf conf))]
@@ -59,21 +60,21 @@
 )
 
 (deftest test-java-serialization
-  (letlocals
+  (util/letlocals
    (bind obj (TestSerObject. 1 2))
    (is (thrown? Exception
-     (roundtrip [obj] {TOPOLOGY-KRYO-REGISTER {"backtype.storm.testing.TestSerObject" nil}
-                       TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))
-   (is (= [obj] (roundtrip [obj] {TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION true})))))
+     (roundtrip [obj] {c/TOPOLOGY-KRYO-REGISTER {"backtype.storm.testing.TestSerObject" nil}
+                       c/TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))
+   (is (= [obj] (roundtrip [obj] {c/TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION true})))))
 
 (deftest test-kryo-decorator
-  (letlocals
+  (util/letlocals
    (bind obj (TestSerObject. 1 2))
    (is (thrown? Exception
-                (roundtrip [obj] {TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))
+                (roundtrip [obj] {c/TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))
 
-   (is (= [obj] (roundtrip [obj] {TOPOLOGY-KRYO-DECORATORS ["backtype.storm.testing.TestKryoDecorator"]
-                                  TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))))
+   (is (= [obj] (roundtrip [obj] {c/TOPOLOGY-KRYO-DECORATORS ["backtype.storm.testing.TestKryoDecorator"]
+                                  c/TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))))
 
 (defn mk-string [size]
   (let [builder (StringBuilder.)]

--- a/storm-core/test/clj/backtype/storm/submitter_test.clj
+++ b/storm-core/test/clj/backtype/storm/submitter_test.clj
@@ -14,8 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.submitter-test
-  (:use [clojure test]
-        [backtype.storm config testing])
+  (:use [backtype.storm config testing])
+  (:require [clojure.test :refer :all])
   (:import [backtype.storm StormSubmitter]))
 
 (deftest test-md5-digest-secret-generation

--- a/storm-core/test/clj/backtype/storm/submitter_test.clj
+++ b/storm-core/test/clj/backtype/storm/submitter_test.clj
@@ -14,10 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.submitter-test
-  (:use [clojure test])
-  (:use [backtype.storm config testing])
-  (:import [backtype.storm StormSubmitter])
-  )
+  (:use [clojure test]
+        [backtype.storm config testing])
+  (:import [backtype.storm StormSubmitter]))
 
 (deftest test-md5-digest-secret-generation
   (testing "No payload or scheme are generated when already present"

--- a/storm-core/test/clj/backtype/storm/subtopology_test.clj
+++ b/storm-core/test/clj/backtype/storm/subtopology_test.clj
@@ -14,12 +14,12 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.subtopology-test
-  (:use [clojure test])
-  (:import [backtype.storm.topology TopologyBuilder])
-  (:import [backtype.storm.testing TestWordSpout PrepareBatchBolt BatchRepeatA BatchProcessWord BatchNumberList])
-  (:import [backtype.storm.coordination BatchSubtopologyBuilder])
-  (:use [backtype.storm testing])
-  (:use [backtype.storm.daemon common]))
+  (:use [clojure test]
+        [backtype.storm testing]
+        [backtype.storm.daemon common])
+  (:import [backtype.storm.topology TopologyBuilder]
+           [backtype.storm.testing TestWordSpout PrepareBatchBolt BatchRepeatA BatchProcessWord BatchNumberList]
+           [backtype.storm.coordination BatchSubtopologyBuilder]))
 
 ;; todo: need to configure coordinatedbolt with streams that aren't subscribed to, should auto-anchor those to the final
 ;; coordination tuple... find all streams that aren't subscribed to
@@ -34,16 +34,16 @@
 ;;           )
 ;;       (bind batch-builder (BatchSubtopologyBuilder. "for-a" (BatchRepeatA.) 2))
 ;;       (-> (.getMasterDeclarer batch-builder)
-;;           (.shuffleGrouping "identity"))  
+;;           (.shuffleGrouping "identity"))
 ;;       (-> (.setBolt batch-builder "process" (BatchProcessWord.) 2)
 ;;           (.fieldsGrouping "for-a" "multi" (Fields. ["id"])))
 ;;       (-> (.setBolt batch-builder "joiner" (BatchNumberList. "for-a") 2)
 ;;           (.fieldsGrouping "process" (Fields. ["id"]))
 ;;           (.fieldsGrouping "for-a" "single" (Fields. ["id"]))
 ;;           )
-;;       
+;;
 ;;       (.extendTopology batch-builder builder)
-;;       
+;;
 ;;       (bind results (complete-topology cluster
 ;;                                        (.createTopology builder)
 ;;                                        :storm-conf {TOPOLOGY-DEBUG true}

--- a/storm-core/test/clj/backtype/storm/subtopology_test.clj
+++ b/storm-core/test/clj/backtype/storm/subtopology_test.clj
@@ -14,9 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.subtopology-test
-  (:use [clojure test]
-        [backtype.storm testing]
+  (:use [backtype.storm testing]
         [backtype.storm.daemon common])
+  (:require [clojure.test :refer :all])
   (:import [backtype.storm.topology TopologyBuilder]
            [backtype.storm.testing TestWordSpout PrepareBatchBolt BatchRepeatA BatchProcessWord BatchNumberList]
            [backtype.storm.coordination BatchSubtopologyBuilder]))

--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -14,8 +14,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.supervisor-test
-  (:use [clojure test]
-        [conjure core]
+  (:use [conjure core]
         [backtype.storm config testing util timer]
         [backtype.storm.daemon common])
   (:require [clojure.java.io :as io]
@@ -23,7 +22,8 @@
             [clojure.contrib [string :as contrib-str]]
             [clojure [string :as string] [set :as set]]
             [backtype.storm.daemon [worker :as worker] [supervisor :as supervisor]]
-            [backtype.storm [thrift :as thrift] [cluster :as cluster]])
+            [backtype.storm [thrift :as thrift] [cluster :as cluster]]
+            [clojure.test :refer :all])
   (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount TestAggregatesCounter TestPlannerSpout]
            [backtype.storm.scheduler ISupervisor]
            [backtype.storm.generated RebalanceOptions]

--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -14,21 +14,20 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.supervisor-test
-  (:use [clojure test])
-  (:require [conjure.core])
-  (:use [conjure core])
-  (:require [clojure.contrib [string :as contrib-str]])
-  (:require [clojure [string :as string] [set :as set]])
-  (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount TestAggregatesCounter TestPlannerSpout])
-  (:import [backtype.storm.scheduler ISupervisor])
-  (:import [backtype.storm.generated RebalanceOptions])
-  (:import [java.util UUID])
-  (:use [backtype.storm config testing util timer])
-  (:use [backtype.storm.daemon common])
-  (:require [backtype.storm.daemon [worker :as worker] [supervisor :as supervisor]]
+  (:use [clojure test]
+        [conjure core]
+        [backtype.storm config testing util timer]
+        [backtype.storm.daemon common])
+  (:require [clojure.java.io :as io]
+            [conjure.core]
+            [clojure.contrib [string :as contrib-str]]
+            [clojure [string :as string] [set :as set]]
+            [backtype.storm.daemon [worker :as worker] [supervisor :as supervisor]]
             [backtype.storm [thrift :as thrift] [cluster :as cluster]])
-  (:use [conjure core])
-  (:require [clojure.java.io :as io]))
+  (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount TestAggregatesCounter TestPlannerSpout]
+           [backtype.storm.scheduler ISupervisor]
+           [backtype.storm.generated RebalanceOptions]
+           [java.util UUID]))
 
 (defn worker-assignment
   "Return [storm-id executors]"

--- a/storm-core/test/clj/backtype/storm/testing4j_test.clj
+++ b/storm-core/test/clj/backtype/storm/testing4j_test.clj
@@ -14,16 +14,16 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.testing4j-test
-  (:use [clojure.test])
-  (:use [backtype.storm config clojure testing util])
-  (:require [backtype.storm.integration-test :as it])
-  (:require [backtype.storm.thrift :as thrift])
-  (:import [backtype.storm Testing Config ILocalCluster])
-  (:import [backtype.storm.tuple Values Tuple])
-  (:import [backtype.storm.utils Time Utils])
-  (:import [backtype.storm.testing MkClusterParam TestJob MockedSources TestWordSpout
-            TestWordCounter TestGlobalCount TestAggregatesCounter CompleteTopologyParam
-            AckFailMapTracker MkTupleParam]))
+  (:use [clojure.test]
+        [backtype.storm config clojure testing util])
+  (:require [backtype.storm.integration-test :as it]
+            [backtype.storm.thrift :as thrift])
+  (:import [backtype.storm Testing Config ILocalCluster]
+           [backtype.storm.tuple Values Tuple]
+           [backtype.storm.utils Time Utils]
+           [backtype.storm.testing MkClusterParam TestJob MockedSources TestWordSpout
+                                   TestWordCounter TestGlobalCount TestAggregatesCounter CompleteTopologyParam
+                                   AckFailMapTracker MkTupleParam]))
 
 (deftest test-with-simulated-time
   (is (= false (Time/isSimulating)))

--- a/storm-core/test/clj/backtype/storm/tick_tuple_test.clj
+++ b/storm-core/test/clj/backtype/storm/tick_tuple_test.clj
@@ -14,10 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.tick-tuple-test
-  (:use [clojure test]
-        [backtype.storm testing clojure config]
+  (:use [backtype.storm testing clojure config]
         [backtype.storm.daemon common])
-  (:require [backtype.storm [thrift :as thrift]]))
+  (:require [backtype.storm [thrift :as thrift]]
+            [clojure.test :refer :all]))
 
 (defbolt noop-bolt ["tuple"] {:prepare true}
   [conf context collector]

--- a/storm-core/test/clj/backtype/storm/tick_tuple_test.clj
+++ b/storm-core/test/clj/backtype/storm/tick_tuple_test.clj
@@ -14,9 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.tick-tuple-test
-  (:use [clojure test])
-  (:use [backtype.storm testing clojure config])
-  (:use [backtype.storm.daemon common])
+  (:use [clojure test]
+        [backtype.storm testing clojure config]
+        [backtype.storm.daemon common])
   (:require [backtype.storm [thrift :as thrift]]))
 
 (defbolt noop-bolt ["tuple"] {:prepare true}

--- a/storm-core/test/clj/backtype/storm/transactional_test.clj
+++ b/storm-core/test/clj/backtype/storm/transactional_test.clj
@@ -14,9 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.transactional-test
-  (:use [clojure test]
-        [backtype.storm testing util config clojure]
+  (:use [backtype.storm testing util config clojure]
         [backtype.storm.daemon common])
+  (:require [clojure.test :refer :all])
   (:import [backtype.storm Constants]
            [backtype.storm.topology TopologyBuilder]
            [backtype.storm.transactional TransactionalSpoutCoordinator ITransactionalSpout

--- a/storm-core/test/clj/backtype/storm/tuple_test.clj
+++ b/storm-core/test/clj/backtype/storm/tuple_test.clj
@@ -14,9 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.tuple-test
-  (:use [clojure test])
-  (:import [backtype.storm.tuple Tuple])
-  (:use [backtype.storm testing]))
+  (:use [clojure test]
+        [backtype.storm testing])
+  (:import [backtype.storm.tuple Tuple]))
 
 (deftest test-lookup
   (let [ tuple (test-tuple [12 "hello"] :fields ["foo" "bar"]) ]
@@ -25,7 +25,7 @@
     (is (= 12 (:foo tuple)))
 
     (is (= "hello" (:bar tuple)))
-    
+
     (is (= :notfound (tuple "404" :notfound)))))
 
 (deftest test-indexed
@@ -45,7 +45,7 @@
       (is (= {"bar" "hello"} (.getMap (dissoc tuple "foo"))))
       (is (= {"bar" "hello"} (.getMap (dissoc tuple :foo))))
 
-      (is (= {"foo" 42 "bar" "world"} (.getMap (assoc 
+      (is (= {"foo" 42 "bar" "world"} (.getMap (assoc
                                         (assoc tuple "foo" 42)
                                         :bar "world"))))))
 

--- a/storm-core/test/clj/backtype/storm/tuple_test.clj
+++ b/storm-core/test/clj/backtype/storm/tuple_test.clj
@@ -14,8 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.tuple-test
-  (:use [clojure test]
-        [backtype.storm testing])
+  (:use [backtype.storm testing])
+  (:require [clojure.test :refer :all])
   (:import [backtype.storm.tuple Tuple]))
 
 (deftest test-lookup

--- a/storm-core/test/clj/backtype/storm/utils/ZookeeperServerCnxnFactory_test.clj
+++ b/storm-core/test/clj/backtype/storm/utils/ZookeeperServerCnxnFactory_test.clj
@@ -14,7 +14,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.utils.ZookeeperServerCnxnFactory-test
-  (:use [clojure test])
+  (:require [clojure.test :refer :all])
   (:import [backtype.storm.utils ZookeeperServerCnxnFactory]))
 
 (deftest test-constructor-throws-runtimeexception-if-port-too-large

--- a/storm-core/test/clj/backtype/storm/utils/ZookeeperServerCnxnFactory_test.clj
+++ b/storm-core/test/clj/backtype/storm/utils/ZookeeperServerCnxnFactory_test.clj
@@ -14,9 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.utils.ZookeeperServerCnxnFactory-test
-  (:import [backtype.storm.utils ZookeeperServerCnxnFactory])
   (:use [clojure test])
-)
+  (:import [backtype.storm.utils ZookeeperServerCnxnFactory]))
 
 (deftest test-constructor-throws-runtimeexception-if-port-too-large
   (is (thrown? RuntimeException (ZookeeperServerCnxnFactory. 65536 42)))

--- a/storm-core/test/clj/backtype/storm/utils_test.clj
+++ b/storm-core/test/clj/backtype/storm/utils_test.clj
@@ -14,8 +14,9 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.utils-test
-  (:use [backtype.storm config util]
-        [clojure test])
+  (:require [backtype.storm.util :as util]
+            [backtype.storm.config :as c]
+            [clojure.test :refer :all])
   (:import [backtype.storm Config]
            [backtype.storm.utils NimbusClient Utils]
            [org.apache.curator.retry ExponentialBackoffRetry]
@@ -25,7 +26,7 @@
   (let [expected_interval 2400
         expected_retries 10
         expected_ceiling 3000
-        conf (merge (clojurify-structure (Utils/readDefaultConfig))
+        conf (merge (util/clojurify-structure (Utils/readDefaultConfig))
           {Config/STORM_ZOOKEEPER_RETRY_INTERVAL expected_interval
            Config/STORM_ZOOKEEPER_RETRY_TIMES expected_retries
            Config/STORM_ZOOKEEPER_RETRY_INTERVAL_CEILING expected_ceiling})
@@ -42,22 +43,22 @@
 )
 
 (deftest test-getConfiguredClient-throws-RunTimeException-on-bad-config
-  (let [storm-conf (merge (read-storm-config)
-                     {STORM-THRIFT-TRANSPORT-PLUGIN
+  (let [storm-conf (merge (c/read-storm-config)
+                     {c/STORM-THRIFT-TRANSPORT-PLUGIN
                        "backtype.storm.security.auth.SimpleTransportPlugin"
                       Config/NIMBUS_HOST ""
                       Config/NIMBUS_THRIFT_PORT 65535
-                      STORM-NIMBUS-RETRY-TIMES 0})]
-    (is (thrown-cause? RuntimeException
+                      c/STORM-NIMBUS-RETRY-TIMES 0})]
+    (is (util/thrown-cause? RuntimeException
       (NimbusClient/getConfiguredClient storm-conf)))
   )
 )
 
 (deftest test-getConfiguredClient-throws-RunTimeException-on-bad-args
   (let [storm-conf (merge
-                    (read-storm-config)
-                    {STORM-NIMBUS-RETRY-TIMES 0})]
-    (is (thrown-cause? TTransportException
+                    (c/read-storm-config)
+                    {c/STORM-NIMBUS-RETRY-TIMES 0})]
+    (is (util/thrown-cause? TTransportException
       (NimbusClient. storm-conf "" 65535)
     ))
   )
@@ -68,15 +69,15 @@
       (is (not (Utils/isZkAuthenticationConfiguredTopology nil))))
     (testing "Returns false on scheme key missing"
       (is (not (Utils/isZkAuthenticationConfiguredTopology
-          {STORM-ZOOKEEPER-TOPOLOGY-AUTH-SCHEME nil}))))
+          {c/STORM-ZOOKEEPER-TOPOLOGY-AUTH-SCHEME nil}))))
     (testing "Returns false on scheme value null"
       (is (not
         (Utils/isZkAuthenticationConfiguredTopology
-          {STORM-ZOOKEEPER-TOPOLOGY-AUTH-SCHEME nil}))))
+          {c/STORM-ZOOKEEPER-TOPOLOGY-AUTH-SCHEME nil}))))
     (testing "Returns true when scheme set to string"
       (is
         (Utils/isZkAuthenticationConfiguredTopology
-          {STORM-ZOOKEEPER-TOPOLOGY-AUTH-SCHEME "foobar"}))))
+          {c/STORM-ZOOKEEPER-TOPOLOGY-AUTH-SCHEME "foobar"}))))
 
 (deftest test-isZkAuthenticationConfiguredStormServer
   (let [k "java.security.auth.login.config"
@@ -87,15 +88,15 @@
         (is (not (Utils/isZkAuthenticationConfiguredStormServer nil))))
       (testing "Returns false on scheme key missing"
         (is (not (Utils/isZkAuthenticationConfiguredStormServer
-            {STORM-ZOOKEEPER-AUTH-SCHEME nil}))))
+            {c/STORM-ZOOKEEPER-AUTH-SCHEME nil}))))
       (testing "Returns false on scheme value null"
         (is (not
           (Utils/isZkAuthenticationConfiguredStormServer
-            {STORM-ZOOKEEPER-AUTH-SCHEME nil}))))
+            {c/STORM-ZOOKEEPER-AUTH-SCHEME nil}))))
       (testing "Returns true when scheme set to string"
         (is
           (Utils/isZkAuthenticationConfiguredStormServer
-            {STORM-ZOOKEEPER-AUTH-SCHEME "foobar"})))
+            {c/STORM-ZOOKEEPER-AUTH-SCHEME "foobar"})))
       (testing "Returns true when java.security.auth.login.config is set"
         (do
           (System/setProperty k "anything")
@@ -105,17 +106,17 @@
           (System/setProperty k "anything")
           (is (Utils/isZkAuthenticationConfiguredStormServer {}))))
     (finally
-      (if (not-nil? oldprop)
+      (if (util/not-nil? oldprop)
         (System/setProperty k oldprop)
         (.remove (System/getProperties) k))))))
 
 (deftest test-secs-to-millis-long
-  (is (= 0 (secs-to-millis-long 0)))
-  (is (= 2 (secs-to-millis-long 0.002)))
-  (is (= 500 (secs-to-millis-long 0.5)))
-  (is (= 1000 (secs-to-millis-long 1)))
-  (is (= 1080 (secs-to-millis-long 1.08)))
-  (is (= 10000 (secs-to-millis-long 10)))
-  (is (= 10100 (secs-to-millis-long 10.1)))
+  (is (= 0 (util/secs-to-millis-long 0)))
+  (is (= 2 (util/secs-to-millis-long 0.002)))
+  (is (= 500 (util/secs-to-millis-long 0.5)))
+  (is (= 1000 (util/secs-to-millis-long 1)))
+  (is (= 1080 (util/secs-to-millis-long 1.08)))
+  (is (= 10000 (util/secs-to-millis-long 10)))
+  (is (= 10100 (util/secs-to-millis-long 10.1)))
 )
 

--- a/storm-core/test/clj/backtype/storm/utils_test.clj
+++ b/storm-core/test/clj/backtype/storm/utils_test.clj
@@ -14,13 +14,12 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.utils-test
-  (:import [backtype.storm Config])
-  (:import [backtype.storm.utils NimbusClient Utils])
-  (:import [org.apache.curator.retry ExponentialBackoffRetry])
-  (:import [org.apache.thrift.transport TTransportException])
-  (:use [backtype.storm config util])
-  (:use [clojure test])
-)
+  (:use [backtype.storm config util]
+        [clojure test])
+  (:import [backtype.storm Config]
+           [backtype.storm.utils NimbusClient Utils]
+           [org.apache.curator.retry ExponentialBackoffRetry]
+           [org.apache.thrift.transport TTransportException]))
 
 (deftest test-new-curator-uses-exponential-backoff
   (let [expected_interval 2400
@@ -105,8 +104,8 @@
         (do
           (System/setProperty k "anything")
           (is (Utils/isZkAuthenticationConfiguredStormServer {}))))
-    (finally 
-      (if (not-nil? oldprop) 
+    (finally
+      (if (not-nil? oldprop)
         (System/setProperty k oldprop)
         (.remove (System/getProperties) k))))))
 

--- a/storm-core/test/clj/backtype/storm/versioned_store_test.clj
+++ b/storm-core/test/clj/backtype/storm/versioned_store_test.clj
@@ -14,13 +14,13 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.versioned-store-test
-  (:use [clojure test]
-        [backtype.storm testing])
+  (:require [backtype.storm.testing :as testing]
+            [clojure.test :refer :all])
   (:import [backtype.storm.utils VersionedStore]))
 
 (defmacro defvstest [name [vs-sym] & body]
   `(deftest ~name
-    (with-local-tmp [dir#]
+    (testing/with-local-tmp [dir#]
       (let [~vs-sym (VersionedStore. dir#)]
         ~@body
         ))))

--- a/storm-core/test/clj/backtype/storm/versioned_store_test.clj
+++ b/storm-core/test/clj/backtype/storm/versioned_store_test.clj
@@ -14,8 +14,8 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.versioned-store-test
-  (:use [clojure test])
-  (:use [backtype.storm testing])
+  (:use [clojure test]
+        [backtype.storm testing])
   (:import [backtype.storm.utils VersionedStore]))
 
 (defmacro defvstest [name [vs-sym] & body]
@@ -39,7 +39,7 @@
     (.succeedVersion vs v)
     (is (= 2 (count (.getAllVersions vs))))
     (is (= v (.mostRecentVersionPath vs)))
-    
+
     (.createVersion vs)
     (is (= v (.mostRecentVersionPath vs)))
     ))

--- a/storm-core/test/clj/backtype/storm/worker_test.clj
+++ b/storm-core/test/clj/backtype/storm/worker_test.clj
@@ -14,10 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.worker-test
-  (:use [clojure test]
-        [backtype.storm testing]
+  (:use [backtype.storm testing]
         [backtype.storm.daemon common])
-  (:require [backtype.storm.daemon [worker :as worker]])
+  (:require [backtype.storm.daemon.worker :as worker]
+            [clojure.test :refer :all])
   (:import [backtype.storm.messaging TaskMessage IContext IConnection ConnectionWithStatus ConnectionWithStatus$Status]
            [org.mockito Mockito]))
 

--- a/storm-core/test/clj/backtype/storm/worker_test.clj
+++ b/storm-core/test/clj/backtype/storm/worker_test.clj
@@ -14,14 +14,12 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns backtype.storm.worker-test
-  (:use [clojure test])
-  (:import [backtype.storm.messaging TaskMessage IContext IConnection ConnectionWithStatus ConnectionWithStatus$Status])
-  (:import [org.mockito Mockito])
-  (:use [backtype.storm testing])
-  (:use [backtype.storm.daemon common])
-
+  (:use [clojure test]
+        [backtype.storm testing]
+        [backtype.storm.daemon common])
   (:require [backtype.storm.daemon [worker :as worker]])
-  )
+  (:import [backtype.storm.messaging TaskMessage IContext IConnection ConnectionWithStatus ConnectionWithStatus$Status]
+           [org.mockito Mockito]))
 
 
 (deftest test-worker-is-connection-ready

--- a/storm-core/test/clj/storm/trident/integration_test.clj
+++ b/storm-core/test/clj/storm/trident/integration_test.clj
@@ -14,10 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.trident.integration-test
-  (:use [clojure test]
-        [storm.trident testing]
-        [backtype.storm util])
-  (:require [backtype.storm [testing :as t]])
+  (:use [storm.trident testing])
+  (:require [backtype.storm [testing :as t]]
+            [backtype.storm.util :as util]
+            [clojure.test :refer :all])
   (:import [storm.trident.testing Split CountAsAggregator StringLength TrueFilter
                                   MemoryMapState$Factory]
            [storm.trident.state StateSpec]
@@ -28,7 +28,7 @@
 (deftest test-memory-map-get-tuples
   (t/with-local-cluster [cluster]
     (with-drpc [drpc]
-      (letlocals
+      (util/letlocals
         (bind topo (TridentTopology.))
         (bind feeder (feeder-spout ["sentence"]))
         (bind word-counts
@@ -55,7 +55,7 @@
 (deftest test-word-count
   (t/with-local-cluster [cluster]
     (with-drpc [drpc]
-      (letlocals
+      (util/letlocals
         (bind topo (TridentTopology.))
         (bind feeder (feeder-spout ["sentence"]))
         (bind word-counts
@@ -88,7 +88,7 @@
 (deftest test-word-count-committer-spout
   (t/with-local-cluster [cluster]
     (with-drpc [drpc]
-      (letlocals
+      (util/letlocals
         (bind topo (TridentTopology.))
         (bind feeder (feeder-committer-spout ["sentence"]))
         (.setWaitToEmit feeder false) ;;this causes lots of empty batches
@@ -127,7 +127,7 @@
 (deftest test-count-agg
   (t/with-local-cluster [cluster]
     (with-drpc [drpc]
-      (letlocals
+      (util/letlocals
         (bind topo (TridentTopology.))
         (-> topo
             (.newDRPCStream "numwords" drpc)
@@ -145,7 +145,7 @@
 (deftest test-split-merge
   (t/with-local-cluster [cluster]
     (with-drpc [drpc]
-      (letlocals
+      (util/letlocals
         (bind topo (TridentTopology.))
         (bind drpc-stream (-> topo (.newDRPCStream "splitter" drpc)))
         (bind s1
@@ -166,7 +166,7 @@
 (deftest test-multiple-groupings-same-stream
   (t/with-local-cluster [cluster]
     (with-drpc [drpc]
-      (letlocals
+      (util/letlocals
         (bind topo (TridentTopology.))
         (bind drpc-stream (-> topo (.newDRPCStream "tester" drpc)
                                    (.each (fields "args") (TrueFilter.))))
@@ -188,7 +188,7 @@
 (deftest test-multi-repartition
   (t/with-local-cluster [cluster]
     (with-drpc [drpc]
-      (letlocals
+      (util/letlocals
         (bind topo (TridentTopology.))
         (bind drpc-stream (-> topo (.newDRPCStream "tester" drpc)
                                    (.each (fields "args") (Split.) (fields "word"))
@@ -203,7 +203,7 @@
 
 (deftest test-stream-projection-validation
   (t/with-local-cluster [cluster]
-    (letlocals
+    (util/letlocals
      (bind feeder (feeder-committer-spout ["sentence"]))
      (bind topo (TridentTopology.))
      ;; valid projection fields will not throw exceptions

--- a/storm-core/test/clj/storm/trident/integration_test.clj
+++ b/storm-core/test/clj/storm/trident/integration_test.clj
@@ -14,15 +14,15 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.trident.integration-test
-  (:use [clojure test])
+  (:use [clojure test]
+        [storm.trident testing]
+        [backtype.storm util])
   (:require [backtype.storm [testing :as t]])
   (:import [storm.trident.testing Split CountAsAggregator StringLength TrueFilter
-            MemoryMapState$Factory])
-  (:import [storm.trident.state StateSpec])
-  (:import [storm.trident.operation.impl CombinerAggStateUpdater])
-  (:use [storm.trident testing])
-  (:use [backtype.storm util]))
-  
+                                  MemoryMapState$Factory]
+           [storm.trident.state StateSpec]
+           [storm.trident.operation.impl CombinerAggStateUpdater]))
+
 (bootstrap-imports)
 
 (deftest test-memory-map-get-tuples
@@ -38,7 +38,7 @@
               (.groupBy (fields "word"))
               (.persistentAggregate (memory-map-state) (Count.) (fields "count"))
               (.parallelismHint 6)
-              ))       
+              ))
         (-> topo
             (.newDRPCStream "all-tuples" drpc)
             (.broadcast)
@@ -83,7 +83,7 @@
           (is (= [[8]] (exec-drpc drpc "words" "man where you the")))
           )))))
 
-;; this test reproduces a bug where committer spouts freeze processing when 
+;; this test reproduces a bug where committer spouts freeze processing when
 ;; there's at least one repartitioning after the spout
 (deftest test-word-count-committer-spout
   (t/with-local-cluster [cluster]
@@ -141,7 +141,7 @@
           (is (= [[0]] (exec-drpc drpc "numwords" "")))
           (is (= [[8]] (exec-drpc drpc "numwords" "1 2 3 4 5 6 7 8")))
           )))))
-          
+
 (deftest test-split-merge
   (t/with-local-cluster [cluster]
     (with-drpc [drpc]
@@ -184,7 +184,7 @@
           (is (t/ms= [["the" 1] ["the" 1]] (exec-drpc drpc "tester" "the")))
           (is (t/ms= [["aaaaa" 1] ["aaaaa" 1]] (exec-drpc drpc "tester" "aaaaa")))
           )))))
-          
+
 (deftest test-multi-repartition
   (t/with-local-cluster [cluster]
     (with-drpc [drpc]
@@ -284,7 +284,7 @@
 ;;           (-> drpc-stream
 ;;               (.each (fields "args") (StringLength.) (fields "len"))
 ;;               (.project (fields "len"))))
-;; 
+;;
 ;;         (.merge topo [s1 s2])
 ;;         (with-topology [cluster topo]
 ;;           (is (t/ms= [[7] ["the"] ["man"]] (exec-drpc drpc "splitter" "the man")))

--- a/storm-core/test/clj/storm/trident/state_test.clj
+++ b/storm-core/test/clj/storm/trident/state_test.clj
@@ -14,10 +14,10 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.trident.state-test
-  (:use [clojure test]
-        [storm.trident testing]
-        [backtype.storm config util])
-  (:require [backtype.storm [testing :as t]])
+  (:use [storm.trident testing])
+  (:require [backtype.storm.testing :as t]
+            [backtype.storm.util :as util]
+            [clojure.test :refer :all])
   (:import [storm.trident.operation.builtin Count]
            [storm.trident.state OpaqueValue]
            [storm.trident.state CombinerValueUpdater]
@@ -128,7 +128,7 @@
           e)))))))
 
 (deftest test-memory-map-state-remove
-  (let [map (MemoryMapState. (uuid))]
+  (let [map (MemoryMapState. (util/uuid))]
     (.beginCommit map 1)
     (single-put map "a" 1)
     (single-put map "b" 2)

--- a/storm-core/test/clj/storm/trident/state_test.clj
+++ b/storm-core/test/clj/storm/trident/state_test.clj
@@ -14,22 +14,22 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.trident.state-test
-  (:use [clojure test])
+  (:use [clojure test]
+        [storm.trident testing]
+        [backtype.storm config util])
   (:require [backtype.storm [testing :as t]])
-  (:import [storm.trident.operation.builtin Count])
-  (:import [storm.trident.state OpaqueValue])
-  (:import [storm.trident.state CombinerValueUpdater])
-  (:import [storm.trident.topology.state TransactionalState TestTransactionalState])
-  (:import [storm.trident.state.map TransactionalMap OpaqueMap])
-  (:import [storm.trident.testing MemoryBackingMap MemoryMapState])
-  (:import [backtype.storm.utils ZookeeperAuthInfo])
-  (:import [org.apache.curator.framework CuratorFramework])
-  (:import [org.apache.curator.framework.api CreateBuilder ProtectACLCreateModePathAndBytesable])
-  (:import [org.apache.zookeeper CreateMode ZooDefs ZooDefs$Ids])
-  (:import [org.mockito Matchers Mockito])
-  (:import [org.mockito.exceptions.base MockitoAssertionError])
-  (:use [storm.trident testing])
-  (:use [backtype.storm config util]))
+  (:import [storm.trident.operation.builtin Count]
+           [storm.trident.state OpaqueValue]
+           [storm.trident.state CombinerValueUpdater]
+           [storm.trident.topology.state TransactionalState TestTransactionalState]
+           [storm.trident.state.map TransactionalMap OpaqueMap]
+           [storm.trident.testing MemoryBackingMap MemoryMapState]
+           [backtype.storm.utils ZookeeperAuthInfo]
+           [org.apache.curator.framework CuratorFramework]
+           [org.apache.curator.framework.api CreateBuilder ProtectACLCreateModePathAndBytesable]
+           [org.apache.zookeeper CreateMode ZooDefs ZooDefs$Ids]
+           [org.mockito Matchers Mockito]
+           [org.mockito.exceptions.base MockitoAssertionError]))
 
 (defn single-remove [map key]
   (-> map (.multiRemove [[key]])))
@@ -145,6 +145,6 @@
     (.commit map 2)
     (.beginCommit map 3)
     (is (nil? (single-get map "a")))
-    (is (= 2 (single-get map "b")))    
+    (is (= 2 (single-get map "b")))
     (.commit map 3)
     ))

--- a/storm-core/test/clj/storm/trident/tuple_test.clj
+++ b/storm-core/test/clj/storm/trident/tuple_test.clj
@@ -14,16 +14,16 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.trident.tuple-test
-  (:use [clojure test]
-        [storm.trident testing]
-        [backtype.storm util])
-  (:require [backtype.storm [testing :as t]])
+  (:use [storm.trident testing])
+  (:require [backtype.storm [testing :as t]]
+            [backtype.storm.util :as util]
+            [clojure.test :refer :all])
   (:import [storm.trident.tuple TridentTupleView TridentTupleView$ProjectionFactory
             TridentTupleView$FreshOutputFactory TridentTupleView$OperationOutputFactory
             TridentTupleView$RootFactory]))
 
 (deftest test-fresh
-  (letlocals
+  (util/letlocals
     (bind fresh-factory (TridentTupleView$FreshOutputFactory. (fields "a" "b" "c")))
     (bind tt (.create fresh-factory [3 2 1]))
     (is (= [3 2 1] tt))
@@ -33,7 +33,7 @@
     ))
 
 (deftest test-projection
-  (letlocals
+  (util/letlocals
     (bind fresh-factory (TridentTupleView$FreshOutputFactory. (fields "a" "b" "c" "d" "e")))
     (bind project-factory (TridentTupleView$ProjectionFactory. fresh-factory (fields "d" "a")))
     (bind tt (.create fresh-factory [3 2 1 4 5]))
@@ -51,7 +51,7 @@
     ))
 
 (deftest test-appends
-  (letlocals
+  (util/letlocals
     (bind fresh-factory (TridentTupleView$FreshOutputFactory. (fields "a" "b" "c")))
     (bind append-factory (TridentTupleView$OperationOutputFactory. fresh-factory (fields "d" "e")))
     (bind append-factory2 (TridentTupleView$OperationOutputFactory. append-factory (fields "f")))
@@ -67,7 +67,7 @@
     ))
 
 (deftest test-root
-  (letlocals
+  (util/letlocals
     (bind root-factory (TridentTupleView$RootFactory. (fields "a" "b")))
     (bind storm-tuple (t/test-tuple ["a" 1]))
     (bind tt (.create root-factory storm-tuple))
@@ -85,7 +85,7 @@
     ))
 
 (deftest test-complex
-  (letlocals
+  (util/letlocals
     (bind fresh-factory (TridentTupleView$FreshOutputFactory. (fields "a" "b" "c")))
     (bind append-factory1 (TridentTupleView$OperationOutputFactory. fresh-factory (fields "d")))
     (bind append-factory2 (TridentTupleView$OperationOutputFactory. append-factory1 (fields "e" "f")))
@@ -111,7 +111,7 @@
     ))
 
 (deftest test-ituple-interface
-  (letlocals
+  (util/letlocals
     (bind tt (TridentTupleView/createFreshTuple (fields "a" "b" "c") [1 2 3]))
     (is (= [1 2 3] tt))
     (is (= ["a" "b" "c"] (.toList (.getFields tt))))

--- a/storm-core/test/clj/storm/trident/tuple_test.clj
+++ b/storm-core/test/clj/storm/trident/tuple_test.clj
@@ -14,13 +14,13 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns storm.trident.tuple-test
-  (:use [clojure test])
+  (:use [clojure test]
+        [storm.trident testing]
+        [backtype.storm util])
   (:require [backtype.storm [testing :as t]])
   (:import [storm.trident.tuple TridentTupleView TridentTupleView$ProjectionFactory
             TridentTupleView$FreshOutputFactory TridentTupleView$OperationOutputFactory
-            TridentTupleView$RootFactory])
-  (:use [storm.trident testing])
-  (:use [backtype.storm util]))
+            TridentTupleView$RootFactory]))
 
 (deftest test-fresh
   (letlocals


### PR DESCRIPTION
[STORM-436](https://issues.apache.org/jira/browse/STORM-436)

The purpose of this change is to remove as many :use's as possible. This will make the codebase codebase easier to understand and maintain because we can see where vars are coming from.

It will also be cleaner and more idiomatic Clojure.