### PR TITLE
STORM-926:change pom to use maven-shade-plugin:2.2 and minimize the size of shade jar and fix duplicated classes warnings of flue-examples

### DIFF
--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -111,9 +111,9 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>1.4</version>
             <configuration>
                 <createDependencyReducedPom>true</createDependencyReducedPom>
+                <minimizeJar>true</minimizeJar>
             </configuration>
             <executions>
                 <execution>

--- a/external/flux/flux-core/pom.xml
+++ b/external/flux/flux-core/pom.xml
@@ -70,9 +70,9 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>1.4</version>
             <configuration>
                 <createDependencyReducedPom>true</createDependencyReducedPom>
+                <minimizeJar>true</minimizeJar>
             </configuration>
             <executions>
                 <execution>

--- a/external/flux/flux-examples/pom.xml
+++ b/external/flux/flux-examples/pom.xml
@@ -46,11 +46,47 @@
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-hdfs</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-yarn-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-hbase</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api-2.5</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>
@@ -79,9 +115,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.4</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <minimizeJar>true</minimizeJar>
                 </configuration>
                 <executions>
                     <execution>

--- a/external/storm-eventhubs/pom.xml
+++ b/external/storm-eventhubs/pom.xml
@@ -40,7 +40,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
                 <executions>
                     <execution>
                         <goals>
@@ -50,6 +49,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <minimizeJar>true</minimizeJar>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
                         </transformer>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -392,7 +392,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
1: fix external/flux/flux-examples duplicated classes warings 
```
[WARNING] commons-collections-3.2.1.jar, commons-beanutils-core-1.8.0.jar, commons-beanutils-1.7.0.jar define 3 overlappping classes: 
[WARNING]   - org.apache.commons.collections.ArrayStack
[WARNING]   - org.apache.commons.collections.BufferUnderflowException
[WARNING]   - org.apache.commons.collections.Buffer
[WARNING] javax.servlet-3.1.jar, servlet-api-2.5-6.1.14.jar, javax.servlet-api-3.0.1.jar, servlet-api-2.5.jar define 17 overlappping classes: 
[WARNING]   - javax.servlet.ServletInputStream
[WARNING]   - javax.servlet.Filter
[WARNING]   - javax.servlet.http.HttpSession
[WARNING]   - javax.servlet.FilterConfig
[WARNING]   - javax.servlet.FilterChain
[WARNING]   - javax.servlet.http.Cookie
[WARNING]   - javax.servlet.http.HttpServletResponse
[WARNING]   - javax.servlet.ServletConfig
[WARNING]   - javax.servlet.RequestDispatcher
[WARNING]   - javax.servlet.ServletRequest
[WARNING]   - 7 more...
[WARNING] javax.servlet-3.1.jar, javax.servlet-api-3.0.1.jar define 26 overlappping classes: 
[WARNING]   - javax.servlet.Registration
[WARNING]   - javax.servlet.DispatcherType
[WARNING]   - javax.servlet.ServletRegistration$Dynamic
[WARNING]   - javax.servlet.FilterRegistration
[WARNING]   - javax.servlet.Registration$Dynamic
[WARNING]   - javax.servlet.annotation.ServletSecurity$TransportGuarantee
[WARNING]   - javax.servlet.FilterRegistration$Dynamic
[WARNING]   - javax.servlet.descriptor.JspPropertyGroupDescriptor
[WARNING]   - javax.servlet.annotation.ServletSecurity$EmptyRoleSemantic
[WARNING]   - javax.servlet.descriptor.TaglibDescriptor
[WARNING]   - 16 more...
[WARNING] hadoop-yarn-api-2.2.0.jar, hadoop-yarn-common-2.2.0.jar define 1 overlappping classes: 
[WARNING]   - org.apache.hadoop.yarn.util.package-info
[WARNING] maven-shade-plugin has detected that some .class files
[WARNING] are present in two or more JARs. When this happens, only
[WARNING] one single version of the class is copied in the uberjar.
[WARNING] Usually this is not harmful and you can skeep these
[WARNING] warnings, otherwise try to manually exclude artifacts
[WARNING] based on mvn dependency:tree -Ddetail=true and the above
[WARNING] output
```

2. minimized shade jars 
For example:
mini flux-examples-0.11.0-SNAPSHOT.jar size from  52M  to 12M