### PR TITLE
[STORM-1037] do not remove storm-code in supervisor until kill job

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -485,7 +485,7 @@
       ;; resources don't exist
       (if on-windows? (shutdown-disallowed-workers supervisor))
       (doseq [storm-id downloaded-storm-ids]
-        (when-not (assigned-storm-ids storm-id)
+        (when-not (storm-code-map storm-id)
           (log-message "Removing code for storm id "
                        storm-id)
           (try


### PR DESCRIPTION
nimbus maybe reschedule topology to this supervisor later, so supervisor need not to re-download code.

Signed-off-by: Xinze Chi <xmdxcxz@gmail.com>