### PR TITLE
[STORM-1115] Stale leader-lock key effectively bans all nodes from becoming leaders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
         <commons-fileupload.version>1.2.1</commons-fileupload.version>
         <commons-codec.version>1.6</commons-codec.version>
         <clj-time.version>0.8.0</clj-time.version>
-        <curator.version>2.5.0</curator.version>
+        <curator.version>2.9.0</curator.version>
         <json-simple.version>1.1</json-simple.version>
         <ring.version>1.3.0</ring.version>
         <ring-json.version>0.3.1</ring-json.version>


### PR DESCRIPTION
From the issue:

```
I believe this curator bug is what's in play causing the above described situation.
https://issues.apache.org/jira/browse/CURATOR-202
```