### PR TITLE
STORM-1033 replace closer.cgi to closer.lua

### DIFF
--- a/docs/downloads.html
+++ b/docs/downloads.html
@@ -32,22 +32,22 @@ older:
   The list of changes for this release can be found <a href="https://github.com/apache/storm/blob/v0.10.0-beta1/CHANGELOG.md">here.</a>
 
   <ul>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.tar.gz">apache-storm-0.10.0-beta1.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.tar.gz">apache-storm-0.10.0-beta1.tar.gz</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.zip">apache-storm-0.10.0-beta1.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.zip">apache-storm-0.10.0-beta1.zip</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.zip.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.zip.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1.zip.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.tar.gz">apache-storm-0.10.0-beta1-src.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.tar.gz">apache-storm-0.10.0-beta1-src.tar.gz</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.zip">apache-storm-0.10.0-beta1-src.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.zip">apache-storm-0.10.0-beta1-src.zip</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.zip.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.zip.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.10.0-beta1/apache-storm-0.10.0-beta1-src.zip.md5">MD5</a>]
@@ -68,22 +68,22 @@ older:
   The list of changes for this release can be found <a href="https://github.com/apache/storm/blob/v0.9.5/CHANGELOG.md">here.</a>
 
   <ul>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.5/apache-storm-0.9.5.tar.gz">apache-storm-0.9.5.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.5/apache-storm-0.9.5.tar.gz">apache-storm-0.9.5.tar.gz</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.5/apache-storm-0.9.5.zip">apache-storm-0.9.5.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.5/apache-storm-0.9.5.zip">apache-storm-0.9.5.zip</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5.zip.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5.zip.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5.zip.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.tar.gz">apache-storm-0.9.5-src.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.tar.gz">apache-storm-0.9.5-src.tar.gz</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.zip">apache-storm-0.9.5-src.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.zip">apache-storm-0.9.5-src.zip</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.zip.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.zip.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.5/apache-storm-0.9.5-src.zip.md5">MD5</a>]
@@ -108,22 +108,22 @@ version: 0.9.5
   <b>0.9.4</b>
   
   <ul>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.4/apache-storm-0.9.4.tar.gz">apache-storm-0.9.4.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.4/apache-storm-0.9.4.tar.gz">apache-storm-0.9.4.tar.gz</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.4/apache-storm-0.9.4.zip">apache-storm-0.9.4.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.4/apache-storm-0.9.4.zip">apache-storm-0.9.4.zip</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4.zip.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4.zip.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4.zip.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.tar.gz">apache-storm-0.9.4-src.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.tar.gz">apache-storm-0.9.4-src.tar.gz</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.zip">apache-storm-0.9.4-src.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.zip">apache-storm-0.9.4-src.zip</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.zip.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.zip.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.4/apache-storm-0.9.4-src.zip.md5">MD5</a>]
@@ -133,22 +133,22 @@ version: 0.9.5
   <b>0.9.3</b>
   
   <ul>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz">apache-storm-0.9.3.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz">apache-storm-0.9.3.tar.gz</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.3/apache-storm-0.9.3.zip">apache-storm-0.9.3.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.3/apache-storm-0.9.3.zip">apache-storm-0.9.3.zip</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3.zip.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3.zip.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3.zip.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.tar.gz">apache-storm-0.9.3-src.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.tar.gz">apache-storm-0.9.3-src.tar.gz</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.zip">apache-storm-0.9.3-src.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.zip">apache-storm-0.9.3-src.zip</a>
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.zip.asc">PGP</a>]
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.zip.sha">SHA512</a>] 
 	     [<a href="http://www.us.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3-src.zip.md5">MD5</a>]
@@ -159,22 +159,22 @@ version: 0.9.5
   <b>0.9.2-incubating</b>
   
   <ul>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.tar.gz">apache-storm-0.9.2-incubating.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.tar.gz">apache-storm-0.9.2-incubating.tar.gz</a>
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.zip">apache-storm-0.9.2-incubating.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.zip">apache-storm-0.9.2-incubating.zip</a>
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.zip.asc">PGP</a>]
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.zip.sha">SHA512</a>] 
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating.zip.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.tar.gz">apache-storm-0.9.2-incubating-src.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.tar.gz">apache-storm-0.9.2-incubating-src.tar.gz</a>
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.zip">apache-storm-0.9.2-incubating-src.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.zip">apache-storm-0.9.2-incubating-src.zip</a>
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.zip.asc">PGP</a>]
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.zip.sha">SHA512</a>] 
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.2-incubating/apache-storm-0.9.2-incubating-src.zip.md5">MD5</a>]
@@ -185,22 +185,22 @@ version: 0.9.5
   <b>0.9.1-incubating</b>
   
   <ul>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.tar.gz">apache-storm-0.9.1-incubating.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.tar.gz">apache-storm-0.9.1-incubating.tar.gz</a>
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.zip">apache-storm-0.9.1-incubating.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.zip">apache-storm-0.9.1-incubating.zip</a>
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.zip.asc">PGP</a>]
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.zip.sha">SHA512</a>] 
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating.zip.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.tar.gz">apache-storm-0.9.1-incubating-src.tar.gz</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.tar.gz">apache-storm-0.9.1-incubating-src.tar.gz</a>
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.tar.gz.asc">PGP</a>]
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.tar.gz.sha">SHA512</a>] 
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.tar.gz.md5">MD5</a>]
 	  </li>
-	  <li><a href="http://www.apache.org/dyn/closer.cgi/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.zip">apache-storm-0.9.1-incubating-src.zip</a>
+	  <li><a href="http://www.apache.org/dyn/closer.lua/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.zip">apache-storm-0.9.1-incubating-src.zip</a>
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.zip.asc">PGP</a>]
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.zip.sha">SHA512</a>] 
 	     [<a href="http://www.apache.org/dist/storm/apache-storm-0.9.1-incubating/apache-storm-0.9.1-incubating-src.zip.md5">MD5</a>]


### PR DESCRIPTION
Please refer https://issues.apache.org/jira/browse/STORM-1033 for more details.

I don't know where to create link for download.html, so if it's created automatically, please fix it there.