### PR TITLE
STORM-1050:Topologies with same name run on one cluster

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -1181,6 +1181,7 @@
             ;; lock protects against multiple topologies being submitted at once and
             ;; cleanup thread killing topology in b/w assignment and starting the topology
             (locking (:submit-lock nimbus)
+              (check-storm-active! nimbus storm-name false)
               ;;cred-update-lock is not needed here because creds are being added for the first time.
               (.set-credentials! storm-cluster-state storm-id credentials storm-conf)
               (setup-storm-code nimbus conf storm-id uploadedJarLocation storm-conf topology)


### PR DESCRIPTION
When a topology is submitted repeatedly very closely, or nimbus is too busy to response the  repeated submit RPC calls from same topology, there is very high probability that nimbus receive the repeatedly calls of the same topology, and finally several topologies with same name will be running on storm cluster.