### PR TITLE
STORM-1086. Make FailedMsgRetryManager configurable when setting up KafkaSpout

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManagerFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ExponentialBackoffMsgRetryManagerFactory.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package storm.kafka;
+
+public class ExponentialBackoffMsgRetryManagerFactory implements FailedMsgRetryManagerFactory {
+
+    public long retryInitialDelayMs = 0;
+    public double retryDelayMultiplier = 1.0;
+    public long retryDelayMaxMs = 60 * 1000;
+
+    public ExponentialBackoffMsgRetryManagerFactory() {
+    }
+
+    public ExponentialBackoffMsgRetryManagerFactory(final long retryInitialDelayMs, final double retryDelayMultiplier, final long retryDelayMaxMs) {
+        this.retryInitialDelayMs = retryInitialDelayMs;
+        this.retryDelayMultiplier = retryDelayMultiplier;
+        this.retryDelayMaxMs = retryDelayMaxMs;
+    }
+
+    @Override
+    public FailedMsgRetryManager construct() {
+        return new ExponentialBackoffMsgRetryManager(
+                this.retryInitialDelayMs,
+                this.retryDelayMultiplier,
+                this.retryDelayMaxMs);
+    }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/FailedMsgRetryManagerFactory.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/FailedMsgRetryManagerFactory.java
@@ -18,26 +18,7 @@
 package storm.kafka;
 
 import java.io.Serializable;
-import java.util.List;
 
-
-public class SpoutConfig extends KafkaConfig implements Serializable {
-    public List<String> zkServers = null;
-    public Integer zkPort = null;
-    public String zkRoot = null;
-    public String id = null;
-
-    // if set to true, spout will set Kafka topic as the emitted Stream ID
-    public boolean topicAsStreamId = false;
-
-    // setting for how often to save the current kafka offset to ZooKeeper
-    public long stateUpdateIntervalMs = 2000;
-
-    public FailedMsgRetryManagerFactory failedMsgRetryManagerFactory = new ExponentialBackoffMsgRetryManagerFactory();
-
-    public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id) {
-        super(hosts, topic);
-        this.zkRoot = zkRoot;
-        this.id = id;
-    }
+public interface FailedMsgRetryManagerFactory extends Serializable {
+    FailedMsgRetryManager construct();
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
@@ -85,16 +85,18 @@ public class KafkaSpout extends BaseRichSpout {
 
         _connections = new DynamicPartitionConnections(_spoutConfig, KafkaUtils.makeBrokerReader(conf, _spoutConfig));
 
+        FailedMsgRetryManager failedMsgRetryManager = _spoutConfig.failedMsgRetryManagerFactory.construct();
+
         // using TransactionalState like this is a hack
         int totalTasks = context.getComponentTasks(context.getThisComponentId()).size();
         if (_spoutConfig.hosts instanceof StaticHosts) {
             _coordinator = new StaticCoordinator(_connections, conf,
                     _spoutConfig, _state, context.getThisTaskIndex(),
-                    totalTasks, topologyInstanceId);
+                    totalTasks, topologyInstanceId, failedMsgRetryManager);
         } else {
             _coordinator = new ZkCoordinator(_connections, conf,
                     _spoutConfig, _state, context.getThisTaskIndex(),
-                    totalTasks, topologyInstanceId);
+                    totalTasks, topologyInstanceId, failedMsgRetryManager);
         }
 
         context.registerMetric("kafkaOffset", new IMetric() {

--- a/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -62,7 +62,8 @@ public class PartitionManager {
     ZkState _state;
     Map _stormConf;
     long numberFailed, numberAcked;
-    public PartitionManager(DynamicPartitionConnections connections, String topologyInstanceId, ZkState state, Map stormConf, SpoutConfig spoutConfig, Partition id) {
+
+    public PartitionManager(DynamicPartitionConnections connections, String topologyInstanceId, ZkState state, Map stormConf, SpoutConfig spoutConfig, Partition id, FailedMsgRetryManager failedMsgRetryManager) {
         _partition = id;
         _connections = connections;
         _spoutConfig = spoutConfig;
@@ -71,10 +72,7 @@ public class PartitionManager {
         _state = state;
         _stormConf = stormConf;
         numberAcked = numberFailed = 0;
-
-        _failedMsgRetryManager = new ExponentialBackoffMsgRetryManager(_spoutConfig.retryInitialDelayMs,
-                                                                           _spoutConfig.retryDelayMultiplier,
-                                                                           _spoutConfig.retryDelayMaxMs);
+        _failedMsgRetryManager = failedMsgRetryManager;
 
         String jsonTopologyId = null;
         Long jsonOffset = null;

--- a/external/storm-kafka/src/jvm/storm/kafka/StaticCoordinator.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/StaticCoordinator.java
@@ -26,13 +26,13 @@ public class StaticCoordinator implements PartitionCoordinator {
     Map<Partition, PartitionManager> _managers = new HashMap<Partition, PartitionManager>();
     List<PartitionManager> _allManagers = new ArrayList();
 
-    public StaticCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig config, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId) {
+    public StaticCoordinator(DynamicPartitionConnections connections, Map stormConf, SpoutConfig config, ZkState state, int taskIndex, int totalTasks, String topologyInstanceId, FailedMsgRetryManager failedMsgRetryManager) {
         StaticHosts hosts = (StaticHosts) config.hosts;
         List<GlobalPartitionInformation> partitions = new ArrayList<GlobalPartitionInformation>();
         partitions.add(hosts.getPartitionInformation());
         List<Partition> myPartitions = KafkaUtils.calculatePartitionsForTask(partitions, totalTasks, taskIndex);
         for (Partition myPartition : myPartitions) {
-            _managers.put(myPartition, new PartitionManager(connections, topologyInstanceId, state, stormConf, config, myPartition));
+            _managers.put(myPartition, new PartitionManager(connections, topologyInstanceId, state, stormConf, config, myPartition, failedMsgRetryManager));
         }
         _allManagers = new ArrayList(_managers.values());
     }

--- a/external/storm-kafka/src/test/storm/kafka/ZkCoordinatorTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/ZkCoordinatorTest.java
@@ -138,11 +138,9 @@ public class ZkCoordinatorTest {
     private List<ZkCoordinator> buildCoordinators(int totalTasks) {
         List<ZkCoordinator> coordinatorList = new ArrayList<ZkCoordinator>();
         for (int i = 0; i < totalTasks; i++) {
-            ZkCoordinator coordinator = new ZkCoordinator(dynamicPartitionConnections, stormConf, spoutConfig, state, i, totalTasks, "test-id", reader);
+            ZkCoordinator coordinator = new ZkCoordinator(dynamicPartitionConnections, stormConf, spoutConfig, state, i, totalTasks, "test-id", new ExponentialBackoffMsgRetryManagerFactory().construct(), reader);
             coordinatorList.add(coordinator);
         }
         return coordinatorList;
     }
-
-
 }


### PR DESCRIPTION
We'd like to be able to drop messages when they've been replayed N times. Seems easy to do if we could extend ExponentialBackoffMsgRetryManager, but there's no way to inject a custom FailedMsgRetryManager without changing the Kafka codebase. This PR allows users to specify the FailedMsgRetryManager as part of SpoutConfig.
