### PR TITLE
[STORM-816] maven-gpg-plugin does not work with gpg 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -632,7 +632,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
GPG 2.1 changed some security things involving password entry, and it looks like our version of the plugin doesn't work with it.

We should upgrade.
