### PR TITLE
STORM-1086. Make FailedMsgRetryManager configurable when setting up KafkaSpout

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -58,7 +58,8 @@ public class PartitionManager {
     ZkState _state;
     Map _stormConf;
     long numberFailed, numberAcked;
-    public PartitionManager(DynamicPartitionConnections connections, String topologyInstanceId, ZkState state, Map stormConf, SpoutConfig spoutConfig, Partition id) {
+
+    public PartitionManager(DynamicPartitionConnections connections, String topologyInstanceId, ZkState state, Map stormConf, SpoutConfig spoutConfig, Partition id, FailedMsgRetryManager failedMsgRetryManager) {
         _partition = id;
         _connections = connections;
         _spoutConfig = spoutConfig;
@@ -67,10 +68,7 @@ public class PartitionManager {
         _state = state;
         _stormConf = stormConf;
         numberAcked = numberFailed = 0;
-
-        _failedMsgRetryManager = new ExponentialBackoffMsgRetryManager(_spoutConfig.retryInitialDelayMs,
-                                                                           _spoutConfig.retryDelayMultiplier,
-                                                                           _spoutConfig.retryDelayMaxMs);
+        _failedMsgRetryManager = failedMsgRetryManager;
 
         String jsonTopologyId = null;
         Long jsonOffset = null;

--- a/external/storm-kafka/src/jvm/storm/kafka/StaticCoordinator.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/StaticCoordinator.java
@@ -27,11 +27,11 @@ public class StaticCoordinator implements PartitionCoordinator {
     Map<Partition, PartitionManager> _managers = new HashMap<Partition, PartitionManager>();
     List<PartitionManager> _allManagers = new ArrayList();
 
-    public StaticCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig config, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId) {
+    public StaticCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig config, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId, FailedMsgRetryManager failedMsgRetryManager) {
         StaticHosts hosts = (StaticHosts) config.hosts;
         List<Partition> myPartitions = KafkaUtils.calculatePartitionsForTask(hosts.getPartitionInformation(), totalTasks, taskIndex);
         for (Partition myPartition : myPartitions) {
-            _managers.put(myPartition, new PartitionManager(connections, topologyInstanceId, state, stormConf, config, myPartition));
+            _managers.put(myPartition, new PartitionManager(connections, topologyInstanceId, state, stormConf, config, myPartition, failedMsgRetryManager));
         }
         _allManagers = new ArrayList(_managers.values());
     }

--- a/external/storm-kafka/src/test/storm/kafka/ZkCoordinatorTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/ZkCoordinatorTest.java
@@ -138,7 +138,11 @@ public class ZkCoordinatorTest {
     private List<ZkCoordinator> buildCoordinators(int totalTasks) {
         List<ZkCoordinator> coordinatorList = new ArrayList<ZkCoordinator>();
         for (int i = 0; i < totalTasks; i++) {
-            ZkCoordinator coordinator = new ZkCoordinator(dynamicPartitionConnections, stormConf, spoutConfig, state, i, totalTasks, "test-id", reader);
+            ZkCoordinator coordinator = new ZkCoordinator(dynamicPartitionConnections, stormConf, spoutConfig, state, i, totalTasks, "test-id", new ExponentialBackoffMsgRetryManager(
+                    spoutConfig.retryInitialDelayMs,
+                    spoutConfig.retryDelayMultiplier,
+                    spoutConfig.retryDelayMaxMs
+            ), reader);
             coordinatorList.add(coordinator);
         }
         return coordinatorList;


### PR DESCRIPTION
We'd like to be able to drop messages when they've been replayed N times. Seems easy to do if we could extend ExponentialBackoffMsgRetryManager, but there's no way to inject a custom FailedMsgRetryManager without changing the Kafka codebase. This PR allows users to inject the FailedMsgRetryManager when creating a KafkaSpout.