### PR TITLE
STORM-849 Add storm-redis to storm binary distribution

### DIFF
--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -201,6 +201,20 @@
                 <include>README.*</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/../../external/storm-redis/target</directory>
+            <outputDirectory>external/storm-redis</outputDirectory>
+            <includes>
+                <include>storm*jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/../../external/storm-redis</directory>
+            <outputDirectory>external/storm-redis</outputDirectory>
+            <includes>
+                <include>README.*</include>
+            </includes>
+        </fileSet>
 
 
         <!-- $STORM_HOME/extlib -->


### PR DESCRIPTION
storm-redis is not added to storm binary distribution while other externals are added.
Since it's a small patch so I didn't file an issue.

@ptgoetz @revans2 
Please review and merge to 0.10.x-branch and master so that storm-redis could be included to storm binary distribution.
Thanks in advance!