### PR TITLE
STORM-965: Fix excessive logging

### DIFF
--- a/storm-core/src/jvm/backtype/storm/security/auth/SaslTransportPlugin.java
+++ b/storm-core/src/jvm/backtype/storm/security/auth/SaslTransportPlugin.java
@@ -32,6 +32,7 @@ import javax.security.auth.login.Configuration;
 import javax.security.sasl.SaslServer;
 
 import backtype.storm.utils.ExtendedThreadPoolExecutor;
+import backtype.storm.security.auth.kerberos.NoOpTTrasport;
 import org.apache.thrift.TException;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -121,6 +122,11 @@ public abstract class SaslTransportPlugin implements ITransportPlugin {
             TTransport trans = inProt.getTransport();
             //Sasl transport
             TSaslServerTransport saslTrans = (TSaslServerTransport)trans;
+
+            if(trans instanceof NoOpTTrasport) {
+                return false;
+            }
+
             //remote address
             TSocket tsocket = (TSocket)saslTrans.getUnderlyingTransport();
             Socket socket = tsocket.getSocket();

--- a/storm-core/src/jvm/backtype/storm/security/auth/kerberos/KerberosSaslTransportPlugin.java
+++ b/storm-core/src/jvm/backtype/storm/security/auth/kerberos/KerberosSaslTransportPlugin.java
@@ -195,8 +195,9 @@ public class KerberosSaslTransportPlugin extends SaslTransportPlugin {
                             return wrapped.getTransport(trans);
                         }
                         catch (Exception e) {
-                            LOG.error("Storm server failed to open transport to interact with a client during session initiation: " + e, e);
-                            return null;
+                            LOG.debug("Storm server failed to open transport " +
+                                    "to interact with a client during session initiation: " + e, e);
+                            return new NoOpTTrasport(null);
                         }
                     }
                 });

--- a/storm-core/src/jvm/backtype/storm/security/auth/kerberos/NoOpTTrasport.java
+++ b/storm-core/src/jvm/backtype/storm/security/auth/kerberos/NoOpTTrasport.java
@@ -1,0 +1,40 @@
+package backtype.storm.security.auth.kerberos;
+
+import org.apache.thrift.transport.TSaslServerTransport;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+/**
+ * Created by pshah on 8/12/15.
+ */
+public class NoOpTTrasport extends TSaslServerTransport {
+
+    public NoOpTTrasport(TTransport transport) {
+        super(transport);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return true;
+    }
+
+    @Override
+    public void open() throws TTransportException {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public int read(byte[] bytes, int i, int i1) throws TTransportException {
+        return 0;
+    }
+
+    @Override
+    public void write(byte[] bytes, int i, int i1) throws TTransportException {
+
+    }
+}


### PR DESCRIPTION
The reason for this pull request is that when a non-secure client tries to connect to nimbus host in a secure cluster, an exception was being thrown and a null transport object was being returned. This null object in turn was being used by thrift library class and threw a null pointer exception. Both the classes where exception was thrown and caught were logging this exception, creating unnecessary lengthy log statements. Disabling logging in storm code by changing it from error to debug took care of one part but to work around the issue of exception being logged in the thrift jar a NoOpTTrasport.java had to be created. Two main things to consider during review
1. Change from Logger.error to Logger.debug in KerberosSaslTransportPlugin.java
2. Early return false in SaslTransportPlugin.java which is presumed and tested with one nimbus client to work okay. 

Note: TProcess interface process method does not have documentation saying what the returned boolean indicates. 