### PR TITLE
STORM-1059: Upgrade Storm to use Clojure 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <test.extra.args>-Djava.net.preferIPv4Stack=true</test.extra.args>
 
         <!-- dependency versions -->
-        <clojure.version>1.6.0</clojure.version>
+        <clojure.version>1.7.0</clojure.version>
         <compojure.version>1.1.3</compojure.version>
         <hiccup.version>0.3.6</hiccup.version>
         <commons-io.version>2.4</commons-io.version>

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -755,10 +755,6 @@
           rest-elems (apply interleave-all (map rest colls))]
       (concat my-elems rest-elems))))
 
-(defn update
-  [m k afn]
-  (assoc m k (afn (get m k))))
-
 (defn any-intersection
   [& sets]
   (let [elem->count (multi-set (apply concat sets))]


### PR DESCRIPTION
All tests passed for me, and ran sample topologies without trouble.