### PR TITLE
[STORM-992] Fixed a bug in the timer.clj that might cause unexpected delay to schedule new event

### DIFF
--- a/storm-core/src/clj/backtype/storm/timer.clj
+++ b/storm-core/src/clj/backtype/storm/timer.clj
@@ -53,8 +53,11 @@
                                    ;; event generation. If any recurring events
                                    ;; are scheduled then we will always go
                                    ;; through this branch, sleeping only the
-                                   ;; exact necessary amount of time.
-                                   (Time/sleep (- time-millis (current-time-millis)))
+                                   ;; exact necessary amount of time. We give
+                                   ;; an upper bound, e.g. 1000 millis, to the
+                                   ;; sleeping time, to limit the response time
+                                   ;; for detecting any new event within 1 secs.
+                                   (Time/sleep (max 1000 (- time-millis (current-time-millis))))
                                    ;; Otherwise poll to see if any new event
                                    ;; was scheduled. This is, in essence, the
                                    ;; response time for detecting any new event

--- a/storm-core/src/clj/backtype/storm/timer.clj
+++ b/storm-core/src/clj/backtype/storm/timer.clj
@@ -57,7 +57,7 @@
                                    ;; an upper bound, e.g. 1000 millis, to the
                                    ;; sleeping time, to limit the response time
                                    ;; for detecting any new event within 1 secs.
-                                   (Time/sleep (max 1000 (- time-millis (current-time-millis))))
+                                   (Time/sleep (min 1000 (- time-millis (current-time-millis))))
                                    ;; Otherwise poll to see if any new event
                                    ;; was scheduled. This is, in essence, the
                                    ;; response time for detecting any new event


### PR DESCRIPTION
Issue description: The timer thread calculates the delay to schedule the head of the queue and sleeps accordingly. However, if a new event with high priority is inserted at the head of the queue during the sleep, this event cannot be scheduled in time. 
    
Solution: Give a upper bound to the sleeping time, to guarantee a bounded response time for detecting new events.