### PR TITLE
STORM-860 disable "Activate" button when topology status is not "inactivate"

### DIFF
--- a/storm-core/src/ui/public/js/script.js
+++ b/storm-core/src/ui/public/js/script.js
@@ -152,7 +152,7 @@ function topologyActionJson(id, encodedId, name,status,msgTimeout) {
     jsonData["encodedId"] = encodedId;
     jsonData["name"] = name;
     jsonData["msgTimeout"] = msgTimeout;
-    jsonData["activateStatus"] = (status === "ACTIVE") ? "disabled" : "enabled";
+    jsonData["activateStatus"] = (status === "INACTIVE") ? "enabled" : "disabled";
     jsonData["deactivateStatus"] = (status === "ACTIVE") ? "enabled" : "disabled";
     jsonData["rebalanceStatus"] = (status === "ACTIVE" || status === "INACTIVE" ) ? "enabled" : "disabled";
     jsonData["killStatus"] = (status !== "KILLED") ? "enabled" : "disabled";


### PR DESCRIPTION
When we activate topology while it is rebalancing or killed from UI, UI shows that "Error while communicating to nimbus".
Based on these, "Activate" only makes sense while inactivated.