### PR TITLE
STORM-1060. Serialize Calcite plans into JSON format.

### DIFF
--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/CalcitePlanSerializer.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/CalcitePlanSerializer.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.sql.compiler;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.base.Joiner;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.util.Pair;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+public class CalcitePlanSerializer extends PostOrderRelNodeVisitor<Void> {
+  private final TypeSerializer typeSerializer = new TypeSerializer();
+  private final ExprSerializer exprSerializer = new ExprSerializer(
+      typeSerializer);
+  private final RelDataTypeFactory sqlTypeFactory = new SqlTypeFactoryImpl(
+      RelDataTypeSystem.DEFAULT);
+
+  private final SchemaPlus schema;
+  private final RelNode tree;
+  private JsonGenerator jg;
+
+  public CalcitePlanSerializer(SchemaPlus schema, RelNode tree) {
+    this.schema = schema;
+    this.tree = tree;
+  }
+
+  public String toJson() throws Exception {
+    StringWriter sw = new StringWriter();
+    JsonFactory jsonFactory = new JsonFactory();
+    try {
+      jg = jsonFactory.createGenerator(sw);
+      jg.writeStartObject();
+      jg.writeNumberField("result", tree.getId());
+      jg.writeArrayFieldStart("tables");
+      serializeDependency(tree);
+      jg.writeEndArray();
+      jg.writeArrayFieldStart("stages");
+      traverse(tree);
+      jg.writeEndArray();
+      jg.writeEndObject();
+    } finally {
+      jg.close();
+    }
+    return sw.toString();
+  }
+
+  private void serializeDependency(RelNode root)
+      throws IOException {
+    if (root == null) {
+      return;
+    }
+    for (RelNode n : root.getInputs()) {
+      serializeDependency(n);
+    }
+    if (root instanceof TableScan) {
+      jg.writeStartObject();
+      String name = Joiner.on('.').join(root.getTable().getQualifiedName());
+      jg.writeStringField("name", name);
+      jg.writeArrayFieldStart("fields");
+      Table t = schema.getTable(name);
+      RelDataType type = t.getRowType(sqlTypeFactory);
+      for (RelDataTypeField field : type.getFieldList()) {
+        jg.writeStartObject();
+        jg.writeStringField("name", field.getName());
+        jg.writeFieldName("type");
+        typeSerializer.serialize(jg, field.getType());
+        jg.writeEndObject();
+      }
+      jg.writeEndArray();
+      jg.writeEndObject();
+    }
+  }
+
+  @Override
+  Void defaultValue(RelNode n) {
+    throw new UnsupportedOperationException("Unsupported RelNode: " + n
+        .getClass().getSimpleName());
+  }
+
+  @Override
+  Void visitFilter(Filter filter) throws Exception {
+    jg.writeStartObject();
+    writeCommonFieldsForRelNode(jg, filter);
+    jg.writeFieldName("expr");
+    exprSerializer.serialize(jg, filter.getCondition());
+    jg.writeEndObject();
+    return null;
+  }
+
+  @Override
+  Void visitProject(Project project) throws Exception {
+    jg.writeStartObject();
+    writeCommonFieldsForRelNode(jg, project);
+    jg.writeArrayFieldStart("exprs");
+    for (Pair<RexNode, String> p : project.getNamedProjects()) {
+      jg.writeStartObject();
+      jg.writeStringField("name", p.getValue());
+      jg.writeFieldName("expr");
+      exprSerializer.serialize(jg, p.getKey());
+      jg.writeEndObject();
+    }
+    jg.writeEndArray();
+    jg.writeEndObject();
+    return null;
+  }
+
+  @Override
+  Void visitTableScan(TableScan scan) throws Exception {
+    jg.writeStartObject();
+    writeCommonFieldsForRelNode(jg, scan);
+    jg.writeStringField("table",
+                        Joiner.on(",").join(scan.getTable().getQualifiedName()));
+    jg.writeEndObject();
+    return null;
+  }
+
+  private void writeCommonFieldsForRelNode(
+      JsonGenerator jg, RelNode n) throws IOException {
+    jg.writeStringField("type", n.getClass().getSimpleName());
+    jg.writeNumberField("id", n.getId());
+    jg.writeArrayFieldStart("inputs");
+    for (RelNode input : n.getInputs()) {
+      jg.writeNumber(input.getId());
+    }
+    jg.writeEndArray();
+  }
+}

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/ExprSerializer.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/ExprSerializer.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.sql.compiler;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexCorrelVariable;
+import org.apache.calcite.rex.RexDynamicParam;
+import org.apache.calcite.rex.RexFieldAccess;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexLocalRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexOver;
+import org.apache.calcite.rex.RexRangeRef;
+import org.apache.calcite.rex.RexVisitor;
+
+import java.io.IOException;
+
+class ExprSerializer {
+  private final TypeSerializer typeSerializer;
+
+  public ExprSerializer(TypeSerializer typeSerializer) {
+    this.typeSerializer = typeSerializer;
+  }
+
+  public void serialize(JsonGenerator jg, RexNode n) throws IOException {
+    new Serializer(jg).serialize(n);
+  }
+
+  private class Serializer implements RexVisitor<Void> {
+    private final JsonGenerator jg;
+
+    private Serializer(JsonGenerator jg) {
+      this.jg = jg;
+    }
+
+    private void serialize(RexNode n) throws IOException {
+      jg.writeStartObject();
+      jg.writeFieldName("type");
+      typeSerializer.serialize(jg, n.getType());
+      jg.writeObjectFieldStart("value");
+      n.accept(this);
+      jg.writeEndObject();
+      jg.writeEndObject();
+    }
+
+    @Override
+    public Void visitInputRef(RexInputRef inputRef) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visitLocalRef(RexLocalRef localRef) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visitLiteral(RexLiteral literal) {
+      try {
+        jg.writeStringField("inst", "literal");
+        jg.writeStringField("value", literal.getValue().toString());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return null;
+    }
+
+    @Override
+    public Void visitCall(RexCall call) {
+      try {
+        jg.writeStringField("inst", "call");
+        jg.writeStringField("operator", call.getOperator().getName());
+        jg.writeArrayFieldStart("operands");
+        for (RexNode operand : call.getOperands()) {
+          serialize(operand);
+        }
+        jg.writeEndArray();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return null;
+    }
+
+    @Override
+    public Void visitOver(RexOver over) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visitCorrelVariable(
+        RexCorrelVariable correlVariable) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visitDynamicParam(
+        RexDynamicParam dynamicParam) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visitRangeRef(RexRangeRef rangeRef) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Void visitFieldAccess(RexFieldAccess fieldAccess) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/PostOrderRelNodeVisitor.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/PostOrderRelNodeVisitor.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.sql.compiler;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Calc;
+import org.apache.calcite.rel.core.Collect;
+import org.apache.calcite.rel.core.Correlate;
+import org.apache.calcite.rel.core.Exchange;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Sample;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.core.Uncollect;
+import org.apache.calcite.rel.core.Window;
+import org.apache.calcite.rel.stream.Delta;
+
+abstract class PostOrderRelNodeVisitor<T> {
+  final T traverse(RelNode n) throws Exception {
+    for (RelNode input : n.getInputs()) {
+      traverse(input);
+    }
+
+    if (n instanceof Aggregate) {
+      return visitAggregate((Aggregate) n);
+    } else if (n instanceof Calc) {
+      return visitCalc((Calc) n);
+    } else if (n instanceof Collect) {
+      return visitCollect((Collect) n);
+    } else if (n instanceof Correlate) {
+      return visitCorrelate((Correlate) n);
+    } else if (n instanceof Delta) {
+      return visitDelta((Delta) n);
+    } else if (n instanceof Exchange) {
+      return visitExchange((Exchange) n);
+    } else if (n instanceof Project) {
+      return visitProject((Project) n);
+    } else if (n instanceof Filter) {
+      return visitFilter((Filter) n);
+    } else if (n instanceof Sample) {
+      return visitSample((Sample) n);
+    } else if (n instanceof Sort) {
+      return visitSort((Sort) n);
+    } else if (n instanceof TableScan) {
+      return visitTableScan((TableScan) n);
+    } else if (n instanceof Uncollect) {
+      return visitUncollect((Uncollect) n);
+    } else if (n instanceof Window) {
+      return visitWindow((Window) n);
+    } else {
+      return defaultValue(n);
+    }
+  }
+
+  T visitAggregate(Aggregate aggregate) throws Exception {
+    return defaultValue(aggregate);
+  }
+
+  T visitCalc(Calc calc) throws Exception {
+    return defaultValue(calc);
+  }
+
+  T visitCollect(Collect collect) throws Exception {
+    return defaultValue(collect);
+  }
+
+  T visitCorrelate(Correlate correlate) throws Exception {
+    return defaultValue(correlate);
+  }
+
+  T visitDelta(Delta delta) throws Exception {
+    return defaultValue(delta);
+  }
+
+  T visitExchange(Exchange exchange) throws Exception {
+    return defaultValue(exchange);
+  }
+
+  T visitProject(Project project) throws Exception {
+    return defaultValue(project);
+  }
+
+  T visitFilter(Filter filter) throws Exception {
+    return defaultValue(filter);
+  }
+
+  T visitSample(Sample sample) throws Exception {
+    return defaultValue(sample);
+  }
+
+  T visitSort(Sort sort) throws Exception {
+    return defaultValue(sort);
+  }
+
+  T visitTableScan(TableScan scan) throws Exception {
+    return defaultValue(scan);
+  }
+
+  T visitUncollect(Uncollect uncollect) throws Exception {
+    return defaultValue(uncollect);
+  }
+
+  T visitWindow(Window window) throws Exception {
+    return defaultValue(window);
+  }
+
+  T defaultValue(RelNode n) {
+    return null;
+  }
+}

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/TypeSerializer.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/TypeSerializer.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.sql.compiler;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.type.BasicSqlType;
+
+import java.io.IOException;
+
+class TypeSerializer {
+  public void serialize(JsonGenerator jg, RelDataType type) throws IOException {
+    if (type instanceof BasicSqlType) {
+      jg.writeString(type.getSqlTypeName().getName());
+    } else {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/TestCalcitePlanSerializer.java
+++ b/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/TestCalcitePlanSerializer.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.sql.compiler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.Planner;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestCalcitePlanSerializer {
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSerializeTableSchema() throws Exception {
+    SchemaPlus schema = Frameworks.createRootSchema(true);
+    Table table = TestUtils.newTable().field("ID", SqlTypeName.INTEGER).build();
+    schema.add("FOO", table);
+    FrameworkConfig config = Frameworks.newConfigBuilder().defaultSchema(
+        schema).build();
+    Planner planner = Frameworks.getPlanner(config);
+    String sql = "SELECT 1 + 2 FROM FOO WHERE 5 > 3";
+    SqlNode parse = planner.parse(sql);
+    SqlNode validate = planner.validate(parse);
+    RelNode tree = planner.convert(validate);
+    String res = new CalcitePlanSerializer(schema, tree).toJson();
+
+    ObjectMapper m = new ObjectMapper();
+    HashMap<String, Object> o = m.readValue(res, HashMap.class);
+    List<HashMap<String, Object>> tables = (List<HashMap<String, Object>>) o.get(
+        "tables");
+    HashMap<String, Object> t = tables.get(0);
+    assertEquals("FOO", t.get("name"));
+    List<HashMap<String, Object>> fields = (List<HashMap<String, Object>>) t.get(
+        "fields");
+    assertEquals(1, fields.size());
+    HashMap<String, Object> field = fields.get(0);
+    assertEquals("ID", field.get("name"));
+    assertEquals("INTEGER", field.get("type"));
+  }
+}

--- a/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/TestUtils.java
+++ b/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/TestUtils.java
@@ -1,0 +1,92 @@
+package org.apache.storm.sql.compiler;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.Statistics;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.ArrayList;
+
+class TestUtils {
+  static class TableBuilderInfo {
+    private static class FieldType {
+      private static final int NO_PRECISION = -1;
+      private final String name;
+      private final SqlTypeName type;
+      private final int precision;
+
+      private FieldType(String name, SqlTypeName type, int precision) {
+        this.name = name;
+        this.type = type;
+        this.precision = precision;
+      }
+
+      private FieldType(String name, SqlTypeName type) {
+        this(name, type, NO_PRECISION);
+      }
+    }
+
+    private final ArrayList<FieldType> fields = new ArrayList<>();
+    private final ArrayList<Object[]> rows = new ArrayList<>();
+    private Statistic stats;
+
+    TableBuilderInfo field(String name, SqlTypeName type) {
+      fields.add(new FieldType(name, type));
+      return this;
+    }
+
+    TableBuilderInfo field(String name, SqlTypeName type, int precision) {
+      fields.add(new FieldType(name, type, precision));
+      return this;
+    }
+
+    TableBuilderInfo statistics(Statistic stats) {
+      this.stats = stats;
+      return this;
+    }
+
+    TableBuilderInfo rows(Object[] data) {
+      rows.add(data);
+      return this;
+    }
+
+    Table build() {
+      final Statistic stat = stats;
+      return new Table() {
+        @Override
+        public RelDataType getRowType(
+            RelDataTypeFactory relDataTypeFactory) {
+          RelDataTypeFactory.FieldInfoBuilder b = relDataTypeFactory.builder();
+          for (FieldType f : fields) {
+            if (f.precision == FieldType.NO_PRECISION) {
+              b.add(f.name, f.type);
+            } else {
+              b.add(f.name, f.type, f.precision);
+            }
+          }
+          return b.build();
+        }
+
+        @Override
+        public Statistic getStatistic() {
+          return stat != null ? stat : Statistics.of(rows.size(),
+                                                     ImmutableList.<ImmutableBitSet>of());
+        }
+
+        @Override
+        public Schema.TableType getJdbcTableType() {
+          return Schema.TableType.TABLE;
+        }
+      };
+    }
+  }
+
+  static TableBuilderInfo newTable() {
+    return new TableBuilderInfo();
+  }
+}


### PR DESCRIPTION
This PR provides an implementation to serialize the results of Calcite to JSON strings. The JSON strings will be passed down to the optimizers and code generators to generate the Storm bolts or Trident functions.