### PR TITLE
configurable supervisor log filename (0.9.x-branch)

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -71,6 +71,8 @@ else:
 if (not os.path.isfile(USER_CONF_DIR + "/storm.yaml")):
     USER_CONF_DIR = CLUSTER_CONF_DIR
 
+STORM_SUPERVISOR_LOG_FILE = os.getenv('STORM_SUPERVISOR_LOG_FILE', "supervisor.log")
+
 init_storm_env()
 
 CONFIG_OPTS = []
@@ -326,7 +328,7 @@ def supervisor(klass="backtype.storm.daemon.supervisor"):
     """
     cppaths = [CLUSTER_CONF_DIR]
     jvmopts = parse_args(confvalue("supervisor.childopts", cppaths)) + [
-        "-Dlogfile.name=supervisor.log",
+        "-Dlogfile.name=" + STORM_SUPERVISOR_LOG_FILE,
         "-Dlogback.configurationFile=" + STORM_DIR + "/logback/cluster.xml",
     ]
     exec_storm_class(


### PR DESCRIPTION
For the storm-on-mesos project there are multiple Storm Supervisors on
every worker host. Each of these Supervisors is dedicated to a
particular topology. A challenge with this design is that the shared
supervisor log file contains logs from every single topology that
has run on a particular host. We instead want the option to have
separate supervisor log files for each topology, so that topology owners
can more easily debug their own problems.

This change allows having configurable log files for every launch of
the Supervisor, since we will be able to embed the topology ID into the
supervisor log filename.

Notably, storm-0.10 already includes a similar change for the worker
log filenames (came in with Yahoo!'s multi-tenant changes).