### PR TITLE
configurable supervisor log filename

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -77,6 +77,7 @@ if (not os.path.isfile(os.path.join(USER_CONF_DIR, "storm.yaml"))):
 STORM_LIB_DIR = os.path.join(STORM_DIR, "lib")
 STORM_BIN_DIR = os.path.join(STORM_DIR, "bin")
 STORM_LOG4J2_CONF_DIR = os.path.join(STORM_DIR, "log4j2")
+STORM_SUPERVISOR_LOG_FILE = os.getenv('STORM_SUPERVISOR_LOG_FILE', "supervisor.log")
 
 init_storm_env()
 
@@ -401,7 +402,7 @@ def supervisor(klass="backtype.storm.daemon.supervisor"):
     """
     cppaths = [CLUSTER_CONF_DIR]
     jvmopts = parse_args(confvalue("supervisor.childopts", cppaths)) + [
-        "-Dlogfile.name=supervisor.log",
+        "-Dlogfile.name=" + STORM_SUPERVISOR_LOG_FILE,
         "-Dlog4j.configurationFile=" + os.path.join(get_log4j2_conf_dir(), "cluster.xml"),
     ]
     exec_storm_class(


### PR DESCRIPTION
For the storm-on-mesos project there are multiple Storm Supervisors on
every worker host.  Each of these Supervisors is dedicated to a
particular topology.  A challenge with this design is that the shared
supervisor log file contains logs from every single topology that
has run on a particular host.  We instead want the option to have
separate supervisor log files for each topology, so that topology owners
can more easily debug their own problems.

This change allows having configurable log files for every launch of
the Supervisor, since we will be able to embed the topology ID into the
supervisor log filename.

Notably, storm-0.10 already includes a similar change for the worker
log filenames (came in with Yahoo!'s multi-tenant changes).