### PR TITLE
STORM-914: AutoHDFS should also update hdfs.config into Configuration

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -29,7 +29,9 @@ import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
 import org.apache.storm.hdfs.bolt.rotation.TimedRotationPolicy;
 import org.apache.storm.hdfs.bolt.sync.SyncPolicy;
 import org.apache.storm.hdfs.common.rotation.RotationAction;
+import org.apache.storm.hdfs.common.security.AutoHDFS;
 import org.apache.storm.hdfs.common.security.HdfsSecurityUtil;
+import org.apache.storm.hdfs.common.security.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,13 +94,10 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
         this.collector = collector;
         this.fileNameFormat.prepare(conf, topologyContext);
         this.hdfsConfig = new Configuration();
-        Map<String, Object> map = (Map<String, Object>)conf.get(this.configKey);
-        if(map != null){
-            for(String key : map.keySet()){
-                this.hdfsConfig.set(key, String.valueOf(map.get(key)));
-            }
+        if (this.configKey == null) {
+            this.configKey = AutoHDFS.TOPOLOGY_HDFS_CONFIG_KEY;
         }
-
+        Utils.addConfigToHdfsConfiguration(this.hdfsConfig, conf, this.configKey);
 
         try{
             HdfsSecurityUtil.login(conf, hdfsConfig);

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/security/AutoHDFS.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/security/AutoHDFS.java
@@ -53,6 +53,7 @@ public class AutoHDFS implements IAutoCredentials, ICredentialsRenewer, INimbusC
     private static final Logger LOG = LoggerFactory.getLogger(AutoHDFS.class);
     public static final String HDFS_CREDENTIALS = "HDFS_CREDENTIALS";
     public static final String TOPOLOGY_HDFS_URI = "topology.hdfs.uri";
+    public static final String TOPOLOGY_HDFS_CONFIG_KEY = "topology.hdfs.config";
 
     private String hdfsKeyTab;
     private String hdfsPrincipal;
@@ -172,6 +173,7 @@ public class AutoHDFS implements IAutoCredentials, ICredentialsRenewer, INimbusC
             Credentials credential = getCredentials(credentials);
             if (credential != null) {
                 Configuration configuration = new Configuration();
+                Utils.addConfigToHdfsConfiguration(configuration, topologyConf, TOPOLOGY_HDFS_CONFIG_KEY);
                 Collection<Token<? extends TokenIdentifier>> tokens = credential.getAllTokens();
 
                 if(tokens != null && tokens.isEmpty() == false) {
@@ -198,6 +200,7 @@ public class AutoHDFS implements IAutoCredentials, ICredentialsRenewer, INimbusC
         try {
             if(UserGroupInformation.isSecurityEnabled()) {
                 final Configuration configuration = new Configuration();
+                Utils.addConfigToHdfsConfiguration(configuration, conf, TOPOLOGY_HDFS_CONFIG_KEY);
 
                 login(configuration);
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/security/Utils.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/security/Utils.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.common.security;
+
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+
+public class Utils {
+    public static void addConfigToHdfsConfiguration(Configuration configuration, Map topologyConf, String hdfsConfigKey) {
+      Map<String, Object> hdfsConfig = (Map<String, Object>)topologyConf.get(hdfsConfigKey);
+        if(hdfsConfig != null){
+            for(String key : hdfsConfig.keySet()){
+                configuration.set(key, String.valueOf(hdfsConfig.get(key)));
+            }
+        }
+    }
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/trident/HdfsState.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/trident/HdfsState.java
@@ -27,7 +27,9 @@ import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.storm.hdfs.common.rotation.RotationAction;
+import org.apache.storm.hdfs.common.security.AutoHDFS;
 import org.apache.storm.hdfs.common.security.HdfsSecurityUtil;
+import org.apache.storm.hdfs.common.security.Utils;
 import org.apache.storm.hdfs.trident.format.FileNameFormat;
 import org.apache.storm.hdfs.trident.format.RecordFormat;
 import org.apache.storm.hdfs.trident.format.SequenceFormat;
@@ -97,12 +99,10 @@ public class HdfsState implements State {
             }
             this.fileNameFormat.prepare(conf, partitionIndex, numPartitions);
             this.hdfsConfig = new Configuration();
-            Map<String, Object> map = (Map<String, Object>)conf.get(this.configKey);
-            if(map != null){
-                for(String key : map.keySet()){
-                    this.hdfsConfig.set(key, String.valueOf(map.get(key)));
-                }
-            }
+            if (this.configKey == null) {
+                this.configKey = AutoHDFS.TOPOLOGY_HDFS_CONFIG_KEY;
+             }
+            Utils.addConfigToHdfsConfiguration(this.hdfsConfig, conf, this.configKey);
             try{
                 HdfsSecurityUtil.login(conf, hdfsConfig);
                 doPrepare(conf, partitionIndex, numPartitions);

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/HdfsFileTopology.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/HdfsFileTopology.java
@@ -41,6 +41,7 @@ import org.apache.storm.hdfs.bolt.rotation.TimedRotationPolicy;
 import org.apache.storm.hdfs.bolt.sync.CountSyncPolicy;
 import org.apache.storm.hdfs.bolt.sync.SyncPolicy;
 import org.apache.storm.hdfs.common.rotation.MoveFileAction;
+import org.apache.storm.hdfs.common.security.AutoHDFS;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.FileInputStream;
@@ -79,10 +80,10 @@ public class HdfsFileTopology {
         InputStream in = new FileInputStream(args[1]);
         Map<String, Object> yamlConf = (Map<String, Object>) yaml.load(in);
         in.close();
-        config.put("hdfs.config", yamlConf);
+        config.put(AutoHDFS.TOPOLOGY_HDFS_CONFIG_KEY, yamlConf);
 
         HdfsBolt bolt = new HdfsBolt()
-                .withConfigKey("hdfs.config")
+                .withConfigKey(AutoHDFS.TOPOLOGY_HDFS_CONFIG_KEY)
                 .withFsUrl(args[0])
                 .withFileNameFormat(fileNameFormat)
                 .withRecordFormat(format)

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/trident/TridentSequenceTopology.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/trident/TridentSequenceTopology.java
@@ -24,6 +24,7 @@ import backtype.storm.generated.StormTopology;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
 import org.apache.storm.hdfs.common.rotation.MoveFileAction;
+import org.apache.storm.hdfs.common.security.AutoHDFS;
 import org.apache.storm.hdfs.trident.format.*;
 import org.apache.storm.hdfs.trident.rotation.FileRotationPolicy;
 import org.apache.storm.hdfs.trident.rotation.FileSizeRotationPolicy;
@@ -60,7 +61,7 @@ public class TridentSequenceTopology {
                 .withSequenceFormat(new DefaultSequenceFormat("key", "sentence"))
                 .withRotationPolicy(rotationPolicy)
                 .withFsUrl(hdfsUrl)
-                .withConfigKey("hdfs.config")
+                .withConfigKey(AutoHDFS.TOPOLOGY_HDFS_CONFIG_KEY)
                 .addRotationAction(new MoveFileAction().toDestination("/tmp/dest2/"));
         StateFactory factory = new HdfsStateFactory().withOptions(seqOpts);
 


### PR DESCRIPTION
PR for [STORM-914](https://issues.apache.org/jira/browse/STORM-914)

When storm user use a specify hdfs cluster, he will put some config such as namenode.host into hdfs.config when submit storm topology, and when HdfsBolt create HdfsConfiguration, it will use hdfs.config update HDFSConfiguration, then HDFSBolt will visit the right hdfs cluster. But in AutoHDFS's renew and getHadoopCredentials, Configuration not for the HDFS that storm user specify, we should update all the Configuration with hdfs.config.
