### PR TITLE
Remove unused clj-time dependency from storm-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,6 @@
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.5</commons-lang.version>
         <commons-exec.version>1.1</commons-exec.version>
-        <clj-time.version>0.8.0</clj-time.version>
         <curator.version>2.5.0</curator.version>
         <json-simple.version>1.1</json-simple.version>
         <ring.version>1.3.0</ring.version>
@@ -334,11 +333,6 @@
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>${commons-lang.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>clj-time</groupId>
-                <artifactId>clj-time</artifactId>
-                <version>${clj-time.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>clojure</artifactId>
         </dependency>
         <dependency>
-            <groupId>clj-time</groupId>
-            <artifactId>clj-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>compojure</groupId>
             <artifactId>compojure</artifactId>
         </dependency>

--- a/storm-core/src/clj/backtype/storm/ui/helpers.clj
+++ b/storm-core/src/clj/backtype/storm/ui/helpers.clj
@@ -21,7 +21,6 @@
          [walk :only [keywordize-keys]]])
   (:use [backtype.storm config log])
   (:use [backtype.storm.util :only [clojurify-structure uuid defnk url-encode not-nil?]])
-  (:use [clj-time coerce format])
   (:import [backtype.storm.generated ExecutorInfo ExecutorSummary])
   (:import [java.util EnumSet])
   (:import [org.eclipse.jetty.server Server]


### PR DESCRIPTION
clj-time was formerly used by UI, but is no longer. This removes
clj-time (and thus joda-time 2.0). This might be a breaking change
if a user assumes joda-time 2.0 or clj-time 0.8.0 is provided by
the worker on the classpath.