### PR TITLE
STORM-910: Submit job failed when submitter user is also set in nimbus.supervisor.users

### DIFF
--- a/storm-core/src/jvm/backtype/storm/security/auth/authorizer/SimpleACLAuthorizer.java
+++ b/storm-core/src/jvm/backtype/storm/security/auth/authorizer/SimpleACLAuthorizer.java
@@ -112,8 +112,8 @@ public class SimpleACLAuthorizer implements IAuthorizer {
             return true;
         }
 
-        if (_supervisors.contains(principal) || _supervisors.contains(user)) {
-            return _supervisorCommands.contains(operation);
+        if (_supervisorCommands.contains(operation)) {
+            return _supervisors.contains(principal) || _supervisors.contains(user);
         }
 
         if (_userCommands.contains(operation)) {


### PR DESCRIPTION
PR for [STORM-910](https://issues.apache.org/jira/browse/STORM-910)

When topology submitter user also set in nimbus.supervisor.users, submit topology will failed.