### PR TITLE
STORM-866: Use storm.log.dir instead of storm.home in log4j2 config

### DIFF
--- a/log4j2/cluster.xml
+++ b/log4j2/cluster.xml
@@ -23,8 +23,8 @@
 </properties>
 <appenders>
     <RollingFile name="A1"
-                 fileName="${sys:storm.log.dir}/logs/${sys:logfile.name}"
-                 filePattern="${sys:storm.log.dir}/logs/${sys:logfile.name}.%i">
+                 fileName="${sys:storm.log.dir}/${sys:logfile.name}"
+                 filePattern="${sys:storm.log.dir}/${sys:logfile.name}.%i">
         <PatternLayout>
             <pattern>${pattern}</pattern>
         </PatternLayout>
@@ -34,8 +34,8 @@
         </Policies>
     </RollingFile>
     <RollingFile name="ACCESS"
-                 fileName="${sys:storm.log.dir}/logs/access.log"
-                 filePattern="${sys:storm.log.dir}/logs/access.log.%i">
+                 fileName="${sys:storm.log.dir}/access.log"
+                 filePattern="${sys:storm.log.dir}/access.log.%i">
         <PatternLayout>
             <pattern>${pattern}</pattern>
         </PatternLayout>
@@ -45,8 +45,8 @@
         </Policies>
     </RollingFile>
     <RollingFile name="METRICS"
-                 fileName="${sys:storm.log.dir}/logs/metrics.log"
-                 filePattern="${sys:storm.log.dir}/logs/metrics.log.%i">
+                 fileName="${sys:storm.log.dir}/metrics.log"
+                 filePattern="${sys:storm.log.dir}/metrics.log.%i">
         <PatternLayout>
             <pattern>${patternMetris}</pattern>
         </PatternLayout>

--- a/log4j2/cluster.xml
+++ b/log4j2/cluster.xml
@@ -23,8 +23,8 @@
 </properties>
 <appenders>
     <RollingFile name="A1"
-                 fileName="${sys:storm.home}/logs/${sys:logfile.name}"
-                 filePattern="${sys:storm.home}/logs/${sys:logfile.name}.%i">
+                 fileName="${sys:storm.log.dir}/logs/${sys:logfile.name}"
+                 filePattern="${sys:storm.log.dir}/logs/${sys:logfile.name}.%i">
         <PatternLayout>
             <pattern>${pattern}</pattern>
         </PatternLayout>
@@ -34,8 +34,8 @@
         </Policies>
     </RollingFile>
     <RollingFile name="ACCESS"
-                 fileName="${sys:storm.home}/logs/access.log"
-                 filePattern="${sys:storm.home}/logs/access.log.%i">
+                 fileName="${sys:storm.log.dir}/logs/access.log"
+                 filePattern="${sys:storm.log.dir}/logs/access.log.%i">
         <PatternLayout>
             <pattern>${pattern}</pattern>
         </PatternLayout>
@@ -45,8 +45,8 @@
         </Policies>
     </RollingFile>
     <RollingFile name="METRICS"
-                 fileName="${sys:storm.home}/logs/metrics.log"
-                 filePattern="${sys:storm.home}/logs/metrics.log.%i">
+                 fileName="${sys:storm.log.dir}/logs/metrics.log"
+                 filePattern="${sys:storm.log.dir}/logs/metrics.log.%i">
         <PatternLayout>
             <pattern>${patternMetris}</pattern>
         </PatternLayout>

--- a/log4j2/worker.xml
+++ b/log4j2/worker.xml
@@ -23,8 +23,8 @@
 </properties>
 <appenders>
     <RollingFile name="A1"
-                 fileName="${sys:storm.log.dir}/logs/${sys:logfile.name}"
-                 filePattern="${sys:storm.log.dir}/logs/${sys:logfile.name}.%i.gz">
+                 fileName="${sys:storm.log.dir}/${sys:logfile.name}"
+                 filePattern="${sys:storm.log.dir}/${sys:logfile.name}.%i.gz">
         <PatternLayout>
             <pattern>${pattern}</pattern>
         </PatternLayout>
@@ -34,8 +34,8 @@
         </Policies>
     </RollingFile>
     <RollingFile name="STDOUT"
-                 fileName="${sys:storm.log.dir}/logs/${sys:logfile.name}.out"
-                 filePattern="${sys:storm.log.dir}/logs/${sys:logfile.name}.out.%i.gz">
+                 fileName="${sys:storm.log.dir}/${sys:logfile.name}.out"
+                 filePattern="${sys:storm.log.dir}/${sys:logfile.name}.out.%i.gz">
         <PatternLayout>
             <pattern>${patternNoTime}</pattern>
         </PatternLayout>
@@ -45,8 +45,8 @@
         </Policies>
     </RollingFile>
     <RollingFile name="STDERR"
-                 fileName="${sys:storm.log.dir}/logs/${sys:logfile.name}.err"
-                 filePattern="${sys:storm.log.dir}/logs/${sys:logfile.name}.err.%i.gz">
+                 fileName="${sys:storm.log.dir}/${sys:logfile.name}.err"
+                 filePattern="${sys:storm.log.dir}/${sys:logfile.name}.err.%i.gz">
         <PatternLayout>
             <pattern>${patternNoTime}</pattern>
         </PatternLayout>

--- a/log4j2/worker.xml
+++ b/log4j2/worker.xml
@@ -23,8 +23,8 @@
 </properties>
 <appenders>
     <RollingFile name="A1"
-                 fileName="${sys:storm.home}/logs/${sys:logfile.name}"
-                 filePattern="${sys:storm.home}/logs/${sys:logfile.name}.%i.gz">
+                 fileName="${sys:storm.log.dir}/logs/${sys:logfile.name}"
+                 filePattern="${sys:storm.log.dir}/logs/${sys:logfile.name}.%i.gz">
         <PatternLayout>
             <pattern>${pattern}</pattern>
         </PatternLayout>
@@ -34,8 +34,8 @@
         </Policies>
     </RollingFile>
     <RollingFile name="STDOUT"
-                 fileName="${sys:storm.home}/logs/${sys:logfile.name}.out"
-                 filePattern="${sys:storm.home}/logs/${sys:logfile.name}.out.%i.gz">
+                 fileName="${sys:storm.log.dir}/logs/${sys:logfile.name}.out"
+                 filePattern="${sys:storm.log.dir}/logs/${sys:logfile.name}.out.%i.gz">
         <PatternLayout>
             <pattern>${patternNoTime}</pattern>
         </PatternLayout>
@@ -45,8 +45,8 @@
         </Policies>
     </RollingFile>
     <RollingFile name="STDERR"
-                 fileName="${sys:storm.home}/logs/${sys:logfile.name}.err"
-                 filePattern="${sys:storm.home}/logs/${sys:logfile.name}.err.%i.gz">
+                 fileName="${sys:storm.log.dir}/logs/${sys:logfile.name}.err"
+                 filePattern="${sys:storm.log.dir}/logs/${sys:logfile.name}.err.%i.gz">
         <PatternLayout>
             <pattern>${patternNoTime}</pattern>
         </PatternLayout>


### PR DESCRIPTION
PR for [STORM-866](https://issues.apache.org/jira/browse/STORM-866)

The config log4j2 use storm.home as log dir, but not storm.log.dir, we should use storm.log.dir instead.