### PR TITLE
advance kafka offset when deserializer yields no object

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -136,7 +136,7 @@ public class PartitionManager {
                 return EmitState.NO_EMITTED;
             }
             Iterable<List<Object>> tups = KafkaUtils.generateTuples(_spoutConfig, toEmit.msg);
-            if ((tups != null) && (tups.size() > 0)) {
+            if ((tups != null) && tups.iterator.hasNext()) {
                 if(_spoutConfig.topicAsStreamId) {
                     for (List<Object> tup : tups) {
                         collector.emit(_spoutConfig.topic, tup, new KafkaMessageId(_partition, toEmit.offset));

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -136,7 +136,7 @@ public class PartitionManager {
                 return EmitState.NO_EMITTED;
             }
             Iterable<List<Object>> tups = KafkaUtils.generateTuples(_spoutConfig, toEmit.msg);
-            if ((tups != null) && tups.iterator.hasNext()) {
+            if ((tups != null) && tups.iterator().hasNext()) {
                 if(_spoutConfig.topicAsStreamId) {
                     for (List<Object> tup : tups) {
                         collector.emit(_spoutConfig.topic, tup, new KafkaMessageId(_partition, toEmit.offset));

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -136,15 +136,15 @@ public class PartitionManager {
                 return EmitState.NO_EMITTED;
             }
             Iterable<List<Object>> tups = KafkaUtils.generateTuples(_spoutConfig, toEmit.msg);
-            if (tups != null) {
-		if(_spoutConfig.topicAsStreamId) {
-	            for (List<Object> tup : tups) {
-			collector.emit(_spoutConfig.topic, tup, new KafkaMessageId(_partition, toEmit.offset));
-		    }
-		} else {
-		    for (List<Object> tup : tups) {
-			collector.emit(tup, new KafkaMessageId(_partition, toEmit.offset));
-		    }
+            if ((tups != null) && (tups.size() > 0)) {
+                if(_spoutConfig.topicAsStreamId) {
+                    for (List<Object> tup : tups) {
+                        collector.emit(_spoutConfig.topic, tup, new KafkaMessageId(_partition, toEmit.offset));
+                    }
+                } else {
+                    for (List<Object> tup : tups) {
+                        collector.emit(tup, new KafkaMessageId(_partition, toEmit.offset));
+                    }
                 }
                 break;
             } else {


### PR DESCRIPTION
also removes some tab-indenting in the surrounding code.  

When a custom scheme returns an empty list of object-lists to the partition manager, it should be handled the same as null.  Otherwise, the partition reader will be stuck at that offset.

