### PR TITLE
[STORM-1058] create CLI kill_workers to kill workers on a supervisor node

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -352,7 +352,7 @@ def kill_workers(*args):
     """Syntax: [storm kill_workers]
 
     Kill the workers running on this supervisor. This command should be run
-    on a supervisor node. If the cluster is running in secure node, then user needs 
+    on a supervisor node. If the cluster is running in secure mode, then user needs
     to have admin rights on the node to be able to successfully kill all workers.
     """
     exec_storm_class(

--- a/bin/storm.py
+++ b/bin/storm.py
@@ -348,6 +348,19 @@ def get_errors(*args):
         jvmtype="-client",
         extrajars=[USER_CONF_DIR, os.path.join(STORM_DIR, "bin")])
 
+def kill_workers(*args):
+    """Syntax: [storm kill_workers]
+
+    Kill the workers running on this supervisor. This command should be run
+    on a supervisor node. If the cluster is running in secure node, then user needs 
+    to have admin rights on the node to be able to successfully kill all workers.
+    """
+    exec_storm_class(
+        "backtype.storm.command.kill_workers",
+        args=args,
+        jvmtype="-client",
+        extrajars=[USER_CONF_DIR, os.path.join(STORM_DIR, "bin")])
+
 def shell(resourcesdir, command, *args):
     tmpjarpath = "stormshell" + str(random.randint(0, 10000000)) + ".jar"
     os.system("jar cf %s %s" % (tmpjarpath, resourcesdir))
@@ -561,7 +574,8 @@ COMMANDS = {"jar": jar, "kill": kill, "shell": shell, "nimbus": nimbus, "ui": ui
             "remoteconfvalue": print_remoteconfvalue, "repl": repl, "classpath": print_classpath,
             "activate": activate, "deactivate": deactivate, "rebalance": rebalance, "help": print_usage,
             "list": listtopos, "dev-zookeeper": dev_zookeeper, "version": version, "monitor": monitor,
-            "upload-credentials": upload_credentials, "get-errors": get_errors }
+            "upload-credentials": upload_credentials, "get-errors": get_errors,
+            "kill_workers": kill_workers }
 
 def parse_config(config_list):
     global CONFIG_OPTS

--- a/storm-core/src/clj/backtype/storm/command/kill_workers.clj
+++ b/storm-core/src/clj/backtype/storm/command/kill_workers.clj
@@ -1,0 +1,33 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns backtype.storm.command.kill-workers
+  (:import [java.io File])
+  (:use [backtype.storm.daemon common])
+  (:use [backtype.storm util config])
+  (:require [backtype.storm.daemon
+             [supervisor :as supervisor]])
+  (:gen-class))
+
+(defn -main 
+  "Construct the supervisor-data from scratch and kill the workers on this supervisor"
+  [& args]
+  (let [conf (read-storm-config)
+        conf (assoc conf STORM-LOCAL-DIR (. (File. (conf STORM-LOCAL-DIR)) getCanonicalPath))
+        isupervisor (supervisor/standalone-supervisor)
+        supervisor-data (supervisor/supervisor-data conf nil isupervisor)
+        ids (supervisor/my-worker-ids conf)]
+    (doseq [id ids]
+      (supervisor/shutdown-worker supervisor-data id))))

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -647,7 +647,6 @@
           
           (let [active? @(:storm-active-atom executor-data)
                 curr-count (.get emitted-count)
-                ;; suspend-time ((:storm-conf executor-data) BACKPRESSURE-SPOUT-SUSPEND-TIME-MS)
                 backpressure-enabled ((:storm-conf executor-data) TOPOLOGY-BACKPRESSURE-ENABLE)
                 throttle-on (and backpressure-enabled
                               @(:throttle-on (:worker executor-data)))


### PR DESCRIPTION
Kill all the workers running on this supervisor. 
Currently there is no direct way to kill all the running workers on a supervisor node from a command line. In addition, if the supervisor dies, the workers will not suicide automatically. 
Also, this CLI can be called by future node health-check script to cleanly shutdown a supervisor on an problematic node.
