### PR TITLE
[STORM-886] Automatic Back Pressure (ABP)

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -145,6 +145,13 @@ task.heartbeat.frequency.secs: 3
 task.refresh.poll.secs: 10
 task.credentials.poll.secs: 30
 
+# now should be null by default
+topology.backpressure.enable: true
+backpressure.worker.high.watermark: 0.9
+backpressure.worker.low.watermark: 0.4
+backpressure.executor.high.watermark: 0.9
+backpressure.executor.low.watermark: 0.4
+
 zmq.threads: 1
 zmq.linger.millis: 5000
 zmq.hwm: 0

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -147,10 +147,8 @@ task.credentials.poll.secs: 30
 
 # now should be null by default
 topology.backpressure.enable: true
-backpressure.worker.high.watermark: 0.9
-backpressure.worker.low.watermark: 0.4
-backpressure.executor.high.watermark: 0.9
-backpressure.executor.low.watermark: 0.4
+backpressure.disruptor.high.watermark: 0.9
+backpressure.disruptor.low.watermark: 0.4
 
 zmq.threads: 1
 zmq.linger.millis: 5000

--- a/storm-core/src/clj/backtype/storm/cluster.clj
+++ b/storm-core/src/clj/backtype/storm/cluster.clj
@@ -181,6 +181,10 @@
   (worker-heartbeat! [this storm-id node port info])
   (remove-worker-heartbeat! [this storm-id node port])
   (supervisor-heartbeat! [this supervisor-id info])
+  (worker-backpressure! [this storm-id node port info])
+  (topology-backpressure [this storm-id callback])
+  (setup-backpressure! [this storm-id])
+  (remove-worker-backpressure! [this storm-id node port])
   (activate-storm! [this storm-id storm-base])
   (update-storm! [this storm-id new-elems])
   (remove-storm-base! [this storm-id])
@@ -200,6 +204,7 @@
 (def STORMS-ROOT "storms")
 (def SUPERVISORS-ROOT "supervisors")
 (def WORKERBEATS-ROOT "workerbeats")
+(def BACKPRESSURE-ROOT "backpressure")
 (def ERRORS-ROOT "errors")
 (def CODE-DISTRIBUTOR-ROOT "code-distributor")
 (def NIMBUSES-ROOT "nimbuses")
@@ -210,6 +215,7 @@
 (def STORMS-SUBTREE (str "/" STORMS-ROOT))
 (def SUPERVISORS-SUBTREE (str "/" SUPERVISORS-ROOT))
 (def WORKERBEATS-SUBTREE (str "/" WORKERBEATS-ROOT))
+(def BACKPRESSURE-SUBTREE (str "/" BACKPRESSURE-ROOT))
 (def ERRORS-SUBTREE (str "/" ERRORS-ROOT))
 (def CODE-DISTRIBUTOR-SUBTREE (str "/" CODE-DISTRIBUTOR-ROOT))
 (def NIMBUSES-SUBTREE (str "/" NIMBUSES-ROOT))
@@ -242,6 +248,14 @@
 (defn workerbeat-path
   [storm-id node port]
   (str (workerbeat-storm-root storm-id) "/" node "-" port))
+
+(defn backpressure-storm-root
+  [storm-id]
+  (str BACKPRESSURE-SUBTREE "/" storm-id))
+
+(defn backpressure-path
+  [storm-id node port]
+  (str (backpressure-storm-root storm-id) "/" node "-" port))
 
 (defn error-storm-root
   [storm-id]
@@ -313,6 +327,7 @@
         assignment-info-with-version-callback (atom {})
         assignment-version-callback (atom {})
         supervisors-callback (atom nil)
+        backpressure-callback (atom {})   ;; we want to reigister a topo directory getChildren callback for all workers of this dir
         assignments-callback (atom nil)
         storm-base-callback (atom {})
         code-distributor-callback (atom nil)
@@ -332,6 +347,7 @@
                          CODE-DISTRIBUTOR-ROOT (issue-callback! code-distributor-callback)
                          STORMS-ROOT (issue-map-callback! storm-base-callback (first args))
                          CREDENTIALS-ROOT (issue-map-callback! credentials-callback (first args))
+                         BACKPRESSURE-ROOT (issue-map-callback! backpressure-callback (first args))
                          ;; this should never happen
                          (exit-process! 30 "Unknown callback for subtree " subtree args)))))]
     (doseq [p [ASSIGNMENTS-SUBTREE STORMS-SUBTREE SUPERVISORS-SUBTREE WORKERBEATS-SUBTREE ERRORS-SUBTREE CODE-DISTRIBUTOR-SUBTREE NIMBUSES-SUBTREE]]
@@ -422,7 +438,6 @@
               (maybe-deserialize ClusterWorkerHeartbeat)
               clojurify-zk-worker-hb))))
 
-
       (executor-beats
         [this storm-id executor->node+port]
         ;; need to take executor->node+port in explicitly so that we don't run into a situation where a
@@ -466,6 +481,35 @@
           (delete-node cluster-state (workerbeat-storm-root storm-id))
           (catch KeeperException e
             (log-warn-error e "Could not teardown heartbeats for " storm-id))))
+
+      (worker-backpressure!
+        [this storm-id node port on?]
+        "if znode exists and to be not on?, delete; if exists and on?, do nothing;
+        if not exists and to be on?, create; if not exists and not on?, do nothing"
+        (let [path (backpressure-path storm-id node port)
+              existed (exists-node? cluster-state path false)]
+          (if existed
+            (if (not on?)
+              (delete-node cluster-state path))   ;; delete the znode since the worker is not congested
+            (if on?
+              (set-ephemeral-node cluster-state path nil acls))))) ;; create the znode since worker is congested
+    
+      (topology-backpressure
+        [this storm-id callback]
+        "if the backpresure/storm-id dir is empty, this topology has throttle-on, otherwise not."
+        (when callback
+          (swap! backpressure-callback assoc storm-id callback))
+        (let [path (backpressure-storm-root storm-id)
+              children (get-children cluster-state path (not-nil? callback))]
+              (> (count children) 0)))
+      
+      (setup-backpressure!
+        [this storm-id]
+        (mkdirs cluster-state (backpressure-storm-root storm-id) acls))
+
+      (remove-worker-backpressure!
+        [this storm-id node port]
+        (delete-node cluster-state (backpressure-path storm-id node port)))
 
       (teardown-topology-errors!
         [this storm-id]

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -1187,6 +1187,7 @@
               (.setup-code-distributor! storm-cluster-state storm-id (:nimbus-host-port-info nimbus))
               (wait-for-desired-code-replication nimbus total-storm-conf storm-id)
               (.setup-heartbeats! storm-cluster-state storm-id)
+              (.setup-backpressure! storm-cluster-state storm-id)
               (let [thrift-status->kw-status {TopologyInitialStatus/INACTIVE :inactive
                                               TopologyInitialStatus/ACTIVE :active}]
                 (start-storm nimbus storm-name storm-id (thrift-status->kw-status (.get_initial_status submitOptions))))

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -140,7 +140,7 @@
       "When worker's queue is above highWaterMark, we set its backpressure flag"
       (if (not @(:backpressure worker))
         (do (reset! (:backpressure worker) true)
-            (DisruptorQueue/notifyBackpressureChecker (:backpressure-trigger worker)))))  ;; set backpressure no matter how the executors are
+            (WorkerBackpressureThread/notifyBackpressureChecker (:backpressure-trigger worker)))))  ;; set backpressure no matter how the executors are
     (fn []
       "If worker's queue is below low watermark, we do nothing since we want the
       WorkerBackPressureThread to also check for all the executors' status"
@@ -493,8 +493,8 @@
 
         disruptor-handler (mk-disruptor-backpressure-handler worker)
         _ (.registerBackpressureCallback (:transfer-queue worker) disruptor-handler)
-        _ (-> (.setHighWaterMark (:transfer-queue worker) ((:storm-conf worker) BACKPRESSURE-WORKER-HIGH-WATERMARK))
-              (.setLowWaterMark ((:storm-conf worker) BACKPRESSURE-WORKER-LOW-WATERMARK))
+        _ (-> (.setHighWaterMark (:transfer-queue worker) ((:storm-conf worker) BACKPRESSURE-DISRUPTOR-HIGH-WATERMARK))
+              (.setLowWaterMark ((:storm-conf worker) BACKPRESSURE-DISRUPTOR-LOW-WATERMARK))
               (.setEnableBackpressure ((:storm-conf worker) TOPOLOGY-BACKPRESSURE-ENABLE)))
         backpressure-handler (mk-backpressure-handler @executors)        
         backpressure-thread (WorkerBackpressureThread. (:backpressure-trigger worker) worker backpressure-handler)

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -22,7 +22,7 @@
   (:require [backtype.storm.messaging.loader :as msg-loader])
   (:import [java.util.concurrent Executors])
   (:import [java.util ArrayList HashMap])
-  (:import [backtype.storm.utils Utils TransferDrainer ThriftTopologyUtils])
+  (:import [backtype.storm.utils Utils TransferDrainer ThriftTopologyUtils WorkerBackpressureThread DisruptorQueue])
   (:import [backtype.storm.messaging TransportFactory])
   (:import [backtype.storm.messaging TaskMessage IContext IConnection ConnectionWithStatus ConnectionWithStatus$Status])
   (:import [backtype.storm.daemon Shutdownable])
@@ -114,12 +114,45 @@
   (fast-list-iter [[task tuple :as pair] tuple-batch]
     (.serialize serializer tuple)))
 
+(defn- mk-backpressure-handler [executors]
+  "make a handler that checks and updates worker's backpressure flag"
+  (disruptor/worker-backpressure-handler
+    (fn [worker]
+      (let [storm-id (:storm-id worker)
+            assignment-id (:assignment-id worker)
+            port (:port worker)
+            storm-cluster-state (:storm-cluster-state worker)
+            prev-backpressure-flag @(:backpressure worker)]
+        (if executors 
+          (if (reduce #(or %1 %2) (map #(.get-backpressure-flag %1) executors))
+            (reset! (:backpressure worker) true)   ;; at least one executor has set backpressure
+            (reset! (:backpressure worker) false))) ;; no executor has backpressure set
+        ;; update the worker's backpressure flag to zookeeper only when it has changed
+        (if (not= prev-backpressure-flag @(:backpressure worker))
+          (.worker-backpressure! storm-cluster-state storm-id assignment-id port @(:backpressure worker)))
+        ))))
+
+(defn- mk-disruptor-backpressure-handler [worker]
+  "make a handler for the worker's send disruptor queue to
+  check highWaterMark and lowWaterMark for backpressure"
+  (disruptor/disruptor-backpressure-handler
+    (fn []
+      "When worker's queue is above highWaterMark, we set its backpressure flag"
+      (if (not @(:backpressure worker))
+        (do (reset! (:backpressure worker) true)
+            (DisruptorQueue/notifyBackpressureChecker (:backpressure-trigger worker)))))  ;; set backpressure no matter how the executors are
+    (fn []
+      "If worker's queue is below low watermark, we do nothing since we want the
+      WorkerBackPressureThread to also check for all the executors' status"
+      )))
+
 (defn mk-transfer-fn [worker]
   (let [local-tasks (-> worker :task-ids set)
         local-transfer (:transfer-local-fn worker)
         ^DisruptorQueue transfer-queue (:transfer-queue worker)
         task->node+port (:cached-task->node+port worker)
         try-serialize-local ((:storm-conf worker) TOPOLOGY-TESTING-ALWAYS-TRY-SERIALIZE)
+
         transfer-fn
           (fn [^KryoTupleSerializer serializer tuple-batch]
             (let [local (ArrayList.)
@@ -137,9 +170,9 @@
                         (.add remote (TaskMessage. task (.serialize serializer tuple)))
                         (log-warn "Can't transfer tuple - task value is nil. tuple type: " (pr-str (type tuple)) " and information: " (pr-str tuple)))
                      ))))
-                (local-transfer local)
-                (disruptor/publish transfer-queue remoteMap)
-              ))]
+
+              (local-transfer local)
+              (disruptor/publish transfer-queue remoteMap)))]
     (if try-serialize-local
       (do 
         (log-warn "WILL TRY TO SERIALIZE ALL TUPLES (Turn off " TOPOLOGY-TESTING-ALWAYS-TRY-SERIALIZE " for production)")
@@ -255,6 +288,9 @@
       :receiver-thread-count (get storm-conf WORKER-RECEIVER-THREAD-COUNT)
       :transfer-fn (mk-transfer-fn <>)
       :assignment-versions assignment-versions
+      :backpressure (atom false) ;; whether this worker is going slow
+      :backpressure-trigger (atom false) ;; a trigger for synchronization with executors
+      :throttle-on (atom false) ;; whether throttle is activated for spouts
       )))
 
 (defn- endpoint->string [[node port]]
@@ -453,7 +489,23 @@
 
         transfer-tuples (mk-transfer-tuples-handler worker)
         
-        transfer-thread (disruptor/consume-loop* (:transfer-queue worker) transfer-tuples)                                       
+        transfer-thread (disruptor/consume-loop* (:transfer-queue worker) transfer-tuples)               
+
+        disruptor-handler (mk-disruptor-backpressure-handler worker)
+        _ (.registerBackpressureCallback (:transfer-queue worker) disruptor-handler)
+        _ (-> (.setHighWaterMark (:transfer-queue worker) ((:storm-conf worker) BACKPRESSURE-WORKER-HIGH-WATERMARK))
+              (.setLowWaterMark ((:storm-conf worker) BACKPRESSURE-WORKER-LOW-WATERMARK))
+              (.setEnableBackpressure ((:storm-conf worker) TOPOLOGY-BACKPRESSURE-ENABLE)))
+        backpressure-handler (mk-backpressure-handler @executors)        
+        backpressure-thread (WorkerBackpressureThread. (:backpressure-trigger worker) worker backpressure-handler)
+        _ (if ((:storm-conf worker) TOPOLOGY-BACKPRESSURE-ENABLE) 
+            (.start backpressure-thread))
+        callback (fn cb [& ignored]
+                   (let [throttle-on (.topology-backpressure storm-cluster-state storm-id cb)]
+                     (reset! (:throttle-on worker) throttle-on)))
+        _ (if ((:storm-conf worker) TOPOLOGY-BACKPRESSURE-ENABLE)
+            (.topology-backpressure storm-cluster-state storm-id callback))
+
         shutdown* (fn []
                     (log-message "Shutting down worker " storm-id " " assignment-id " " port)
                     (doseq [[_ socket] @(:cached-node+port->socket worker)]
@@ -477,6 +529,9 @@
                     (.interrupt transfer-thread)
                     (.join transfer-thread)
                     (log-message "Shut down transfer thread")
+                    (.interrupt backpressure-thread)
+                    (.join backpressure-thread)
+                    (log-message "Shut down backpressure thread")
                     (cancel-timer (:heartbeat-timer worker))
                     (cancel-timer (:refresh-connections-timer worker))
                     (cancel-timer (:refresh-credentials-timer worker))
@@ -516,9 +571,18 @@
                                         (AuthUtils/updateSubject subject auto-creds new-creds)
                                         (dofor [e @executors] (.credentials-changed e new-creds))
                                         (reset! credentials new-creds))))
-      ]
+       check-throttle-changed (fn []
+                                (let [callback (fn cb [& ignored]
+                                                 (let [throttle-on (.topology-backpressure (:storm-cluster-state worker) storm-id cb)]
+                                                   (reset! (:throttle-on worker) throttle-on)))
+                                      new-throttle-on (.topology-backpressure (:storm-cluster-state worker) storm-id callback)]
+                                    (reset! (:throttle-on worker) new-throttle-on)))]
     (.credentials (:storm-cluster-state worker) storm-id (fn [args] (check-credentials-changed)))
-    (schedule-recurring (:refresh-credentials-timer worker) 0 (conf TASK-CREDENTIALS-POLL-SECS) check-credentials-changed)
+    (schedule-recurring (:refresh-credentials-timer worker) 0 (conf TASK-CREDENTIALS-POLL-SECS)
+                        (fn [& args]
+                          (check-credentials-changed)
+                          (if ((:storm-conf worker) TOPOLOGY-BACKPRESSURE-ENABLE)
+                            (check-throttle-changed))))
     (schedule-recurring (:refresh-connections-timer worker) 0 (conf TASK-REFRESH-POLL-SECS) refresh-connections)
     (schedule-recurring (:refresh-active-timer worker) 0 (conf TASK-REFRESH-POLL-SECS) (partial refresh-storm-active worker))
 

--- a/storm-core/src/clj/backtype/storm/disruptor.clj
+++ b/storm-core/src/clj/backtype/storm/disruptor.clj
@@ -88,10 +88,6 @@
   [^DisruptorQueue q o]
   (.tryPublish q o))
 
-(defn notify-backpressure-checker
-  [trigger]
-  (DisruptorQueue/notifyBackpressureChecker trigger))
-
 (defn consume-batch
   [^DisruptorQueue queue handler]
   (.consumeBatch queue handler))

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1053,40 +1053,21 @@ public class Config extends HashMap<String, Object> {
     public static final Object TOPOLOGY_BACKPRESSURE_ENABLE_SCHEMA = Boolean.class;
 
     /**
-     * This signifies the tuple congestion in a worker's out-going queue.
-     * When the used ratio of a worker's outgoing queue is higher than the high watermark,
+     * This signifies the tuple congestion in a disruptor queue.
+     * When the used ratio of a disruptor queue is higher than the high watermark,
      * the backpressure scheme, if enabled, should slow down the tuple sending speed of
      * the spouts until reaching the low watermark.
      */
-    public static final String BACKPRESSURE_WORKER_HIGH_WATERMARK="backpressure.worker.high.watermark";
-    public static final Object BACKPRESSURE_WORKER_HIGH_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
+    public static final String BACKPRESSURE_DISRUPTOR_HIGH_WATERMARK="backpressure.disruptor.high.watermark";
+    public static final Object BACKPRESSURE_DISRUPTOR_HIGH_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
 
     /**
-     * This signifies a state that a worker has left the congestion.
-     * If the used ratio of a worker's outgoing queue is lower than the low watermark,
-     * it notifies the worker to check whether all its executors have also left congestion,
-     * if yes, it will unset the worker's backpressure flag on the Zookeeper
+     * This signifies a state that a disruptor queue has left the congestion.
+     * If the used ratio of a disruptor queue is lower than the low watermark,
+     * it will unset the backpressure flag.
      */
-    public static final String BACKPRESSURE_WORKER_LOW_WATERMARK="backpressure.worker.low.watermark";
-    public static final Object BACKPRESSURE_WORKER_LOW_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
-
-    /**
-     * This signifies the tuple congestion in an executor's receiving queue.
-     * When the used ratio of an executor's receiving queue is higher than the high watermark,
-     * the backpressure scheme, if enabled, should slow down the tuple sending speed of
-     * the spouts until reaching the low watermark.
-     */
-    public static final String BACKPRESSURE_EXECUTOR_HIGH_WATERMARK="backpressure.executor.high.watermark";
-    public static final Object BACKPRESSURE_EXECUTOR_HIGH_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
-
-    /**
-     * This signifies a state that an executor has left the congestion.
-     * If the used ratio of an execuotr's receive queue is lower than the low watermark,
-     * it may notify the worker to check whether all its executors have also left congestion,
-     * if yes, the worker's backpressure flag will be unset on the Zookeeper
-     */
-    public static final String BACKPRESSURE_EXECUTOR_LOW_WATERMARK="backpressure.executor.low.watermark";
-    public static final Object BACKPRESSURE_EXECUTOR_LOW_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
+    public static final String BACKPRESSURE_DISRUPTOR_LOW_WATERMARK="backpressure.disruptor.low.watermark";
+    public static final Object BACKPRESSURE_DISRUPTOR_LOW_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
 
     /**
      * A list of users that are allowed to interact with the topology.  To use this set

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1047,6 +1047,48 @@ public class Config extends HashMap<String, Object> {
 
 
     /**
+     * Whether to enable backpressure in for a certain topology
+     */
+    public static final String TOPOLOGY_BACKPRESSURE_ENABLE = "topology.backpressure.enable";
+    public static final Object TOPOLOGY_BACKPRESSURE_ENABLE_SCHEMA = Boolean.class;
+
+    /**
+     * This signifies the tuple congestion in a worker's out-going queue.
+     * When the used ratio of a worker's outgoing queue is higher than the high watermark,
+     * the backpressure scheme, if enabled, should slow down the tuple sending speed of
+     * the spouts until reaching the low watermark.
+     */
+    public static final String BACKPRESSURE_WORKER_HIGH_WATERMARK="backpressure.worker.high.watermark";
+    public static final Object BACKPRESSURE_WORKER_HIGH_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
+
+    /**
+     * This signifies a state that a worker has left the congestion.
+     * If the used ratio of a worker's outgoing queue is lower than the low watermark,
+     * it notifies the worker to check whether all its executors have also left congestion,
+     * if yes, it will unset the worker's backpressure flag on the Zookeeper
+     */
+    public static final String BACKPRESSURE_WORKER_LOW_WATERMARK="backpressure.worker.low.watermark";
+    public static final Object BACKPRESSURE_WORKER_LOW_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
+
+    /**
+     * This signifies the tuple congestion in an executor's receiving queue.
+     * When the used ratio of an executor's receiving queue is higher than the high watermark,
+     * the backpressure scheme, if enabled, should slow down the tuple sending speed of
+     * the spouts until reaching the low watermark.
+     */
+    public static final String BACKPRESSURE_EXECUTOR_HIGH_WATERMARK="backpressure.executor.high.watermark";
+    public static final Object BACKPRESSURE_EXECUTOR_HIGH_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
+
+    /**
+     * This signifies a state that an executor has left the congestion.
+     * If the used ratio of an execuotr's receive queue is lower than the low watermark,
+     * it may notify the worker to check whether all its executors have also left congestion,
+     * if yes, the worker's backpressure flag will be unset on the Zookeeper
+     */
+    public static final String BACKPRESSURE_EXECUTOR_LOW_WATERMARK="backpressure.executor.low.watermark";
+    public static final Object BACKPRESSURE_EXECUTOR_LOW_WATERMARK_SCHEMA =ConfigValidation.PositiveNumberValidator;
+
+    /**
      * A list of users that are allowed to interact with the topology.  To use this set
      * nimbus.authorizer to backtype.storm.security.auth.authorizer.SimpleACLAuthorizer
      */

--- a/storm-core/src/jvm/backtype/storm/utils/DisruptorBackpressureCallback.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DisruptorBackpressureCallback.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package backtype.storm.utils;
+
+public interface DisruptorBackpressureCallback {
+
+    void highWaterMark() throws Exception;
+
+    void lowWaterMark() throws Exception;
+}

--- a/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import backtype.storm.metric.api.IStatefulObject;
+import org.jgrapht.graph.DirectedSubgraph;
 
 
 /**
@@ -65,6 +66,10 @@ public class DisruptorQueue implements IStatefulObject {
     private long _waitTimeout;
 
     private final QueueMetrics _metrics;
+    private DisruptorBackpressureCallback _cb = null;
+    private int _highWaterMark = 0;
+    private int _lowWaterMark = 0;
+    private boolean _enableBackpressure = false;
 
     public DisruptorQueue(String queueName, ClaimStrategy claim, WaitStrategy wait, long timeout) {
         this._queueName = PREFIX + queueName;
@@ -135,6 +140,13 @@ public class DisruptorQueue implements IStatefulObject {
                     throw new InterruptedException("Disruptor processing interrupted");
                 } else {
                     handler.onEvent(o, curr, curr == cursor);
+                    if (_enableBackpressure && _cb != null && _metrics.writePos() - curr <= _lowWaterMark) {
+                        try {
+                            _cb.lowWaterMark();
+                        } catch (Exception e) {
+                            throw new RuntimeException("Exception during calling lowWaterMark callback!");
+                        }
+                    }
                 }
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -142,6 +154,20 @@ public class DisruptorQueue implements IStatefulObject {
         }
         //TODO: only set this if the consumer cursor has changed?
         _consumer.set(cursor);
+    }
+
+    public void registerBackpressureCallback(DisruptorBackpressureCallback cb) {
+        this._cb = cb;
+    }
+
+    static public void notifyBackpressureChecker(Object trigger) {
+        try {
+            synchronized (trigger) {
+                trigger.notifyAll();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /*
@@ -191,6 +217,13 @@ public class DisruptorQueue implements IStatefulObject {
         m.setObject(obj);
         _buffer.publish(id);
         _metrics.notifyArrivals(1);
+        if (_enableBackpressure && _cb != null && _metrics.population() >= _highWaterMark) {
+           try {
+               _cb.highWaterMark();
+           } catch (Exception e) {
+               throw new RuntimeException("Exception during calling highWaterMark callback!");
+           }
+        }
     }
 
     public void consumerStarted() {
@@ -205,6 +238,29 @@ public class DisruptorQueue implements IStatefulObject {
     @Override
     public Object getState() {
         return _metrics.getState();
+    }
+
+    public DisruptorQueue setHighWaterMark(double highWaterMark) {
+        this._highWaterMark = (int)(_metrics.capacity() * highWaterMark);
+        return this;
+    }
+
+    public DisruptorQueue setLowWaterMark(double lowWaterMark) {
+        this._lowWaterMark = (int)(_metrics.capacity() * lowWaterMark);
+        return this;
+    }
+
+    public int getHighWaterMark() {
+        return this._highWaterMark;
+    }
+
+    public int getLowWaterMark() {
+        return this._lowWaterMark;
+    }
+
+    public DisruptorQueue setEnableBackpressure(boolean enableBackpressure) {
+        this._enableBackpressure = enableBackpressure;
+        return this;
     }
 
     public static class ObjectEventFactory implements EventFactory<MutableObject> {

--- a/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import backtype.storm.metric.api.IStatefulObject;
-import org.jgrapht.graph.DirectedSubgraph;
 
 
 /**
@@ -158,16 +157,6 @@ public class DisruptorQueue implements IStatefulObject {
 
     public void registerBackpressureCallback(DisruptorBackpressureCallback cb) {
         this._cb = cb;
-    }
-
-    static public void notifyBackpressureChecker(Object trigger) {
-        try {
-            synchronized (trigger) {
-                trigger.notifyAll();
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
     /*

--- a/storm-core/src/jvm/backtype/storm/utils/WorkerBackpressureCallback.java
+++ b/storm-core/src/jvm/backtype/storm/utils/WorkerBackpressureCallback.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package backtype.storm.utils;
+
+public interface WorkerBackpressureCallback {
+
+    void onEvent(Object obj) throws Exception;
+
+}

--- a/storm-core/src/jvm/backtype/storm/utils/WorkerBackpressureThread.java
+++ b/storm-core/src/jvm/backtype/storm/utils/WorkerBackpressureThread.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package backtype.storm.utils;
+
+import java.util.Map;
+
+public class WorkerBackpressureThread extends Thread {
+
+    Object trigger;
+    Object workerData;
+    WorkerBackpressureCallback callback;
+
+    public WorkerBackpressureThread(Object trigger, Object workerData, WorkerBackpressureCallback callback) {
+        this.trigger = trigger;
+        this.workerData = workerData;
+        this.callback = callback;
+    }
+
+    public void run() {
+        try {
+            while (true) {
+                synchronized(trigger) {
+                    trigger.wait(100);
+                }
+                callback.onEvent(workerData); // check all executors and update zk backpressure throttle for the worker if needed
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+

--- a/storm-core/src/jvm/backtype/storm/utils/WorkerBackpressureThread.java
+++ b/storm-core/src/jvm/backtype/storm/utils/WorkerBackpressureThread.java
@@ -33,6 +33,16 @@ public class WorkerBackpressureThread extends Thread {
         this.callback = callback;
     }
 
+    static public void notifyBackpressureChecker(Object trigger) {
+        try {
+            synchronized (trigger) {
+                trigger.notifyAll();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void run() {
         try {
             while (true) {

--- a/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueBackpressureTest.java
+++ b/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueBackpressureTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.utils;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.lmax.disruptor.BlockingWaitStrategy;
+import com.lmax.disruptor.EventHandler;
+import com.lmax.disruptor.MultiThreadedClaimStrategy;
+import org.junit.Assert;
+import org.junit.Test;
+import junit.framework.TestCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DisruptorQueueBackpressureTest extends TestCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DisruptorQueueBackpressureTest.class);
+
+    private final static int MESSAGES = 100;
+    private final static int CAPACITY = 128;
+    private final static double HIGH_WATERMARK = 0.6;
+    private final static double LOW_WATERMARK = 0.2;
+
+
+    @Test
+    public void testBackPressureCallback() throws Exception {
+
+        final DisruptorQueue queue = createQueue("testBackPressure", CAPACITY);
+        queue.setEnableBackpressure(true);
+        queue.setHighWaterMark(HIGH_WATERMARK);
+        queue.setLowWaterMark(LOW_WATERMARK);
+
+        final AtomicBoolean throttleOn = new AtomicBoolean(false);
+        // we need to record the cursor because the DisruptorQueue does not update the readPos during batch consuming
+        final AtomicLong consumerCursor = new AtomicLong(-1);
+
+        DisruptorBackpressureCallbackImpl cb = new DisruptorBackpressureCallbackImpl(queue, throttleOn, consumerCursor);
+        queue.registerBackpressureCallback(cb);
+        queue.consumerStarted();
+
+        for (int i = 0; i < MESSAGES; i++) {
+            queue.publish(String.valueOf(i));
+        }
+
+
+        queue.consumeBatchWhenAvailable(new EventHandler<Object>() {
+            @Override
+            public void onEvent(Object o, long l, boolean b) throws Exception {
+                 consumerCursor.set(l);
+            }
+        });
+
+
+        Assert.assertEquals("Check the calling time of throttle on. ",
+                cb.highWaterMarkCalledPopulation, queue.getHighWaterMark());
+        Assert.assertEquals("Checking the calling time of throttle off. ",
+                cb.lowWaterMarkCalledPopulation, queue.getLowWaterMark());
+    }
+
+    class DisruptorBackpressureCallbackImpl implements DisruptorBackpressureCallback {
+        // the queue's population when the high water mark callback is called for the first time
+        public long highWaterMarkCalledPopulation = -1;
+        // the queue's population when the low water mark callback is called for the first time
+        public long lowWaterMarkCalledPopulation = -1;
+
+        DisruptorQueue queue;
+        AtomicBoolean throttleOn;
+        AtomicLong consumerCursor;
+
+        public DisruptorBackpressureCallbackImpl(DisruptorQueue queue, AtomicBoolean throttleOn,
+                                                 AtomicLong consumerCursor) {
+            this.queue = queue;
+            this.throttleOn = throttleOn;
+            this.consumerCursor = consumerCursor;
+        }
+
+        @Override
+        public void highWaterMark() throws Exception {
+            if (!throttleOn.get()) {
+                highWaterMarkCalledPopulation = queue.population();
+                throttleOn.set(true);
+            }
+        }
+
+        @Override
+        public void lowWaterMark() throws Exception {
+             if (throttleOn.get()) {
+                 lowWaterMarkCalledPopulation = queue.writePos() - consumerCursor.get();
+                 throttleOn.set(false);
+             }
+        }
+    }
+
+    private static DisruptorQueue createQueue(String name, int queueSize) {
+        return new DisruptorQueue(name, new MultiThreadedClaimStrategy(
+                queueSize), new BlockingWaitStrategy(), 10L);
+    }
+}

--- a/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueBackpressureTest.java
+++ b/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueBackpressureTest.java
@@ -94,7 +94,7 @@ public class DisruptorQueueBackpressureTest extends TestCase {
         @Override
         public void highWaterMark() throws Exception {
             if (!throttleOn.get()) {
-                highWaterMarkCalledPopulation = queue.population();
+                highWaterMarkCalledPopulation = queue.getMetrics().population();
                 throttleOn.set(true);
             }
         }
@@ -102,7 +102,7 @@ public class DisruptorQueueBackpressureTest extends TestCase {
         @Override
         public void lowWaterMark() throws Exception {
              if (throttleOn.get()) {
-                 lowWaterMarkCalledPopulation = queue.writePos() - consumerCursor.get();
+                 lowWaterMarkCalledPopulation = queue.getMetrics().writePos() - consumerCursor.get();
                  throttleOn.set(false);
              }
         }


### PR DESCRIPTION
This new feature is aimed for automatic flow control through the topology DAG since different components may have unmatched tuple processing speed. Currently, the tuples may get dropped if the downstream components can not process as quickly, thereby causing a waste of network bandwidth and processing capability. In addition, it is difficult to tune the max.spout.pending parameter for best backpressure performance. Therefore, an automatic back pressure scheme is highly desirable.

Recently, Heron proposed a form of back pressure that does not rely on acking or max spout pending. Instead spouts throttle not only when max.spout.pending is hit, but also if any bolt has gone over a high water mark in their input queue, and has not yet gone below a low water mark again. There is a lot of room for potential improvement here around control theory and having spouts only respond to downstream bolts backing up, but a simple bang-bang controller like this is a great start.

Our ABP scheme implements a light-weight yet efficient back pressure scheme. It monitors certain queues in executors and exploits the callback schemes on ZooKeeper and disruptor queue for a fast-responding (in a push manner) flow control.

Please check the attached figures for more details about the implementation.
https://issues.apache.org/jira/secure/attachment/12752518/an%20simple%20example%20for%20backpressure.png
![image](https://issues.apache.org/jira/secure/attachment/12752521/backpressure.png)

