### PR TITLE
STORM-966 ConfigValidation.DoubleValidator is misleading and not neccessary

### DIFF
--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1194,7 +1194,7 @@ public class Config extends HashMap<String, Object> {
      * The percentage of tuples to sample to produce stats for a task.
      */
     public static final String TOPOLOGY_STATS_SAMPLE_RATE="topology.stats.sample.rate";
-    public static final Object TOPOLOGY_STATS_SAMPLE_RATE_SCHEMA = ConfigValidation.DoubleValidator;
+    public static final Object TOPOLOGY_STATS_SAMPLE_RATE_SCHEMA = Number.class;
 
     /**
      * The time period that builtin metrics data in bucketed into.

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1194,7 +1194,7 @@ public class Config extends HashMap<String, Object> {
      * The percentage of tuples to sample to produce stats for a task.
      */
     public static final String TOPOLOGY_STATS_SAMPLE_RATE="topology.stats.sample.rate";
-    public static final Object TOPOLOGY_STATS_SAMPLE_RATE_SCHEMA = Number.class;
+    public static final Object TOPOLOGY_STATS_SAMPLE_RATE_SCHEMA =ConfigValidation.PositiveNumberValidator;
 
     /**
      * The time period that builtin metrics data in bucketed into.

--- a/storm-core/src/jvm/backtype/storm/ConfigValidation.java
+++ b/storm-core/src/jvm/backtype/storm/ConfigValidation.java
@@ -28,7 +28,6 @@ public class ConfigValidation {
     /**
      * Declares methods for validating configuration values.
      */
-    public static interface FieldValidator {
         /**
          * Validates the given field.
          * @param name the name of the field.
@@ -268,7 +267,7 @@ public class ConfigValidation {
                     return;
                 }
             }
-            throw new IllegalArgumentException("Field " + name + " must be a Number");
+            throw new IllegalArgumentException("Field " + name + " must be a Positive Number");
         }
     };
 

--- a/storm-core/src/jvm/backtype/storm/ConfigValidation.java
+++ b/storm-core/src/jvm/backtype/storm/ConfigValidation.java
@@ -254,6 +254,25 @@ public class ConfigValidation {
     };
 
     /**
+     * Validates a Positive Number
+     */
+    public static Object PositiveNumberValidator = new FieldValidator() {
+        @Override
+        public void validateField(String name, Object o) throws IllegalArgumentException {
+            if (o == null) {
+                // A null value is acceptable.
+                return;
+            }
+            if(o instanceof Number) {
+                if(((Number)o).doubleValue() > 0.0) {
+                    return;
+                }
+            }
+            throw new IllegalArgumentException("Field " + name + " must be a Number");
+        }
+    };
+
+    /**
      * Validates a power of 2.
      */
     public static Object PowerOf2Validator = new FieldValidator() {

--- a/storm-core/src/jvm/backtype/storm/ConfigValidation.java
+++ b/storm-core/src/jvm/backtype/storm/ConfigValidation.java
@@ -254,26 +254,6 @@ public class ConfigValidation {
     };
 
     /**
-     * Validates a Double.
-     */
-    public static Object DoubleValidator = new FieldValidator() {
-        @Override
-        public void validateField(String name, Object o) throws IllegalArgumentException {
-            if (o == null) {
-                // A null value is acceptable.
-                return;
-            }
-
-            // we can provide a lenient way to convert int/long to double with losing some precision
-            if (o instanceof Number) {
-                return;
-            }
-
-            throw new IllegalArgumentException("Field " + name + " must be an Double.");
-        }
-    };
-
-    /**
      * Validates a power of 2.
      */
     public static Object PowerOf2Validator = new FieldValidator() {

--- a/storm-core/src/jvm/backtype/storm/ConfigValidation.java
+++ b/storm-core/src/jvm/backtype/storm/ConfigValidation.java
@@ -28,6 +28,7 @@ public class ConfigValidation {
     /**
      * Declares methods for validating configuration values.
      */
+    public static interface FieldValidator {
         /**
          * Validates the given field.
          * @param name the name of the field.

--- a/storm-core/test/clj/backtype/storm/config_test.clj
+++ b/storm-core/test/clj/backtype/storm/config_test.clj
@@ -99,15 +99,6 @@
     (is (thrown-cause? java.lang.IllegalArgumentException
           (.validateField validator "test" [-100 (inc Integer/MAX_VALUE)])))))
 
-(deftest test-double-validator
-  (let [validator ConfigValidation/DoubleValidator]
-    (.validateField validator "test" nil)
-    (.validateField validator "test" 10)
-    ;; we can provide lenient way to convert int/long to double with losing precision
-    (.validateField validator "test" Integer/MAX_VALUE)
-    (.validateField validator "test" (inc Integer/MAX_VALUE))
-    (.validateField validator "test" Double/MAX_VALUE)))
-
 (deftest test-topology-workers-is-integer
   (let [validator (CONFIG-SCHEMA-MAP TOPOLOGY-WORKERS)]
     (.validateField validator "test" 42)

--- a/storm-core/test/clj/backtype/storm/config_test.clj
+++ b/storm-core/test/clj/backtype/storm/config_test.clj
@@ -99,6 +99,20 @@
     (is (thrown-cause? java.lang.IllegalArgumentException
           (.validateField validator "test" [-100 (inc Integer/MAX_VALUE)])))))
 
+(deftest test-positive-number-validator
+  (let [validator ConfigValidation/PositiveNumberValidator]
+    (.validateField validator "test" nil)
+    (.validateField validator "test" 1.0)
+    (.validateField validator "test" 1)
+    (is (thrown-cause? java.lang.IllegalArgumentException
+          (.validateField validator "test" -1.0)))
+    (is (thrown-cause? java.lang.IllegalArgumentException
+          (.validateField validator "test" -1)))
+    (is (thrown-cause? java.lang.IllegalArgumentException
+          (.validateField validator "test" 0)))
+    (is (thrown-cause? java.lang.IllegalArgumentException
+          (.validateField validator "test" 0.0)))))
+
 (deftest test-topology-workers-is-integer
   (let [validator (CONFIG-SCHEMA-MAP TOPOLOGY-WORKERS)]
     (.validateField validator "test" 42)


### PR DESCRIPTION
ConfigValidation.DoubleValidator doesn't really validate whether the type of the object is a double.

ConfigValidation.DoubleValidator code only checks if the object is null whether if the object is a instance of Number which is a parent class of Double.
DoubleValidator is only used once in Config.java and in that instance:
public static final Object TOPOLOGY_STATS_SAMPLE_RATE_SCHEMA = ConfigValidation.DoubleValidator;
can just be set to:
public static final Object TOPOLOGY_STATS_SAMPLE_RATE_SCHEMA = NUMBER.class;
Then we can just get rid of the misleading function ConfigValidation.DoubleValidator since it doesn't really check if a object is of double type thus the validator function doesn't really do anything and the name is misleading. In previous commit https://github.com/apache/storm/commit/214ee7454548b884c591991b1faea770d1478cec Number.Class was used anyway