### PR TITLE
[STORM-1032] Add generics to component configuration methods

### DIFF
--- a/docs/documentation/Tutorial.md
+++ b/docs/documentation/Tutorial.md
@@ -160,7 +160,7 @@ public static class ExclamationBolt implements IRichBolt {
     }
     
     @Override
-    public Map getComponentConfiguration() {
+    public Map<String, Object> getComponentConfiguration() {
         return null;
     }
 }

--- a/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/trident/TridentEsTopology.java
+++ b/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/trident/TridentEsTopology.java
@@ -126,7 +126,7 @@ public class TridentEsTopology {
         }
 
         @Override
-        public Map getComponentConfiguration() {
+        public Map<String, Object> getComponentConfiguration() {
             Config conf = new Config();
             conf.setMaxTaskParallelism(1);
             return conf;

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/trident/OpaqueTridentEventHubSpout.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/trident/OpaqueTridentEventHubSpout.java
@@ -40,7 +40,7 @@ public class OpaqueTridentEventHubSpout implements IOpaquePartitionedTridentSpou
   }
 
   @Override
-  public Map getComponentConfiguration() {
+  public Map<String, Object> getComponentConfiguration() {
     return null;
   }
 

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/trident/TransactionalTridentEventHubSpout.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/trident/TransactionalTridentEventHubSpout.java
@@ -42,7 +42,7 @@ public class TransactionalTridentEventHubSpout implements
   }
   
   @Override
-  public Map getComponentConfiguration() {
+  public Map<String, Object> getComponentConfiguration() {
     return null;
   }
 

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/trident/FixedBatchSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/trident/FixedBatchSpout.java
@@ -84,7 +84,7 @@ public class FixedBatchSpout implements IBatchSpout {
     }
 
     @Override
-    public Map getComponentConfiguration() {
+    public Map<String, Object> getComponentConfiguration() {
         Config conf = new Config();
         conf.setMaxTaskParallelism(1);
         return conf;

--- a/external/storm-hive/src/test/java/org/apache/storm/hive/trident/TridentHiveTopology.java
+++ b/external/storm-hive/src/test/java/org/apache/storm/hive/trident/TridentHiveTopology.java
@@ -179,7 +179,7 @@ public class TridentHiveTopology {
         }
 
         @Override
-        public Map getComponentConfiguration() {
+        public Map<String, Object> getComponentConfiguration() {
             Config conf = new Config();
             conf.setMaxTaskParallelism(1);
             return conf;

--- a/storm-core/src/jvm/backtype/storm/coordination/BatchSubtopologyBuilder.java
+++ b/storm-core/src/jvm/backtype/storm/coordination/BatchSubtopologyBuilder.java
@@ -132,7 +132,7 @@ public class BatchSubtopologyBuilder {
         public IRichBolt bolt;
         public Integer parallelism;
         public List<InputDeclaration> declarations = new ArrayList<InputDeclaration>();
-        public List<Map> componentConfs = new ArrayList<Map>();
+        public List<Map<String, Object>> componentConfs = new ArrayList<>();
         
         public Component(IRichBolt bolt, Integer parallelism) {
             this.bolt = bolt;
@@ -439,7 +439,7 @@ public class BatchSubtopologyBuilder {
         }
 
         @Override
-        public BoltDeclarer addConfigurations(Map conf) {
+        public BoltDeclarer addConfigurations(Map<String, Object> conf) {
             _component.componentConfs.add(conf);
             return this;
         }

--- a/storm-core/src/jvm/backtype/storm/drpc/LinearDRPCTopologyBuilder.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/LinearDRPCTopologyBuilder.java
@@ -120,7 +120,7 @@ public class LinearDRPCTopologyBuilder {
                     new CoordinatedBolt(component.bolt, source, idSpec),
                     component.parallelism);
             
-            for(Map conf: component.componentConfs) {
+            for(Map<String, Object> conf: component.componentConfs) {
                 declarer.addConfigurations(conf);
             }
             
@@ -174,13 +174,12 @@ public class LinearDRPCTopologyBuilder {
     private static class Component {
         public IRichBolt bolt;
         public int parallelism;
-        public List<Map> componentConfs;
+        public List<Map<String, Object>> componentConfs = new ArrayList<>();
         public List<InputDeclaration> declarations = new ArrayList<InputDeclaration>();
         
         public Component(IRichBolt bolt, int parallelism) {
             this.bolt = bolt;
             this.parallelism = parallelism;
-            this.componentConfs = new ArrayList();
         }
     }
     
@@ -386,7 +385,7 @@ public class LinearDRPCTopologyBuilder {
         }
 
         @Override
-        public LinearDRPCInputDeclarer addConfigurations(Map conf) {
+        public LinearDRPCInputDeclarer addConfigurations(Map<String, Object> conf) {
             _component.componentConfs.add(conf);
             return this;
         }

--- a/storm-core/src/jvm/backtype/storm/topology/BaseConfigurationDeclarer.java
+++ b/storm-core/src/jvm/backtype/storm/topology/BaseConfigurationDeclarer.java
@@ -24,7 +24,7 @@ import java.util.Map;
 public abstract class BaseConfigurationDeclarer<T extends ComponentConfigurationDeclarer> implements ComponentConfigurationDeclarer<T> {
     @Override
     public T addConfiguration(String config, Object value) {
-        Map configMap = new HashMap();
+        Map<String, Object> configMap = new HashMap<>();
         configMap.put(config, value);
         return addConfigurations(configMap);
     }

--- a/storm-core/src/jvm/backtype/storm/topology/ComponentConfigurationDeclarer.java
+++ b/storm-core/src/jvm/backtype/storm/topology/ComponentConfigurationDeclarer.java
@@ -20,7 +20,7 @@ package backtype.storm.topology;
 import java.util.Map;
 
 public interface ComponentConfigurationDeclarer<T extends ComponentConfigurationDeclarer> {
-    T addConfigurations(Map conf);
+    T addConfigurations(Map<String, Object> conf);
     T addConfiguration(String config, Object value);
     T setDebug(boolean debug);
     T setMaxTaskParallelism(Number val);

--- a/storm-core/src/jvm/backtype/storm/topology/TopologyBuilder.java
+++ b/storm-core/src/jvm/backtype/storm/topology/TopologyBuilder.java
@@ -246,7 +246,7 @@ public class TopologyBuilder {
         }
         
         @Override
-        public T addConfigurations(Map conf) {
+        public T addConfigurations(Map<String, Object> conf) {
             if(conf!=null && conf.containsKey(Config.TOPOLOGY_KRYO_REGISTER)) {
                 throw new IllegalArgumentException("Cannot set serializations for a component using fluent API");
             }

--- a/storm-core/src/jvm/backtype/storm/transactional/TransactionalTopologyBuilder.java
+++ b/storm-core/src/jvm/backtype/storm/transactional/TransactionalTopologyBuilder.java
@@ -61,7 +61,7 @@ public class TransactionalTopologyBuilder {
     ITransactionalSpout _spout;
     Map<String, Component> _bolts = new HashMap<String, Component>();
     Integer _spoutParallelism;
-    List<Map> _spoutConfs = new ArrayList();
+    List<Map<String, Object>> _spoutConfs = new ArrayList<>();
     
     // id is used to store the state of this transactionalspout in zookeeper
     // it would be very dangerous to have 2 topologies active with the same id in the same cluster    
@@ -132,7 +132,7 @@ public class TransactionalTopologyBuilder {
         String coordinator = _spoutId + "/coordinator";
         TopologyBuilder builder = new TopologyBuilder();
         SpoutDeclarer declarer = builder.setSpout(coordinator, new TransactionalSpoutCoordinator(_spout));
-        for(Map conf: _spoutConfs) {
+        for(Map<String, Object> conf: _spoutConfs) {
             declarer.addConfigurations(conf);
         }
         declarer.addConfiguration(Config.TOPOLOGY_TRANSACTIONAL_ID, _id);
@@ -196,7 +196,7 @@ public class TransactionalTopologyBuilder {
         public IRichBolt bolt;
         public Integer parallelism;
         public List<InputDeclaration> declarations = new ArrayList<InputDeclaration>();
-        public List<Map> componentConfs = new ArrayList<Map>();
+        public List<Map<String, Object>> componentConfs = new ArrayList<>();
         public boolean committer;
         
         public Component(IRichBolt bolt, Integer parallelism, boolean committer) {
@@ -213,7 +213,7 @@ public class TransactionalTopologyBuilder {
     
     private class SpoutDeclarerImpl extends BaseConfigurationDeclarer<SpoutDeclarer> implements SpoutDeclarer {
         @Override
-        public SpoutDeclarer addConfigurations(Map conf) {
+        public SpoutDeclarer addConfigurations(Map<String, Object> conf) {
             _spoutConfs.add(conf);
             return this;
         }        
@@ -513,7 +513,7 @@ public class TransactionalTopologyBuilder {
         }
 
         @Override
-        public BoltDeclarer addConfigurations(Map conf) {
+        public BoltDeclarer addConfigurations(Map<String, Object> conf) {
             _component.componentConfs.add(conf);
             return this;
         }

--- a/storm-core/src/jvm/storm/trident/spout/BatchSpoutExecutor.java
+++ b/storm-core/src/jvm/storm/trident/spout/BatchSpoutExecutor.java
@@ -80,7 +80,7 @@ public class BatchSpoutExecutor implements ITridentSpout {
     }
 
     @Override
-    public Map getComponentConfiguration() {
+    public Map<String, Object> getComponentConfiguration() {
         return _spout.getComponentConfiguration();
     }
 

--- a/storm-core/src/jvm/storm/trident/spout/IBatchSpout.java
+++ b/storm-core/src/jvm/storm/trident/spout/IBatchSpout.java
@@ -28,6 +28,6 @@ public interface IBatchSpout extends Serializable {
     void emitBatch(long batchId, TridentCollector collector);
     void ack(long batchId);
     void close();
-    Map getComponentConfiguration();
+    Map<String, Object> getComponentConfiguration();
     Fields getOutputFields();
 }

--- a/storm-core/src/jvm/storm/trident/spout/IOpaquePartitionedTridentSpout.java
+++ b/storm-core/src/jvm/storm/trident/spout/IOpaquePartitionedTridentSpout.java
@@ -57,6 +57,6 @@ public interface IOpaquePartitionedTridentSpout<Partitions, Partition extends IS
     
     Emitter<Partitions, Partition, M> getEmitter(Map conf, TopologyContext context);     
     Coordinator getCoordinator(Map conf, TopologyContext context);     
-    Map getComponentConfiguration();
+    Map<String, Object> getComponentConfiguration();
     Fields getOutputFields();
 }

--- a/storm-core/src/jvm/storm/trident/spout/IPartitionedTridentSpout.java
+++ b/storm-core/src/jvm/storm/trident/spout/IPartitionedTridentSpout.java
@@ -72,6 +72,6 @@ public interface IPartitionedTridentSpout<Partitions, Partition extends ISpoutPa
     Coordinator<Partitions> getCoordinator(Map conf, TopologyContext context);
     Emitter<Partitions, Partition, T> getEmitter(Map conf, TopologyContext context);
     
-    Map getComponentConfiguration();
+    Map<String, Object> getComponentConfiguration();
     Fields getOutputFields();
 }

--- a/storm-core/src/jvm/storm/trident/spout/ITridentSpout.java
+++ b/storm-core/src/jvm/storm/trident/spout/ITridentSpout.java
@@ -89,6 +89,6 @@ public interface ITridentSpout<T> extends Serializable {
      */    
     Emitter<T> getEmitter(String txStateId, Map conf, TopologyContext context); 
     
-    Map getComponentConfiguration();
+    Map<String, Object> getComponentConfiguration();
     Fields getOutputFields();
 }

--- a/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchExecutor.java
+++ b/storm-core/src/jvm/storm/trident/spout/RichSpoutBatchExecutor.java
@@ -41,7 +41,7 @@ public class RichSpoutBatchExecutor implements ITridentSpout {
     }
 
     @Override
-    public Map getComponentConfiguration() {
+    public Map<String, Object> getComponentConfiguration() {
         return _spout.getComponentConfiguration();
     }
 

--- a/storm-core/src/jvm/storm/trident/testing/FeederBatchSpout.java
+++ b/storm-core/src/jvm/storm/trident/testing/FeederBatchSpout.java
@@ -157,7 +157,7 @@ public class FeederBatchSpout implements ITridentSpout, IFeeder {
     
     
     @Override
-    public Map getComponentConfiguration() {
+    public Map<String, Object> getComponentConfiguration() {
         return null;
     }
 

--- a/storm-core/src/jvm/storm/trident/testing/FeederCommitterBatchSpout.java
+++ b/storm-core/src/jvm/storm/trident/testing/FeederCommitterBatchSpout.java
@@ -84,7 +84,7 @@ public class FeederCommitterBatchSpout implements ICommitterTridentSpout, IFeede
     }
 
     @Override
-    public Map getComponentConfiguration() {
+    public Map<String, Object> getComponentConfiguration() {
         return _spout.getComponentConfiguration();
     }
 

--- a/storm-core/src/jvm/storm/trident/testing/FixedBatchSpout.java
+++ b/storm-core/src/jvm/storm/trident/testing/FixedBatchSpout.java
@@ -83,7 +83,7 @@ public class FixedBatchSpout implements IBatchSpout {
     }
 
     @Override
-    public Map getComponentConfiguration() {
+    public Map<String, Object> getComponentConfiguration() {
         Config conf = new Config();
         conf.setMaxTaskParallelism(1);
         return conf;

--- a/storm-core/src/jvm/storm/trident/topology/TridentTopologyBuilder.java
+++ b/storm-core/src/jvm/storm/trident/topology/TridentTopologyBuilder.java
@@ -161,7 +161,7 @@ public class TridentTopologyBuilder {
                         .globalGrouping(masterCoordinator(c.batchGroupId), MasterBatchCoordinator.BATCH_STREAM_ID)
                         .globalGrouping(masterCoordinator(c.batchGroupId), MasterBatchCoordinator.SUCCESS_STREAM_ID);
                 
-                for(Map m: c.componentConfs) {
+                for(Map<String, Object> m: c.componentConfs) {
                     scd.addConfigurations(m);
                 }
                 
@@ -181,7 +181,7 @@ public class TridentTopologyBuilder {
                 if(c.spout instanceof ICommitterTridentSpout) {
                     bd.allGrouping(masterCoordinator(batchGroup), MasterBatchCoordinator.COMMIT_STREAM_ID);
                 }
-                for(Map m: c.componentConfs) {
+                for(Map<String, Object> m: c.componentConfs) {
                     bd.addConfigurations(m);
                 }
             }
@@ -191,7 +191,7 @@ public class TridentTopologyBuilder {
             SpoutComponent c = _batchPerTupleSpouts.get(id);
             SpoutDeclarer d = builder.setSpout(id, new RichSpoutBatchTriggerer((IRichSpout) c.spout, c.streamName, c.batchGroupId), c.parallelism);
             
-            for(Map conf: c.componentConfs) {
+            for(Map<String, Object> conf: c.componentConfs) {
                 d.addConfigurations(conf);
             }
         }
@@ -204,7 +204,7 @@ public class TridentTopologyBuilder {
         for(String id: _bolts.keySet()) {
             Component c = _bolts.get(id);
             
-            Map<String, CoordSpec> specs = new HashMap();
+            Map<String, CoordSpec> specs = new HashMap<>();
             
             for(GlobalStreamId s: getBoltSubscriptionStreams(id)) {
                 String batch = batchIdsForBolts.get(s);
@@ -224,7 +224,7 @@ public class TridentTopologyBuilder {
             }
             
             BoltDeclarer d = builder.setBolt(id, new TridentBoltExecutor(c.bolt, batchIdsForBolts, specs), c.parallelism);
-            for(Map conf: c.componentConfs) {
+            for(Map<String, Object> conf: c.componentConfs) {
                 d.addConfigurations(conf);
             }
             
@@ -257,7 +257,7 @@ public class TridentTopologyBuilder {
     private static class SpoutComponent {
         public Object spout;
         public Integer parallelism;
-        public List<Map> componentConfs = new ArrayList<Map>();
+        public List<Map<String, Object>> componentConfs = new ArrayList<>();
         String batchGroupId;
         String streamName;
         
@@ -292,7 +292,7 @@ public class TridentTopologyBuilder {
         public ITridentBatchBolt bolt;
         public Integer parallelism;
         public List<InputDeclaration> declarations = new ArrayList<InputDeclaration>();
-        public List<Map> componentConfs = new ArrayList<Map>();
+        public List<Map<String, Object>> componentConfs = new ArrayList<>();
         public Set<String> committerBatches;
         
         public Component(ITridentBatchBolt bolt, Integer parallelism,Set<String> committerBatches) {
@@ -340,7 +340,7 @@ public class TridentTopologyBuilder {
         }
         
         @Override
-        public SpoutDeclarer addConfigurations(Map conf) {
+        public SpoutDeclarer addConfigurations(Map<String, Object> conf) {
             _component.componentConfs.add(conf);
             return this;
         }        
@@ -725,7 +725,7 @@ public class TridentTopologyBuilder {
         }
 
         @Override
-        public BoltDeclarer addConfigurations(Map conf) {
+        public BoltDeclarer addConfigurations(Map<String, Object> conf) {
             _component.componentConfs.add(conf);
             return this;
         }


### PR DESCRIPTION
The getComponentConfiguration methods currently return a simple Map object. In fact they should be returning a Map<String, Object>. 
By changing this, it will make it slightly clear what is being returned by the method and potentially pick up some issues at compile time. 