### PR TITLE
STORM-945:<DefaultRolloverStrategy> element is not a policy,and should not be putted in the <Policies> element

### DIFF
--- a/log4j2/cluster.xml
+++ b/log4j2/cluster.xml
@@ -30,8 +30,8 @@
         </PatternLayout>
         <Policies>
             <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
-            <DefaultRolloverStrategy max="9"/>
         </Policies>
+        <DefaultRolloverStrategy max="9"/>
     </RollingFile>
     <RollingFile name="ACCESS"
                  fileName="${sys:storm.log.dir}/access.log"
@@ -41,8 +41,8 @@
         </PatternLayout>
         <Policies>
             <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
-            <DefaultRolloverStrategy max="9"/>
         </Policies>
+        <DefaultRolloverStrategy max="9"/>
     </RollingFile>
     <RollingFile name="METRICS"
                  fileName="${sys:storm.log.dir}/metrics.log"
@@ -52,8 +52,8 @@
         </PatternLayout>
         <Policies>
             <SizeBasedTriggeringPolicy size="2 MB"/> <!-- Or every 100 MB -->
-            <DefaultRolloverStrategy max="9"/>
         </Policies>
+        <DefaultRolloverStrategy max="9"/>
     </RollingFile>
     <Syslog name="syslog" format="RFC5424" host="localhost" port="514"
             protocol="UDP" appName="[${sys:daemon.name}]" mdcId="mdc" includeMDC="true"

--- a/log4j2/worker.xml
+++ b/log4j2/worker.xml
@@ -30,8 +30,8 @@
         </PatternLayout>
         <Policies>
             <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
-            <DefaultRolloverStrategy max="9"/>
         </Policies>
+        <DefaultRolloverStrategy max="9"/>
     </RollingFile>
     <RollingFile name="STDOUT"
                  fileName="${sys:storm.log.dir}/${sys:logfile.name}.out"
@@ -41,8 +41,8 @@
         </PatternLayout>
         <Policies>
             <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
-            <DefaultRolloverStrategy max="4"/>
         </Policies>
+        <DefaultRolloverStrategy max="4"/>
     </RollingFile>
     <RollingFile name="STDERR"
                  fileName="${sys:storm.log.dir}/${sys:logfile.name}.err"
@@ -52,8 +52,8 @@
         </PatternLayout>
         <Policies>
             <SizeBasedTriggeringPolicy size="100 MB"/> <!-- Or every 100 MB -->
-            <DefaultRolloverStrategy max="4"/>
         </Policies>
+        <DefaultRolloverStrategy max="4"/>
     </RollingFile>
     <Syslog name="syslog" format="RFC5424" host="localhost" port="514"
         protocol="UDP" appName="[${sys:storm.id}:${sys:worker.port}]" mdcId="mdc" includeMDC="true"


### PR DESCRIPTION
```
-> storm-current  bin/storm nimbus
Running: /usr/share/jdk-current/bin/java -server -Ddaemon.name=nimbus ... ...
2015-07-17 10:23:36,776 ERROR Policies has no parameter that matches element DefaultRolloverStrategy
2015-07-17 10:23:36,787 ERROR Policies has no parameter that matches element DefaultRolloverStrategy
2015-07-17 10:23:36,795 ERROR Policies has no parameter that matches element DefaultRolloverStrategy
```