### PR TITLE
fix the dismatch between doc and code for read-all-supervisor-details

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -503,7 +503,7 @@
              {tid (SchedulerAssignmentImpl. tid executor->slot)})))
 
 (defn- read-all-supervisor-details [nimbus all-scheduling-slots supervisor->dead-ports]
-  "return a map: {topology-id SupervisorDetails}"
+  "return a map: {supervisor-id SupervisorDetails}"
   (let [storm-cluster-state (:storm-cluster-state nimbus)
         supervisor-infos (all-supervisor-info storm-cluster-state)
         nonexistent-supervisor-slots (apply dissoc all-scheduling-slots (keys supervisor-infos))


### PR DESCRIPTION
fix the dismatch between doc and source code in function read-all-supervisor-details