### PR TITLE
[STORM-1007] Added tuple arrival rate and tuple sojourn time to QueueMetrics

### DIFF
--- a/storm-core/src/jvm/backtype/storm/utils/RateTracker.java
+++ b/storm-core/src/jvm/backtype/storm/utils/RateTracker.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.utils;
+
+import java.util.*;
+
+/**
+ * This class is a utility to track the rate.
+ */
+public class RateTracker{
+    /* number of slides to keep in the history. */
+    public final int _numOfSlides; // number of slides to keep in the history
+
+    public final int _slideSizeInMils;
+    private final long[] _histograms;// an array storing the number of element for each time slide.
+
+    private int _currentValidSlideNum;
+
+    private static Timer _timer = new Timer();
+
+    /**
+     * @param validTimeWindowInMils events that happened before validTimeWindowInMils are not considered
+     *                        when reporting the rate.
+     * @param numOfSlides the number of time sildes to divide validTimeWindows. The more slides,
+     *                    the smother the reported results will be.
+     */
+    public RateTracker(int validTimeWindowInMils, int numOfSlides) {
+        this(validTimeWindowInMils, numOfSlides, false);
+    }
+
+    /**
+     * Constructor
+     * @param validTimeWindowInMils events that happened before validTimeWindow are not considered
+     *                        when reporting the rate.
+     * @param numOfSlides the number of time sildes to divide validTimeWindows. The more slides,
+     *                    the smother the reported results will be.
+     * @param simulate set true if it use simulated time rather than system time for testing purpose.
+     */
+    public RateTracker(int validTimeWindowInMils, int numOfSlides, boolean simulate ){
+        _numOfSlides = Math.max(numOfSlides, 1);
+        _slideSizeInMils = validTimeWindowInMils / _numOfSlides;
+        if (_slideSizeInMils < 1 ) {
+            throw new IllegalArgumentException("Illeggal argument for RateTracker");
+        }
+        assert(_slideSizeInMils > 1);
+        _histograms = new long[_numOfSlides];
+        Arrays.fill(_histograms,0L);
+        if(!simulate) {
+            _timer.scheduleAtFixedRate(new Fresher(), _slideSizeInMils, _slideSizeInMils);
+        }
+        _currentValidSlideNum = 1;
+    }
+
+    /**
+     * Notify the tracker upon new arrivals
+     *
+     * @param count number of arrivals
+     */
+    public void notify(long count) {
+        _histograms[_histograms.length-1]+=count;
+    }
+
+    /**
+     * Return the average rate in slides.
+     *
+     * @return the average rate
+     */
+    public final float reportRate() {
+        long sum = 0;
+        long duration = _currentValidSlideNum * _slideSizeInMils;
+        for(int i=_numOfSlides - _currentValidSlideNum; i < _numOfSlides; i++ ){
+            sum += _histograms[i];
+        }
+
+        return sum / (float) duration * 1000;
+    }
+
+    public final void forceUpdateSlides(int numToEclipse) {
+
+        for(int i=0; i< numToEclipse; i++) {
+            updateSlides();
+        }
+
+    }
+
+    private void updateSlides(){
+
+        for (int i = 0; i < _numOfSlides - 1; i++) {
+            _histograms[i] = _histograms[i + 1];
+        }
+
+        _histograms[_histograms.length - 1] = 0;
+
+        _currentValidSlideNum = Math.min(_currentValidSlideNum + 1, _numOfSlides);
+    }
+
+    private class Fresher extends TimerTask {
+        public void run () {
+            updateSlides();
+        }
+    }
+
+
+}

--- a/storm-core/test/jvm/backtype/storm/utils/RateTrackerTest.java
+++ b/storm-core/test/jvm/backtype/storm/utils/RateTrackerTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/storm-core/test/jvm/backtype/storm/utils/RateTrackerTest.java
+++ b/storm-core/test/jvm/backtype/storm/utils/RateTrackerTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import junit.framework.TestCase;
+
+/**
+ * Unit test for RateTracker
+ */
+public class RateTrackerTest extends TestCase {
+
+    @Test
+    public void testEclipsedAllWindows() {
+        RateTracker rt = new RateTracker(10000, 10, true);
+        rt.notify(10);
+        rt.forceUpdateSlides(10);
+        assert (rt.reportRate() == 0);
+    }
+
+    @Test
+    public void testEclipsedOneWindow() {
+        RateTracker rt = new RateTracker(10000, 10, true);
+        rt.notify(1);
+        float r1 = rt.reportRate();
+        rt.forceUpdateSlides(1);
+        rt.notify(1);
+        float r2 = rt.reportRate();
+
+        System.out.format("r1:%f, r2:%f\n", r1, r2);
+
+        assert (r1 == r2);
+    }
+
+    @Test
+    public void testEclipsedNineWindows() {
+        RateTracker rt = new RateTracker(10000, 10, true);
+        rt.notify(1);
+        float r1 = rt.reportRate();
+        rt.forceUpdateSlides(9);
+        rt.notify(9);
+        float r2 = rt.reportRate();
+
+        assert (r1 == r2);
+    }
+}


### PR DESCRIPTION
I added two important metrics, namely *arrival time* and *sojourn time*, to QueueMetrics. 

Modification Summary:
1. Created a new RateTracker utility, which could report instantaneous rate upon certain event;
2. Added test cases for RateTracker;
3. Added arrival rate and sojourn time metrics to QueueMetrics; 
4. Use sampling in QueueMetrics to reduce the metric maintenance cost. 

Such metrics are very useful to performance tuning, especially for application with strong constraint on processing latency such as threat detection and smart traffic. A high sojourn time, for example, indicates that a higher degree of parallelism should be applied to the current bolt in order to reduce processing delay. 

Any comment or suggestion regarding to this pull request is welcomed. 

Thanks.

