### PR TITLE
[STORM-1068], configure request.required.acks in KafkaUtilsTest

### DIFF
--- a/external/storm-kafka/src/test/storm/kafka/KafkaUtilsTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/KafkaUtilsTest.java
@@ -195,6 +195,7 @@ public class KafkaUtilsTest {
 
     private void createTopicAndSendMessage(String key, String value) {
         Properties p = new Properties();
+        p.put("request.required.acks", "1");
         p.put("serializer.class", "kafka.serializer.StringEncoder");
         p.put("bootstrap.servers", broker.getBrokerConnectionString());
         p.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");


### PR DESCRIPTION
configure request.required.acks to be 1 in KafkaUtilsTest to make sure that the send() function gets synchronized to the broker for avoiding potential offset-out-of-range error.