### PR TITLE
HiveBolt: misc code cleanups

### DIFF
--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
@@ -52,7 +52,6 @@ public class HiveBolt extends  BaseRichBolt {
     private Integer currentBatchSize;
     private ExecutorService callTimeoutPool;
     private transient Timer heartBeatTimer;
-    private Boolean kerberosEnabled = false;
     private AtomicBoolean timeToSendHeartBeat = new AtomicBoolean(false);
     private UserGroupInformation ugi = null;
     HashMap<HiveEndPoint, HiveWriter> allWriters;
@@ -65,6 +64,7 @@ public class HiveBolt extends  BaseRichBolt {
     @Override
     public void prepare(Map conf, TopologyContext topologyContext, OutputCollector collector)  {
         try {
+            boolean kerberosEnabled;
             if(options.getKerberosPrincipal() == null && options.getKerberosKeytab() == null) {
                 kerberosEnabled = false;
             } else if(options.getKerberosPrincipal() != null && options.getKerberosKeytab() != null) {
@@ -83,7 +83,7 @@ public class HiveBolt extends  BaseRichBolt {
                 }
             }
             this.collector = collector;
-            allWriters = new HashMap<HiveEndPoint,HiveWriter>();
+            allWriters = new HashMap<>();
             String timeoutName = "hive-bolt-%d";
             this.callTimeoutPool = Executors.newFixedThreadPool(1,
                                 new ThreadFactoryBuilder().setNameFormat(timeoutName).build());
@@ -179,7 +179,6 @@ public class HiveBolt extends  BaseRichBolt {
 
     /**
      * Closes all writers and remove them from cache
-     * @return number of writers retired
      */
     private void closeAllWriters() {
         try {
@@ -262,7 +261,7 @@ public class HiveBolt extends  BaseRichBolt {
     private int retireIdleWriters() {
         int count = 0;
         long now = System.currentTimeMillis();
-        ArrayList<HiveEndPoint> retirees = new ArrayList<HiveEndPoint>();
+        ArrayList<HiveEndPoint> retirees = new ArrayList<>();
 
         //1) Find retirement candidates
         for (Entry<HiveEndPoint,HiveWriter> entry : allWriters.entrySet()) {

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/HiveMapper.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/HiveMapper.java
@@ -38,7 +38,7 @@ public interface HiveMapper extends Serializable {
     /**
      * Given a endPoint, returns a RecordWriter with columnNames.
      *
-     * @param tuple
+     * @param endPoint
      * @return
      */
 
@@ -66,7 +66,7 @@ public interface HiveMapper extends Serializable {
     /**
      * Given a TridetnTuple, return a hive partition values list.
      *
-     * @param TridentTuple
+     * @param tuple
      * @return List<String>
      */
     List<String> mapPartitions(TridentTuple tuple);

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/JsonRecordHiveMapper.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/JsonRecordHiveMapper.java
@@ -90,11 +90,12 @@ public class JsonRecordHiveMapper implements HiveMapper {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public byte[] mapRecord(Tuple tuple) {
         JSONObject obj = new JSONObject();
         if(this.columnFields != null) {
             for(String field: this.columnFields) {
-                obj.put(field,tuple.getValueByField(field));
+                        obj.put(field,tuple.getValueByField(field));
             }
         }
         return obj.toJSONString().getBytes();
@@ -115,6 +116,7 @@ public class JsonRecordHiveMapper implements HiveMapper {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public byte[] mapRecord(TridentTuple tuple) {
         JSONObject obj = new JSONObject();
         if(this.columnFields != null) {

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveUtils.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveUtils.java
@@ -18,8 +18,6 @@
 
 package org.apache.storm.hive.common;
 
-import org.apache.storm.hive.common.HiveWriter;
-import org.apache.storm.hive.bolt.mapper.HiveMapper;
 import org.apache.hive.hcatalog.streaming.*;
 
 import org.apache.hadoop.security.SecurityUtil;


### PR DESCRIPTION
Contributing back very minor cleanups as I am trying to learn more about Storm code:
- javadoc fixes
- consolidate exception catches
- suppress unavoidable "unchecked" warnings
- remove unnecessary type parameters from constructors where possible

There should not be any functional changes introduced