### PR TITLE
STORM-903: fix java.lang.ClassNotFoundException with org.apache.commo…

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -256,10 +256,6 @@
                <artifactId>slf4j-api</artifactId>
              </exclusion>
              <exclusion>
-               <groupId>commons-codec</groupId>
-               <artifactId>commons-codec</artifactId>
-             </exclusion>
-             <exclusion>
                <groupId>log4j</groupId>
                <artifactId>log4j</artifactId>
              </exclusion>

--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -50,7 +50,6 @@
                 <exclude>org.apache.commons:commons-compress</exclude>
                 <exclude>org.apache.commons:commons-exec</exclude>
                 <exclude>commons-io:commons-io</exclude>
-                <exclude>commons-codec:commons-codec</exclude>
                 <exclude>commons-fileupload:commons-fileupload</exclude>
                 <exclude>commons-lang:commons-lang</exclude>
                 <exclude>com.googlecode.json-simple:json-simple</exclude>


### PR DESCRIPTION
…ns.codec.binary.Base64 when set ui.filter to org.apache.hadoop.security.authentication.server.AuthenticationFilter

PR for [STORM-903](https://issues.apache.org/jira/browse/STORM-903)
