### PR TITLE
STORM-864 Exclude storm-kafka tests from Travis CI build

### DIFF
--- a/dev-tools/travis/print-errors-from-clojure-test-reports.py
+++ b/dev-tools/travis/print-errors-from-clojure-test-reports.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import glob
+import traceback
 from xml.etree.ElementTree import ElementTree
 
 
@@ -48,6 +49,7 @@ def main(report_dir_path):
         except Exception, e:
             print "Error while reading report file, %s" % file_path
             print "Exception: %s" % e
+            traceback.print_exc()
 
 
 if __name__ == "__main__":

--- a/dev-tools/travis/travis-build.sh
+++ b/dev-tools/travis/travis-build.sh
@@ -33,7 +33,7 @@ export LOG_LEVEL=WARN
 export STORM_TEST_TIMEOUT_MS=100000
 
 # We now lean on Travis CI's implicit behavior, ```mvn clean install -DskipTests``` before running script
-mvn test -fae
+mvn -fae -pl '!external/storm-kafka' test
 
 BUILD_RET_VAL=$?
 

--- a/storm-core/test/clj/backtype/storm/security/auth/drpc_auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/drpc_auth_test.clj
@@ -31,6 +31,8 @@
 
 (def drpc-timeout (Integer. 30))
 
+(def DRPC-TIMEOUT-SEC (* (/ TEST-TIMEOUT-MS 1000) 2))
+
 (defn launch-server [conf drpcAznClass transportPluginClass login-cfg client-port invocations-port]
   (let [conf (if drpcAznClass (assoc conf DRPC-AUTHORIZER drpcAznClass) conf)
         conf (if transportPluginClass (assoc conf STORM-THRIFT-TRANSPORT-PLUGIN transportPluginClass) conf)
@@ -145,7 +147,7 @@
 
 (deftest drpc-per-function-auth-strict-test
   (with-simple-drpc-test-scenario [true alice-client bob-client charlie-client alice-invok charlie-invok]
-    (let [drpc-timeout-seconds 10]
+    (let [drpc-timeout-seconds DRPC-TIMEOUT-SEC]
       (testing "Permitted user can execute a function in the ACL"
         (let [func "jump"
               exec-ftr (future (.execute alice-client func "some args"))
@@ -221,7 +223,7 @@
 
 (deftest drpc-per-function-auth-non-strict-test
   (with-simple-drpc-test-scenario [false alice-client bob-client charlie-client alice-invok charlie-invok]
-    (let [drpc-timeout-seconds 10]
+    (let [drpc-timeout-seconds DRPC-TIMEOUT-SEC]
       (testing "Permitted user can execute a function in the ACL"
         (let [func "jump"
               exec-ftr (future (.execute alice-client func "some args"))


### PR DESCRIPTION
Please refer https://issues.apache.org/jira/browse/STORM-864 to see why I'm trying to exclude storm-kafka from Travis CI.

After applying this patch, we can get rid of random test failures on storm-kafka with Travis CI.
Please note that there's small probabilities to random test failures on storm-core yet.