### PR TITLE
STORM-867: fix bug with mk-ssl-connector

### DIFF
--- a/storm-core/src/clj/backtype/storm/ui/helpers.clj
+++ b/storm-core/src/clj/backtype/storm/ui/helpers.clj
@@ -149,9 +149,9 @@
     (if (and (not-nil? ts-path) (not-nil? ts-password) (not-nil? ts-type))
       ((.setTrustStore sslContextFactory ts-path)
        (.setTrustStoreType sslContextFactory ts-type)
-       (.setTrustStoreType sslContextFactory ts-password)))
-    (if (need-client-auth) (.setNeedClientAuth sslContextFactory true)
-        (if (want-client-auth) (.setWantClientAuth sslContextFactory true)))
+       (.setTrustStorePassword sslContextFactory ts-password)))
+    (if need-client-auth (.setNeedClientAuth sslContextFactory true)
+        (if want-client-auth (.setWantClientAuth sslContextFactory true)))
     (doto (SslSocketConnector. sslContextFactory)
       (.setPort port))))
 


### PR DESCRIPTION
PR for [STORM-867](https://issues.apache.org/jira/browse/STORM-867)

There are two error about mk-ssl-connector in storm-core/src/clj/backtype/storm/ui/helpers.clj
1. set trustStore password with setTrustStoreType
2. need-client-auth and want-client-auth are boolen, but use as function