### PR TITLE
STORM-810: PartitionManager should commit latest offset before close

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -269,6 +269,7 @@ public class PartitionManager {
     }
 
     public void close() {
+        commit();
         _connections.unregister(_partition.host, _partition.partition);
     }
 


### PR DESCRIPTION
PR for [STORM-810](https://issues.apache.org/jira/browse/STORM-810)

When KafkaSpout refresh with kafka partitions, it will remove patitions that no longer served by this spout and close the connection. But before close the connection, PartitionManager don't commit the latest offset. As a result some other spout that serve the removed partition will replay some tuple that between last commit and close.