### PR TITLE
[STORM-1051] Fix for flushMessagse NPE

### DIFF
--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
@@ -317,7 +317,7 @@ public class Client extends ConnectionWithStatus implements IStatefulObject {
      * If the write operation fails, then we will close the channel and trigger a reconnect.
      */
     private void flushMessages(Channel channel, final MessageBatch batch) {
-        if(batch.isEmpty()){
+        if(null == batch || batch.isEmpty()){
             return;
         }
 


### PR DESCRIPTION
STORM-763 introduced a situation in which flushMessages could receive batch = null, in which case, an NPE is thrown because we weren't validating != null