### PR TITLE
[STORM-874] Add UncaughtExceptionHandler for netty threads

### DIFF
--- a/storm-core/src/jvm/backtype/storm/messaging/netty/NettyRenameThreadFactory.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/NettyRenameThreadFactory.java
@@ -33,6 +33,7 @@ public class NettyRenameThreadFactory  implements ThreadFactory {
     final ThreadGroup group;
     final AtomicInteger index = new AtomicInteger(1);
     final String name;
+    static final NettyUncaughtExceptionHandler uncaughtExceptionHandler = new NettyUncaughtExceptionHandler();
 
     NettyRenameThreadFactory(String name) {
         SecurityManager s = System.getSecurityManager();
@@ -43,10 +44,13 @@ public class NettyRenameThreadFactory  implements ThreadFactory {
 
     public Thread newThread(Runnable r) {
         Thread t = new Thread(group, r, name + "-" + index.getAndIncrement(), 0);
-        if (t.isDaemon())
+        if (t.isDaemon()) {
             t.setDaemon(false);
-        if (t.getPriority() != Thread.NORM_PRIORITY)
+        }
+        if (t.getPriority() != Thread.NORM_PRIORITY) {
             t.setPriority(Thread.NORM_PRIORITY);
+        }
+        t.setUncaughtExceptionHandler(uncaughtExceptionHandler);
         return t;
     }
 }

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/NettyUncaughtExceptionHandler.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/NettyUncaughtExceptionHandler.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.messaging.netty;
+
+import backtype.storm.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NettyUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(NettyUncaughtExceptionHandler.class);
+  @Override
+  public void uncaughtException(Thread t, Throwable e) {
+    try {
+      Utils.handleUncaughtException(e);
+    } catch (Error error) {
+      LOG.info("Received error in netty thread.. terminating server...");
+      Runtime.getRuntime().exit(1);
+    }
+  }
+}


### PR DESCRIPTION
The netty threads need to handle uncaught exceptions. This would help ensure that JVM exits if netty threads hit OOM Error  while allocating new buffer.