### PR TITLE
STORM-850 Convert storm-core's logback-test.xml to log4j2-test.xml

### DIFF
--- a/storm-core/test/resources/log4j2-test.xml
+++ b/storm-core/test/resources/log4j2-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -6,21 +6,27 @@
  The ASF licenses this file to You under the Apache License, Version 2.0
  (the "License"); you may not use this file except in compliance with
  the License.  You may obtain a copy of the License at
+
      http://www.apache.org/licenses/LICENSE-2.0
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<configuration scan="true" scanPeriod="30 seconds">
-    <appender name="A1" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%-4r [%t] %-5p %c - %m%n</pattern>
-        </encoder>
-    </appender>
-    <logger name="org.apache.zookeeper" level="WARN"/>
-    <root level="${LOG_LEVEL:-INFO}">
-        <appender-ref ref="A1"/>
-    </root>
+
+<configuration monitorInterval="60">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%-4r [%t] %-5p %c{1.} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.apache.zookeeper" level="WARN"/>
+        <Root level="${env:LOG_LEVEL:-INFO}">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
 </configuration>
+


### PR DESCRIPTION
In order to prevent Travis CI complaining about log exceeding, we need to apply this.

Please review and comment. Thanks in advance!