### PR TITLE
[STORM-856] use serialized value of delay secs for topo actions

### DIFF
--- a/storm-core/src/clj/backtype/storm/converter.clj
+++ b/storm-core/src/clj/backtype/storm/converter.clj
@@ -134,10 +134,13 @@
       thrift-topology-action-options)))
 
 (defn clojurify-topology-action-options [^TopologyActionOptions topology-action-options]
-  (if (and topology-action-options (.is_set_kill_options topology-action-options))
-      (clojurify-kill-options (.get_kill_options topology-action-options)))
-  (if (and topology-action-options (.is_set_rebalance_options topology-action-options))
-      (clojurify-rebalance-options (.get_rebalance_options topology-action-options))))
+  (if topology-action-options
+    (or (and (.is_set_kill_options topology-action-options)
+             (clojurify-kill-options
+               (.get_kill_options topology-action-options)))
+        (and (.is_set_rebalance_options topology-action-options)
+             (clojurify-rebalance-options
+               (.get_rebalance_options topology-action-options))))))
 
 (defn thriftify-storm-base [storm-base]
   (doto (StormBase.)

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -170,7 +170,9 @@
               }
    :killed {:startup (fn [] (delay-event nimbus
                                          storm-id
-                                         (:delay-secs storm-base)
+                                         (-> storm-base
+                                             :topology-action-options
+                                             :delay-secs)
                                          :remove)
                              nil)
             :kill (kill-transition nimbus storm-id)
@@ -182,7 +184,9 @@
             }
    :rebalancing {:startup (fn [] (delay-event nimbus
                                               storm-id
-                                              (:delay-secs storm-base)
+                                              (-> storm-base
+                                                  :topology-action-options
+                                                  :delay-secs)
                                               :do-rebalance)
                                  nil)
                  :kill (kill-transition nimbus storm-id)


### PR DESCRIPTION
* Use serialized values for delay in rebalance and kill topology actions, in case nimbus has initialized sometime after the action was given
* Fix logic in deserialization of topology action options