### PR TITLE
[STORM-1063] support relative log4j conf dir for both daemons and workers

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -375,6 +375,8 @@ def get_log4j2_conf_dir():
     storm_log4j2_conf_dir = confvalue("storm.log4j2.conf.dir", cppaths)
     if(storm_log4j2_conf_dir == None or storm_log4j2_conf_dir == "nil"):
         storm_log4j2_conf_dir = STORM_LOG4J2_CONF_DIR
+    elif(not os.path.isabs(storm_log4j2_conf_dir)):
+        storm_log4j2_conf_dir = os.path.join(STORM_DIR, storm_log4j2_conf_dir)
     return storm_log4j2_conf_dir
 
 def nimbus(klass="backtype.storm.daemon.nimbus"):

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -668,7 +668,7 @@
                                   (if (is-absolute-path? storm-log-conf-dir)
                                     storm-log-conf-dir
                                     (str storm-home file-path-separator storm-log-conf-dir))
-                                  (str storm-home file-path-separator "log4j"))
+                                  (str storm-home file-path-separator "log4j2"))
           stormroot (supervisor-stormdist-root conf storm-id)
           jlp (jlp stormroot conf)
           stormjar (supervisor-stormjar-path stormroot)

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -665,7 +665,7 @@
           storm-log-dir (or (System/getProperty "storm.log.dir") (str storm-home file-path-separator "logs"))
           storm-log-conf-dir (conf STORM-LOG4J2-CONF-DIR)
           storm-log4j2-conf-dir (if storm-log-conf-dir
-                                  (if (is-absolute-path storm-log-conf-dir)
+                                  (if (is-absolute-path? storm-log-conf-dir)
                                     storm-log-conf-dir
                                     (str storm-home file-path-separator storm-log-conf-dir))
                                   (str storm-home file-path-separator "log4j"))

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -664,7 +664,11 @@
           storm-conf-file (System/getProperty "storm.conf.file")
           storm-log-dir (or (System/getProperty "storm.log.dir") (str storm-home file-path-separator "logs"))
           storm-log-conf-dir (conf STORM-LOG4J2-CONF-DIR)
-          storm-log4j2-conf-dir (or storm-log-conf-dir (str storm-home file-path-separator "log4j2"))
+          storm-log4j2-conf-dir (if storm-log-conf-dir
+                                  (if (is-absolute-path storm-log-conf-dir)
+                                    storm-log-conf-dir
+                                    (str storm-home file-path-separator storm-log-conf-dir))
+                                  (str storm-home file-path-separator "log4j"))
           stormroot (supervisor-stormdist-root conf storm-id)
           jlp (jlp stormroot conf)
           stormjar (supervisor-stormjar-path stormroot)

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -148,6 +148,8 @@ public class Config extends HashMap<String, Object> {
 
     /**
      * A directory that holds configuration files for log4j2.
+     * It can be either a relative or an absolute directory.
+     * If relative, it is relative to the storm's home directory.
      */
     public static final String STORM_LOG4J2_CONF_DIR = "storm.log4j2.conf.dir";
     public static final Object STORM_LOG4J2_CONF_DIR_SCHEMA = String.class;


### PR DESCRIPTION
An easier fix might be dropping the default configuration of "log4j" and force users to provide complete path, however, we still prefer to support relative path of log4j conf dir.