### PR TITLE
STORM-813 Change storm-starter's README so that it explains mvn exec:java cannot run multilang topology

### DIFF
--- a/examples/storm-starter/README.markdown
+++ b/examples/storm-starter/README.markdown
@@ -76,10 +76,10 @@ of Storm in this local Maven repository at `$HOME/.m2/repository`.
 
 > Note: All following examples require that you run `cd examples/storm-starter` beforehand.
 
-storm-starter topologies can be run with the maven-exec-plugin. For example, to
-compile and run `WordCountTopology` in local mode, use the command:
+storm-starter topologies which don't use multilang feature can be run with the maven-exec-plugin. 
+For example, to compile and run `ExclamationTopology` in local mode, use the command:
 
-    $ mvn compile exec:java -Dstorm.topology=storm.starter.WordCountTopology
+    $ mvn compile exec:java -Dstorm.topology=storm.starter.ExclamationTopology
 
 You can also run clojure topologies with Maven:
 
@@ -110,6 +110,8 @@ You can submit (run) a topology contained in this uberjar to Storm via the `stor
     # Example 2: Run the RollingTopWords in remote/cluster mode,
     #            under the name "production-topology"
     $ storm jar storm-starter-*.jar storm.starter.RollingTopWords production-topology remote
+
+With submitting you can run topologies which use multilang, for example, `WordCountTopology`.
 
 _Submitting a topology in local vs. remote mode:_
 It depends on the actual code of a topology how you can or even must tell Storm whether to run the topology locally (in


### PR DESCRIPTION
New multilang packages rely on supervisor deploy or maven dependency plugin.
Therefore, storm-starter README should remove example which is not working now. 

Btw, actually storm-core shows that it could be possible to unpack multilang artifacts with maven plugin and run multilang topology with mvn exec:java, and I confirmed that can work with storm-starter.

```
        <plugin>
            <artifactId>maven-dependency-plugin</artifactId>
            <version>2.8</version>
            <executions>
                <execution>
                    <id>copy-dependencies</id>
                    <phase>compile</phase>
                    <goals>
                        <goal>copy-dependencies</goal>
                    </goals>
                    <configuration>
                        <overWriteReleases>false</overWriteReleases>
                        <overWriteSnapshots>false</overWriteSnapshots>
                        <overWriteIfNewer>true</overWriteIfNewer>
                        <includeScope>runtime</includeScope>
                    </configuration>
                </execution>
                <!-- multi-lang resources -->
                <execution>
                    <id>unpack</id>
                    <phase>process-resources</phase>
                    <goals>
                        <goal>unpack</goal>
                    </goals>
                    <configuration>
                        <artifactItems>
                            <artifactItem>
                                <groupId>org.apache.storm</groupId>
                                <artifactId>multilang-ruby</artifactId>
                                <version>${project.version}</version>
                            </artifactItem>
                            <artifactItem>
                                <groupId>org.apache.storm</groupId>
                                <artifactId>multilang-python</artifactId>
                                <version>${project.version}</version>
                            </artifactItem>
                            <artifactItem>
                                <groupId>org.apache.storm</groupId>
                                <artifactId>multilang-javascript</artifactId>
                                <version>${project.version}</version>
                            </artifactItem>
                        </artifactItems>
                        <outputDirectory>${project.build.directory}/classes</outputDirectory>
                    </configuration>
                </execution>
            </executions>
        </plugin>
```

If we prefer latter approach, I'll change my PR.

Thanks in advance!