### PR TITLE
[STORM-1005]replace default storm.local.dir value to absolute path.

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -22,7 +22,7 @@ java.library.path: "/usr/local/lib:/opt/local/lib:/usr/lib"
 
 ### storm.* configs are general configurations
 # the local dir is where jars are kept
-storm.local.dir: "storm-local"
+storm.local.dir: "/var/storm-local"
 storm.log4j2.conf.dir: "log4j2"
 storm.zookeeper.servers:
     - "localhost"

--- a/docs/documentation/Setting-up-a-Storm-cluster.md
+++ b/docs/documentation/Setting-up-a-Storm-cluster.md
@@ -52,10 +52,13 @@ storm.zookeeper.servers:
 
 If the port that your Zookeeper cluster uses is different than the default, you should set **storm.zookeeper.port** as well.
 
-2) **storm.local.dir**: The Nimbus and Supervisor daemons require a directory on the local disk to store small amounts of state (like jars, confs, and things like that). You should create that directory on each machine, give it proper permissions, and then fill in the directory location using this config. For example:
+2) **storm.local.dir**: The Nimbus and Supervisor daemons require a directory on the local disk to store small amounts of state (like jars, confs, and things like that).
+ You should create that directory on each machine, give it proper permissions, and then fill in the directory location using this config.
+ You'd better set it to absolute path rather than relative path,otherwise it will cause unexpected behavior when you launch daemons
+ from different directories.For example:
 
 ```yaml
-storm.local.dir: "/mnt/storm"
+storm.local.dir: "/var/storm-local"
 ```
 
 3) **nimbus.host**: The worker nodes need to know which machine is the master in order to download topology jars and confs. For example:

--- a/storm-core/src/clj/backtype/storm/config.clj
+++ b/storm-core/src/clj/backtype/storm/config.clj
@@ -102,7 +102,7 @@
 ;
 ; ### storm.* configs are general configurations
 ; # the local dir is where jars are kept
-; storm.local.dir: "/mnt/storm"
+; storm.local.dir: "/var/storm-local"
 ; storm.zookeeper.port: 2181
 ; storm.zookeeper.root: "/storm"
 


### PR DESCRIPTION
One of my supervisors shutdown by it self after running for a few weeks.After I restart the supervisor from         another directory(actually I don't remember which directory I started the supervisor at first.Then the workers running on that machine become wild.They running as usual,but the supervisor can't detect them,and I can't shutdown them with `storm kill`.When I submit a new topology,the supervisor will try to start new a worker with the port running workers already used,it will cause failure.

It's hard form a typical user to know why such exception happens,so I think it's better to set storm.local.dir as a absolute path.

If `storm.local.dir` can be set to `$STORM_HOME/storm-local`,it may be best.But it seems yaml file only support constant values.