### PR TITLE
STORM-917 : Ability to emit from the spout to a specific stream, by default it will emit to the default stream.

### DIFF
--- a/external/storm-kafka/README.md
+++ b/external/storm-kafka/README.md
@@ -70,6 +70,8 @@ In addition to these parameters, SpoutConfig contains the following fields that 
     public long retryInitialDelayMs = 0;
     public double retryDelayMultiplier = 1.0;
     public long retryDelayMaxMs = 60 * 1000;
+    // by default the spout emits to the default storm stream. Provide a different stream id to change it.
+    public String emitStreamId = Utils.DEFAULT_STREAM_ID;
 ```
 Core KafkaSpout only accepts an instance of SpoutConfig.
 

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
@@ -138,7 +138,7 @@ public class KafkaSpout extends BaseRichSpout {
             try {
                 // in case the number of managers decreased
                 _currPartitionIndex = _currPartitionIndex % managers.size();
-                EmitState state = managers.get(_currPartitionIndex).next(_collector);
+                EmitState state = managers.get(_currPartitionIndex).next(_collector, _spoutConfig.emitStreamId);
                 if (state != EmitState.EMITTED_MORE_LEFT) {
                     _currPartitionIndex = (_currPartitionIndex + 1) % managers.size();
                 }

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -23,6 +23,7 @@ import backtype.storm.metric.api.CountMetric;
 import backtype.storm.metric.api.MeanReducer;
 import backtype.storm.metric.api.ReducedMetric;
 import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.utils.Utils;
 import com.google.common.collect.ImmutableMap;
 import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.javaapi.message.ByteBufferMessageSet;
@@ -125,8 +126,12 @@ public class PartitionManager {
         return ret;
     }
 
-    //returns false if it's reached the end of current batch
     public EmitState next(SpoutOutputCollector collector) {
+        return this.next(collector, Utils.DEFAULT_STREAM_ID);
+    }
+
+    //returns false if it's reached the end of current batch
+    public EmitState next(SpoutOutputCollector collector, String emitStreamId) {
         if (_waitingToEmit.isEmpty()) {
             fill();
         }
@@ -138,7 +143,7 @@ public class PartitionManager {
             Iterable<List<Object>> tups = KafkaUtils.generateTuples(_spoutConfig, toEmit.msg);
             if (tups != null) {
                 for (List<Object> tup : tups) {
-                    collector.emit(tup, new KafkaMessageId(_partition, toEmit.offset));
+                    collector.emit(emitStreamId, tup, new KafkaMessageId(_partition, toEmit.offset));
                 }
                 break;
             } else {

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -126,10 +126,6 @@ public class PartitionManager {
         return ret;
     }
 
-    public EmitState next(SpoutOutputCollector collector) {
-        return this.next(collector, Utils.DEFAULT_STREAM_ID);
-    }
-
     //returns false if it's reached the end of current batch
     public EmitState next(SpoutOutputCollector collector, String emitStreamId) {
         if (_waitingToEmit.isEmpty()) {

--- a/external/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
@@ -17,6 +17,8 @@
  */
 package storm.kafka;
 
+import backtype.storm.utils.Utils;
+
 import java.io.Serializable;
 import java.util.List;
 
@@ -29,7 +31,8 @@ public class SpoutConfig extends KafkaConfig implements Serializable {
 
     // setting for how often to save the current kafka offset to ZooKeeper
     public long stateUpdateIntervalMs = 2000;
-    public String emitStreamId;
+    // by default the spout emits to the default storm stream. Provide a different stream id to change it.
+    public String emitStreamId = Utils.DEFAULT_STREAM_ID;
 
     // Exponential back-off retry settings.  These are used when retrying messages after a bolt
     // calls OutputCollector.fail().

--- a/external/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
@@ -29,6 +29,7 @@ public class SpoutConfig extends KafkaConfig implements Serializable {
 
     // setting for how often to save the current kafka offset to ZooKeeper
     public long stateUpdateIntervalMs = 2000;
+    public String emitStreamId;
 
     // Exponential back-off retry settings.  These are used when retrying messages after a bolt
     // calls OutputCollector.fail().


### PR DESCRIPTION
STORM-917: This is to allow kafka spout to emit to a specific stream part from the default stream.
