### PR TITLE
[STORM-1099]  Fix worker childopts as arraylist of strings

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -644,7 +644,7 @@
                         replacement-map)]
     (cond
       (nil? value) nil
-      (list? value) (map sub-fn value)
+      (sequential? value) (vec (map sub-fn value))
       :else (-> value sub-fn (clojure.string/split #"\s+")))))
 
 (defn java-cmd []

--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -573,15 +573,14 @@
           childopts-with-ids (supervisor/substitute-childopts childopts worker-id topology-id port)]
       (is (= expected-childopts childopts-with-ids)))))
 
-(deftest test-substitute-childopts-happy-path-arraylist
-  (testing "worker-launcher replaces ids in childopts from arraylist"
+(deftest test-substitute-childopts-happy-path-list-arraylist
+  (testing "worker-launcher replaces ids in childopts"
     (let [worker-id "w-01"
           topology-id "s-01"
           port 9999
-          mem-onheap 512
-          childopts '["-Xloggc:/home/y/lib/storm/current/logs/gc.worker-%ID%-%TOPOLOGY-ID%-%WORKER-ID%-%WORKER-PORT%.log" "-Xms256m" "-Xmx%HEAP-MEM%m"]
-          expected-childopts '("-Xloggc:/home/y/lib/storm/current/logs/gc.worker-9999-s-01-w-01-9999.log" "-Xms256m" "-Xmx512m")
-          childopts-with-ids (supervisor/substitute-childopts childopts worker-id topology-id port mem-onheap)]
+          childopts '["-Xloggc:/home/y/lib/storm/current/logs/gc.worker-%ID%-%TOPOLOGY-ID%-%WORKER-ID%-%WORKER-PORT%.log" "-Xms256m"]
+          expected-childopts '("-Xloggc:/home/y/lib/storm/current/logs/gc.worker-9999-s-01-w-01-9999.log" "-Xms256m")
+          childopts-with-ids (supervisor/substitute-childopts childopts worker-id topology-id port)]
       (is (= expected-childopts childopts-with-ids)))))
 
 (deftest test-substitute-childopts-topology-id-alone

--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -573,6 +573,17 @@
           childopts-with-ids (supervisor/substitute-childopts childopts worker-id topology-id port)]
       (is (= expected-childopts childopts-with-ids)))))
 
+(deftest test-substitute-childopts-happy-path-arraylist
+  (testing "worker-launcher replaces ids in childopts from arraylist"
+    (let [worker-id "w-01"
+          topology-id "s-01"
+          port 9999
+          mem-onheap 512
+          childopts '["-Xloggc:/home/y/lib/storm/current/logs/gc.worker-%ID%-%TOPOLOGY-ID%-%WORKER-ID%-%WORKER-PORT%.log" "-Xms256m" "-Xmx%HEAP-MEM%m"]
+          expected-childopts '("-Xloggc:/home/y/lib/storm/current/logs/gc.worker-9999-s-01-w-01-9999.log" "-Xms256m" "-Xmx512m")
+          childopts-with-ids (supervisor/substitute-childopts childopts worker-id topology-id port mem-onheap)]
+      (is (= expected-childopts childopts-with-ids)))))
+
 (deftest test-substitute-childopts-topology-id-alone
   (testing "worker-launcher replaces ids in childopts"
     (let [worker-id "w-01"


### PR DESCRIPTION
This fixes the bug by changing supervisor.clj to operate on any sequential, not just a list.  

A unit test was added to verify that this works.  I ran the unit test without the supervisor change, and it did fail.