### PR TITLE
added missing installation instructions for installation of rvm and n…

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -222,6 +222,23 @@ To pull in a merge request you should generally follow the command line instruct
 
 # Build the code and run the tests
 
+## Prerequisites
+In order to build `storm` you need `python`, `ruby` and `nodejs`. In order to avoid an overful page we don't provide platform/OS specific installation instructions for those here. Please refer to you platform's/OS' documentation for support.
+
+The `ruby` package manager `rvm` and `nodejs` package manager `nvm` are for convenience and are used in the tests which run on [travis](https://travis-ci.org/apache/storm). They can be installed using `curl -L https://get.rvm.io | bash -s stable --autolibs=enabled && source ~/.profile` (see the [rvm installation instructions](https://github.com/rvm/rvm) for details) and `wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.26.1/install.sh | bash && source ~/.bashrc` (see the [nvm installation instructions](https://github.com/creationix/nvm) for details).
+
+With `rvm` and `nvm` installed you can run
+
+```sh
+rvm use 2.1.5 --install
+nvm install 0.12.2
+nvm use 0.12.2
+```
+
+in order to get started as fast as possible. Users can still install a specific version of `ruby` and/or `node` manually.
+
+## Building
+
 The following commands must be run from the top-level directory.
 
     # Build the code and run the tests (requires nodejs, python and ruby installed) 
@@ -242,6 +259,8 @@ In case you modified `storm.thrift`, you have to regenerate thrift code as java 
 cd storm-core/src
 sh genthrift.sh
 ```
+
+## Testing
 
 You can also run tests selectively via the Clojure REPL.  The following example runs the tests in
 [auth_test.clj](storm-core/test/clj/backtype/storm/security/auth/auth_test.clj), which has the namespace

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -284,6 +284,8 @@ Now we run the tests in `auth_test.clj` in the REPL:
 > Sometimes you may find that tests pass/fail depending on which REPL you use, which -- although frustrating --
 > can be helpful to narrow down errors.
 
+Unfortunately you might experience failures in clojure tests which are wrapped in the `maven-clojure-plugin` and thus doesn't provide too much useful output at first sight - you might end up with a maven test failure with an error message as unhelpful as `Clojure failed.`. In this case it's recommended to look into `target/test-reports` of the failed project to see what actual tests have failed or scroll through the maven output looking for obvious issues like missing binaries.
+
 
 <a name="packaging"></a>
 


### PR DESCRIPTION
…vm of DEVELOPER.md (without running \`mvn clean install\`) isn't possible on an average system (like Ubuntu 15.04) and subheadings to increase readability