### PR TITLE
STORM-1039: Remove commons-codec shading, commons-codec is used by ha…

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -379,7 +379,6 @@
                             <include>org.apache.commons:commons-compress</include>
                             <include>org.apache.commons:commons-exec</include>
                             <include>commons-io:commons-io</include>
-                            <include>commons-codec:commons-codec</include>
                             <include>commons-fileupload:commons-fileupload</include>
                             <include>commons-lang:commons-lang</include>
                             <include>com.googlecode.json-simple:json-simple</include>
@@ -493,10 +492,6 @@
                         <relocation>
                           <pattern>org.apache.commons.io</pattern>
                           <shadedPattern>org.apache.storm.commons.io</shadedPattern>
-                        </relocation>
-                        <relocation>
-                          <pattern>org.apache.commons.codec</pattern>
-                          <shadedPattern>org.apache.storm.commons.codec</shadedPattern>
                         </relocation>
                         <relocation>
                           <pattern>org.apache.commons.fileupload</pattern>
@@ -617,14 +612,7 @@
                                 <exclude>META-INF/NOTICE.txt</exclude>
                             </excludes>
                         </filter>
-                        <filter>
-                            <artifact>commons-codec:commons-codec</artifact>
-                            <excludes>
-                                <exclude>META-INF/LICENSE.txt</exclude>
-                                <exclude>META-INF/NOTICE.txt</exclude>
-                            </excludes>
-                        </filter>
-                        <filter>
+                       <filter>
                             <artifact>commons-fileupload:commons-fileupload</artifact>
                             <excludes>
                                 <exclude>META-INF/LICENSE.txt</exclude>

--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -50,7 +50,6 @@
                 <exclude>org.apache.commons:commons-compress</exclude>
                 <exclude>org.apache.commons:commons-exec</exclude>
                 <exclude>commons-io:commons-io</exclude>
-                <exclude>commons-codec:commons-codec</exclude>
                 <exclude>commons-fileupload:commons-fileupload</exclude>
                 <exclude>commons-lang:commons-lang</exclude>
                 <exclude>com.googlecode.json-simple:json-simple</exclude>


### PR DESCRIPTION
…doop authentication library which is used during ui authentication in secured environment.
