### PR TITLE
STORM-67 Provide API for spouts to know how many pending messages there are

### DIFF
--- a/external/storm-eventhubs/src/test/java/org/apache/storm/eventhubs/spout/SpoutOutputCollectorMock.java
+++ b/external/storm-eventhubs/src/test/java/org/apache/storm/eventhubs/spout/SpoutOutputCollectorMock.java
@@ -17,10 +17,9 @@
  *******************************************************************************/
 package org.apache.storm.eventhubs.spout;
 
-import backtype.storm.spout.ISpoutOutputCollector;
-import backtype.storm.spout.SpoutOutputCollector;
-
 import java.util.List;
+
+import backtype.storm.spout.ISpoutOutputCollector;
 
 /**
  * Mock of ISpoutOutputCollector
@@ -28,7 +27,6 @@ import java.util.List;
 public class SpoutOutputCollectorMock implements ISpoutOutputCollector {
   //comma separated offsets
   StringBuilder emittedOffset;
-  SpoutOutputCollector _collector;
   
   public SpoutOutputCollectorMock() {
     emittedOffset = new StringBuilder();
@@ -63,8 +61,6 @@ public class SpoutOutputCollectorMock implements ISpoutOutputCollector {
 
   @Override
   public long getPendingCount() {
-    return _collector.getPendingCount();
+    return 0;
   }
-
-
 }

--- a/external/storm-eventhubs/src/test/java/org/apache/storm/eventhubs/spout/SpoutOutputCollectorMock.java
+++ b/external/storm-eventhubs/src/test/java/org/apache/storm/eventhubs/spout/SpoutOutputCollectorMock.java
@@ -17,9 +17,10 @@
  *******************************************************************************/
 package org.apache.storm.eventhubs.spout;
 
-import java.util.List;
-
 import backtype.storm.spout.ISpoutOutputCollector;
+import backtype.storm.spout.SpoutOutputCollector;
+
+import java.util.List;
 
 /**
  * Mock of ISpoutOutputCollector
@@ -27,6 +28,7 @@ import backtype.storm.spout.ISpoutOutputCollector;
 public class SpoutOutputCollectorMock implements ISpoutOutputCollector {
   //comma separated offsets
   StringBuilder emittedOffset;
+  SpoutOutputCollector _collector;
   
   public SpoutOutputCollectorMock() {
     emittedOffset = new StringBuilder();
@@ -58,4 +60,11 @@ public class SpoutOutputCollectorMock implements ISpoutOutputCollector {
   @Override
   public void reportError(Throwable arg0) {
   }
+
+  @Override
+  public long getPendingCount() {
+    return _collector.getPendingCount();
+  }
+
+
 }

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -558,6 +558,9 @@
                  (:user-context task-data)
                  (SpoutOutputCollector.
                   (reify ISpoutOutputCollector
+                    (^long getPendingCount[this]
+                      (.size pending)
+                      )
                     (^List emit [this ^String stream-id ^List tuple ^Object message-id]
                       (send-spout-msg stream-id tuple message-id nil)
                       )

--- a/storm-core/src/jvm/backtype/storm/spout/ISpoutOutputCollector.java
+++ b/storm-core/src/jvm/backtype/storm/spout/ISpoutOutputCollector.java
@@ -26,5 +26,6 @@ public interface ISpoutOutputCollector {
     List<Integer> emit(String streamId, List<Object> tuple, Object messageId);
     void emitDirect(int taskId, String streamId, List<Object> tuple, Object messageId);
     void reportError(Throwable error);
+    long getPendingCount();
 }
 

--- a/storm-core/src/jvm/backtype/storm/spout/SpoutOutputCollector.java
+++ b/storm-core/src/jvm/backtype/storm/spout/SpoutOutputCollector.java
@@ -131,4 +131,9 @@ public class SpoutOutputCollector implements ISpoutOutputCollector {
     public void reportError(Throwable error) {
         _delegate.reportError(error);
     }
+
+    @Override
+    public long getPendingCount() {
+        return _delegate.getPendingCount();
+    }
 }

--- a/storm-core/src/jvm/backtype/storm/testing/SpoutTracker.java
+++ b/storm-core/src/jvm/backtype/storm/testing/SpoutTracker.java
@@ -65,6 +65,12 @@ public class SpoutTracker extends BaseRichSpout {
         public void reportError(Throwable error) {
         	_collector.reportError(error);
         }
+
+        @Override
+        public long getPendingCount() {
+            return _collector.getPendingCount();
+        }
+
     }
 
 

--- a/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchExecutor.java
+++ b/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchExecutor.java
@@ -24,13 +24,12 @@ import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.IRichSpout;
 import backtype.storm.tuple.Fields;
 import backtype.storm.utils.RotatingMap;
-import storm.trident.operation.TridentCollector;
-import storm.trident.topology.TransactionAttempt;
-import storm.trident.util.TridentUtils;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import storm.trident.operation.TridentCollector;
+import storm.trident.topology.TransactionAttempt;
+import storm.trident.util.TridentUtils;
 
 public class RichSpoutBatchExecutor implements ITridentSpout {
     public static final String MAX_BATCH_SIZE_CONF = "topology.spout.max.batch.size";
@@ -82,8 +81,7 @@ public class RichSpoutBatchExecutor implements ITridentSpout {
             idsMap = new RotatingMap(3);
             rotateTime = 1000L * ((Number)conf.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS)).intValue();
         }
-
-
+        
         @Override
         public void emitBatch(TransactionAttempt tx, Object coordinatorMeta, TridentCollector collector) {
             long txid = tx.getTransactionId();
@@ -140,8 +138,6 @@ public class RichSpoutBatchExecutor implements ITridentSpout {
                 }
             }
         }
-
-
         
         @Override
         public void close() {
@@ -198,7 +194,7 @@ public class RichSpoutBatchExecutor implements ITridentSpout {
         public void emitDirect(int task, String stream, List<Object> values, Object id) {
             throw new UnsupportedOperationException("Trident does not support direct streams");
         }
-
+        
         @Override
         public long getPendingCount() {
             return pendingCount;

--- a/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchTriggerer.java
+++ b/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchTriggerer.java
@@ -27,12 +27,12 @@ import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
 import backtype.storm.utils.Utils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.ArrayList;		
+import java.util.HashMap;		
+import java.util.HashSet;		
+import java.util.List;		
+import java.util.Map;		
+import java.util.Random;		
 import java.util.Set;
 import storm.trident.topology.TridentBoltExecutor;
 import storm.trident.tuple.ConsList;
@@ -173,6 +173,10 @@ public class RichSpoutBatchTriggerer implements IRichSpout {
         public void reportError(Throwable t) {
             _collector.reportError(t);
         }
-        
+
+        @Override
+        public long getPendingCount() {
+            return _collector.getPendingCount();
+        }
     }
 }

--- a/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchTriggerer.java
+++ b/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchTriggerer.java
@@ -27,12 +27,12 @@ import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
 import backtype.storm.utils.Utils;
-import java.util.ArrayList;		
-import java.util.HashMap;		
-import java.util.HashSet;		
-import java.util.List;		
-import java.util.Map;		
-import java.util.Random;		
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import storm.trident.topology.TridentBoltExecutor;
 import storm.trident.tuple.ConsList;
@@ -173,7 +173,7 @@ public class RichSpoutBatchTriggerer implements IRichSpout {
         public void reportError(Throwable t) {
             _collector.reportError(t);
         }
-
+        
         @Override
         public long getPendingCount() {
             return _collector.getPendingCount();


### PR DESCRIPTION
Changes made to expose the pending tuple count saved inside the RotatingMap [ 
https://github.com/apache/storm/blob/master/docs/documentation/Acking-framework-implementation.md#pending-tuples-and-the-rotatingmap ] 