### PR TITLE
STORM-969: HDFS Bolt can end up in an unrecoverable state

### DIFF
--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -41,6 +41,14 @@
             <artifactId>storm-core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <!--log4j-over-slf4j must be excluded for hadoop-minicluster
+                    see: http://stackoverflow.com/q/20469026/3542091 -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -69,6 +77,17 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minicluster</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
@@ -81,19 +100,28 @@
         </dependency>
     </dependencies>
     <build>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>2.2</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>test-jar</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/HdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/HdfsBolt.java
@@ -17,9 +17,11 @@
  */
 package org.apache.storm.hdfs.bolt;
 
+import backtype.storm.Config;
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.tuple.Tuple;
+import backtype.storm.utils.TupleUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -37,13 +39,19 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.List;
+import java.util.LinkedList;
 
 public class HdfsBolt extends AbstractHdfsBolt{
     private static final Logger LOG = LoggerFactory.getLogger(HdfsBolt.class);
+    private static final Integer DEFAULT_RETRY_COUNT = 3;
 
     private transient FSDataOutputStream out;
     private RecordFormat format;
     private long offset = 0;
+    private List<Tuple> tupleBatch = new LinkedList<>();
+    Integer tickTupleInterval = 0;
+    Integer fileRetryCount = DEFAULT_RETRY_COUNT;
 
     public HdfsBolt withFsUrl(String fsUrl){
         this.fsUrl = fsUrl;
@@ -80,41 +88,136 @@ public class HdfsBolt extends AbstractHdfsBolt{
         return this;
     }
 
+    public HdfsBolt withTickTupleIntervalSeconds(int interval) {
+        this.tickTupleInterval = interval;
+        return this;
+    }
+
+    public HdfsBolt withRetryCount(int fileRetryCount) {
+        this.fileRetryCount = fileRetryCount;
+        return this;
+    }
+
     @Override
     public void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException {
         LOG.info("Preparing HDFS Bolt...");
         this.fs = FileSystem.get(URI.create(this.fsUrl), hdfsConfig);
+
+        // If interval is non-zero then it has already been explicitly set and we should not default it
+        if (conf.containsKey("topology.message.timeout.secs") && tickTupleInterval == 0)
+        {
+            Integer topologyTimeout = Integer.parseInt(conf.get("topology.message.timeout.secs").toString());
+            tickTupleInterval = (int)(Math.floor(topologyTimeout / 2));
+            LOG.debug("Setting tick tuple interval to [" + tickTupleInterval + "] based on topology timeout");
+        }
     }
 
     @Override
     public void execute(Tuple tuple) {
-        try {
-            byte[] bytes = this.format.format(tuple);
-            synchronized (this.writeLock) {
-                out.write(bytes);
-                this.offset += bytes.length;
 
-                if (this.syncPolicy.mark(tuple, this.offset)) {
-                    if (this.out instanceof HdfsDataOutputStream) {
-                        ((HdfsDataOutputStream) this.out).hsync(EnumSet.of(SyncFlag.UPDATE_LENGTH));
-                    } else {
-                        this.out.hsync();
-                    }
-                    this.syncPolicy.reset();
+        synchronized (this.writeLock) {
+            boolean forceSync = false;
+            if (TupleUtils.isTick(tuple)) {
+                LOG.debug("TICK! forcing a file system flush");
+                forceSync = true;
+            }
+            else {
+                try {
+                    writeAndAddTuple(tuple);
+                } catch (IOException e) {
+                    //If the write failed, try to sync anything already written
+                    LOG.info("Tuple failed to write, forcing a flush of existing data.");
+                    this.collector.reportError(e);
+                    forceSync = true;
+                    this.collector.fail(tuple);
                 }
             }
 
-            this.collector.ack(tuple);
+            if (this.syncPolicy.mark(tuple, this.offset) || (forceSync && tupleBatch.size() > 0)) {
+                int attempts = 0;
+                boolean success = false;
+                IOException lastException = null;
+                // Make every attempt to sync the data we have.  If it can't be done then kill the bolt with
+                // a runtime exception.  The filesystem is presumably in a very bad state.
+                while (success == false && attempts < fileRetryCount)
+                {
+                    attempts += 1;
+                    try {
+                        syncAndAckTuples();
+                        success = true;
+                    } catch (IOException e) {
+                        LOG.warn("Data could not be synced to filesystem on attempt [" + attempts + "]");
+                        this.collector.reportError(e);
+                        lastException = e;
+                    }
+                }
 
-            if(this.rotationPolicy.mark(tuple, this.offset)){
-                rotateOutputFile(); // synchronized
-                this.offset = 0;
-                this.rotationPolicy.reset();
+                // If unsuccesful fail the pending tuples
+                if (success == false)
+                {
+                    LOG.warn("Data could not be synced to filesystem, failing this batch of tuples");
+                    for (Tuple t : tupleBatch)
+                        this.collector.fail(t);
+                    tupleBatch.clear();
+
+                    throw new RuntimeException("Sync failed [" + attempts + "] times.", lastException);
+                }
             }
-        } catch (IOException e) {
-            this.collector.reportError(e);
-            this.collector.fail(tuple);
+
         }
+
+        if(this.rotationPolicy.mark(tuple, this.offset)) {
+            try {
+                rotateAndReset();
+            } catch (IOException e) {
+                this.collector.reportError(e);
+                LOG.warn("File could not be rotated");
+                //At this point there is nothing to do.  In all likelihood any filesystem operations will fail.
+                //The next tuple will almost certainly fail to write and/or sync, which force a rotation.  That
+                //will give rotateAndReset() a chance to work which includes creating a fresh file handle.
+            }
+        }
+    }
+
+    private void rotateAndReset() throws IOException {
+        rotateOutputFile(); // synchronized
+        this.offset = 0;
+        this.rotationPolicy.reset();
+    }
+
+    private void syncAndAckTuples() throws IOException {
+        LOG.debug("Attempting to sync all data to filesystem");
+        if (this.out instanceof HdfsDataOutputStream) {
+            ((HdfsDataOutputStream) this.out).hsync(EnumSet.of(SyncFlag.UPDATE_LENGTH));
+        } else {
+            this.out.hsync();
+        }
+        this.syncPolicy.reset();
+        LOG.debug("Data synced to filesystem. Ack'ing [" + tupleBatch.size() +"] tuples");
+        for (Tuple t : tupleBatch)
+            this.collector.ack(t);
+        tupleBatch.clear();
+    }
+
+    private void writeAndAddTuple(Tuple tuple) throws IOException {
+        byte[] bytes = this.format.format(tuple);
+        out.write(bytes);
+        this.offset += bytes.length;
+        tupleBatch.add(tuple);
+    }
+
+    @Override
+    public Map<String, Object> getComponentConfiguration() {
+        Map<String, Object> conf = super.getComponentConfiguration();
+        if (conf == null)
+            conf = new Config();
+
+        if (tickTupleInterval > 0) {
+            LOG.info("Enabling tick tuple with interval [" + tickTupleInterval + "]");
+            conf.put(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS, tickTupleInterval);
+        }
+
+        return conf;
     }
 
     @Override

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestHdfsBolt.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestHdfsBolt.java
@@ -1,0 +1,242 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.bolt;
+
+import backtype.storm.Config;
+import backtype.storm.task.GeneralTopologyContext;
+import backtype.storm.task.OutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.TopologyBuilder;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.tuple.TupleImpl;
+import backtype.storm.tuple.Values;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.storm.hdfs.bolt.format.DefaultFileNameFormat;
+import org.apache.storm.hdfs.bolt.format.DelimitedRecordFormat;
+import org.apache.storm.hdfs.bolt.format.FileNameFormat;
+import org.apache.storm.hdfs.bolt.format.RecordFormat;
+import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
+import org.apache.storm.hdfs.bolt.rotation.FileSizeRotationPolicy;
+import org.apache.storm.hdfs.bolt.sync.CountSyncPolicy;
+import org.apache.storm.hdfs.bolt.sync.SyncPolicy;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Assert;
+
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.Mockito.*;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.protocol.HdfsConstants.SafeModeAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+public class TestHdfsBolt {
+
+    private String hdfsURI;
+    private DistributedFileSystem fs;
+    private MiniDFSCluster hdfsCluster;
+    private static final String testRoot = "/unittest";
+    Tuple tuple1 = generateTestTuple(1, "First Tuple", "SFO", "CA");
+    Tuple tuple2 = generateTestTuple(1, "Second Tuple", "SJO", "CA");
+
+    @Mock private OutputCollector collector;
+    @Mock private TopologyContext topologyContext;
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        Configuration conf = new Configuration();
+        conf.set("fs.trash.interval", "10");
+        conf.setBoolean("dfs.permissions", true);
+        File baseDir = new File("./target/hdfs/").getAbsoluteFile();
+        FileUtil.fullyDelete(baseDir);
+        conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+
+        MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
+        hdfsCluster = builder.build();
+        fs = hdfsCluster.getFileSystem();
+        hdfsURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/";
+    }
+
+    @After
+    public void shutDown() throws IOException {
+        fs.close();
+        hdfsCluster.shutdown();
+    }
+
+    @Test
+    public void testTwoTuplesTwoFiles() throws IOException {
+        HdfsBolt bolt = makeHdfsBolt(hdfsURI, 1, .00001f);
+
+        bolt.prepare(new Config(), topologyContext, collector);
+        bolt.execute(tuple1);
+        bolt.execute(tuple2);
+
+        verify(collector).ack(tuple1);
+        verify(collector).ack(tuple2);
+
+        Assert.assertEquals(2, countNonZeroLengthFiles(testRoot));
+    }
+
+    @Test
+    public void testTwoTuplesOneFile() throws IOException
+    {
+        HdfsBolt bolt = makeHdfsBolt(hdfsURI, 2, 10000f);
+        bolt.prepare(new Config(), topologyContext, collector);
+        bolt.execute(tuple1);
+
+        verifyZeroInteractions(collector);
+
+        bolt.execute(tuple2);
+        verify(collector).ack(tuple1);
+        verify(collector).ack(tuple2);
+
+        Assert.assertEquals(1, countNonZeroLengthFiles(testRoot));
+    }
+
+    @Test
+    public void testFailedSync() throws IOException
+    {
+        HdfsBolt bolt = makeHdfsBolt(hdfsURI, 1, .00001f);
+        bolt.prepare(new Config(), topologyContext, collector);
+
+        fs.setSafeMode(SafeModeAction.SAFEMODE_ENTER);
+
+        // All writes/syncs will fail so this should cause a RuntimeException
+        thrown.expect(RuntimeException.class);
+        bolt.execute(tuple1);
+
+    }
+
+    // One tuple and one rotation should yield one file with data and one zero length file
+    // The failed executions should not cause rotations and new zero length files
+    @Test
+    public void testFailureFilecount() throws IOException, InterruptedException
+    {
+        HdfsBolt bolt = makeHdfsBolt(hdfsURI, 1, .000001f);
+        bolt.prepare(new Config(), topologyContext, collector);
+
+        bolt.execute(tuple1);
+        fs.setSafeMode(SafeModeAction.SAFEMODE_ENTER);
+        try
+        {
+            bolt.execute(tuple2);
+        } catch (RuntimeException e) {
+            //
+        }
+        try
+        {
+            bolt.execute(tuple2);
+        } catch (RuntimeException e) {
+            //
+        }
+        try
+        {
+            bolt.execute(tuple2);
+        } catch (RuntimeException e) {
+            //
+        }
+
+        Assert.assertEquals(1, countNonZeroLengthFiles(testRoot));
+        Assert.assertEquals(1, countZeroLengthFiles(testRoot));
+    }
+
+
+    public void createBaseDirectory(FileSystem passedFs, String path) throws IOException {
+        Path p = new Path(path);
+        passedFs.mkdirs(p);
+    }
+
+    private HdfsBolt makeHdfsBolt(String nameNodeAddr, int countSync, float rotationSizeMB) {
+
+        RecordFormat fieldsFormat = new DelimitedRecordFormat().withFieldDelimiter("|");
+
+        SyncPolicy fieldsSyncPolicy = new CountSyncPolicy(countSync);
+
+        FileRotationPolicy fieldsRotationPolicy =
+                new FileSizeRotationPolicy(rotationSizeMB, FileSizeRotationPolicy.Units.MB);
+
+        FileNameFormat fieldsFileNameFormat = new DefaultFileNameFormat().withPath(testRoot);
+
+        return new HdfsBolt()
+                .withFsUrl(nameNodeAddr)
+                .withFileNameFormat(fieldsFileNameFormat)
+                .withRecordFormat(fieldsFormat)
+                .withRotationPolicy(fieldsRotationPolicy)
+                .withSyncPolicy(fieldsSyncPolicy);
+    }
+
+    private Tuple generateTestTuple(Object id, Object msg,Object city,Object state) {
+        TopologyBuilder builder = new TopologyBuilder();
+        GeneralTopologyContext topologyContext = new GeneralTopologyContext(builder.createTopology(),
+                new Config(), new HashMap(), new HashMap(), new HashMap(), "") {
+            @Override
+            public Fields getComponentOutputFields(String componentId, String streamId) {
+                return new Fields("id", "msg","city","state");
+            }
+        };
+        return new TupleImpl(topologyContext, new Values(id, msg,city,state), 1, "");
+    }
+
+    private void printFiles(String path) throws IOException {
+        Path p = new Path(path);
+        FileStatus[] fileStatuses = fs.listStatus(p);
+        for (FileStatus file : fileStatuses) {
+            System.out.println("@@@ " + file.getPath() + " [" + file.getLen() + "]");
+        }
+    }
+
+    // Generally used to compare how files were actually written and compare to expectations based on total
+    // amount of data written and rotation policies
+    private int countNonZeroLengthFiles(String path) throws IOException {
+        Path p = new Path(path);
+        int nonZero = 0;
+
+        for (FileStatus file : fs.listStatus(p))
+            if (file.getLen() > 0)
+                nonZero++;
+
+        return nonZero;
+    }
+
+    private int countZeroLengthFiles(String path) throws IOException {
+        Path p = new Path(path);
+        int zeroLength = 0;
+
+        for (FileStatus file : fs.listStatus(p))
+            if (file.getLen() == 0)
+                zeroLength++;
+
+        return zeroLength;
+    }
+}


### PR DESCRIPTION
A few notes about this PR:
- I updated the storm-hdfs pom.xml to align with other external modules.  Most significant change was probably going from hdfs version 2.2 to ${hadoop.version} (i.e. currently 2.6)

- Many errors are recovered by forcing a file rotation which opens a new, valid File.  So the rotation now occurs either according to rotation policy or when a serious error happens.  Work could probably be done to reopen the same file name to reduce the number of rotations.

- Added unittests with MiniDFSCluster