### PR TITLE
[STORM-1008] Isolate the code for metric collection and retrieval from DisruptorQueue

### DIFF
--- a/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
@@ -45,31 +45,35 @@ import backtype.storm.metric.api.IStatefulObject;
 public class DisruptorQueue implements IStatefulObject {
     static final Object FLUSH_CACHE = new Object();
     static final Object INTERRUPT = new Object();
-    
+
     RingBuffer<MutableObject> _buffer;
     Sequence _consumer;
     SequenceBarrier _barrier;
-    
+
     // TODO: consider having a threadlocal cache of this variable to speed up reads?
     volatile boolean consumerStartedFlag = false;
     ConcurrentLinkedQueue<Object> _cache = new ConcurrentLinkedQueue();
-    
+
     private final ReentrantReadWriteLock cacheLock = new ReentrantReadWriteLock();
-    private final Lock readLock  = cacheLock.readLock();
+    private final Lock readLock = cacheLock.readLock();
     private final Lock writeLock = cacheLock.writeLock();
-    
+
     private static String PREFIX = "disruptor-";
     private String _queueName = "";
 
     private long _waitTimeout;
-    
+
+    private final QueueMetrics _metrics;
+
     public DisruptorQueue(String queueName, ClaimStrategy claim, WaitStrategy wait, long timeout) {
-         this._queueName = PREFIX + queueName;
+        this._queueName = PREFIX + queueName;
         _buffer = new RingBuffer<MutableObject>(new ObjectEventFactory(), claim, wait);
         _consumer = new Sequence();
         _barrier = _buffer.newBarrier();
         _buffer.setGatingSequences(_consumer);
-        if(claim instanceof SingleThreadedClaimStrategy) {
+        _metrics = new QueueMetrics();
+
+        if (claim instanceof SingleThreadedClaimStrategy) {
             consumerStartedFlag = true;
         } else {
             // make sure we flush the pending messages in cache first
@@ -82,19 +86,19 @@ public class DisruptorQueue implements IStatefulObject {
 
         _waitTimeout = timeout;
     }
-    
+
     public String getName() {
-      return _queueName;
+        return _queueName;
     }
-    
+
     public void consumeBatch(EventHandler<Object> handler) {
         consumeBatchToCursor(_barrier.getCursor(), handler);
     }
-    
+
     public void haltWithInterrupt() {
         publish(INTERRUPT);
     }
-    
+
     public void consumeBatchWhenAvailable(EventHandler<Object> handler) {
         try {
             final long nextSequence = _consumer.get() + 1;
@@ -111,22 +115,22 @@ public class DisruptorQueue implements IStatefulObject {
             throw new RuntimeException(e);
         }
     }
-    
-    
+
+
     private void consumeBatchToCursor(long cursor, EventHandler<Object> handler) {
-        for(long curr = _consumer.get() + 1; curr <= cursor; curr++) {
+        for (long curr = _consumer.get() + 1; curr <= cursor; curr++) {
             try {
                 MutableObject mo = _buffer.get(curr);
                 Object o = mo.o;
                 mo.setObject(null);
-                if(o==FLUSH_CACHE) {
+                if (o == FLUSH_CACHE) {
                     Object c = null;
-                    while(true) {                        
+                    while (true) {
                         c = _cache.poll();
-                        if(c==null) break;
+                        if (c == null) break;
                         else handler.onEvent(c, curr, true);
                     }
-                } else if(o==INTERRUPT) {
+                } else if (o == INTERRUPT) {
                     throw new InterruptedException("Disruptor processing interrupted");
                 } else {
                     handler.onEvent(o, curr, curr == cursor);
@@ -138,7 +142,7 @@ public class DisruptorQueue implements IStatefulObject {
         //TODO: only set this if the consumer cursor has changed?
         _consumer.set(cursor);
     }
-    
+
     /*
      * Caches until consumerStarted is called, upon which the cache is flushed to the consumer
      */
@@ -149,17 +153,17 @@ public class DisruptorQueue implements IStatefulObject {
             throw new RuntimeException("This code should be unreachable!");
         }
     }
-    
+
     public void tryPublish(Object obj) throws InsufficientCapacityException {
         publish(obj, false);
     }
-    
+
     public void publish(Object obj, boolean block) throws InsufficientCapacityException {
 
         boolean publishNow = consumerStartedFlag;
 
         if (!publishNow) {
-            readLock.lock(); 
+            readLock.lock();
             try {
                 publishNow = consumerStartedFlag;
                 if (!publishNow) {
@@ -169,15 +173,15 @@ public class DisruptorQueue implements IStatefulObject {
                 readLock.unlock();
             }
         }
-        
+
         if (publishNow) {
             publishDirect(obj, block);
         }
     }
-    
+
     private void publishDirect(Object obj, boolean block) throws InsufficientCapacityException {
         final long id;
-        if(block) {
+        if (block) {
             id = _buffer.next();
         } else {
             id = _buffer.tryNext(1);
@@ -186,39 +190,72 @@ public class DisruptorQueue implements IStatefulObject {
         m.setObject(obj);
         _buffer.publish(id);
     }
-    
+
     public void consumerStarted() {
 
         consumerStartedFlag = true;
-        
+
         // Use writeLock to make sure all pending cache add opearation completed
         writeLock.lock();
         writeLock.unlock();
     }
-    
-    public long  population() { return (writePos() - readPos()); }
-    public long  capacity()   { return _buffer.getBufferSize(); }
-    public long  writePos()   { return _buffer.getCursor(); }
-    public long  readPos()    { return _consumer.get(); }
-    public float pctFull()    { return (1.0F * population() / capacity()); }
 
     @Override
     public Object getState() {
-        Map state = new HashMap<String, Object>();
-        // get readPos then writePos so it's never an under-estimate
-        long rp = readPos();
-        long wp = writePos();
-        state.put("capacity",   capacity());
-        state.put("population", wp - rp);
-        state.put("write_pos",  wp);
-        state.put("read_pos",   rp);
-        return state;
+        return _metrics.getState();
     }
 
     public static class ObjectEventFactory implements EventFactory<MutableObject> {
         @Override
         public MutableObject newInstance() {
             return new MutableObject();
-        }        
+        }
     }
+
+    //This method enables the metrics to be accessed from outside of the DisruptorQueue class
+    public QueueMetrics getMetrics() {
+        return _metrics;
+    }
+
+
+    /**
+     * This inner class provides methods to access the metrics of the disruptor queue.
+     */
+    public class QueueMetrics {
+
+        public long writePos() {
+            return _buffer.getCursor();
+        }
+
+        public long readPos() {
+            return _consumer.get();
+        }
+
+        public long population() {
+            return writePos() - readPos();
+        }
+
+        public long capacity() {
+            return _buffer.getBufferSize();
+        }
+
+        public float pctFull() {
+            return (1.0F * population() / capacity());
+        }
+
+        public Object getState() {
+            Map state = new HashMap<String, Object>();
+
+            // get readPos then writePos so it's never an under-estimate
+            long rp = readPos();
+            long wp = writePos();
+            state.put("capacity", capacity());
+            state.put("population", wp - rp);
+            state.put("write_pos", wp);
+            state.put("read_pos", rp);
+
+            return state;
+        }
+    }
+
 }


### PR DESCRIPTION
I created an inner class QueueMetrics for DisruptorQueue. The QueueMetrics class handles metric collection logics and exposes metric retrieval methods.

The benefits of such modification are twofold: 
1. It improves the readability of the metric code.
2. It facilitates to add more metrics, such as average throughput and element sojourn time.  (That is because the data  maintained for such "stateful" metrics can reside in QueueMetrics rather than in DisruptorQueue. )