### PR TITLE
STORM-1151: Batching in DisruptorQueue

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -210,7 +210,6 @@ topology.executor.send.buffer.size: 1024 #individual messages
 topology.transfer.buffer.size: 1024 # batched
 topology.tick.tuple.freq.secs: null
 topology.worker.shared.thread.pool.size: 4
-topology.disruptor.wait.strategy: "com.lmax.disruptor.BlockingWaitStrategy"
 topology.spout.wait.strategy: "backtype.storm.spout.SleepSpoutWaitStrategy"
 topology.sleep.spout.wait.strategy.time.ms: 1
 topology.error.throttle.interval.secs: 10

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -222,6 +222,8 @@ topology.classpath: null
 topology.environment: null
 topology.bolts.outgoing.overflow.buffer.enable: false
 topology.disruptor.wait.timeout.millis: 1000
+topology.disruptor.batch.size: 100
+topology.disruptor.batch.timeout.millis: 1
 
 # Configs for Resource Aware Scheduler
 topology.component.resources.onheap.memory.mb: 128.0

--- a/examples/storm-starter/src/jvm/storm/starter/FastWordCountTopology.java
+++ b/examples/storm-starter/src/jvm/storm/starter/FastWordCountTopology.java
@@ -47,6 +47,13 @@ public class FastWordCountTopology {
   public static class FastRandomSentenceSpout extends BaseRichSpout {
     SpoutOutputCollector _collector;
     Random _rand;
+    private static final String[] CHOICES = {
+        "marry had a little lamb whos fleese was white as snow",
+        "and every where that marry went the lamb was sure to go",
+        "one two three four five six seven eight nine ten",
+        "this is a test of the emergency broadcast system this is only a test",
+        "peter piper picked a peck of pickeled peppers"
+    };
 
     @Override
     public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
@@ -56,9 +63,7 @@ public class FastWordCountTopology {
 
     @Override
     public void nextTuple() {
-      String[] sentences = new String[]{ "the cow jumped over the moon", "an apple a day keeps the doctor away",
-          "four score and seven years ago", "snow white and the seven dwarfs", "i am at two with nature" };
-      String sentence = sentences[_rand.nextInt(sentences.length)];
+      String sentence = CHOICES[_rand.nextInt(CHOICES.length)];
       _collector.emit(new Values(sentence), sentence);
     }
 

--- a/examples/storm-starter/src/jvm/storm/starter/FastWordCountTopology.java
+++ b/examples/storm-starter/src/jvm/storm/starter/FastWordCountTopology.java
@@ -1,0 +1,185 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package storm.starter;
+
+import backtype.storm.Config;
+import backtype.storm.StormSubmitter;
+import backtype.storm.generated.*;
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.BasicOutputCollector;
+import backtype.storm.topology.IRichBolt;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.topology.TopologyBuilder;
+import backtype.storm.topology.base.BaseBasicBolt;
+import backtype.storm.topology.base.BaseRichSpout;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.tuple.Values;
+import backtype.storm.utils.NimbusClient;
+import backtype.storm.utils.Utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * WordCount but teh spout does not stop, and the bolts are implemented in
+ * java.  This can show how fast the word count can run.
+ */
+public class FastWordCountTopology {
+  public static class FastRandomSentenceSpout extends BaseRichSpout {
+    SpoutOutputCollector _collector;
+    Random _rand;
+
+    @Override
+    public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
+      _collector = collector;
+      _rand = ThreadLocalRandom.current();
+    }
+
+    @Override
+    public void nextTuple() {
+      String[] sentences = new String[]{ "the cow jumped over the moon", "an apple a day keeps the doctor away",
+          "four score and seven years ago", "snow white and the seven dwarfs", "i am at two with nature" };
+      String sentence = sentences[_rand.nextInt(sentences.length)];
+      _collector.emit(new Values(sentence), sentence);
+    }
+
+    @Override
+    public void ack(Object id) {
+        //Ignored
+    }
+
+    @Override
+    public void fail(Object id) {
+      _collector.emit(new Values(id), id);
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+      declarer.declare(new Fields("sentence"));
+    }
+  }
+
+  public static class SplitSentence extends BaseBasicBolt {
+    @Override
+    public void execute(Tuple tuple, BasicOutputCollector collector) {
+      String sentence = tuple.getString(0);
+      for (String word: sentence.split("\\s+")) {
+          collector.emit(new Values(word, 1));
+      }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+      declarer.declare(new Fields("word", "count"));
+    }
+  }
+
+  public static class WordCount extends BaseBasicBolt {
+    Map<String, Integer> counts = new HashMap<String, Integer>();
+
+    @Override
+    public void execute(Tuple tuple, BasicOutputCollector collector) {
+      String word = tuple.getString(0);
+      Integer count = counts.get(word);
+      if (count == null)
+        count = 0;
+      count++;
+      counts.put(word, count);
+      collector.emit(new Values(word, count));
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+      declarer.declare(new Fields("word", "count"));
+    }
+  }
+
+  public static void printMetrics(Nimbus.Client client, String name) throws Exception {
+    ClusterSummary summary = client.getClusterInfo();
+    String id = null;
+    for (TopologySummary ts: summary.get_topologies()) {
+      if (name.equals(ts.get_name())) {
+        id = ts.get_id();
+      }
+    }
+    if (id == null) {
+      throw new Exception("Could not find a topology named "+name);
+    }
+    TopologyInfo info = client.getTopologyInfo(id);
+    int uptime = info.get_uptime_secs();
+    long acked = 0;
+    double weightedAvgTotal = 0.0;
+    for (ExecutorSummary exec: info.get_executors()) {
+      if ("spout".equals(exec.get_component_id())) {
+        SpoutStats stats = exec.get_stats().get_specific().get_spout();
+        Map<String, Long> ackedMap = stats.get_acked().get(":all-time");
+        Map<String, Double> avgLatMap = stats.get_complete_ms_avg().get(":all-time");
+        for (String key: ackedMap.keySet()) {
+          long ackVal = ackedMap.get(key);
+          double latVal = avgLatMap.get(key) * ackVal;
+          acked += ackVal;
+          weightedAvgTotal += latVal;
+        }
+      }
+    }
+    double avgLatency = weightedAvgTotal/acked;
+    System.out.println("uptime: "+uptime+" acked: "+acked+" avgLatency: "+avgLatency+" acked/sec: "+(((double)acked)/uptime));
+  } 
+
+  public static void kill(Nimbus.Client client, String name) throws Exception {
+    KillOptions opts = new KillOptions();
+    opts.set_wait_secs(0);
+    client.killTopologyWithOpts(name, opts);
+  } 
+
+  public static void main(String[] args) throws Exception {
+
+    TopologyBuilder builder = new TopologyBuilder();
+
+    builder.setSpout("spout", new FastRandomSentenceSpout(), 4);
+
+    builder.setBolt("split", new SplitSentence(), 4).shuffleGrouping("spout");
+    builder.setBolt("count", new WordCount(), 4).fieldsGrouping("split", new Fields("word"));
+
+    Config conf = new Config();
+    conf.registerMetricsConsumer(backtype.storm.metric.LoggingMetricsConsumer.class);
+
+    String name = "wc-test";
+    if (args != null && args.length > 0) {
+        name = args[0];
+    }
+
+    conf.setNumWorkers(1);
+    StormSubmitter.submitTopologyWithProgressBar(args[0], conf, builder.createTopology());
+
+    Map clusterConf = Utils.readStormConfig();
+    clusterConf.putAll(Utils.readCommandLineOpts());
+    Nimbus.Client client = NimbusClient.getConfiguredClient(clusterConf).getClient();
+
+    //Sleep for 5 mins
+    for (int i = 0; i < 10; i++) {
+        Thread.sleep(30 * 1000);
+        printMetrics(client, name);
+    }
+    kill(client, name);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <snakeyaml.version>1.11</snakeyaml.version>
         <httpclient.version>4.3.3</httpclient.version>
         <clojure.tools.cli.version>0.2.4</clojure.tools.cli.version>
-        <disruptor.version>2.10.4</disruptor.version>
+        <disruptor.version>3.3.2</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>16.0.1</guava.version>
         <netty.version>3.9.0.Final</netty.version>
@@ -549,7 +549,7 @@
                 <version>${clojure.tools.cli.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.googlecode.disruptor</groupId>
+                <groupId>com.lmax</groupId>
                 <artifactId>disruptor</artifactId>
                 <version>${disruptor.version}</version>
             </dependency>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -205,7 +205,7 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.googlecode.disruptor</groupId>
+            <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
         </dependency>
         <dependency>

--- a/storm-core/src/clj/backtype/storm/cluster.clj
+++ b/storm-core/src/clj/backtype/storm/cluster.clj
@@ -525,10 +525,10 @@
         (let [path (backpressure-path storm-id node port)
               existed (exists-node? cluster-state path false)]
           (if existed
-            (if (not on?)
-              (delete-node cluster-state path))   ;; delete the znode since the worker is not congested
-            (if on?
-              (set-ephemeral-node cluster-state path nil acls))))) ;; create the znode since worker is congested
+            (when (not on?)
+              (delete-node cluster-state path))
+            (when on?
+              (set-ephemeral-node cluster-state path nil acls)))))
     
       (topology-backpressure
         [this storm-id callback]

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -225,8 +225,7 @@
                                   (str "executor"  executor-id "-send-queue")
                                   (storm-conf TOPOLOGY-EXECUTOR-SEND-BUFFER-SIZE)
                                   (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS)
-                                  :claim-strategy :single-threaded
-                                  :wait-strategy (storm-conf TOPOLOGY-DISRUPTOR-WAIT-STRATEGY))
+                                  :producer-type :single-threaded)
         ]
     (recursive-map
      :worker worker

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -197,23 +197,10 @@
 ;; in its own function so that it can be mocked out by tracked topologies
 (defn mk-executor-transfer-fn [batch-transfer->worker storm-conf]
   (fn this
-    ([task tuple block? ^ConcurrentLinkedQueue overflow-buffer]
-      (when (= true (storm-conf TOPOLOGY-DEBUG))
-        (log-message "TRANSFERING tuple TASK: " task " TUPLE: " tuple))
-      (if (and overflow-buffer (not (.isEmpty overflow-buffer)))
-        (.add overflow-buffer [task tuple])
-        (try-cause
-          (disruptor/publish batch-transfer->worker [task tuple] block?)
-        (catch InsufficientCapacityException e
-          (if overflow-buffer
-            (.add overflow-buffer [task tuple])
-            (throw e))
-          ))))
-    ([task tuple overflow-buffer]
-      (this task tuple (nil? overflow-buffer) overflow-buffer))
-    ([task tuple]
-      (this task tuple nil)
-      )))
+    [task tuple]
+    (when (= true (storm-conf TOPOLOGY-DEBUG))
+      (log-message "TRANSFERING tuple TASK: " task " TUPLE: " tuple))
+    (disruptor/publish batch-transfer->worker [task tuple])))
 
 (defn mk-executor-data [worker executor-id]
   (let [worker-context (worker-context worker)
@@ -225,7 +212,9 @@
                                   (str "executor"  executor-id "-send-queue")
                                   (storm-conf TOPOLOGY-EXECUTOR-SEND-BUFFER-SIZE)
                                   (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS)
-                                  :producer-type :single-threaded)
+                                  :producer-type :single-threaded
+                                  :batch-size (storm-conf TOPOLOGY-DISRUPTOR-BATCH-SIZE)
+                                  :batch-timeout (storm-conf TOPOLOGY-DISRUPTOR-BATCH-TIMEOUT-MILLIS))
         ]
     (recursive-map
      :worker worker
@@ -283,6 +272,7 @@
       "When receive queue is below lowWaterMark"
       (if @(:backpressure executor-data)
         (do (reset! (:backpressure executor-data) false)
+            (log-debug "executor " (:executor-id executor-data) " is not-congested, set backpressure flag false")
             (WorkerBackpressureThread/notifyBackpressureChecker (:backpressure-trigger (:worker executor-data))))))))
 
 (defn start-batch-transfer->worker-handler! [worker executor-data]
@@ -316,7 +306,7 @@
           [[nil (TupleImpl. worker-context [interval] Constants/SYSTEM_TASK_ID Constants/METRICS_TICK_STREAM_ID)]]))))))
 
 (defn metrics-tick
-  ([executor-data task-data ^TupleImpl tuple overflow-buffer]
+  [executor-data task-data ^TupleImpl tuple]
    (let [{:keys [interval->task->metric-registry ^WorkerTopologyContext worker-context]} executor-data
          interval (.getInteger tuple 0)
          task-id (:task-id task-data)
@@ -336,11 +326,7 @@
                           (filter identity)
                           (into []))]
      (if (seq data-points)
-       (task/send-unanchored task-data Constants/METRICS_STREAM_ID [task-info data-points] overflow-buffer))))
-  ([executor-data task-data ^TupleImpl tuple]
-    (metrics-tick executor-data task-data tuple nil)
-    ))
-
+       (task/send-unanchored task-data Constants/METRICS_STREAM_ID [task-info data-points]))))
 
 (defn setup-ticks! [worker executor-data]
   (let [storm-conf (:storm-conf executor-data)
@@ -403,8 +389,7 @@
               context (:worker-context executor-data)]
           (disruptor/publish
             receive-queue
-            [[nil (TupleImpl. context [creds] Constants/SYSTEM_TASK_ID Constants/CREDENTIALS_CHANGED_STREAM_ID)]]
-              )))
+            [[nil (TupleImpl. context [creds] Constants/SYSTEM_TASK_ID Constants/CREDENTIALS_CHANGED_STREAM_ID)]])))
       (get-backpressure-flag [this]
         @(:backpressure executor-data))
       Shutdownable
@@ -480,7 +465,7 @@
 
 ;; Send sampled data to the eventlogger if the global or component level
 ;; debug flag is set (via nimbus api).
-(defn send-to-eventlogger [executor-data task-data values overflow-buffer component-id message-id random]
+(defn send-to-eventlogger [executor-data task-data values component-id message-id random]
     (let [c->d @(:storm-component->debug-atom executor-data)
           options (get c->d component-id (get c->d (:storm-id executor-data)))
           spct    (if (and (not-nil? options) (:enable options)) (:samplingpct options) 0)]
@@ -490,8 +475,7 @@
         (task/send-unanchored
           task-data
           EVENTLOGGER-STREAM-ID
-          [component-id message-id (System/currentTimeMillis) values]
-          overflow-buffer))))
+          [component-id message-id (System/currentTimeMillis) values]))))
 
 (defmethod mk-threads :spout [executor-data task-datas initial-credentials]
   (let [{:keys [storm-conf component-id worker-context transfer-fn report-error sampler open-or-prepare-was-called?]} executor-data
@@ -501,15 +485,7 @@
         last-active (atom false)        
         spouts (ArrayList. (map :object (vals task-datas)))
         rand (Random. (Utils/secureRandomLong))
-
-        ;; the overflow buffer is used to ensure that spouts never block when emitting
-        ;; this ensures that the spout can always clear the incoming buffer (acks and fails), which
-        ;; prevents deadlock from occuring across the topology (e.g. Spout -> Bolt -> Acker -> Spout, and all
-        ;; buffers filled up)
-        ;; when the overflow buffer is full, spouts stop calling nextTuple until it's able to clear the overflow buffer
-        ;; this limits the size of the overflow buffer to however many tuples a spout emits in one call of nextTuple, 
-        ;; preventing memory issues
-        overflow-buffer (ConcurrentLinkedQueue.)
+        ^DisruptorQueue transfer-queue (executor-data :batch-transfer-queue)
 
         pending (RotatingMap.
                  2 ;; microoptimize for performance of .size method
@@ -522,7 +498,7 @@
                           (let [stream-id (.getSourceStreamId tuple)]
                             (condp = stream-id
                               Constants/SYSTEM_TICK_STREAM_ID (.rotate pending)
-                              Constants/METRICS_TICK_STREAM_ID (metrics-tick executor-data (get task-datas task-id) tuple overflow-buffer)
+                              Constants/METRICS_TICK_STREAM_ID (metrics-tick executor-data (get task-datas task-id) tuple)
                               Constants/CREDENTIALS_CHANGED_STREAM_ID 
                                 (let [task-data (get task-datas task-id)
                                       spout-obj (:object task-data)]
@@ -578,11 +554,10 @@
                                                                                      out-stream-id
                                                                                      tuple-id)]
                                                            (transfer-fn out-task
-                                                                        out-tuple
-                                                                        overflow-buffer)
+                                                                        out-tuple)
                                                            ))
                                          (if has-eventloggers?
-                                           (send-to-eventlogger executor-data task-data values overflow-buffer component-id message-id rand))
+                                           (send-to-eventlogger executor-data task-data values component-id message-id rand))
                                          (if (and rooted?
                                                   (not (.isEmpty out-ids)))
                                            (do
@@ -592,8 +567,7 @@
                                                                     (if (sampler) (System/currentTimeMillis))])
                                              (task/send-unanchored task-data
                                                                    ACKER-INIT-STREAM-ID
-                                                                   [root-id (bit-xor-vals out-ids) task-id]
-                                                                   overflow-buffer))
+                                                                   [root-id (bit-xor-vals out-ids) task-id]))
                                            (when message-id
                                              (ack-spout-msg executor-data task-data message-id
                                                             {:stream out-stream-id :values values}
@@ -628,19 +602,9 @@
         (log-message "Opened spout " component-id ":" (keys task-datas))
         (setup-metrics! executor-data)
         
-        (disruptor/consumer-started! (:receive-queue executor-data))
         (fn []
           ;; This design requires that spouts be non-blocking
           (disruptor/consume-batch receive-queue event-handler)
-          
-          ;; try to clear the overflow-buffer
-          (try-cause
-            (while (not (.isEmpty overflow-buffer))
-              (let [[out-task out-tuple] (.peek overflow-buffer)]
-                (transfer-fn out-task out-tuple false nil)
-                (.poll overflow-buffer)))
-          (catch InsufficientCapacityException e
-            ))
           
           (let [active? @(:storm-active-atom executor-data)
                 curr-count (.get emitted-count)
@@ -650,7 +614,7 @@
                 reached-max-spout-pending (and max-spout-pending
                                                (>= (.size pending) max-spout-pending))
                 ]
-            (if (and (.isEmpty overflow-buffer)
+            (if (and (not (.isFull transfer-queue))
                      (not throttle-on)
                      (not reached-max-spout-pending))
               (if active?
@@ -706,14 +670,6 @@
                 open-or-prepare-was-called?]} executor-data
         rand (Random. (Utils/secureRandomLong))
 
-        ;; the overflow buffer is used to ensure that bolts do not block when emitting
-        ;; this ensures that the bolt can always clear the incoming messages, which
-        ;; prevents deadlock from occurs across the topology
-        ;; (e.g. Spout -> BoltA -> Splitter -> BoltB -> BoltA, and all
-        ;; buffers filled up)
-        ;; the overflow buffer is might gradually fill degrading the performance gradually
-        ;; eventually running out of memory, but at least prevent live-locks/deadlocks.
-        overflow-buffer (if (storm-conf TOPOLOGY-BOLTS-OUTGOING-OVERFLOW-BUFFER-ENABLE) (ConcurrentLinkedQueue.) nil)
         tuple-action-fn (fn [task-id ^TupleImpl tuple]
                           ;; synchronization needs to be done with a key provided by this bolt, otherwise:
                           ;; spout 1 sends synchronization (s1), dies, same spout restarts somewhere else, sends synchronization (s2) and incremental update. s2 and update finish before s1 -> lose the incremental update
@@ -738,7 +694,7 @@
                                       bolt-obj (:object task-data)]
                                   (when (instance? ICredentialsListener bolt-obj)
                                     (.setCredentials bolt-obj (.getValue tuple 0))))
-                              Constants/METRICS_TICK_STREAM_ID (metrics-tick executor-data (get task-datas task-id) tuple overflow-buffer)
+                              Constants/METRICS_TICK_STREAM_ID (metrics-tick executor-data (get task-datas task-id) tuple)
                               (let [task-data (get task-datas task-id)
                                     ^IBolt bolt-obj (:object task-data)
                                     user-context (:user-context task-data)
@@ -795,10 +751,9 @@
                                                                                values
                                                                                task-id
                                                                                stream
-                                                                               (MessageId/makeId anchors-to-ids))
-                                                                   overflow-buffer)))
+                                                                               (MessageId/makeId anchors-to-ids)))))
                                     (if has-eventloggers?
-                                      (send-to-eventlogger executor-data task-data values overflow-buffer component-id nil rand))
+                                      (send-to-eventlogger executor-data task-data values component-id nil rand))
                                     (or out-tasks [])))]]
           (builtin-metrics/register-all (:builtin-metrics task-data) storm-conf user-context)
           (when (instance? ICredentialsListener bolt-obj) (.setCredentials bolt-obj initial-credentials)) 
@@ -830,7 +785,7 @@
                            (fast-map-iter [[root id] (.. tuple getMessageId getAnchorsToIds)]
                                           (task/send-unanchored task-data
                                                                 ACKER-ACK-STREAM-ID
-                                                                [root (bit-xor id ack-val)] overflow-buffer)
+                                                                [root (bit-xor id ack-val)])
                                           ))
                          (let [delta (tuple-time-delta! tuple)
                                debug? (= true (storm-conf TOPOLOGY-DEBUG))]
@@ -846,7 +801,7 @@
                          (fast-list-iter [root (.. tuple getMessageId getAnchors)]
                                          (task/send-unanchored task-data
                                                                ACKER-FAIL-STREAM-ID
-                                                               [root] overflow-buffer))
+                                                               [root]))
                          (let [delta (tuple-time-delta! tuple)
                                debug? (= true (storm-conf TOPOLOGY-DEBUG))]
                            (when debug? 
@@ -866,19 +821,8 @@
 
         (let [receive-queue (:receive-queue executor-data)
               event-handler (mk-task-receiver executor-data tuple-action-fn)]
-          (disruptor/consumer-started! receive-queue)
           (fn []            
             (disruptor/consume-batch-when-available receive-queue event-handler)
-            ;; try to clear the overflow-buffer
-            (try-cause
-              (while (and overflow-buffer (not (.isEmpty overflow-buffer)))
-                (let [[out-task out-tuple] (.peek overflow-buffer)]
-                  (transfer-fn out-task out-tuple false nil)
-                  (.poll overflow-buffer)))
-              (catch InsufficientCapacityException e
-                (when (= true (storm-conf TOPOLOGY-DEBUG))
-                  (log-message "Insufficient Capacity on queue to emit by bolt " component-id ":" (keys task-datas) ))
-                ))
             0)))
       :kill-fn (:report-error-and-die executor-data)
       :factory? true

--- a/storm-core/src/clj/backtype/storm/daemon/task.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/task.clj
@@ -105,7 +105,7 @@
 
 ;; TODO: this is all expensive... should be precomputed
 (defn send-unanchored
-  ([task-data stream values overflow-buffer]
+  [task-data stream values]
     (let [^TopologyContext topology-context (:system-context task-data)
           tasks-fn (:tasks-fn task-data)
           transfer-fn (-> task-data :executor-data :transfer-fn)
@@ -114,13 +114,7 @@
                                  (.getThisTaskId topology-context)
                                  stream)]
       (fast-list-iter [t (tasks-fn stream values)]
-        (transfer-fn t
-                     out-tuple
-                     overflow-buffer)
-        )))
-    ([task-data stream values]
-      (send-unanchored task-data stream values nil)
-      ))
+        (transfer-fn t out-tuple))))
 
 (defn mk-tasks-fn [task-data]
   (let [task-id (:task-id task-data)

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -190,8 +190,7 @@
        ;; TODO: this depends on the type of executor
        (map (fn [e] [e (disruptor/disruptor-queue (str "receive-queue" e)
                                                   (storm-conf TOPOLOGY-EXECUTOR-RECEIVE-BUFFER-SIZE)
-                                                  (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS)
-                                                  :wait-strategy (storm-conf TOPOLOGY-DISRUPTOR-WAIT-STRATEGY))]))
+                                                  (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS))]))
        (into {})
        ))
 
@@ -232,8 +231,7 @@
   (let [assignment-versions (atom {})
         executors (set (read-worker-executors storm-conf storm-cluster-state storm-id assignment-id port assignment-versions))
         transfer-queue (disruptor/disruptor-queue "worker-transfer-queue" (storm-conf TOPOLOGY-TRANSFER-BUFFER-SIZE)
-                                                  (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS)
-                                                  :wait-strategy (storm-conf TOPOLOGY-DISRUPTOR-WAIT-STRATEGY))
+                                                  (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS))
         executor-receive-queue-map (mk-receive-queue-map storm-conf executors)
 
         receive-queue-map (->> executor-receive-queue-map

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -159,8 +159,8 @@
 
         transfer-fn
           (fn [^KryoTupleSerializer serializer tuple-batch]
-            (let [local (ArrayList.)
-                  remoteMap (HashMap.)]
+            (let [^ArrayList local (ArrayList.)
+                  ^HashMap remoteMap (HashMap.)]
               (fast-list-iter [[task tuple :as pair] tuple-batch]
                 (if (local-tasks task)
                   (.add local pair)
@@ -190,7 +190,9 @@
        ;; TODO: this depends on the type of executor
        (map (fn [e] [e (disruptor/disruptor-queue (str "receive-queue" e)
                                                   (storm-conf TOPOLOGY-EXECUTOR-RECEIVE-BUFFER-SIZE)
-                                                  (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS))]))
+                                                  (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS)
+                                                  :batch-size (storm-conf TOPOLOGY-DISRUPTOR-BATCH-SIZE)
+                                                  :batch-timeout (storm-conf TOPOLOGY-DISRUPTOR-BATCH-TIMEOUT-MILLIS))]))
        (into {})
        ))
 
@@ -231,7 +233,9 @@
   (let [assignment-versions (atom {})
         executors (set (read-worker-executors storm-conf storm-cluster-state storm-id assignment-id port assignment-versions))
         transfer-queue (disruptor/disruptor-queue "worker-transfer-queue" (storm-conf TOPOLOGY-TRANSFER-BUFFER-SIZE)
-                                                  (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS))
+                                                  (storm-conf TOPOLOGY-DISRUPTOR-WAIT-TIMEOUT-MILLIS)
+                                                  :batch-size (storm-conf TOPOLOGY-DISRUPTOR-BATCH-SIZE)
+                                                  :batch-timeout (storm-conf TOPOLOGY-DISRUPTOR-BATCH-TIMEOUT-MILLIS))
         executor-receive-queue-map (mk-receive-queue-map storm-conf executors)
 
         receive-queue-map (->> executor-receive-queue-map

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1256,7 +1256,7 @@ public class Config extends HashMap<String, Object> {
      * event logging will be disabled.</p>
      */
     @isInteger
-    @isPositiveNumber
+    @isPositiveNumber(includeZero = true)
     public static final String TOPOLOGY_EVENTLOGGER_EXECUTORS = "topology.eventlogger.executors";
 
     /**

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1479,10 +1479,12 @@ public class Config extends HashMap<String, Object> {
     @isInteger
     public static final String TOPOLOGY_TICK_TUPLE_FREQ_SECS="topology.tick.tuple.freq.secs";
 
-    /**
-     * Configure the wait strategy used for internal queuing. Can be used to tradeoff latency
-     * vs. throughput
-     */
+   /**
+    * @deprecated this is no longer supported
+    * Configure the wait strategy used for internal queuing. Can be used to tradeoff latency
+    * vs. throughput
+    */
+    @Deprecated
     @isString
     public static final String TOPOLOGY_DISRUPTOR_WAIT_STRATEGY="topology.disruptor.wait.strategy";
 
@@ -1658,7 +1660,6 @@ public class Config extends HashMap<String, Object> {
      * vs. CPU usage
      */
     @isInteger
-    @isPositiveNumber
     @NotNull
     public static final String TOPOLOGY_DISRUPTOR_WAIT_TIMEOUT_MILLIS="topology.disruptor.wait.timeout.millis";
 

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1664,6 +1664,24 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_DISRUPTOR_WAIT_TIMEOUT_MILLIS="topology.disruptor.wait.timeout.millis";
 
     /**
+     * The number of tuples to batch before sending to the next thread.  This number is just an initial suggestion and
+     * the code may adjust it as your topology runs.
+     */
+    @isInteger
+    @isPositiveNumber
+    @NotNull
+    public static final String TOPOLOGY_DISRUPTOR_BATCH_SIZE="topology.disruptor.batch.size";
+
+    /**
+     * The maximum age in milliseconds a batch can be before being sent to the next thread.  This number is just an
+     * initial suggestion and the code may adjust it as your topology runs.
+     */
+    @isInteger
+    @isPositiveNumber
+    @NotNull
+    public static final String TOPOLOGY_DISRUPTOR_BATCH_TIMEOUT_MILLIS="topology.disruptor.batch.timeout.millis";
+
+    /**
      * Which implementation of {@link backtype.storm.codedistributor.ICodeDistributor} should be used by storm for code
      * distribution.
      */

--- a/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p/>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
@@ -18,52 +18,51 @@
 package backtype.storm.utils;
 
 import com.lmax.disruptor.AlertException;
-import com.lmax.disruptor.ClaimStrategy;
 import com.lmax.disruptor.EventFactory;
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.InsufficientCapacityException;
+import com.lmax.disruptor.LiteBlockingWaitStrategy;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.Sequence;
 import com.lmax.disruptor.SequenceBarrier;
-import com.lmax.disruptor.SingleThreadedClaimStrategy;
+import com.lmax.disruptor.TimeoutBlockingWaitStrategy;
+import com.lmax.disruptor.TimeoutException;
 import com.lmax.disruptor.WaitStrategy;
+import com.lmax.disruptor.dsl.ProducerType;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.HashMap;
-import java.util.Map;
 
 import backtype.storm.metric.api.IStatefulObject;
 import backtype.storm.metric.internal.RateTracker;
-
 
 /**
  * A single consumer queue that uses the LMAX Disruptor. They key to the performance is
  * the ability to catch up to the producer by processing tuples in batches.
  */
 public class DisruptorQueue implements IStatefulObject {
-    static final Object FLUSH_CACHE = new Object();
-    static final Object INTERRUPT = new Object();
+    private static final Object FLUSH_CACHE = new Object();
+    private static final Object INTERRUPT = new Object();
+    private static final String PREFIX = "disruptor-";
 
-    RingBuffer<MutableObject> _buffer;
-    Sequence _consumer;
-    SequenceBarrier _barrier;
+    private final RingBuffer<MutableObject> _buffer;
+    private final Sequence _consumer;
+    private final SequenceBarrier _barrier;
 
-    // TODO: consider having a threadlocal cache of this variable to speed up reads?
-    volatile boolean consumerStartedFlag = false;
-    ConcurrentLinkedQueue<Object> _cache = new ConcurrentLinkedQueue();
+    private volatile boolean consumerStartedFlag = false;
+    private final ConcurrentLinkedQueue<Object> _cache = new ConcurrentLinkedQueue();
 
     private final ReentrantReadWriteLock cacheLock = new ReentrantReadWriteLock();
     private final Lock readLock = cacheLock.readLock();
     private final Lock writeLock = cacheLock.writeLock();
 
-    private static String PREFIX = "disruptor-";
     private String _queueName = "";
-
-    private long _waitTimeout;
 
     private final QueueMetrics _metrics;
     private DisruptorBackpressureCallback _cb = null;
@@ -72,15 +71,22 @@ public class DisruptorQueue implements IStatefulObject {
     private boolean _enableBackpressure = false;
     private volatile boolean _throttleOn = false;
 
-    public DisruptorQueue(String queueName, ClaimStrategy claim, WaitStrategy wait, long timeout) {
+    public DisruptorQueue(String queueName, ProducerType type, int size, long timeout) {
         this._queueName = PREFIX + queueName;
-        _buffer = new RingBuffer<MutableObject>(new ObjectEventFactory(), claim, wait);
+        WaitStrategy wait = null;
+        if (timeout <= 0) {
+            wait = new LiteBlockingWaitStrategy();
+        } else {
+            wait = new TimeoutBlockingWaitStrategy(timeout, TimeUnit.MILLISECONDS);
+        }
+
+        _buffer = RingBuffer.create(type, new ObjectEventFactory(), size, wait);
         _consumer = new Sequence();
         _barrier = _buffer.newBarrier();
-        _buffer.setGatingSequences(_consumer);
+        _buffer.addGatingSequences(_consumer);
         _metrics = new QueueMetrics();
 
-        if (claim instanceof SingleThreadedClaimStrategy) {
+        if (type == ProducerType.SINGLE) {
             consumerStartedFlag = true;
         } else {
             // make sure we flush the pending messages in cache first
@@ -90,8 +96,6 @@ public class DisruptorQueue implements IStatefulObject {
                 throw new RuntimeException("This code should be unreachable!", e);
             }
         }
-
-        _waitTimeout = timeout;
     }
 
     public String getName() {
@@ -109,9 +113,12 @@ public class DisruptorQueue implements IStatefulObject {
     public void consumeBatchWhenAvailable(EventHandler<Object> handler) {
         try {
             final long nextSequence = _consumer.get() + 1;
-            final long availableSequence =
-                    _waitTimeout == 0L ? _barrier.waitFor(nextSequence) : _barrier.waitFor(nextSequence, _waitTimeout,
-                            TimeUnit.MILLISECONDS);
+            long availableSequence = 0;
+            try {
+                availableSequence = _barrier.waitFor(nextSequence);
+            } catch (TimeoutException te) {
+                availableSequence = _barrier.getCursor();
+            }
 
             if (availableSequence >= nextSequence) {
                 consumeBatchToCursor(availableSequence, handler);
@@ -122,7 +129,6 @@ public class DisruptorQueue implements IStatefulObject {
             throw new RuntimeException(e);
         }
     }
-
 
     private void consumeBatchToCursor(long cursor, EventHandler<Object> handler) {
         for (long curr = _consumer.get() + 1; curr <= cursor; curr++) {
@@ -180,7 +186,6 @@ public class DisruptorQueue implements IStatefulObject {
     }
 
     public void publish(Object obj, boolean block) throws InsufficientCapacityException {
-
         boolean publishNow = consumerStartedFlag;
 
         if (!publishNow) {
@@ -218,13 +223,12 @@ public class DisruptorQueue implements IStatefulObject {
                    _throttleOn = true;
                }
            } catch (Exception e) {
-               throw new RuntimeException("Exception during calling highWaterMark callback!");
+               throw new RuntimeException("Exception during calling highWaterMark callback!", e);
            }
         }
     }
 
     public void consumerStarted() {
-
         consumerStartedFlag = true;
 
         // Use writeLock to make sure all pending cache add opearation completed

--- a/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
@@ -103,7 +103,9 @@ public class DisruptorQueue implements IStatefulObject {
     }
 
     public void consumeBatch(EventHandler<Object> handler) {
-        consumeBatchToCursor(_barrier.getCursor(), handler);
+        if (_metrics.population() > 0) {
+            consumeBatchWhenAvailable(handler);
+        }
     }
 
     public void haltWithInterrupt() {
@@ -134,7 +136,7 @@ public class DisruptorQueue implements IStatefulObject {
         for (long curr = _consumer.get() + 1; curr <= cursor; curr++) {
             try {
                 MutableObject mo = _buffer.get(curr);
-                Object o = mo.o;
+                Object o = mo.getObject();
                 mo.setObject(null);
                 if (o == FLUSH_CACHE) {
                     Object c = null;

--- a/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
@@ -30,15 +30,19 @@ import com.lmax.disruptor.TimeoutException;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.dsl.ProducerType;
 
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,237 +55,126 @@ import backtype.storm.metric.internal.RateTracker;
  * the ability to catch up to the producer by processing tuples in batches.
  */
 public class DisruptorQueue implements IStatefulObject {
-    private static final Logger LOG = LoggerFactory.getLogger(DisruptorQueue.class);
-    private static final Object FLUSH_CACHE = new Object();
+    private static final Logger LOG = LoggerFactory.getLogger(DisruptorQueue.class);    
     private static final Object INTERRUPT = new Object();
     private static final String PREFIX = "disruptor-";
 
-    private final RingBuffer<AtomicReference<Object>> _buffer;
-    private final Sequence _consumer;
-    private final SequenceBarrier _barrier;
-
-    private volatile boolean consumerStartedFlag = false;
-    private final ConcurrentLinkedQueue<Object> _cache = new ConcurrentLinkedQueue();
-
-    private final ReentrantReadWriteLock cacheLock = new ReentrantReadWriteLock();
-    private final Lock readLock = cacheLock.readLock();
-    private final Lock writeLock = cacheLock.writeLock();
-
-    private String _queueName = "";
-
-    private final QueueMetrics _metrics;
-    private DisruptorBackpressureCallback _cb = null;
-    private int _highWaterMark = 0;
-    private int _lowWaterMark = 0;
-    private boolean _enableBackpressure = false;
-    private volatile boolean _throttleOn = false;
-
-    public DisruptorQueue(String queueName, ProducerType type, int size, long timeout) {
-        this._queueName = PREFIX + queueName;
-        WaitStrategy wait = null;
-        if (timeout <= 0) {
-            wait = new LiteBlockingWaitStrategy();
-        } else {
-            wait = new TimeoutBlockingWaitStrategy(timeout, TimeUnit.MILLISECONDS);
-        }
-
-        _buffer = RingBuffer.create(type, new ObjectEventFactory(), size, wait);
-        _consumer = new Sequence();
-        _barrier = _buffer.newBarrier();
-        _buffer.addGatingSequences(_consumer);
-        _metrics = new QueueMetrics();
-
-        if (type == ProducerType.SINGLE) {
-            consumerStartedFlag = true;
-        } else {
-            // make sure we flush the pending messages in cache first
-            try {
-                publishDirect(FLUSH_CACHE, true);
-            } catch (InsufficientCapacityException e) {
-                throw new RuntimeException("This code should be unreachable!", e);
-            }
-        }
-    }
-
-    public String getName() {
-        return _queueName;
-    }
-
-    public void consumeBatch(EventHandler<Object> handler) {
-        if (_metrics.population() > 0) {
-            consumeBatchWhenAvailable(handler);
-        }
-    }
-
-    public void haltWithInterrupt() {
-        publish(INTERRUPT);
-    }
-
-    public void consumeBatchWhenAvailable(EventHandler<Object> handler) {
-        try {
-            final long nextSequence = _consumer.get() + 1;
-            long availableSequence = _barrier.waitFor(nextSequence);
-
-            if (availableSequence >= nextSequence) {
-                consumeBatchToCursor(availableSequence, handler);
-            }
-        } catch (TimeoutException te) {
-            //Ignored
-        } catch (AlertException e) {
-            throw new RuntimeException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void consumeBatchToCursor(long cursor, EventHandler<Object> handler) {
-        for (long curr = _consumer.get() + 1; curr <= cursor; curr++) {
-            try {
-                AtomicReference<Object> mo = _buffer.get(curr);
-                Object o = mo.getAndSet(null);
-
-                if (o == null) {
-                    LOG.error("NULL found in {}:{}", this.getName(), cursor);
-                } else if (o == FLUSH_CACHE) {
-                    Object c = null;
-                    while (true) {
-                        c = _cache.poll();
-                        if (c == null) break;
-                        else handler.onEvent(c, curr, true);
-                    }
-                } else if (o == INTERRUPT) {
-                    throw new InterruptedException("Disruptor processing interrupted");
-                } else {
-                    handler.onEvent(o, curr, curr == cursor);
-                    if (_enableBackpressure && _cb != null && _metrics.writePos() - curr <= _lowWaterMark) {
-                        try {
-                            if (_throttleOn) {
-                                _throttleOn = false;
-                                _cb.lowWaterMark();
-                            }
-                        } catch (Exception e) {
-                            throw new RuntimeException("Exception during calling lowWaterMark callback!");
-                        }
-                    }
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-        _consumer.set(cursor);
-    }
-
-    public void registerBackpressureCallback(DisruptorBackpressureCallback cb) {
-        this._cb = cb;
-    }
-
-    /*
-     * Caches until consumerStarted is called, upon which the cache is flushed to the consumer
-     */
-    public void publish(Object obj) {
-        try {
-            publish(obj, true);
-        } catch (InsufficientCapacityException ex) {
-            throw new RuntimeException("This code should be unreachable!");
-        }
-    }
-
-    public void tryPublish(Object obj) throws InsufficientCapacityException {
-        publish(obj, false);
-    }
-
-    public void publish(Object obj, boolean block) throws InsufficientCapacityException {
-        boolean publishNow = consumerStartedFlag;
-
-        if (!publishNow) {
-            readLock.lock();
-            try {
-                publishNow = consumerStartedFlag;
-                if (!publishNow) {
-                    _cache.add(obj);
-                }
-            } finally {
-                readLock.unlock();
-            }
-        }
-
-        if (publishNow) {
-            publishDirect(obj, block);
-        }
-    }
-
-    private void publishDirect(Object obj, boolean block) throws InsufficientCapacityException {
-        final long id;
-        if (block) {
-            id = _buffer.next();
-        } else {
-            id = _buffer.tryNext(1);
-        }
-        final AtomicReference<Object> m = _buffer.get(id);
-        Object old = m.getAndSet(obj);
-        _buffer.publish(id);
-        _metrics.notifyArrivals(1);
-        if (_enableBackpressure && _cb != null && _metrics.population() >= _highWaterMark) {
-           try {
-               if (!_throttleOn) {
-                   _cb.highWaterMark();
-                   _throttleOn = true;
-               }
-           } catch (Exception e) {
-               throw new RuntimeException("Exception during calling highWaterMark callback!", e);
-           }
-        }
-        if (old != null) {
-            LOG.warn("Tuple was overwritten in {}:{}", getName(), id);
-        }
-    }
-
-    public void consumerStarted() {
-        consumerStartedFlag = true;
-
-        // Use writeLock to make sure all pending cache add opearation completed
-        writeLock.lock();
-        writeLock.unlock();
-    }
-
-    @Override
-    public Object getState() {
-        return _metrics.getState();
-    }
-
-    public DisruptorQueue setHighWaterMark(double highWaterMark) {
-        this._highWaterMark = (int)(_metrics.capacity() * highWaterMark);
-        return this;
-    }
-
-    public DisruptorQueue setLowWaterMark(double lowWaterMark) {
-        this._lowWaterMark = (int)(_metrics.capacity() * lowWaterMark);
-        return this;
-    }
-
-    public int getHighWaterMark() {
-        return this._highWaterMark;
-    }
-
-    public int getLowWaterMark() {
-        return this._lowWaterMark;
-    }
-
-    public DisruptorQueue setEnableBackpressure(boolean enableBackpressure) {
-        this._enableBackpressure = enableBackpressure;
-        return this;
-    }
-
-    public static class ObjectEventFactory implements EventFactory<AtomicReference<Object>> {
+    private static class ObjectEventFactory implements EventFactory<AtomicReference<Object>> {
         @Override
         public AtomicReference<Object> newInstance() {
             return new AtomicReference<Object>();
         }
     }
 
-    //This method enables the metrics to be accessed from outside of the DisruptorQueue class
-    public QueueMetrics getMetrics() {
-        return _metrics;
+    private class ThreadLocalBatcher {
+        private final ReentrantLock _flushLock;
+        private final ConcurrentLinkedQueue<ArrayList<Object>> _overflow;
+        private ArrayList<Object> _currentBatch;
+
+        public ThreadLocalBatcher() {
+            _flushLock = new ReentrantLock();
+            _overflow = new ConcurrentLinkedQueue<ArrayList<Object>>();
+            _currentBatch = new ArrayList<Object>(_inputBatchSize);
+        }
+
+        //called by the main thread and should not block for an undefined period of time
+        public synchronized void add(Object obj) {
+            _currentBatch.add(obj);
+            _overflowCount.incrementAndGet();
+            if (_enableBackpressure && _cb != null && (_metrics.population() + _overflowCount.get()) >= _highWaterMark) {
+                try {
+                    if (!_throttleOn) {
+                        _cb.highWaterMark();
+                        _throttleOn = true;
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException("Exception during calling highWaterMark callback!", e);
+                }
+            }
+            if (_currentBatch.size() >= _inputBatchSize) {
+                boolean flushed = false;
+                if (_overflow.isEmpty()) {
+                    try {
+                        publishDirect(_currentBatch, false);
+                        _overflowCount.addAndGet(0 - _currentBatch.size());
+                        _currentBatch.clear();
+                        flushed = true;
+                    } catch (InsufficientCapacityException e) {
+                        //Ignored we will flush later
+                    }
+                }
+
+                if (!flushed) {        
+                    _overflow.add(_currentBatch);
+                    _currentBatch = new ArrayList<Object>(_inputBatchSize);
+                }
+            }
+        }
+
+        //May be called by a background thread
+        public synchronized void forceBatch() {
+            if (!_currentBatch.isEmpty()) {
+                _overflow.add(_currentBatch);
+                _currentBatch = new ArrayList<Object>(_inputBatchSize);
+            }
+        }
+
+        //May be called by a background thread
+        public void flush(boolean block) {
+            if (block) {
+                _flushLock.lock();
+            } else if (!_flushLock.tryLock()) {
+               //Someone else if flushing so don't do anything
+               return;
+            }
+            try {
+                while (!_overflow.isEmpty()) {
+                    publishDirect(_overflow.peek(), block);
+                    _overflowCount.addAndGet(0 - _overflow.poll().size());
+                }
+            } catch (InsufficientCapacityException e) {
+                //Ignored we should not block
+            } finally {
+                _flushLock.unlock();
+            }
+        }
+    }
+
+    private class FlusherThread extends Thread {
+        private final long _flushInterval;
+        private volatile boolean _done;
+
+        public FlusherThread(long flushInterval, String name) {
+            super(name+"-flusher");
+            _flushInterval = flushInterval;
+            _done = false;
+            setDaemon(true);
+        }
+
+        public void run() {
+            try {
+                long nextFlushTime = System.currentTimeMillis();
+                while (!_done) {
+                    long now = System.currentTimeMillis();
+                    if (now >= nextFlushTime) {
+                        for (ThreadLocalBatcher batcher: _batchers.values()) {
+                            batcher.forceBatch();
+                            batcher.flush(true);
+                        }
+                        nextFlushTime = now + _flushInterval;
+                    } else {
+                        Thread.sleep(nextFlushTime - now);
+                    }
+                }
+            } catch (InterruptedException e) {
+                //Ignored we are done
+            }
+        }
+
+        public void close() {
+            _done = true;
+            interrupt();
+        }
     }
 
     /**
@@ -296,6 +189,10 @@ public class DisruptorQueue implements IStatefulObject {
 
         public long readPos() {
             return _consumer.get();
+        }
+
+        public long overflow() {
+            return _overflowCount.get();
         }
 
         public long population() {
@@ -330,6 +227,7 @@ public class DisruptorQueue implements IStatefulObject {
             state.put("read_pos", rp);
             state.put("arrival_rate_secs", arrivalRateInSecs);
             state.put("sojourn_time_ms", sojournTime); //element sojourn time in milliseconds
+            state.put("overflow", _overflowCount.get());
 
             return state;
         }
@@ -337,5 +235,190 @@ public class DisruptorQueue implements IStatefulObject {
         public void notifyArrivals(long counts) {
             _rateTracker.notify(counts);
         }
+    }
+
+    private final RingBuffer<AtomicReference<Object>> _buffer;
+    private final Sequence _consumer;
+    private final SequenceBarrier _barrier;
+    private final int _inputBatchSize;
+    private final ConcurrentHashMap<Long, ThreadLocalBatcher> _batchers = new ConcurrentHashMap<Long, ThreadLocalBatcher>();
+    private final FlusherThread _flusher;
+    private final QueueMetrics _metrics;
+
+    private String _queueName = "";
+    private DisruptorBackpressureCallback _cb = null;
+    private int _highWaterMark = 0;
+    private int _lowWaterMark = 0;
+    private boolean _enableBackpressure = false;
+    private final AtomicLong _overflowCount = new AtomicLong(0);
+    private volatile boolean _throttleOn = false;
+
+    public DisruptorQueue(String queueName, ProducerType type, int size, long readTimeout, int inputBatchSize, long flushInterval) {
+        this._queueName = PREFIX + queueName;
+        WaitStrategy wait = null;
+        if (readTimeout <= 0) {
+            wait = new LiteBlockingWaitStrategy();
+        } else {
+            wait = new TimeoutBlockingWaitStrategy(readTimeout, TimeUnit.MILLISECONDS);
+        }
+
+        _buffer = RingBuffer.create(type, new ObjectEventFactory(), size, wait);
+        _consumer = new Sequence();
+        _barrier = _buffer.newBarrier();
+        _buffer.addGatingSequences(_consumer);
+        _metrics = new QueueMetrics();
+        //The batch size can be no larger than half the full queue size.
+        //This is mostly to avoid contention issues.
+        _inputBatchSize = Math.max(1, Math.min(inputBatchSize, size/2));
+
+        _flusher = new FlusherThread(Math.max(flushInterval, 1), _queueName);
+        _flusher.start();
+    }
+
+    public String getName() {
+        return _queueName;
+    }
+
+    public boolean isFull() {
+        return (_metrics.population() + _overflowCount.get()) >= _metrics.capacity();
+    }
+
+    public void haltWithInterrupt() {
+        try {
+            publishDirect(new ArrayList<Object>(Arrays.asList(INTERRUPT)), true);
+            _flusher.close();
+            _flusher.join();
+        } catch (InsufficientCapacityException e) {
+            //This should be impossible
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void consumeBatch(EventHandler<Object> handler) {
+        if (_metrics.population() > 0) {
+            consumeBatchWhenAvailable(handler);
+        }
+    }
+
+    public void consumeBatchWhenAvailable(EventHandler<Object> handler) {
+        try {
+            final long nextSequence = _consumer.get() + 1;
+            long availableSequence = _barrier.waitFor(nextSequence);
+
+            if (availableSequence >= nextSequence) {
+                consumeBatchToCursor(availableSequence, handler);
+            }
+        } catch (TimeoutException te) {
+            //Ignored
+        } catch (AlertException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void consumeBatchToCursor(long cursor, EventHandler<Object> handler) {
+        for (long curr = _consumer.get() + 1; curr <= cursor; curr++) {
+            try {
+                AtomicReference<Object> mo = _buffer.get(curr);
+                Object o = mo.getAndSet(null);
+                if (o == INTERRUPT) {
+                    throw new InterruptedException("Disruptor processing interrupted");
+                } else if (o == null) {
+                    LOG.error("NULL found in {}:{}", this.getName(), cursor);
+                } else {
+                    handler.onEvent(o, curr, curr == cursor);
+                    if (_enableBackpressure && _cb != null && (_metrics.writePos() - curr + _overflowCount.get()) <= _lowWaterMark) {
+                        try {
+                            if (_throttleOn) {
+                                _throttleOn = false;
+                                _cb.lowWaterMark();
+                            }
+                        } catch (Exception e) {
+                            throw new RuntimeException("Exception during calling lowWaterMark callback!");
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        _consumer.set(cursor);
+    }
+
+    public void registerBackpressureCallback(DisruptorBackpressureCallback cb) {
+        this._cb = cb;
+    }
+
+    private static Long getId() {
+        return Thread.currentThread().getId();
+    }
+
+    private void publishDirect(ArrayList<Object> objs, boolean block) throws InsufficientCapacityException {
+        int size = objs.size();
+        if (size > 0) {
+            long end;
+            if (block) {
+                end = _buffer.next(size);
+            } else {
+                end = _buffer.tryNext(size);
+            }
+            long begin = end - (size - 1);
+            long at = begin;
+            for (Object obj: objs) {
+                AtomicReference<Object> m = _buffer.get(at);
+                m.set(obj);
+                at++;
+            }
+            _buffer.publish(begin, end);
+            _metrics.notifyArrivals(size);
+        }
+    }
+
+    public void publish(Object obj) {
+        Long id = getId();
+        ThreadLocalBatcher batcher = _batchers.get(id);
+        if (batcher == null) {
+            //This thread is the only one ever creating this, so this is safe
+            batcher = new ThreadLocalBatcher();
+            _batchers.put(id, batcher);
+        }
+        batcher.add(obj);
+        batcher.flush(false);
+    }
+
+    @Override
+    public Object getState() {
+        return _metrics.getState();
+    }
+
+    public DisruptorQueue setHighWaterMark(double highWaterMark) {
+        this._highWaterMark = (int)(_metrics.capacity() * highWaterMark);
+        return this;
+    }
+
+    public DisruptorQueue setLowWaterMark(double lowWaterMark) {
+        this._lowWaterMark = (int)(_metrics.capacity() * lowWaterMark);
+        return this;
+    }
+
+    public int getHighWaterMark() {
+        return this._highWaterMark;
+    }
+
+    public int getLowWaterMark() {
+        return this._lowWaterMark;
+    }
+
+    public DisruptorQueue setEnableBackpressure(boolean enableBackpressure) {
+        this._enableBackpressure = enableBackpressure;
+        return this;
+    }
+
+    //This method enables the metrics to be accessed from outside of the DisruptorQueue class
+    public QueueMetrics getMetrics() {
+        return _metrics;
     }
 }

--- a/storm-core/src/jvm/backtype/storm/utils/MutableObject.java
+++ b/storm-core/src/jvm/backtype/storm/utils/MutableObject.java
@@ -18,7 +18,7 @@
 package backtype.storm.utils;
 
 public class MutableObject {
-    Object o = null;
+    private Object o = null;
     
     public MutableObject() {
         
@@ -28,11 +28,11 @@ public class MutableObject {
         this.o = o;
     }
     
-    public void setObject(Object o) {
+    public synchronized void setObject(Object o) {
         this.o = o;
     }
     
-    public Object getObject() {
+    public synchronized Object getObject() {
         return o;
     }
 }

--- a/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueBackpressureTest.java
+++ b/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueBackpressureTest.java
@@ -20,9 +20,8 @@ package backtype.storm.utils;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.lmax.disruptor.BlockingWaitStrategy;
 import com.lmax.disruptor.EventHandler;
-import com.lmax.disruptor.MultiThreadedClaimStrategy;
+import com.lmax.disruptor.dsl.ProducerType;
 import org.junit.Assert;
 import org.junit.Test;
 import junit.framework.TestCase;
@@ -30,14 +29,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DisruptorQueueBackpressureTest extends TestCase {
-
     private static final Logger LOG = LoggerFactory.getLogger(DisruptorQueueBackpressureTest.class);
 
     private final static int MESSAGES = 100;
     private final static int CAPACITY = 128;
     private final static double HIGH_WATERMARK = 0.6;
     private final static double LOW_WATERMARK = 0.2;
-
 
     @Test
     public void testBackPressureCallback() throws Exception {
@@ -109,7 +106,6 @@ public class DisruptorQueueBackpressureTest extends TestCase {
     }
 
     private static DisruptorQueue createQueue(String name, int queueSize) {
-        return new DisruptorQueue(name, new MultiThreadedClaimStrategy(
-                queueSize), new BlockingWaitStrategy(), 10L);
+        return new DisruptorQueue(name, ProducerType.MULTI, queueSize, 0L);
     }
 }


### PR DESCRIPTION
I wanted to come up with an alternative to #694 that does batching at the queue level instead of at that spout level.  This is the result of that work, although it still needs some testing/cleanup before I consider it fully ready. This is based off of #750 using the latest version of disruptor, and has a few bug fixes for automatic back-pressure that I need to split out and include as a separate pull request.

The work here is driven by results I got from some micro benchmarks I wrote looking at what the bottlenecks are in storm and what the theoretical limit is for storm.  In this case doing a simple word count topology as represented by Q_SWC_X_04.  With the same batching here the throughput when from 300,000 sentences/second processed to around 1.5 million, as run on my Mac Book Pro Laptop.

https://github.com/revans2/storm-micro-perf

The reason for queue level batching is that it gives a finer grained control over latency, which I would like to use for automatic tuning in the future.  It also is a smaller code change.  If others disagree I am okay with #694. But I do want to do a head to head comparison between the two approaches.