### PR TITLE
[STORM-1110] Fix Component Page for system components

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/common.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/common.clj
@@ -29,9 +29,6 @@
   (:require [backtype.storm.thrift :as thrift])
   )
 
-(defn system-id? [id]
-  (Utils/isSystemId id))
-
 (def ACKER-COMPONENT-ID acker/ACKER-COMPONENT-ID)
 (def ACKER-INIT-STREAM-ID acker/ACKER-INIT-STREAM-ID)
 (def ACKER-ACK-STREAM-ID acker/ACKER-ACK-STREAM-ID)
@@ -114,12 +111,12 @@
     (doseq [f thrift/STORM-TOPOLOGY-FIELDS
             :let [obj-map (.getFieldValue topology f)]]
       (doseq [id (keys obj-map)]
-        (if (system-id? id)
+        (if (Utils/isSystemId id)
           (throw (InvalidTopologyException.
                   (str id " is not a valid component id")))))
       (doseq [obj (vals obj-map)
               id (-> obj .get_common .get_streams keys)]
-        (if (system-id? id)
+        (if (Utils/isSystemId id)
           (throw (InvalidTopologyException.
                   (str id " is not a valid stream id"))))))
     ))

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -349,7 +349,7 @@
         receive-queue (:receive-queue executor-data)
         context (:worker-context executor-data)]
     (when tick-time-secs
-      (if (or (system-id? (:component-id executor-data))
+      (if (or (Utils/isSystemId (:component-id executor-data))
               (and (= false (storm-conf TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS))
                    (= :spout (:type executor-data))))
         (log-message "Timeouts disabled for executor " (:component-id executor-data) ":" (:executor-id executor-data))

--- a/storm-core/src/clj/backtype/storm/stats.clj
+++ b/storm-core/src/clj/backtype/storm/stats.clj
@@ -883,6 +883,7 @@
   (let [bolts (.get_bolts topology)
         spouts (.get_spouts topology)]
     (cond
+      (Utils/isSystemId id) :bolt
       (.containsKey bolts id) :bolt
       (.containsKey spouts id) :spout)))
 

--- a/storm-core/src/clj/backtype/storm/stats.clj
+++ b/storm-core/src/clj/backtype/storm/stats.clj
@@ -23,9 +23,9 @@
             ComponentPageInfo ComponentType BoltAggregateStats
             ExecutorAggregateStats SpecificAggregateStats
             SpoutAggregateStats TopologyPageInfo TopologyStats])
+  (:import [backtype.storm.utils Utils])
   (:use [backtype.storm log util])
-  (:use [clojure.math.numeric-tower :only [ceil]])
-  (:use [backtype.storm.daemon [common :only [system-id?]]]))
+  (:use [clojure.math.numeric-tower :only [ceil]]))
 
 ;;TODO: consider replacing this with some sort of RRD
 
@@ -399,7 +399,7 @@
   [include-sys?]
   (if include-sys?
     (fn [_] true)
-    (fn [stream] (and (string? stream) (not (system-id? stream))))))
+    (fn [stream] (and (string? stream) (not (Utils/isSystemId stream))))))
 
 (defn mk-include-sys-filter
   "Returns a function that includes or excludes map entries whose keys are
@@ -892,7 +892,7 @@
          :let [beat (beats executor)
                id (task->component start)]
          :when (and (or (nil? comp-id) (= comp-id id))
-                    (or include-sys? (not (system-id? id))))]
+                    (or include-sys? (not (Utils/isSystemId id))))]
      {:exec-id executor
       :comp-id id
       :num-tasks (count (range start (inc end)))

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -24,7 +24,7 @@
   (:use [backtype.storm config util log stats tuple zookeeper])
   (:use [backtype.storm.ui helpers])
   (:use [backtype.storm.daemon [common :only [ACKER-COMPONENT-ID ACKER-INIT-STREAM-ID ACKER-ACK-STREAM-ID
-                                              ACKER-FAIL-STREAM-ID system-id? mk-authorization-handler]]])
+                                              ACKER-FAIL-STREAM-ID mk-authorization-handler]]])
   (:use [clojure.string :only [blank? lower-case trim]])
   (:import [backtype.storm.utils Utils]
            [backtype.storm.generated NimbusSummary])


### PR DESCRIPTION
- Remove redundant method `system-id?` - as is calls into static `Utils/isSystemId`
- All System components are of type bolts.