### PR TITLE
[STORM-1104] Nimbus HA fails to find newly downloaded code files

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -1666,9 +1666,8 @@
 
 (defmethod sync-code :distributed [conf nimbus]
   (let [storm-cluster-state (:storm-cluster-state nimbus)
-        code-ids (set (code-ids (:conf nimbus)))
         active-topologies (set (.code-distributor storm-cluster-state (fn [] (sync-code conf nimbus))))
-        missing-topologies (set/difference active-topologies code-ids)]
+        missing-topologies (set/difference active-topologies (set (code-ids (:conf nimbus))))]
     (if (not (empty? missing-topologies))
       (do
         (.removeFromLeaderLockQueue (:leader-elector nimbus))


### PR DESCRIPTION
Nimbus HA using Local File System code distribution is broken. We seem to be "caching" the return value of `(code-ids (:conf nimbus))` in the sync-code method, by overriding the `code-ids` var from a method ([nimbus.clj#854](../blob/master/storm-core/src/clj/backtype/storm/daemon/nimbus.clj#L854) `defn code-ids`), to a local var ([nimbus.clj#1669](../blob/master/storm-core/src/clj/backtype/storm/daemon/nimbus.clj#L1669) `code-ids (set (code-ids (:conf nimbus)))`).

The problem is, that after downloading code for missing topologies, sync-code doesn't realize it has gotten the new missing topology files.
