### PR TITLE
[STORM-949] On the topology summary UI page, added Elapsed time since error column.

### DIFF
--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -647,7 +647,8 @@
      "errorPort" error-port
      "errorWorkerLogLink" (worker-log-link error-host error-port top-id secure?)
      "errorLapsedSecs" (get-error-time last-error)
-     "lastError" (get-error-data last-error)}))
+     "lastError" (get-error-data last-error)
+     "time" (if last-error (* 1000 (long (.get_error_time_secs ^ErrorInfo last-error))))}))
 
 (defn bolt-comp [top-id summ-map errors window include-sys? secure?]
   (for [[id summs] summ-map
@@ -674,7 +675,8 @@
      "errorPort" error-port
      "errorWorkerLogLink" (worker-log-link error-host error-port top-id secure?)
      "errorLapsedSecs" (get-error-time last-error)
-     "lastError" (get-error-data last-error)}))
+     "lastError" (get-error-data last-error)
+     "time" (if last-error (* 1000 (long (.get_error_time_secs ^ErrorInfo last-error))))}))
 
 (defn topology-summary [^TopologyInfo summ]
   (let [executors (.get_executors summ)

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -226,6 +226,10 @@
         </th>
         <th class="header">Last error
         </th>
+        <th class="header">
+          <span data-toggle="tooltip" data-placement="left" title="Format: Hours:Minutes:Seconds">
+            Time Elapsed Since Error
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -243,6 +247,9 @@
         <td><a href="{{errorWorkerLogLink}}">{{errorPort}}</a></td>
         <td>
           <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
+        </td>
+        <td>
+          <span id="{{errorLapsedSecs}}" class="elapsedErrorTime">{{errorLapsedSecs}}</span>
         </td>
         {{/spouts}}
     </tbody>
@@ -313,6 +320,10 @@
         </th>
         <th class="header">Last error
         </th>
+        <th class="header">
+          <span data-toggle="tooltip" data-placement="left" title="Format: Hours:Minutes:Seconds">
+            Time Elapsed Since Error
+        </th>
     </tr></thead>
     <tbody>
       {{#bolts}}
@@ -332,6 +343,9 @@
         <td><a href="{{errorWorkerLogLink}}">{{errorPort}}</a></td>
         <td>
           <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
+        </td>
+        <td>
+          <span id="{{errorLapsedSecs}}" class="elapsedErrorTime">{{errorLapsedSecs}}</span>
         </td>
         {{/bolts}}
     </tbody>

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -226,9 +226,7 @@
         </th>
         <th class="header">Last error
         </th>
-        <th class="header">
-          <span data-toggle="tooltip" data-placement="left" title="Format: Hours:Minutes:Seconds">
-            Time Elapsed Since Error
+        <th class="header">Error Time
         </th>
       </tr>
     </thead>
@@ -249,7 +247,7 @@
           <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
         </td>
         <td>
-          <span id="{{errorLapsedSecs}}" class="elapsedErrorTime">{{errorLapsedSecs}}</span>
+          <span id="{{time}}" class="errorTime" data-toggle="tooltip" title="{{errorLapsedSecs}}">{{time}}</span>
         </td>
         {{/spouts}}
     </tbody>
@@ -320,9 +318,7 @@
         </th>
         <th class="header">Last error
         </th>
-        <th class="header">
-          <span data-toggle="tooltip" data-placement="left" title="Format: Hours:Minutes:Seconds">
-            Time Elapsed Since Error
+        <th class="header">Error Time
         </th>
     </tr></thead>
     <tbody>
@@ -345,7 +341,7 @@
           <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
         </td>
         <td>
-          <span id="{{errorLapsedSecs}}" class="elapsedErrorTime">{{errorLapsedSecs}}</span>
+          <span id="{{time}}" class="errorTime" data-toggle="tooltip" title="{{errorLapsedSecs}}">{{time}}</span>
         </td>
         {{/bolts}}
     </tbody>

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -181,6 +181,24 @@ $(document).ready(function() {
                 errorCells[i].style.borderBottomColor = "#9d261d";
               }
             }
+            var errorElapsedTime = document.getElementsByClassName("elapsedErrorTime");
+            for (i =0; i < errorElapsedTime.length; i++)
+            {
+                if((errorElapsedTime[i].id))
+                {
+                    var sec_num = parseInt(errorElapsedTime[i].id, 10);
+                    var hours   = Math.floor(sec_num / 3600);
+                    var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
+                    var seconds = sec_num - (hours * 3600) - (minutes * 60);
+
+                    if (hours   < 10) {hours   = "0"+hours;}
+                    if (minutes < 10) {minutes = "0"+minutes;}
+                    if (seconds < 10) {seconds = "0"+seconds;}
+                    var time    = hours+':'+minutes+':'+seconds;
+
+                    errorElapsedTime[i].innerHTML = time;
+                }
+            }
             $('#topology-summary [data-toggle="tooltip"]').tooltip();
             $('#topology-stats [data-toggle="tooltip"]').tooltip();
             $('#spout-stats [data-toggle="tooltip"]').tooltip();

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -181,23 +181,38 @@ $(document).ready(function() {
                 errorCells[i].style.borderBottomColor = "#9d261d";
               }
             }
-            var errorElapsedTime = document.getElementsByClassName("elapsedErrorTime");
-            for (i =0; i < errorElapsedTime.length; i++)
+            
+            var errorTime = document.getElementsByClassName("errorTime");
+            for (i=0; i < errorTime.length; i++)
             {
-                if((errorElapsedTime[i].id))
-                {
-                    var sec_num = parseInt(errorElapsedTime[i].id, 10);
-                    var hours   = Math.floor(sec_num / 3600);
-                    var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
-                    var seconds = sec_num - (hours * 3600) - (minutes * 60);
-
-                    if (hours   < 10) {hours   = "0"+hours;}
-                    if (minutes < 10) {minutes = "0"+minutes;}
-                    if (seconds < 10) {seconds = "0"+seconds;}
-                    var time    = hours+':'+minutes+':'+seconds;
-
-                    errorElapsedTime[i].innerHTML = time;
-                }
+              if((errorTime[i].id))
+              {
+                var a = new Date(parseInt(errorTime[i].id));
+                var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                var days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'];
+                var year = a.getFullYear();
+                var month = months[a.getMonth()];
+                var date = a.getDate();
+                var hour = a.getHours();
+                var min = a.getMinutes();
+                var sec = a.getSeconds();
+                var day = days[a.getDay()];
+                if (hour < 10) {hour = "0"+hour;}
+                if (min  < 10) {min  = "0"+min;}
+                if (sec  < 10) {sec  = "0"+sec;}
+                var time = day + ', '+date + ' ' + month + ' ' + year + ' ' + hour + ':' + min + ':' + sec;
+                
+                errorTime[i].innerHTML = time;
+                var sec_num = parseInt(errorTime[i].title, 10);
+                var hours   = Math.floor(sec_num / 3600);
+                var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
+                var seconds = sec_num - (hours * 3600) - (minutes * 60);
+                if (hours   < 10) {hours   = "0"+hours;}
+                if (minutes < 10) {minutes = "0"+minutes;}
+                if (seconds < 10) {seconds = "0"+seconds;}
+                var time    = hours+':'+minutes+':'+seconds;
+                errorTime[i].title = "Elapsed Time Since Error: " + time;
+              }
             }
             $('#topology-summary [data-toggle="tooltip"]').tooltip();
             $('#topology-stats [data-toggle="tooltip"]').tooltip();


### PR DESCRIPTION
Current on the topology summary UI page and tells you the last error and highlights it red if it happened within the last 30 min.  However, I think its useful if there was a column that told you the time that has elapsed since the most recent error occurred.  I found this useful for monitoring the well being of my storm cluster.