### PR TITLE
STORM-964, add config for worker logwriter to restrict its mem usage

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -181,6 +181,7 @@ topology.stats.sample.rate: 0.05
 topology.builtin.metrics.bucket.size.secs: 60
 topology.fall.back.on.java.serialization: true
 topology.worker.childopts: null
+topology.worker.lw.childopts: "-Xmx64m"
 topology.executor.receive.buffer.size: 1024 #batched
 topology.executor.send.buffer.size: 1024 #individual messages
 topology.transfer.buffer.size: 1024 # batched

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -181,7 +181,7 @@ topology.stats.sample.rate: 0.05
 topology.builtin.metrics.bucket.size.secs: 60
 topology.fall.back.on.java.serialization: true
 topology.worker.childopts: null
-topology.worker.lw.childopts: "-Xmx64m"
+topology.worker.logwriter.childopts: "-Xmx64m"
 topology.executor.receive.buffer.size: 1024 #batched
 topology.executor.send.buffer.size: 1024 #individual messages
 topology.transfer.buffer.size: 1024 # batched

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -675,7 +675,7 @@
                         (add-to-classpath topo-classpath))
           top-gc-opts (storm-conf TOPOLOGY-WORKER-GC-CHILDOPTS)
           gc-opts (substitute-childopts (if top-gc-opts top-gc-opts (conf WORKER-GC-CHILDOPTS)) worker-id storm-id port)
-          topo-worker-lw-childopts (conf TOPOLOGY-WORKER-LW-CHILDOPTS)
+          topo-worker-logwriter-childopts (conf TOPOLOGY-WORKER-LOGWRITER-CHILDOPTS)
           user (storm-conf TOPOLOGY-SUBMITTER-USER)
           logging-sensitivity (storm-conf TOPOLOGY-LOGGING-SENSITIVITY "S3")
           logfilename (logs-filename storm-id port)
@@ -688,7 +688,7 @@
                                         {"LD_LIBRARY_PATH" jlp})
           command (concat
                     [(java-cmd) "-cp" classpath 
-                     topo-worker-lw-childopts
+                     topo-worker-logwriter-childopts
                      (str "-Dlogfile.name=" logfilename)
                      (str "-Dstorm.home=" storm-home)
                      (str "-Dstorm.id=" storm-id)

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -675,7 +675,7 @@
                         (add-to-classpath topo-classpath))
           top-gc-opts (storm-conf TOPOLOGY-WORKER-GC-CHILDOPTS)
           gc-opts (substitute-childopts (if top-gc-opts top-gc-opts (conf WORKER-GC-CHILDOPTS)) worker-id storm-id port)
-          topo-worker-logwriter-childopts (conf TOPOLOGY-WORKER-LOGWRITER-CHILDOPTS)
+          topo-worker-logwriter-childopts (storm-conf TOPOLOGY-WORKER-LOGWRITER-CHILDOPTS)
           user (storm-conf TOPOLOGY-SUBMITTER-USER)
           logging-sensitivity (storm-conf TOPOLOGY-LOGGING-SENSITIVITY "S3")
           logfilename (logs-filename storm-id port)

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -675,6 +675,7 @@
                         (add-to-classpath topo-classpath))
           top-gc-opts (storm-conf TOPOLOGY-WORKER-GC-CHILDOPTS)
           gc-opts (substitute-childopts (if top-gc-opts top-gc-opts (conf WORKER-GC-CHILDOPTS)) worker-id storm-id port)
+          topo-worker-lw-childopts (conf TOPOLOGY-WORKER-LW-CHILDOPTS)
           user (storm-conf TOPOLOGY-SUBMITTER-USER)
           logging-sensitivity (storm-conf TOPOLOGY-LOGGING-SENSITIVITY "S3")
           logfilename (logs-filename storm-id port)
@@ -687,6 +688,7 @@
                                         {"LD_LIBRARY_PATH" jlp})
           command (concat
                     [(java-cmd) "-cp" classpath 
+                     topo-worker-lw-childopts
                      (str "-Dlogfile.name=" logfilename)
                      (str "-Dstorm.home=" storm-home)
                      (str "-Dstorm.id=" storm-id)

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1223,8 +1223,8 @@ public class Config extends HashMap<String, Object> {
     /**
      * Topology-specific options for the logwriter process of a worker.
      */
-    public static final String TOPOLOGY_WORKER_LW_CHILDOPTS="topology.worker.lw.childopts";
-    public static final Object TOPOLOGY_WORKER_LW_CHILDOPTS_SCHEMA = ConfigValidation.StringOrStringListValidator;
+    public static final String TOPOLOGY_WORKER_LOGWRITER_CHILDOPTS="topology.worker.logwriter.childopts";
+    public static final Object TOPOLOGY_WORKER_LOGWRITER_CHILDOPTS_SCHEMA = ConfigValidation.StringOrStringListValidator;
 
     /**
      * Topology-specific classpath for the worker child process. This is combined to the usual classpath.

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1221,6 +1221,12 @@ public class Config extends HashMap<String, Object> {
     public static final Object TOPOLOGY_WORKER_GC_CHILDOPTS_SCHEMA = ConfigValidation.StringOrStringListValidator;
 
     /**
+     * Topology-specific options for the logwriter process of a worker.
+     */
+    public static final String TOPOLOGY_WORKER_LW_CHILDOPTS="topology.worker.lw.childopts";
+    public static final Object TOPOLOGY_WORKER_LW_CHILDOPTS_SCHEMA = ConfigValidation.StringOrStringListValidator;
+
+    /**
      * Topology-specific classpath for the worker child process. This is combined to the usual classpath.
      */
     public static final String TOPOLOGY_CLASSPATH="topology.classpath";


### PR DESCRIPTION
The log writer process that writes out stderr and stdout should have a config that controls it's memory usage and it should default to a very small value, probably 50MB in most cases.

To address above issue, one new parameter is defined for logwriter's jvmopts: "topology.worker.lw.childopts".
The default heap size of logwriter is set as 64M, or user can override it through "-c topology.worker.lw.childopts='xxxx " when submitting a topology.
