### PR TITLE
[Storm-650] Added new option to allow Kafka spout to save offset and other state using Kafka's offset management api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ _site
 dependency-reduced-pom.xml
 derby.log
 metastore_db
+*.versionsBackup

--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -20,7 +20,7 @@
   <parent>
       <artifactId>storm</artifactId>
       <groupId>org.apache.storm</groupId>
-      <version>0.11.0-SNAPSHOT</version>
+      <version>0.11.0-CXT-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/flux/flux-core/pom.xml
+++ b/external/flux/flux-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.storm</groupId>
         <artifactId>flux</artifactId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/external/flux/flux-examples/pom.xml
+++ b/external/flux/flux-examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.storm</groupId>
         <artifactId>flux</artifactId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/external/flux/flux-wrappers/pom.xml
+++ b/external/flux/flux-wrappers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.storm</groupId>
         <artifactId>flux</artifactId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/external/flux/pom.xml
+++ b/external/flux/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/external/storm-elasticsearch/pom.xml
+++ b/external/storm-elasticsearch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/external/storm-eventhubs/pom.xml
+++ b/external/storm-eventhubs/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <artifactId>storm-eventhubs</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.11.0-CXT-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>storm-eventhubs</name>
     <description>EventHubs Storm Spout</description>

--- a/external/storm-hbase/pom.xml
+++ b/external/storm-hbase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>storm</artifactId>
     <groupId>org.apache.storm</groupId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.11.0-CXT-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/external/storm-jdbc/pom.xml
+++ b/external/storm-jdbc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -141,6 +141,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+        	<groupId>org.scala-lang</groupId>
+        	<artifactId>scala-library</artifactId>
+        	<version>2.10.5</version>
+            <!-- use provided scope, so users can pull in whichever scala version they choose -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -148,5 +155,34 @@
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
         </dependency>
+
+        <dependency>
+        	<groupId>com.yammer.metrics</groupId>
+        	<artifactId>metrics-core</artifactId>
+        	<version>2.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+        	<groupId>com.101tec</groupId>
+        	<artifactId>zkclient</artifactId>
+        	<version>0.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaBackedPartitionStateManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaBackedPartitionStateManager.java
@@ -1,0 +1,32 @@
+package storm.kafka;
+
+import org.json.simple.JSONValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class KafkaBackedPartitionStateManager implements PartitionStateManager {
+
+    public static final Logger LOG = LoggerFactory.getLogger(KafkaBackedPartitionStateManager.class);
+
+    private KafkaDataStore _dataStore;
+
+    public KafkaBackedPartitionStateManager(Map stormConf, SpoutConfig spoutConfig, Partition partition, KafkaDataStore dataStore) {
+        this._dataStore = dataStore;
+    }
+
+    @Override
+    public Map<Object, Object> getState() {
+        return  (Map<Object, Object>) JSONValue.parse(_dataStore.read());
+    }
+
+    @Override
+    public void writeState(Map<Object, Object> data) {
+        assert data.containsKey("offset");
+
+        Long offsetOfPartition = (Long)data.get("offset");
+        String stateData = JSONValue.toJSONString(data);
+        _dataStore.write(offsetOfPartition, stateData);
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaConfig.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaConfig.java
@@ -34,6 +34,7 @@ public class KafkaConfig implements Serializable {
     public int bufferSizeBytes = 1024 * 1024;
     public MultiScheme scheme = new RawMultiScheme();
     public boolean ignoreZkOffsets = false;
+    public boolean ignoreStoredOffsets = false;
     public long startOffsetTime = kafka.api.OffsetRequest.EarliestTime();
     public long maxOffsetBehind = Long.MAX_VALUE;
     public boolean useStartOffsetTimeIfOffsetOutOfRange = true;

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaDataStore.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaDataStore.java
@@ -1,0 +1,204 @@
+package storm.kafka;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import kafka.api.ConsumerMetadataRequest;
+import kafka.common.ErrorMapping;
+import kafka.common.OffsetAndMetadata;
+import kafka.common.OffsetMetadataAndError;
+import kafka.common.TopicAndPartition;
+import kafka.javaapi.*;
+import kafka.network.BlockingChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class KafkaDataStore {
+    public static final Logger LOG = LoggerFactory.getLogger(KafkaDataStore.class);
+
+    private SpoutConfig _spoutConfig;
+    private Partition _partition;
+
+    private String _consumerGroupId;
+    private String _consumerClientId;
+    private int _stateOpTimeout;
+    private int _stateOpMaxRetry;
+
+    private int _correlationId = 0;
+    private BlockingChannel _offsetManager;
+
+    public KafkaDataStore(Map stormConf, SpoutConfig spoutConfig, Partition partition) {
+        this._spoutConfig = spoutConfig;
+        this._partition = partition;
+        this._consumerGroupId = _spoutConfig.id;
+        this._consumerClientId = _spoutConfig.clientId;
+        this._stateOpTimeout = _spoutConfig.stateOpTimeout;
+        this._stateOpMaxRetry = _spoutConfig.stateOpMaxRetry;
+    }
+
+    // as there is a manager per topic per partition and the stateUpdateIntervalMs should not be too small
+    // feels ok to  place a sync here
+    private synchronized BlockingChannel locateOffsetManager() {
+        if (_offsetManager == null) {
+            BlockingChannel channel = new BlockingChannel(_partition.host.host, _partition.host.port,
+                    BlockingChannel.UseDefaultBufferSize(),
+                    BlockingChannel.UseDefaultBufferSize(),
+                    1000000 /* read timeout in millis */);
+            channel.connect();
+
+            ConsumerMetadataResponse metadataResponse = null;
+            long backoffMillis = 3000L;
+            int maxRetry = 3;
+            int retryCount = 0;
+            // this usually only happens when the internal offsets topic does not exist before and we need to wait until
+            // the topic is automatically created and the meta data are populated across cluster. So we hard-code the retry here.
+
+            // one scenario when this could happen is during unit test.
+            while (retryCount < maxRetry) {
+                channel.send(new ConsumerMetadataRequest(_consumerGroupId, ConsumerMetadataRequest.CurrentVersion(),
+                        _correlationId++, _consumerClientId));
+                metadataResponse = ConsumerMetadataResponse.readFrom(channel.receive().buffer());
+                if (metadataResponse.errorCode() == ErrorMapping.ConsumerCoordinatorNotAvailableCode()) {
+                    LOG.warn("Failed to get coordinator: " + metadataResponse.errorCode());
+                    retryCount++;
+                    try {
+                        Thread.sleep(backoffMillis);
+                    } catch (InterruptedException e) {
+                        // eat the exception
+                    }
+                } else {
+                    break;
+                }
+            }
+
+            if (metadataResponse.errorCode() == ErrorMapping.NoError()) {
+                kafka.cluster.Broker offsetManager = metadataResponse.coordinator();
+                if (!offsetManager.host().equals(_partition.host.host)
+                        || !(offsetManager.port() == _partition.host.port)) {
+                    // if the coordinator is different, from the above channel's host then reconnect
+                    channel.disconnect();
+                    channel = new BlockingChannel(offsetManager.host(), offsetManager.port(),
+                            BlockingChannel.UseDefaultBufferSize(),
+                            BlockingChannel.UseDefaultBufferSize(),
+                            _stateOpTimeout /* read timeout in millis */);
+                    channel.connect();
+                }
+            } else {
+                throw new RuntimeException("Kafka metadata fetch error: " + metadataResponse.errorCode());
+            }
+            _offsetManager = channel;
+        }
+        return _offsetManager;
+    }
+
+    private String attemptToRead() {
+        List<TopicAndPartition> partitions = new ArrayList<TopicAndPartition>();
+        TopicAndPartition thisTopicPartition = new TopicAndPartition(_spoutConfig.topic, _partition.partition);
+        partitions.add(thisTopicPartition);
+        OffsetFetchRequest fetchRequest = new OffsetFetchRequest(
+                _consumerGroupId,
+                partitions,
+                (short) 1, // version 1 and above fetch from Kafka, version 0 fetches from ZooKeeper
+                _correlationId++,
+                _consumerClientId);
+
+        BlockingChannel offsetManager = locateOffsetManager();
+        offsetManager.send(fetchRequest.underlying());
+        OffsetFetchResponse fetchResponse = OffsetFetchResponse.readFrom(offsetManager.receive().buffer());
+        OffsetMetadataAndError result = fetchResponse.offsets().get(thisTopicPartition);
+        if (result.error() == ErrorMapping.NoError()) {
+            String retrievedMetadata = result.metadata();
+            if (retrievedMetadata != null) {
+                return retrievedMetadata;
+            } else {
+                // let it return null, this maybe the first time it is called before the state is persisted
+                return null;
+            }
+
+        } else {
+            // may attempt to implement retry later
+            _offsetManager = null;
+            throw new RuntimeException("Kafka offset fetch error: " + result.error());
+        }
+    }
+
+    public String read() {
+        int attemptCount = 0;
+        while (true) {
+            try {
+                return attemptToRead();
+
+            } catch(RuntimeException re) {
+                if (++attemptCount > _stateOpMaxRetry) {
+                    _offsetManager = null;
+                    throw re;
+                } else {
+                    LOG.warn("Attempt " + attemptCount + " out of " + _stateOpMaxRetry
+                            + ". Failed to fetch state for partition " + _partition.partition
+                            + " of topic " + _spoutConfig.topic + " due to Kafka offset fetch error: " + re.getMessage());
+                }
+            }
+        }
+    }
+
+    private void attemptToWrite(long offsetOfPartition, String data) {
+        long now = System.currentTimeMillis();
+        Map<TopicAndPartition, OffsetAndMetadata> offsets = Maps.newLinkedHashMap();
+        TopicAndPartition thisTopicPartition = new TopicAndPartition(_spoutConfig.topic, _partition.partition);
+        offsets.put(thisTopicPartition, new OffsetAndMetadata(
+                offsetOfPartition,
+                data,
+                now));
+        OffsetCommitRequest commitRequest = new OffsetCommitRequest(
+                _consumerGroupId,
+                offsets,
+                _correlationId,
+                _consumerClientId,
+                (short) 1); // version 1 and above commit to Kafka, version 0 commits to ZooKeeper
+
+        BlockingChannel offsetManager = locateOffsetManager();
+        offsetManager.send(commitRequest.underlying());
+        OffsetCommitResponse commitResponse = OffsetCommitResponse.readFrom(offsetManager.receive().buffer());
+        if (commitResponse.hasError()) {
+            // note: here we should have only 1 error for the partition in request
+            for (Object partitionErrorCode : commitResponse.errors().values()) {
+                if (partitionErrorCode == ErrorMapping.OffsetMetadataTooLargeCode()) {
+                    throw new RuntimeException("Data is too big. The data object is " + data);
+                } else {
+                    _offsetManager = null;
+                    // may attempt to implement retry later
+                    throw new RuntimeException("Kafka offset commit error: " + partitionErrorCode);
+                }
+            }
+        }
+    }
+
+    public void write(Long offsetOfPartition,  String data) {
+        int attemptCount = 0;
+        while (true) {
+            try {
+                attemptToWrite(offsetOfPartition, data);
+                return;
+
+            } catch(RuntimeException re) {
+                if (++attemptCount > _stateOpMaxRetry) {
+                    _offsetManager = null;
+                    throw re;
+                } else {
+                    LOG.warn("Attempt " + attemptCount + " out of " + _stateOpMaxRetry
+                            + ". Failed to save state for partition " + _partition.partition
+                            + " of topic " + _spoutConfig.topic + " due to Kafka offset commit error: " + re.getMessage());
+                }
+            }
+        }
+    }
+
+    public void close() {
+        _offsetManager.disconnect();
+        _offsetManager = null;
+    }
+
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
@@ -71,7 +71,7 @@ public class KafkaUtils {
         OffsetRequest request = new OffsetRequest(
                 requestInfo, kafka.api.OffsetRequest.CurrentVersion(), consumer.clientId());
 
-        long[] offsets = consumer.getOffsetsBefore(request).offsets(topic, partition);
+        long[] offsets = (long[])consumer.getOffsetsBefore(request).offsets(topic, partition);
         if (offsets.length > 0) {
             return offsets[0];
         } else {

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -55,16 +55,18 @@ public class PartitionManager {
     String _topologyInstanceId;
     SimpleConsumer _consumer;
     DynamicPartitionConnections _connections;
-    ZkState _state;
+    PartitionStateManager _partitionStateManager;
     Map _stormConf;
     long numberFailed, numberAcked;
-    public PartitionManager(DynamicPartitionConnections connections, String topologyInstanceId, ZkState state, Map stormConf, SpoutConfig spoutConfig, Partition id) {
+
+    public PartitionManager(DynamicPartitionConnections connections, String topologyInstanceId, PartitionStateManager partitionStateManager,
+                            Map stormConf, SpoutConfig spoutConfig, Partition id) {
         _partition = id;
         _connections = connections;
         _spoutConfig = spoutConfig;
         _topologyInstanceId = topologyInstanceId;
         _consumer = connections.register(id.host, id.partition);
-        _state = state;
+        _partitionStateManager = partitionStateManager;
         _stormConf = stormConf;
         numberAcked = numberFailed = 0;
 
@@ -72,18 +74,17 @@ public class PartitionManager {
                                                                            _spoutConfig.retryDelayMultiplier,
                                                                            _spoutConfig.retryDelayMaxMs);
 
+
         String jsonTopologyId = null;
         Long jsonOffset = null;
-        String path = committedPath();
         try {
-            Map<Object, Object> json = _state.readJSON(path);
-            LOG.info("Read partition information from: " + path +  "  --> " + json );
+            Map<Object, Object> json = _partitionStateManager.getState();
             if (json != null) {
                 jsonTopologyId = (String) ((Map<Object, Object>) json.get("topology")).get("id");
                 jsonOffset = (Long) json.get("offset");
             }
         } catch (Throwable e) {
-            LOG.warn("Error reading and/or parsing at ZkNode: " + path, e);
+            LOG.warn("Error reading and/or parsing partition state", e);
         }
 
         Long currentOffset = KafkaUtils.getOffset(_consumer, spoutConfig.topic, id.partition, spoutConfig);
@@ -91,7 +92,7 @@ public class PartitionManager {
         if (jsonTopologyId == null || jsonOffset == null) { // failed to parse JSON?
             _committedTo = currentOffset;
             LOG.info("No partition information found, using configuration to determine offset");
-        } else if (!topologyInstanceId.equals(jsonTopologyId) && spoutConfig.ignoreZkOffsets) {
+        } else if (!topologyInstanceId.equals(jsonTopologyId) && (spoutConfig.ignoreStoredOffsets || spoutConfig.ignoreZkOffsets)) {
             _committedTo = KafkaUtils.getOffset(_consumer, spoutConfig.topic, id.partition, spoutConfig.startOffsetTime);
             LOG.info("Topology change detected and ignore zookeeper offsets set to true, using configuration to determine offset");
         } else {
@@ -261,17 +262,13 @@ public class PartitionManager {
                     .put("broker", ImmutableMap.of("host", _partition.host.host,
                             "port", _partition.host.port))
                     .put("topic", _spoutConfig.topic).build();
-            _state.writeJSON(committedPath(), data);
+            _partitionStateManager.writeState(data);
 
             _committedTo = lastCompletedOffset;
             LOG.debug("Wrote last completed offset (" + lastCompletedOffset + ") to ZK for " + _partition + " for topology: " + _topologyInstanceId);
         } else {
             LOG.debug("No new offset for " + _partition + " for topology: " + _topologyInstanceId);
         }
-    }
-
-    private String committedPath() {
-        return _spoutConfig.zkRoot + "/" + _spoutConfig.id + "/" + _partition.getId();
     }
 
     public long lastCompletedOffset() {
@@ -300,4 +297,5 @@ public class PartitionManager {
             this.offset = offset;
         }
     }
+
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionStateManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionStateManager.java
@@ -1,0 +1,10 @@
+package storm.kafka;
+
+import java.util.Map;
+
+public interface PartitionStateManager {
+
+    Map<Object, Object> getState();
+
+    void writeState(Map<Object, Object> data);
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionStateManagerFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionStateManagerFactory.java
@@ -1,0 +1,68 @@
+package storm.kafka;
+
+import backtype.storm.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PartitionStateManagerFactory {
+
+    public static final Logger LOG = LoggerFactory.getLogger(PartitionStateManagerFactory.class);
+
+    private ZkDataStore sharedZkDataStore;
+
+    private Map _stormConf;
+    private SpoutConfig _spoutConfig;
+
+
+    private ZkDataStore createZkDataStore(Map conf, SpoutConfig spoutConfig) {
+        Map _zkDataStoreConf = new HashMap(conf);
+        List<String> zkServers = _spoutConfig.zkServers;
+        if (zkServers == null) {
+            zkServers = (List<String>) conf.get(Config.STORM_ZOOKEEPER_SERVERS);
+        }
+        Integer zkPort = _spoutConfig.zkPort;
+        if (zkPort == null) {
+            zkPort = ((Number) conf.get(Config.STORM_ZOOKEEPER_PORT)).intValue();
+        }
+        _zkDataStoreConf.put(Config.TRANSACTIONAL_ZOOKEEPER_SERVERS, zkServers);
+        _zkDataStoreConf.put(Config.TRANSACTIONAL_ZOOKEEPER_PORT, zkPort);
+        _zkDataStoreConf.put(Config.TRANSACTIONAL_ZOOKEEPER_ROOT, _spoutConfig.zkRoot);
+        return new ZkDataStore(_zkDataStoreConf);
+
+    }
+
+    public PartitionStateManagerFactory(Map stormConf, SpoutConfig spoutConfig) {
+        this._stormConf = stormConf;
+        this._spoutConfig = spoutConfig;
+
+        // default to orignal storm storage format
+        if (_spoutConfig.stateStore == null || "storm".equals(_spoutConfig.stateStore)) {
+            sharedZkDataStore = createZkDataStore(_stormConf, _spoutConfig);
+        }
+    }
+
+    public PartitionStateManager getInstance(Partition partition) {
+
+        if (_spoutConfig.stateStore == null || "storm".equals(_spoutConfig.stateStore)) {
+           return new ZKBackedPartitionStateManager(_stormConf,_spoutConfig,  partition, sharedZkDataStore);
+
+        } else if ("kafka".equals(_spoutConfig.stateStore)) {
+            KafkaDataStore kafkaDataStore =  new KafkaDataStore(_stormConf, _spoutConfig, partition);
+            return new KafkaBackedPartitionStateManager(_stormConf, _spoutConfig, partition, kafkaDataStore);
+
+        } else {
+            throw new RuntimeException("Invalid value defined for _spoutConfig.stateStore: " + _spoutConfig.stateStore
+                + ". Valid values are storm, kafka. Default to storm");
+        }
+    }
+
+    public void close() {
+        if (sharedZkDataStore != null) {
+            sharedZkDataStore.close();
+        }
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
@@ -39,6 +39,18 @@ public class SpoutConfig extends KafkaConfig implements Serializable {
     public double retryDelayMultiplier = 1.0;
     public long retryDelayMaxMs = 60 * 1000;
 
+    // offset state information storage. validate options are storm and kafka
+    public String stateStore = "storm";
+    // timeout in millis for state read/write operations
+    public int stateOpTimeout = 5000;
+    // max retries allowed for state read/write operations
+    public int stateOpMaxRetry = 3;
+
+    public SpoutConfig(BrokerHosts hosts, String topic, String id) {
+        super(hosts, topic);
+        this.id = id;
+    }
+
     public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id) {
         super(hosts, topic);
         this.zkRoot = zkRoot;

--- a/external/storm-kafka/src/jvm/storm/kafka/StaticCoordinator.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/StaticCoordinator.java
@@ -24,14 +24,16 @@ import java.util.Map;
 
 
 public class StaticCoordinator implements PartitionCoordinator {
+
     Map<Partition, PartitionManager> _managers = new HashMap<Partition, PartitionManager>();
     List<PartitionManager> _allManagers = new ArrayList();
 
-    public StaticCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig config, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId) {
-        StaticHosts hosts = (StaticHosts) config.hosts;
+    public StaticCoordinator(DynamicPartitionConnections connections, PartitionStateManagerFactory partitionStateManagerFactory, Map stormConf, SpoutConfig spoutConfig, int taskIndex, int totalTasks, String topologyInstanceId) {
+        StaticHosts hosts = (StaticHosts) spoutConfig.hosts;
         List<Partition> myPartitions = KafkaUtils.calculatePartitionsForTask(hosts.getPartitionInformation(), totalTasks, taskIndex);
+
         for (Partition myPartition : myPartitions) {
-            _managers.put(myPartition, new PartitionManager(connections, topologyInstanceId, state, stormConf, config, myPartition));
+            _managers.put(myPartition, new PartitionManager(connections, topologyInstanceId, partitionStateManagerFactory.getInstance(myPartition), stormConf, spoutConfig, myPartition));
         }
         _allManagers = new ArrayList(_managers.values());
     }
@@ -47,5 +49,4 @@ public class StaticCoordinator implements PartitionCoordinator {
 
     @Override
     public void refresh() { return; }
-
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/ZKBackedPartitionStateManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ZKBackedPartitionStateManager.java
@@ -1,0 +1,47 @@
+package storm.kafka;
+
+import org.json.simple.JSONValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.util.Map;
+
+public class ZKBackedPartitionStateManager implements PartitionStateManager  {
+
+    public static final Logger LOG = LoggerFactory.getLogger(ZKBackedPartitionStateManager.class);
+
+    private SpoutConfig _spoutConfig;
+    private Partition _partition;
+    private ZkDataStore _zkDataStore;
+
+    public ZKBackedPartitionStateManager(Map stormConfig, SpoutConfig spoutConfig, Partition partition, ZkDataStore zkDataStore) {
+        this._spoutConfig = spoutConfig;
+        this._partition = partition;
+        this._zkDataStore = zkDataStore;
+    }
+
+    private String committedPath() {
+        return _spoutConfig.zkRoot + "/" + _spoutConfig.id + "/" + _partition.getId();
+    }
+
+    @Override
+    public Map<Object, Object> getState() {
+        LOG.debug("Reading from " + committedPath() + " for state data");
+        try {
+            byte[] b = _zkDataStore.read(committedPath());
+            if (b == null) {
+                return null;
+            }
+            return (Map<Object, Object>) JSONValue.parse(new String(b, "UTF-8"));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void writeState(Map<Object, Object> data) {
+        LOG.debug("Writing to " + committedPath() + " with stat data " + data.toString());
+        _zkDataStore.write(committedPath(), JSONValue.toJSONString(data).getBytes(Charset.forName("UTF-8")));
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/ZkCoordinator.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ZkCoordinator.java
@@ -34,25 +34,25 @@ public class ZkCoordinator implements PartitionCoordinator {
     String _topologyInstanceId;
     Map<Partition, PartitionManager> _managers = new HashMap();
     List<PartitionManager> _cachedList = new ArrayList<PartitionManager>();
+    PartitionStateManagerFactory _partitionStateManagerFactory;
     Long _lastRefreshTime = null;
     int _refreshFreqMs;
     DynamicPartitionConnections _connections;
     DynamicBrokersReader _reader;
-    ZkState _state;
     Map _stormConf;
 
-    public ZkCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig spoutConfig, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId) {
-        this(connections, stormConf, spoutConfig, state, taskIndex, totalTasks, topologyInstanceId, buildReader(stormConf, spoutConfig));
+    public ZkCoordinator(DynamicPartitionConnections connections, PartitionStateManagerFactory partitionStateManagerFactory,  Map stormConf, SpoutConfig spoutConfig, int taskIndex, int totalTasks, String topologyInstanceId) {
+        this(connections, partitionStateManagerFactory, stormConf, spoutConfig, taskIndex, totalTasks, topologyInstanceId, buildReader(stormConf, spoutConfig));
     }
 
-    public ZkCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig spoutConfig, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId, DynamicBrokersReader reader) {
-        _spoutConfig = spoutConfig;
+    public ZkCoordinator(DynamicPartitionConnections connections, PartitionStateManagerFactory partitionStateManagerFactory, Map stormConf, SpoutConfig spoutConfig, int taskIndex, int totalTasks, String topologyInstanceId, DynamicBrokersReader reader) {
         _connections = connections;
+        _partitionStateManagerFactory = partitionStateManagerFactory;
         _taskIndex = taskIndex;
         _totalTasks = totalTasks;
         _topologyInstanceId = topologyInstanceId;
         _stormConf = stormConf;
-        _state = state;
+        _spoutConfig = spoutConfig;
         ZkHosts brokerConf = (ZkHosts) spoutConfig.hosts;
         _refreshFreqMs = brokerConf.refreshFreqSecs * 1000;
         _reader = reader;
@@ -95,7 +95,7 @@ public class ZkCoordinator implements PartitionCoordinator {
             LOG.info(taskId(_taskIndex, _totalTasks) + "New partition managers: " + newPartitions.toString());
 
             for (Partition id : newPartitions) {
-                PartitionManager man = new PartitionManager(_connections, _topologyInstanceId, _state, _stormConf, _spoutConfig, id);
+                PartitionManager man = new PartitionManager(_connections, _topologyInstanceId, _partitionStateManagerFactory.getInstance(id), _stormConf, _spoutConfig, id);
                 _managers.put(id, man);
             }
 

--- a/external/storm-kafka/src/jvm/storm/kafka/ZkDataStore.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ZkDataStore.java
@@ -32,8 +32,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ZkState {
-    public static final Logger LOG = LoggerFactory.getLogger(ZkState.class);
+public class ZkDataStore {
+    public static final Logger LOG = LoggerFactory.getLogger(ZkDataStore.class);
+
     CuratorFramework _curator;
 
     private CuratorFramework newCurator(Map stateConf) throws Exception {
@@ -54,7 +55,7 @@ public class ZkState {
         return _curator;
     }
 
-    public ZkState(Map stateConf) {
+    public ZkDataStore(Map stateConf) {
         stateConf = new HashMap(stateConf);
 
         try {
@@ -65,12 +66,7 @@ public class ZkState {
         }
     }
 
-    public void writeJSON(String path, Map<Object, Object> data) {
-        LOG.debug("Writing " + path + " the data " + data.toString());
-        writeBytes(path, JSONValue.toJSONString(data).getBytes(Charset.forName("UTF-8")));
-    }
-
-    public void writeBytes(String path, byte[] bytes) {
+    public void write(String path, byte[] bytes) {
         try {
             if (_curator.checkExists().forPath(path) == null) {
                 _curator.create()
@@ -85,19 +81,7 @@ public class ZkState {
         }
     }
 
-    public Map<Object, Object> readJSON(String path) {
-        try {
-            byte[] b = readBytes(path);
-            if (b == null) {
-                return null;
-            }
-            return (Map<Object, Object>) JSONValue.parse(new String(b, "UTF-8"));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public byte[] readBytes(String path) {
+    public byte[] read(String path) {
         try {
             if (_curator.checkExists().forPath(path) != null) {
                 return _curator.getData().forPath(path);

--- a/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
@@ -100,7 +100,7 @@ public class TridentKafkaEmitter {
             if (lastTopoMeta != null) {
                 lastInstanceId = (String) lastTopoMeta.get("id");
             }
-            if (_config.ignoreZkOffsets && !_topologyInstanceId.equals(lastInstanceId)) {
+            if (_config.ignoreStoredOffsets && !_topologyInstanceId.equals(lastInstanceId)) {
                 offset = KafkaUtils.getOffset(consumer, _config.topic, partition.partition, _config.startOffsetTime);
             } else {
                 offset = (Long) lastMeta.get("nextOffset");
@@ -157,7 +157,7 @@ public class TridentKafkaEmitter {
     private void reEmitPartitionBatch(TransactionAttempt attempt, TridentCollector collector, Partition partition, Map meta) {
         LOG.info("re-emitting batch, attempt " + attempt);
         String instanceId = (String) meta.get("instanceId");
-        if (!_config.ignoreZkOffsets || instanceId.equals(_topologyInstanceId)) {
+        if (!_config.ignoreStoredOffsets || instanceId.equals(_topologyInstanceId)) {
             SimpleConsumer consumer = _connections.register(partition);
             long offset = (Long) meta.get("offset");
             long nextOffset = (Long) meta.get("nextOffset");

--- a/external/storm-kafka/src/test/storm/kafka/KafkaBackedPartitionStateManagerTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/KafkaBackedPartitionStateManagerTest.java
@@ -1,0 +1,81 @@
+package storm.kafka;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class KafkaBackedPartitionStateManagerTest {
+
+    @Mock
+    private KafkaDataStore dataStore;
+
+    private String stateJson = "{\n" +
+                    "    \"broker\": {\n" +
+                    "        \"host\": \"kafka.sample.net\",\n" +
+                    "        \"port\": 9092\n" +
+                    "    },\n" +
+                    "    \"offset\": 4285,\n" +
+                    "    \"partition\": 1,\n" +
+                    "    \"topic\": \"testTopic\",\n" +
+                    "    \"topology\": {\n" +
+                    "        \"id\": \"fce905ff-25e0 -409e-bc3a-d855f 787d13b\",\n" +
+                    "        \"name\": \"Test Topology\"\n" +
+                    "    }\n" +
+                    "}";
+
+    private KafkaBackedPartitionStateManager partitionStateManager;
+
+
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        Map stormConf = new HashMap();
+
+        ZkHosts hosts = new ZkHosts("localhost:2181");
+        SpoutConfig spoutConfig = new SpoutConfig(hosts, "topic", "/test", "id");
+
+        Broker broker = new Broker("localhost", 9100);
+        Partition testPartition = new Partition(broker, 1);
+
+        partitionStateManager = new KafkaBackedPartitionStateManager(stormConf, spoutConfig, testPartition, dataStore);
+    }
+
+    @Test
+    public void testReadState() throws Exception {
+
+        when(dataStore.read()).thenReturn(stateJson);
+
+        Map state =  partitionStateManager.getState();
+
+        assertEquals("kafka.sample.net", ((Map)state.get("broker")).get("host"));
+        assertEquals(9092L, ((Map)state.get("broker")).get("port"));
+        assertEquals(4285L, state.get("offset"));
+        assertEquals(1L, state.get("partition"));
+        assertEquals(4285L, state.get("offset"));
+        assertEquals("testTopic", state.get("topic"));
+        assertEquals("fce905ff-25e0 -409e-bc3a-d855f 787d13b", ((Map)state.get("topology")).get("id"));
+        assertEquals("Test Topology", ((Map)state.get("topology")).get("name"));
+    }
+
+    @Test
+    public void testWriteState() throws Exception {
+
+        Map broker = ImmutableMap.of("host", "kafka.sample.net", "port", 9092L);
+        Map topology = ImmutableMap.of("id", "fce905ff-25e0 -409e-bc3a-d855f 787d13b", "name", "Test Topology");
+        Map state = ImmutableMap.of("broker", broker, "offset", 4285L, "partition", 1L, "topic", "testTopic", "topology", topology);
+
+        partitionStateManager.writeState(state);
+
+        verify(dataStore).write(eq(4285L), anyString());
+    }
+}

--- a/external/storm-kafka/src/test/storm/kafka/KafkaDataSourceTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/KafkaDataSourceTest.java
@@ -1,0 +1,62 @@
+package storm.kafka;
+
+import kafka.javaapi.producer.Producer;
+import kafka.producer.KeyedMessage;
+import kafka.producer.ProducerConfig;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class KafkaDataSourceTest {
+
+    private KafkaTestBroker testBroker;
+    private KafkaDataStore dataStore;
+
+    @Before
+    public void setUp() throws Exception {
+        String testTopic = "testTopic";
+
+        TestingServer server = new TestingServer();
+        testBroker = new KafkaTestBroker(server, 0);
+        String connectionString = server.getConnectString();
+
+        Properties props = new Properties();
+        props.put("metadata.broker.list", testBroker.getBrokerConnectionString());
+        Producer p = new Producer(new ProducerConfig(props));
+        KeyedMessage msg = new KeyedMessage(testTopic, "test message".getBytes());
+        p.send(msg);
+
+        ZkHosts hosts = new ZkHosts(connectionString);
+        SpoutConfig spoutConfig = new SpoutConfig(hosts, testTopic, "/", "testConsumerGroup");
+
+        Map stormConf = new HashMap();
+
+        Broker broker = new Broker("localhost", testBroker.getPort());
+        Partition testPartition = new Partition(broker, 0);
+
+        dataStore = new KafkaDataStore(stormConf, spoutConfig, testPartition);
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        testBroker.shutdown();
+    }
+
+    @Test
+    public void testStoreReadWrite() {
+        Long offset = 100L;
+        String testData = "abcdefg";
+
+        dataStore.write(offset, testData);
+        String readBack = dataStore.read();
+
+        assertEquals(testData, readBack);
+    }
+}

--- a/external/storm-kafka/src/test/storm/kafka/KafkaUtilsTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/KafkaUtilsTest.java
@@ -26,7 +26,6 @@ import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.MessageAndOffset;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -113,7 +112,7 @@ public class KafkaUtilsTest {
 
     @Test
     public void getOffsetFromConfigAndDontForceFromStart() {
-        config.ignoreZkOffsets = false;
+        config.ignoreStoredOffsets = false;
         config.startOffsetTime = OffsetRequest.EarliestTime();
         createTopicAndSendMessage();
         long latestOffset = KafkaUtils.getOffset(simpleConsumer, config.topic, 0, OffsetRequest.EarliestTime());
@@ -123,7 +122,7 @@ public class KafkaUtilsTest {
 
     @Test
     public void getOffsetFromConfigAndFroceFromStart() {
-        config.ignoreZkOffsets = true;
+        config.ignoreStoredOffsets = true;
         config.startOffsetTime = OffsetRequest.EarliestTime();
         createTopicAndSendMessage();
         long earliestOffset = KafkaUtils.getOffset(simpleConsumer, config.topic, 0, OffsetRequest.EarliestTime());

--- a/external/storm-kafka/src/test/storm/kafka/ZKBackedPartitionStateManagerTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/ZKBackedPartitionStateManagerTest.java
@@ -1,0 +1,82 @@
+package storm.kafka;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+
+public class ZKBackedPartitionStateManagerTest {
+
+    @Mock
+    private ZkDataStore dataStore;
+
+    private String stateJson = "{\n" +
+                    "    \"broker\": {\n" +
+                    "        \"host\": \"kafka.sample.net\",\n" +
+                    "        \"port\": 9092\n" +
+                    "    },\n" +
+                    "    \"offset\": 4285,\n" +
+                    "    \"partition\": 1,\n" +
+                    "    \"topic\": \"testTopic\",\n" +
+                    "    \"topology\": {\n" +
+                    "        \"id\": \"fce905ff-25e0 -409e-bc3a-d855f 787d13b\",\n" +
+                    "        \"name\": \"Test Topology\"\n" +
+                    "    }\n" +
+                    "}";
+
+    private ZKBackedPartitionStateManager partitionStateManager;
+
+
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        Map stormConf = new HashMap();
+
+        ZkHosts hosts = new ZkHosts("localhost:2181");
+        SpoutConfig spoutConfig = new SpoutConfig(hosts, "topic", "/test", "id");
+
+        Broker broker = new Broker("localhost", 9100);
+        Partition testPartition = new Partition(broker, 1);
+
+        partitionStateManager = new ZKBackedPartitionStateManager(stormConf, spoutConfig, testPartition, dataStore);
+    }
+
+    @Test
+    public void testReadState() throws Exception {
+
+        when(dataStore.read("/test/id/partition_1")).thenReturn(stateJson.getBytes());
+
+        Map state =  partitionStateManager.getState();
+
+        assertEquals("kafka.sample.net", ((Map)state.get("broker")).get("host"));
+        assertEquals(9092L, ((Map)state.get("broker")).get("port"));
+        assertEquals(4285L, state.get("offset"));
+        assertEquals(1L, state.get("partition"));
+        assertEquals(4285L, state.get("offset"));
+        assertEquals("testTopic", state.get("topic"));
+        assertEquals("fce905ff-25e0 -409e-bc3a-d855f 787d13b", ((Map)state.get("topology")).get("id"));
+        assertEquals("Test Topology", ((Map)state.get("topology")).get("name"));
+    }
+
+    @Test
+    public void testWriteState() throws Exception {
+
+        Map broker = ImmutableMap.of("host", "kafka.sample.net", "port", 9092L);
+        Map topology = ImmutableMap.of("id", "fce905ff-25e0 -409e-bc3a-d855f 787d13b", "name", "Test Topology");
+        Map state = ImmutableMap.of("broker", broker, "offset", 4285L, "partition", 1L, "topic", "testTopic", "topology", topology);
+
+        partitionStateManager.writeState(state);
+
+        verify(dataStore).write(eq("/test/id/partition_1"), any(byte[].class));
+    }
+}

--- a/external/storm-kafka/src/test/storm/kafka/ZKDataSourceTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/ZKDataSourceTest.java
@@ -1,0 +1,67 @@
+package storm.kafka;
+
+import backtype.storm.Config;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ZKDataSourceTest {
+
+    private TestingServer server;
+    private ZkDataStore dataStore;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        server = new TestingServer();
+        String connectionString = server.getConnectString();
+        ZkHosts hosts = new ZkHosts(connectionString);
+
+        SpoutConfig spoutConfig;
+        spoutConfig = new SpoutConfig(hosts, "topic", "/test", "id");
+        spoutConfig.zkServers = Arrays.asList("localhost");
+        spoutConfig.zkPort = server.getPort();
+
+        Map stormConf = new HashMap();
+        stormConf.put(Config.TRANSACTIONAL_ZOOKEEPER_PORT, spoutConfig.zkPort);
+        stormConf.put(Config.TRANSACTIONAL_ZOOKEEPER_SERVERS, spoutConfig.zkServers);
+        stormConf.put(Config.STORM_ZOOKEEPER_SESSION_TIMEOUT, 20000);
+        stormConf.put(Config.STORM_ZOOKEEPER_CONNECTION_TIMEOUT, 20000);
+        stormConf.put(Config.STORM_ZOOKEEPER_RETRY_TIMES, 3);
+        stormConf.put(Config.STORM_ZOOKEEPER_RETRY_INTERVAL, 30);
+
+        Map storeConfig = new HashMap(stormConf);
+        storeConfig.put(Config.TRANSACTIONAL_ZOOKEEPER_SERVERS, spoutConfig.zkServers);
+        storeConfig.put(Config.TRANSACTIONAL_ZOOKEEPER_PORT, spoutConfig.zkPort);
+        storeConfig.put(Config.TRANSACTIONAL_ZOOKEEPER_ROOT, spoutConfig.zkRoot);
+
+        dataStore = new ZkDataStore(storeConfig);
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        dataStore.close();
+        server.close();
+    }
+
+    @Test
+    public void testStoreReadWrite() {
+
+        String dataPath = "/myplace";
+        String testData = "abcdefg";
+
+        dataStore.write(dataPath, testData.getBytes());
+        String readBack = new String(dataStore.read(dataPath));
+
+        assertEquals(testData, readBack);
+    }
+}

--- a/external/storm-redis/pom.xml
+++ b/external/storm-redis/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.apache.storm</groupId>
     <artifactId>storm</artifactId>
-    <version>0.11.0-SNAPSHOT</version>
+    <version>0.11.0-CXT-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Storm</name>
     <description>Distributed and fault-tolerant realtime computation</description>

--- a/storm-buildtools/maven-shade-clojure-transformer/pom.xml
+++ b/storm-buildtools/maven-shade-clojure-transformer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/storm-buildtools/storm-maven-plugins/pom.xml
+++ b/storm-buildtools/storm-maven-plugins/pom.xml
@@ -22,7 +22,7 @@
   <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
   </parent>
   <groupId>org.apache.storm</groupId>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <groupId>org.apache.storm</groupId>

--- a/storm-dist/binary/pom.xml
+++ b/storm-dist/binary/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.storm</groupId>

--- a/storm-dist/source/pom.xml
+++ b/storm-dist/source/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.storm</groupId>

--- a/storm-multilang/javascript/pom.xml
+++ b/storm-multilang/javascript/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.storm</groupId>

--- a/storm-multilang/python/pom.xml
+++ b/storm-multilang/python/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.storm</groupId>

--- a/storm-multilang/ruby/pom.xml
+++ b/storm-multilang/ruby/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>0.11.0-CXT-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.storm</groupId>


### PR DESCRIPTION
Current Kafka spout stores the offsets (and some other states) inside ZK with its proprietary format.  This does not work well with other Kafka offset monitoring tools such as Burrow, KafkaOffsetMonitor etc. In addition, the performance does not scale well compared with offsets managed by Kafka's built-in offset management api.  I have added a new option for Kafka to store the same data using Kafka's built-in offset management capability.  The change is completely backward compatible with the current ZK storage option.  The feature can be turned on by a single configuration option.  Hope this will help people who wants to explore the option of using  Kafka's built-in offset management api.

-thanks 