### PR TITLE
[STORM-1024] Pass -Dstorm.log.dir arg to LogWriter

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -696,6 +696,7 @@
                      (str "-Dstorm.id=" storm-id)
                      (str "-Dworker.id=" worker-id)
                      (str "-Dworker.port=" port)
+                     (str "-Dstorm.log.dir=" storm-log-dir)
                      (str "-Dlog4j.configurationFile=" storm-log4j2-conf-dir file-path-separator "worker.xml")
                      "backtype.storm.LogWriter"]
                     [(java-cmd) "-server"]


### PR DESCRIPTION
The log4j variable `${sys:storm.log.dir}` is used in `worker.xml` to set the fileName however the system property was not being set while launching worker (via LogWriter) causing a directory by the name ${sys:storm.log.dir} to be created under `STORM_HOME` dir.

This fix is to pass the system property while launching LogWriter