### PR TITLE
STORM-160 Allow ShellBolt to set env vars (particularly PATH)

### DIFF
--- a/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -25,19 +25,18 @@ import backtype.storm.multilang.ShellMsg;
 import backtype.storm.multilang.SpoutMsg;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.utils.ShellProcess;
-import clojure.lang.RT;
-import com.google.common.util.concurrent.MoreExecutors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.List;
 import java.util.TimerTask;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+
+import clojure.lang.RT;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ShellSpout implements ISpout {
@@ -47,9 +46,9 @@ public class ShellSpout implements ISpout {
     private String[] _command;
     private Map<String, String> env = new HashMap<String, String>();
     private ShellProcess _process;
-
+    
     private TopologyContext _context;
-
+    
     private SpoutMsg _spoutMsg;
 
     private int workerTimeoutMills;

--- a/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -26,6 +26,7 @@ import backtype.storm.multilang.SpoutMsg;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.utils.ShellProcess;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.List;
 import java.util.TimerTask;
 import java.util.concurrent.ScheduledExecutorService;

--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -74,6 +74,7 @@ public class ShellBolt implements IBolt {
     Map<String, Tuple> _inputs = new ConcurrentHashMap<String, Tuple>();
 
     private String[] _command;
+    private Map<String, String> env = new HashMap<String, String>();
     private ShellProcess _process;
     private volatile boolean _running = true;
     private volatile Throwable _exception;
@@ -98,6 +99,12 @@ public class ShellBolt implements IBolt {
         _command = command;
     }
 
+
+    public ShellBolt setEnv(Map<String, String> env) {
+        this.env = env;
+        return this;
+    }
+
     public void prepare(Map stormConf, TopologyContext context,
                         final OutputCollector collector) {
         Object maxPending = stormConf.get(Config.TOPOLOGY_SHELLBOLT_MAX_PENDING);
@@ -112,6 +119,9 @@ public class ShellBolt implements IBolt {
         workerTimeoutMills = 1000 * RT.intCast(stormConf.get(Config.SUPERVISOR_WORKER_TIMEOUT_SECS));
 
         _process = new ShellProcess(_command);
+        if (!env.isEmpty()) {
+            _process.setEnv(env);
+        }
 
         //subprocesses must send their pid first thing
         Number subpid = _process.launch(stormConf, context);

--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -99,7 +99,6 @@ public class ShellBolt implements IBolt {
         _command = command;
     }
 
-
     public ShellBolt setEnv(Map<String, String> env) {
         this.env = env;
         return this;

--- a/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
@@ -18,14 +18,16 @@
 package backtype.storm.utils;
 
 import backtype.storm.Config;
-import backtype.storm.multilang.*;
+import backtype.storm.multilang.ISerializer;
+import backtype.storm.multilang.BoltMsg;
+import backtype.storm.multilang.NoOutputException;
+import backtype.storm.multilang.ShellMsg;
+import backtype.storm.multilang.SpoutMsg;
 import backtype.storm.task.TopologyContext;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,8 +55,8 @@ public class ShellProcess implements Serializable {
 
     private void modifyEnvironment(Map<String, String> buildEnv) {
         for (Map.Entry<String, String> entry : env.entrySet()) {
-            if (entry.getKey().equals("PATH")) {
-                buildEnv.put("PATH", buildEnv.get("PATH") + ":" + env.get("PATH"));
+            if ("PATH".equals(entry.getKey())) {
+                buildEnv.put("PATH", buildEnv.get("PATH") + File.pathSeparatorChar + env.get("PATH"));
             } else {
                 buildEnv.put(entry.getKey(), entry.getValue());
             }

--- a/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -62,6 +63,7 @@ public class ShellProcess implements Serializable {
             }
         }
     }
+
 
     public Number launch(Map conf, TopologyContext context) {
         ProcessBuilder builder = new ProcessBuilder(command);


### PR DESCRIPTION
Support to allow ShellBolt to set environment variables
Example :
WordCountTopology.java builder.setBolt("split", (IRichBolt) new SplitSentence().setEnv(envMap) ,  8).shuffleGrouping("spout");

where envMap is a map of environment variables to be exported.

Map<String, String> envMap = new HashMap<>(); 
envMap.put("PATH","/usr/local"); // append to PATH variable 
envMap.put("HOME", "/usr/local"); // override HOME variable

NOTE: PATH variable is appended by default while others are overridden.