### PR TITLE
[STORM-848] Shade external dependencies

### DIFF
--- a/external/flux/flux-core/pom.xml
+++ b/external/flux/flux-core/pom.xml
@@ -54,6 +54,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -54,6 +54,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>2.2.0</version>

--- a/external/storm-jdbc/pom.xml
+++ b/external/storm-jdbc/pom.xml
@@ -74,6 +74,10 @@
             <version>2.3.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -134,5 +134,13 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -215,13 +215,13 @@
         <clojure.tools.nrepl.version>0.2.3</clojure.tools.nrepl.version>
         <clojure-complete.version>0.2.3</clojure-complete.version>
         <mockito.version>1.9.5</mockito.version>
-        <reply.version>0.3.0</reply.version>
         <conjure.version>2.1.3</conjure.version>
         <zookeeper.version>3.4.6</zookeeper.version>
         <clojure-data-codec.version>0.1.0</clojure-data-codec.version>
         <clojure-contrib.version>1.2.0</clojure-contrib.version>
         <hive.version>0.14.0</hive.version>
         <hadoop.version>2.6.0</hadoop.version>
+        <kryo.version>2.21</kryo.version>
     </properties>
 
     <profiles>
@@ -320,6 +320,11 @@
                 <groupId>org.clojure</groupId>
                 <artifactId>clojure</artifactId>
                 <version>${clojure.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.esotericsoftware.kryo</groupId>
+                <artifactId>kryo</artifactId>
+                <version>${kryo.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -544,17 +549,6 @@
 		    </dependency>
         </dependencies>
     </dependencyManagement>
-
-
-    <dependencies>
-        <!-- reply dependency adds leiningen-style REPL -->
-        <dependency>
-            <groupId>reply</groupId>
-            <artifactId>reply</artifactId>
-            <version>${reply.version}</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
 
     <repositories>
         <repository>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -424,6 +424,7 @@
                             <include>org.clojure:tools.cli</include>
                             <include>org.clojure:tools.macro</include>
                             <include>joda-time:joda-time</include>
+                            <include>org.eclipse.jetty:*</include>
                         </includes>
                     </artifactSet>
 
@@ -563,6 +564,10 @@
                         <relocation>
                           <pattern>org.joda.time</pattern>
                           <shadedPattern>org.apache.storm.joda.time</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.eclipse.jetty</pattern>
+                          <shadedPattern>org.apache.storm.jetty</shadedPattern>
                         </relocation>
                     </relocations>
                     <transformers>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -35,11 +35,9 @@
     </properties>
 
     <dependencies>
-        <!-- multi-lang resources -->
         <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>multilang-ruby</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.esotericsoftware.kryo</groupId>
+            <artifactId>kryo</artifactId>
         </dependency>
         <!--clojure-->
         <dependency>
@@ -127,14 +125,17 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.thrift</groupId>
@@ -157,6 +158,7 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
+            <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>
@@ -171,22 +173,20 @@
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
+            <scope>compile</scope>
         </dependency>
 
 
         <dependency>
             <groupId>com.twitter</groupId>
             <artifactId>carbonite</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
+            <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>com.googlecode.disruptor</groupId>
             <artifactId>disruptor</artifactId>
@@ -194,10 +194,12 @@
         <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -390,7 +392,7 @@
                 </executions>
                 <configuration>
                     <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
-                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                    <promoteTransitiveDependencies>false</promoteTransitiveDependencies>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                     <minimizeJar>false</minimizeJar>
                     <artifactSet>
@@ -401,6 +403,27 @@
                             <include>org.apache.httpcomponents:http*</include>
                             <include>org.apache.zookeeper:zookeeper</include>
                             <include>org.apache.curator:*</include>
+                            <include>org.apache.httpcomponents:http*</include>
+                            <include>org.apache.zookeeper:zookeeper</include>
+                            <include>org.apache.curator:*</include>
+                            <include>com.twitter:carbonite</include>
+                            <include>com.twitter:chill-java</include>
+                            <include>org.objenesis:objenesis</include>
+                            <include>org.tukaani:xz</include>
+                            <include>org.yaml:snakeyaml</include>
+                            <include>org.jgrapht:jgrapht-core</include>
+                            <include>commons-httpclient:commons-httpclient</include>
+                            <include>org.apache.commons:commons-compress</include>
+                            <include>org.apache.commons:commons-exec</include>
+                            <include>commons-io:commons-io</include>
+                            <include>commons-codec:commons-codec</include>
+                            <include>commons-fileupload:commons-fileupload</include>
+                            <include>commons-lang:commons-lang</include>
+                            <include>com.googlecode.json-simple:json-simple</include>
+                            <include>org.clojure:math.numeric-tower</include>
+                            <include>org.clojure:tools.cli</include>
+                            <include>org.clojure:tools.macro</include>
+                            <include>joda-time:joda-time</include>
                         </includes>
                     </artifactSet>
 
@@ -433,6 +456,114 @@
                             <pattern>org.apache.curator</pattern>
                             <shadedPattern>org.apache.storm.curator</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>org.jboss.netty</pattern>
+                            <shadedPattern>org.apache.storm.netty</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>org.apache.storm.guava</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.google.thirdparty</pattern>
+                            <shadedPattern>org.apache.storm.guava.thirdparty</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.apache.http</pattern>
+                            <shadedPattern>org.apache.storm.http</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.apache.zookeeper</pattern>
+                            <shadedPattern>org.apache.storm.zookeeper</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.apache.jute</pattern>
+                            <shadedPattern>org.apache.storm.jute</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.apache.curator</pattern>
+                            <shadedPattern>org.apache.storm.curator</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>carbonite</pattern>
+                          <shadedPattern>org.apache.storm.carbonite</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>com.twitter.chill</pattern>
+                          <shadedPattern>org.apache.storm.chill</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.objenesis</pattern>
+                          <shadedPattern>org.apache.storm.objenesis</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.tukaani.xz</pattern>
+                          <shadedPattern>org.apache.storm.xz</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.yaml.snakeyaml</pattern>
+                          <shadedPattern>org.apache.storm.snakeyaml</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.jgrapht</pattern>
+                          <shadedPattern>org.apache.storm.jgrapht</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.fusesource</pattern>
+                          <shadedPattern>org.apache.storm.fusesource</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>com.metamx.http.client</pattern>
+                          <shadedPattern>org.apache.storm.metamx.http.client</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.apache.commons.io</pattern>
+                          <shadedPattern>org.apache.storm.commons.io</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.apache.commons.codec</pattern>
+                          <shadedPattern>org.apache.storm.commons.codec</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.apache.commons.fileupload</pattern>
+                          <shadedPattern>org.apache.storm.commons.fileupload</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.apache.commons.compress</pattern>
+                          <shadedPattern>org.apache.storm.commons.compress</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.apache.commons.exec</pattern>
+                          <shadedPattern>org.apache.storm.commons.exec</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.apache.commons.lang</pattern>
+                          <shadedPattern>org.apache.storm.commons.lang</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.json.simple</pattern>
+                          <shadedPattern>org.apache.storm.json.simple</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>clojure.math</pattern>
+                          <shadedPattern>org.apache.storm.clojure.math</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>clojure.tools.cli</pattern>
+                          <shadedPattern>org.apache.storm.clojure.tools.cli</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>cljs.tools.cli</pattern>
+                          <shadedPattern>org.apache.storm.cljs.tools.cli</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>clojure.tools.macro</pattern>
+                          <shadedPattern>org.apache.storm.clojure.tools.macro</shadedPattern>
+                        </relocation>
+                        <relocation>
+                          <pattern>org.joda.time</pattern>
+                          <shadedPattern>org.apache.storm.joda.time</shadedPattern>
+                        </relocation>
                     </relocations>
                     <transformers>
                         <transformer implementation="org.apache.storm.maven.shade.clojure.ClojureTransformer" />
@@ -464,6 +595,76 @@
                             <artifact>org.apache.zookeeper:zookeeper</artifact>
                             <excludes>
                                 <exclude>LICENSE.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>commons-httpclient:commons-httpclient</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
+                                <exclude>META-INF/README.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>org.apache.zookeeper:zookeeper</artifact>
+                            <excludes>
+                                <exclude>LICENSE.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>org.objenesis:objenesis</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>org.apache.commons:commons-compress</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>org.apache.commons:commons-exec</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>commons-io:commons-io</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>commons-codec:commons-codec</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>commons-fileupload:commons-fileupload</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>commons-lang:commons-lang</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>joda-time:joda-time</artifact>
+                            <excludes>
+                                <exclude>META-INF/LICENSE.txt</exclude>
+                                <exclude>META-INF/NOTICE.txt</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -58,6 +58,7 @@
                 <exclude>org.clojure:tools.cli</exclude>
                 <exclude>org.clojure:tools.macro</exclude>
                 <exclude>joda-time:joda-time</exclude>
+                <exclude>org.eclipse.jetty:*</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>

--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -30,6 +30,35 @@
             <useProjectArtifact>false</useProjectArtifact>
             <outputDirectory>lib</outputDirectory>
             <unpack>false</unpack>
+            <excludes>
+                <exclude>org.apache.thrift:*</exclude>
+                <exclude>io.netty:netty</exclude>
+                <exclude>com.google.guava:guava</exclude>
+                <exclude>org.apache.httpcomponents:http*</exclude>
+                <exclude>org.apache.zookeeper:zookeeper</exclude>
+                <exclude>org.apache.curator:*</exclude>
+                <exclude>org.apache.httpcomponents:http*</exclude>
+                <exclude>org.apache.zookeeper:zookeeper</exclude>
+                <exclude>org.apache.curator:*</exclude>
+                <exclude>com.twitter:carbonite</exclude>
+                <exclude>com.twitter:chill-java</exclude>
+                <exclude>org.objenesis:objenesis</exclude>
+                <exclude>org.tukaani:xz</exclude>
+                <exclude>org.yaml:snakeyaml</exclude>
+                <exclude>org.jgrapht:jgrapht-core</exclude>
+                <exclude>commons-httpclient:commons-httpclient</exclude>
+                <exclude>org.apache.commons:commons-compress</exclude>
+                <exclude>org.apache.commons:commons-exec</exclude>
+                <exclude>commons-io:commons-io</exclude>
+                <exclude>commons-codec:commons-codec</exclude>
+                <exclude>commons-fileupload:commons-fileupload</exclude>
+                <exclude>commons-lang:commons-lang</exclude>
+                <exclude>com.googlecode.json-simple:json-simple</exclude>
+                <exclude>org.clojure:math.numeric-tower</exclude>
+                <exclude>org.clojure:tools.cli</exclude>
+                <exclude>org.clojure:tools.macro</exclude>
+                <exclude>joda-time:joda-time</exclude>
+            </excludes>
         </dependencySet>
     </dependencySets>
 


### PR DESCRIPTION
Shading following dependencies:
org.apache.httpcomponents:http*
org.apache.zookeeper:zookeeper
org.apache.curator:*
com.twitter:carbonite
com.twitter:chill-java
org.objenesis:objenesis
org.tukaani:xz
org.yaml:snakeyaml
org.jgrapht:jgrapht-core
commons-httpclient:commons-httpclient
org.apache.commons:commons-compress
org.apache.commons:commons-exec
commons-io:commons-io
commons-codec:commons-codec
commons-fileupload:commons-fileupload
commons-lang:commons-lang
com.googlecode.json-simple:json-simple
org.clojure:math.numeric-tower
org.clojure:tools.cli
org.clojure:tools.macro
joda-time:joda-time