### PR TITLE
STORM-1028: Eventhub spout meta data

### DIFF
--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/EventDataScheme.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/EventDataScheme.java
@@ -22,8 +22,10 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.qpid.amqp_1_0.client.Message;
 import org.apache.qpid.amqp_1_0.type.Section;
+import org.apache.qpid.amqp_1_0.type.Symbol;
 import org.apache.qpid.amqp_1_0.type.messaging.AmqpValue;
 import org.apache.qpid.amqp_1_0.type.messaging.Data;
+import org.apache.qpid.amqp_1_0.type.messaging.MessageAnnotations;
 
 public class EventDataScheme implements IEventDataScheme {
 
@@ -42,6 +44,9 @@ public class EventDataScheme implements IEventDataScheme {
         AmqpValue amqpValue = (AmqpValue) section;
         fieldContents.add(amqpValue.getValue().toString());
         return fieldContents;
+      }else if (section instanceof MessageAnnotations) {
+        MessageAnnotations messageAnnotations = (MessageAnnotations) section;
+        fieldContents.add(messageAnnotations.getValue().get(Symbol.getSymbol("x-opt-sequence-number")));
       }
     }
 
@@ -50,6 +55,6 @@ public class EventDataScheme implements IEventDataScheme {
 
   @Override
   public Fields getOutputFields() {
-    return new Fields(FieldConstants.Message);
+    return new Fields(FieldConstants.sequenceNumber, FieldConstants.Message, FieldConstants.Partition);
   }
 }

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/EventDataScheme.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/EventDataScheme.java
@@ -44,7 +44,7 @@ public class EventDataScheme implements IEventDataScheme {
         AmqpValue amqpValue = (AmqpValue) section;
         fieldContents.add(amqpValue.getValue().toString());
         return fieldContents;
-      }else if (section instanceof MessageAnnotations) {
+      } else if (section instanceof MessageAnnotations) {
         MessageAnnotations messageAnnotations = (MessageAnnotations) section;
         fieldContents.add(messageAnnotations.getValue().get(Symbol.getSymbol("x-opt-sequence-number")));
       }

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/EventDataScheme.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/EventDataScheme.java
@@ -55,6 +55,6 @@ public class EventDataScheme implements IEventDataScheme {
 
   @Override
   public Fields getOutputFields() {
-    return new Fields(FieldConstants.sequenceNumber, FieldConstants.Message, FieldConstants.Partition);
+    return new Fields(FieldConstants.SequenceNumber, FieldConstants.Message, FieldConstants.Partition);
   }
 }

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/EventHubSpout.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/EventHubSpout.java
@@ -199,6 +199,7 @@ public class EventHubSpout extends BaseRichSpout {
       List<Object> tuples = scheme.deserialize(message);
 
       if (tuples != null) {
+        tuples.add(messageId.getPartitionId());
         collector.emit(tuples, messageId);
       }
     }

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/FieldConstants.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/FieldConstants.java
@@ -22,4 +22,6 @@ public class FieldConstants {
   public static final String PartitionKey = "partitionKey";
   public static final String Offset = "offset";
   public static final String Message = "message";
+  public static final String Partition = "partition";
+  public static final String sequenceNumber = "seq-number";
 }

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/FieldConstants.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/spout/FieldConstants.java
@@ -23,5 +23,5 @@ public class FieldConstants {
   public static final String Offset = "offset";
   public static final String Message = "message";
   public static final String Partition = "partition";
-  public static final String sequenceNumber = "seq-number";
+  public static final String SequenceNumber = "sequenceNumber";
 }


### PR DESCRIPTION
Add "partition","seq-number" fields to emitted tupples for event sourcing consumers, which need to preserve partition order and be able to replay.
