### PR TITLE
STORM-944 storm-hive: Fix apache calcite dependency conflict

### DIFF
--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -53,6 +53,14 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-avatica</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -65,6 +73,14 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-avatica</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -75,6 +91,14 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.calcite</groupId>
+          <artifactId>calcite-avatica</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Hive 0.14 depends on apache calcite 0.9.2-incubating-SNAPSHOT, which causes a conflict with the 0.9.2-incubating dependency further down in this pom.  Excluding it from the Hive dependencies resolves a minor conflict.