### PR TITLE
[STORM-991] General cleanup of the generics.

### DIFF
--- a/storm-core/src/jvm/storm/trident/spout/ITridentSpout.java
+++ b/storm-core/src/jvm/storm/trident/spout/ITridentSpout.java
@@ -26,7 +26,7 @@ import storm.trident.operation.TridentCollector;
 
 
 public interface ITridentSpout<T> extends Serializable {
-    public interface BatchCoordinator<X> {
+    interface BatchCoordinator<X> {
         /**
          * Create metadata for this particular transaction id which has never
          * been emitted before. The metadata should contain whatever is necessary
@@ -55,7 +55,7 @@ public interface ITridentSpout<T> extends Serializable {
         void close();
     }
     
-    public interface Emitter<X> {
+    interface Emitter<X> {
         /**
          * Emit a batch for the specified transaction attempt and metadata for the transaction. The metadata
          * was created by the Coordinator in the initializeTranaction method. This method must always emit

--- a/storm-core/src/jvm/storm/trident/spout/OpaquePartitionedTridentSpoutExecutor.java
+++ b/storm-core/src/jvm/storm/trident/spout/OpaquePartitionedTridentSpoutExecutor.java
@@ -35,7 +35,7 @@ import storm.trident.topology.TransactionAttempt;
 
 
 public class OpaquePartitionedTridentSpoutExecutor implements ICommitterTridentSpout<Object> {
-    IOpaquePartitionedTridentSpout _spout;
+    IOpaquePartitionedTridentSpout<Object, ISpoutPartition, Object> _spout;
     
     public class Coordinator implements ITridentSpout.BatchCoordinator<Object> {
         IOpaquePartitionedTridentSpout.Coordinator _coordinator;
@@ -75,10 +75,10 @@ public class OpaquePartitionedTridentSpoutExecutor implements ICommitterTridentS
     }
     
     public class Emitter implements ICommitterTridentSpout.Emitter {        
-        IOpaquePartitionedTridentSpout.Emitter _emitter;
+        IOpaquePartitionedTridentSpout.Emitter<Object, ISpoutPartition, Object> _emitter;
         TransactionalState _state;
-        TreeMap<Long, Map<String, Object>> _cachedMetas = new TreeMap<Long, Map<String, Object>>();
-        Map<String, EmitterPartitionState> _partitionStates = new HashMap<String, EmitterPartitionState>();
+        TreeMap<Long, Map<String, Object>> _cachedMetas = new TreeMap<>();
+        Map<String, EmitterPartitionState> _partitionStates = new HashMap<>();
         int _index;
         int _numTasks;
         
@@ -97,7 +97,7 @@ public class OpaquePartitionedTridentSpoutExecutor implements ICommitterTridentS
             if(_savedCoordinatorMeta==null || !_savedCoordinatorMeta.equals(coordinatorMeta)) {
                 List<ISpoutPartition> partitions = _emitter.getOrderedPartitions(coordinatorMeta);
                 _partitionStates.clear();
-                List<ISpoutPartition> myPartitions = new ArrayList();
+                List<ISpoutPartition> myPartitions = new ArrayList<>();
                 for(int i=_index; i < partitions.size(); i+=_numTasks) {
                     ISpoutPartition p = partitions.get(i);
                     String id = p.getId();
@@ -108,7 +108,7 @@ public class OpaquePartitionedTridentSpoutExecutor implements ICommitterTridentS
                 _savedCoordinatorMeta = coordinatorMeta;
                 _changedMeta = true;
             }
-            Map<String, Object> metas = new HashMap<String, Object>();
+            Map<String, Object> metas = new HashMap<>();
             _cachedMetas.put(tx.getTransactionId(), metas);
 
             Entry<Long, Map<String, Object>> entry = _cachedMetas.lowerEntry(tx.getTransactionId());
@@ -116,7 +116,7 @@ public class OpaquePartitionedTridentSpoutExecutor implements ICommitterTridentS
             if(entry!=null) {
                 prevCached = entry.getValue();
             } else {
-                prevCached = new HashMap<String, Object>();
+                prevCached = new HashMap<>();
             }
             
             for(String id: _partitionStates.keySet()) {
@@ -147,8 +147,8 @@ public class OpaquePartitionedTridentSpoutExecutor implements ICommitterTridentS
             // another attempt of the batch to commit, the batch phase must have succeeded in between.
             // hence, all tasks for the prior commit must have finished committing (whether successfully or not)
             if(_changedMeta && _index==0) {
-                Set<String> validIds = new HashSet<String>();
-                for(ISpoutPartition p: (List<ISpoutPartition>) _emitter.getOrderedPartitions(_savedCoordinatorMeta)) {
+                Set<String> validIds = new HashSet<>();
+                for(ISpoutPartition p: _emitter.getOrderedPartitions(_savedCoordinatorMeta)) {
                     validIds.add(p.getId());
                 }
                 for(String existingPartition: _state.list("")) {
@@ -174,7 +174,7 @@ public class OpaquePartitionedTridentSpoutExecutor implements ICommitterTridentS
         }
     } 
     
-    public OpaquePartitionedTridentSpoutExecutor(IOpaquePartitionedTridentSpout spout) {
+    public OpaquePartitionedTridentSpoutExecutor(IOpaquePartitionedTridentSpout<Object, ISpoutPartition, Object> spout) {
         _spout = spout;
     }
     

--- a/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchExecutor.java
+++ b/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchExecutor.java
@@ -78,7 +78,7 @@ public class RichSpoutBatchExecutor implements ITridentSpout {
             if(batchSize==null) batchSize = 1000;
             _maxBatchSize = batchSize.intValue();
             _collector = new CaptureCollector();
-            idsMap = new RotatingMap(3);
+            idsMap = new RotatingMap<>(3);
             rotateTime = 1000L * ((Number)conf.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS)).intValue();
         }
         
@@ -174,7 +174,7 @@ public class RichSpoutBatchExecutor implements ITridentSpout {
         public long pendingCount;
         public void reset(TridentCollector c) {
             _collector = c;
-            ids = new ArrayList<Object>();
+            ids = new ArrayList<>();
         }
         
         @Override

--- a/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchTriggerer.java
+++ b/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchTriggerer.java
@@ -56,7 +56,7 @@ public class RichSpoutBatchTriggerer implements IRichSpout {
     @Override
     public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
         _delegate.open(conf, context, new SpoutOutputCollector(new StreamOverrideCollector(collector)));
-        _outputTasks = new ArrayList<Integer>();
+        _outputTasks = new ArrayList<>();
         for(String component: Utils.get(context.getThisTargets(),
                                         _coordStream,
                                         new HashMap<String, Grouping>()).keySet()) {
@@ -119,20 +119,20 @@ public class RichSpoutBatchTriggerer implements IRichSpout {
     @Override
     public Map<String, Object> getComponentConfiguration() {
         Map<String, Object> conf = _delegate.getComponentConfiguration();
-        if(conf==null) conf = new HashMap();
-        else conf = new HashMap(conf);
+        if(conf==null) conf = new HashMap<>();
+        else conf = new HashMap<>(conf);
         Config.registerSerialization(conf, RichSpoutBatchId.class, RichSpoutBatchIdSerializer.class);
         return conf;
     }
     
     static class FinishCondition {
-        Set<Long> vals = new HashSet<Long>();
+        Set<Long> vals = new HashSet<>();
         Object msgId;
     }
     
-    Map<Long, Long> _msgIdToBatchId = new HashMap();
+    Map<Long, Long> _msgIdToBatchId = new HashMap<>();
     
-    Map<Long, FinishCondition> _finishConditions = new HashMap();
+    Map<Long, FinishCondition> _finishConditions = new HashMap<>();
     
     class StreamOverrideCollector implements ISpoutOutputCollector {
         
@@ -149,7 +149,7 @@ public class RichSpoutBatchTriggerer implements IRichSpout {
             FinishCondition finish = new FinishCondition();
             finish.msgId = msgId;
             List<Integer> tasks = _collector.emit(_stream, new ConsList(batchId, values));
-            Set<Integer> outTasksSet = new HashSet<Integer>(tasks);
+            Set<Integer> outTasksSet = new HashSet<>(tasks);
             for(Integer t: _outputTasks) {
                 int count = 0;
                 if(outTasksSet.contains(t)) {

--- a/storm-core/src/jvm/storm/trident/spout/TridentSpoutCoordinator.java
+++ b/storm-core/src/jvm/storm/trident/spout/TridentSpoutCoordinator.java
@@ -38,14 +38,14 @@ public class TridentSpoutCoordinator implements IBasicBolt {
     public static final Logger LOG = LoggerFactory.getLogger(TridentSpoutCoordinator.class);
     private static final String META_DIR = "meta";
 
-    ITridentSpout _spout;
-    ITridentSpout.BatchCoordinator _coord;
+    ITridentSpout<Object> _spout;
+    ITridentSpout.BatchCoordinator<Object> _coord;
     RotatingTransactionalState _state;
     TransactionalState _underlyingState;
     String _id;
 
     
-    public TridentSpoutCoordinator(String id, ITridentSpout spout) {
+    public TridentSpoutCoordinator(String id, ITridentSpout<Object> spout) {
         _spout = spout;
         _id = id;
     }

--- a/storm-core/src/jvm/storm/trident/spout/TridentSpoutExecutor.java
+++ b/storm-core/src/jvm/storm/trident/spout/TridentSpoutExecutor.java
@@ -42,14 +42,14 @@ public class TridentSpoutExecutor implements ITridentBatchBolt {
     public static Logger LOG = LoggerFactory.getLogger(TridentSpoutExecutor.class);    
 
     AddIdCollector _collector;
-    ITridentSpout _spout;
-    ITridentSpout.Emitter _emitter;
+    ITridentSpout<Object> _spout;
+    ITridentSpout.Emitter<Object> _emitter;
     String _streamName;
     String _txStateId;
     
-    TreeMap<Long, TransactionAttempt> _activeBatches = new TreeMap<Long, TransactionAttempt>();
+    TreeMap<Long, TransactionAttempt> _activeBatches = new TreeMap<>();
 
-    public TridentSpoutExecutor(String txStateId, String streamName, ITridentSpout spout) {
+    public TridentSpoutExecutor(String txStateId, String streamName, ITridentSpout<Object> spout) {
         _txStateId = txStateId;
         _spout = spout;
         _streamName = streamName;
@@ -91,7 +91,7 @@ public class TridentSpoutExecutor implements ITridentBatchBolt {
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
-        List<String> fields = new ArrayList(_spout.getOutputFields().toList());
+        List<String> fields = new ArrayList<>(_spout.getOutputFields().toList());
         fields.add(0, ID_FIELD);
         declarer.declareStream(_streamName, new Fields(fields));
     }

--- a/storm-core/src/jvm/storm/trident/topology/TridentBoltExecutor.java
+++ b/storm-core/src/jvm/storm/trident/topology/TridentBoltExecutor.java
@@ -18,7 +18,6 @@
 package storm.trident.topology;
 
 import backtype.storm.Config;
-import backtype.storm.Constants;
 import backtype.storm.coordination.BatchOutputCollector;
 import backtype.storm.coordination.BatchOutputCollectorImpl;
 import backtype.storm.generated.GlobalStreamId;
@@ -106,7 +105,7 @@ public class TridentBoltExecutor implements IRichBolt {
     long _messageTimeoutMs;
     long _lastRotate;
     
-    RotatingMap _batches;
+    RotatingMap<Object, TrackedBatch> _batches;
     
     // map from batchgroupid to coordspec
     public TridentBoltExecutor(ITridentBatchBolt bolt, Map<GlobalStreamId, String> batchGroupIds, Map<String, CoordSpec> coordinationSpecs) {
@@ -122,7 +121,7 @@ public class TridentBoltExecutor implements IRichBolt {
         int reportedTasks = 0;
         int expectedTupleCount = 0;
         int receivedTuples = 0;
-        Map<Integer, Integer> taskEmittedTuples = new HashMap();
+        Map<Integer, Integer> taskEmittedTuples = new HashMap<>();
         boolean failed = false;
         boolean receivedCommit;
         Tuple delayedAck = null;
@@ -143,7 +142,7 @@ public class TridentBoltExecutor implements IRichBolt {
     public class CoordinatedOutputCollector implements IOutputCollector {
         IOutputCollector _delegate;
         
-        TrackedBatch _currBatch = null;;
+        TrackedBatch _currBatch = null;
         
         public void setCurrBatch(TrackedBatch batch) {
             _currBatch = batch;
@@ -197,7 +196,7 @@ public class TridentBoltExecutor implements IRichBolt {
     public void prepare(Map conf, TopologyContext context, OutputCollector collector) {        
         _messageTimeoutMs = context.maxTopologyMessageTimeout() * 1000L;
         _lastRotate = System.currentTimeMillis();
-        _batches = new RotatingMap(2);
+        _batches = new RotatingMap<>(2);
         _context = context;
         _collector = collector;
         _coordCollector = new CoordinatedOutputCollector(collector);
@@ -205,7 +204,7 @@ public class TridentBoltExecutor implements IRichBolt {
                 
         _coordConditions = (Map) context.getExecutorData("__coordConditions");
         if(_coordConditions==null) {
-            _coordConditions = new HashMap();
+            _coordConditions = new HashMap<>();
             for(String batchGroup: _coordSpecs.keySet()) {
                 CoordSpec spec = _coordSpecs.get(batchGroup);
                 CoordCondition cond = new CoordCondition();
@@ -219,7 +218,7 @@ public class TridentBoltExecutor implements IRichBolt {
                         cond.expectedTaskReports+=context.getComponentTasks(comp).size();
                     }
                 }
-                cond.targetTasks = new HashSet<Integer>();
+                cond.targetTasks = new HashSet<>();
                 for(String component: Utils.get(context.getThisTargets(),
                                         COORD_STREAM(batchGroup),
                                         new HashMap<String, Grouping>()).keySet()) {
@@ -399,7 +398,7 @@ public class TridentBoltExecutor implements IRichBolt {
     @Override
     public Map<String, Object> getComponentConfiguration() {
         Map<String, Object> ret = _bolt.getComponentConfiguration();
-        if(ret==null) ret = new HashMap();
+        if(ret==null) ret = new HashMap<>();
         ret.put(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS, 5);
         // TODO: Need to be able to set the tick tuple time to the message timeout, ideally without parameterization
         return ret;


### PR DESCRIPTION
Generally added generics to classes within the storm.trident.spout package. This generally removes some of the casts that were in place, and simplifies the code slightly. 
A typical example of what was done is 

    ITridentSpout _spout;

was converted to:

    ITridentSpout<Object> _spout;