### PR TITLE
STORM-980 Re-include storm-kafka to Travis CI build

### DIFF
--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -31,7 +31,7 @@ cd ${STORM_SRC_ROOT_DIR}
 export STORM_TEST_TIMEOUT_MS=100000
 
 # We now lean on Travis CI's implicit behavior, ```mvn clean install -DskipTests``` before running script
-mvn test -fae -Pnative -pl '!external/storm-kafka'
+mvn test -fae -Pnative
 BUILD_RET_VAL=$?
 
 for dir in `find . -type d -and -wholename \*/target/\*-reports`;


### PR DESCRIPTION
Please refer https://issues.apache.org/jira/browse/STORM-980 to more details.

We should resolve storm-hive build issue first (#609 may help to resolve), so that Travis CI has a chance to run unit tests on storm-kafka.

For confirmation, I merged #609 and current PR into another branch on my fork and built it from Travis CI.
https://travis-ci.org/HeartSaVioR/storm/builds/75071270