### PR TITLE
STORM-1071 Task Message format to include source task id

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -117,7 +117,7 @@
 
 (defn- assert-can-serialize [^KryoTupleSerializer serializer tuple-batch]
   "Check that all of the tuples can be serialized by serializing them."
-  (fast-list-iter [[task tuple :as pair] tuple-batch]
+  (fast-list-iter [[task task-src tuple :as pair] tuple-batch]
     (.serialize serializer tuple)))
 
 (defn- mk-backpressure-handler [executors]
@@ -161,7 +161,7 @@
           (fn [^KryoTupleSerializer serializer tuple-batch]
             (let [local (ArrayList.)
                   remoteMap (HashMap.)]
-              (fast-list-iter [[task tuple :as pair] tuple-batch]
+              (fast-list-iter [[task task-src tuple :as pair] tuple-batch]
                 (if (local-tasks task)
                   (.add local pair)
 
@@ -171,7 +171,7 @@
                       (.put remoteMap task (ArrayList.)))
                     (let [remote (.get remoteMap task)]
                       (if (not-nil? task)
-                        (.add remote (TaskMessage. task (.serialize serializer tuple)))
+                        (.add remote (TaskMessage. task task-src (.serialize serializer tuple)))
                         (log-warn "Can't transfer tuple - task value is nil. tuple type: " (pr-str (type tuple)) " and information: " (pr-str tuple)))
                      ))))
 

--- a/storm-core/src/clj/backtype/storm/messaging/local.clj
+++ b/storm-core/src/clj/backtype/storm/messaging/local.clj
@@ -41,9 +41,9 @@
           (.add ret msg)
           (.iterator ret))
         nil)))
-  (^void send [this ^int taskId ^bytes payload]
+  (^void send [this ^int taskId ^int taskSrc ^bytes payload]
     (let [send-queue (add-queue! queues-map lock storm-id port)]
-      (.put send-queue (TaskMessage. taskId payload))
+      (.put send-queue (TaskMessage. taskId taskSrc payload))
       ))
   (^void send [this ^Iterator iter]
     (let [send-queue (add-queue! queues-map lock storm-id port)]

--- a/storm-core/src/jvm/backtype/storm/messaging/IConnection.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/IConnection.java
@@ -31,9 +31,10 @@ public interface IConnection {
     /**
      * send a message with taskId and payload
      * @param taskId task ID
+     * @param taskSrc task ID
      * @param payload
      */
-    public void send(int taskId,  byte[] payload);
+    public void send(int taskId, int taskSrc, byte[] payload);
     
     /**
      * send batch messages

--- a/storm-core/src/jvm/backtype/storm/messaging/TaskMessage.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/TaskMessage.java
@@ -21,10 +21,17 @@ import java.nio.ByteBuffer;
 
 public class TaskMessage {
     private int _task;
+    private int _taskSrc;
     private byte[] _message;
     
     public TaskMessage(int task, byte[] message) {
         _task = task;
+        _message = message;
+    }
+
+    public TaskMessage(int task, int taskSrc, byte[] message) {
+        _task = task;
+        _taskSrc = taskSrc;
         _message = message;
     }
     
@@ -32,13 +39,18 @@ public class TaskMessage {
         return _task;
     }
 
+    public int taskSrc() {
+        return _taskSrc;
+    }
+
     public byte[] message() {
         return _message;
     }
     
     public ByteBuffer serialize() {
-        ByteBuffer bb = ByteBuffer.allocate(_message.length+2);
+        ByteBuffer bb = ByteBuffer.allocate(_message.length+4);
         bb.putShort((short)_task);
+        bb.putShort((short)_taskSrc);
         bb.put(_message);
         return bb;
     }
@@ -46,7 +58,8 @@ public class TaskMessage {
     public void deserialize(ByteBuffer packet) {
         if (packet==null) return;
         _task = packet.getShort();
-        _message = new byte[packet.limit()-2];
+        _taskSrc = packet.getShort();
+        _message = new byte[packet.limit()-4];
         packet.get(_message);
     }
 

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Client.java
@@ -205,8 +205,8 @@ public class Client extends ConnectionWithStatus implements IStatefulObject {
     }
 
     @Override
-    public void send(int taskId, byte[] payload) {
-        TaskMessage msg = new TaskMessage(taskId, payload);
+    public void send(int taskId, int task_src, byte[] payload) {
+        TaskMessage msg = new TaskMessage(taskId, task_src, payload);
         List<TaskMessage> wrapper = new ArrayList<TaskMessage>(1);
         wrapper.add(msg);
         send(wrapper.iterator());

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/MessageBatch.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/MessageBatch.java
@@ -47,7 +47,7 @@ class MessageBatch {
     private int msgEncodeLength(TaskMessage taskMsg) {
         if (taskMsg == null) return 0;
 
-        int size = 6; //INT + SHORT
+        int size = 8; //INT + SHORT + SHORT
         if (taskMsg.message() != null) 
             size += taskMsg.message().length;
         return size;
@@ -99,6 +99,7 @@ class MessageBatch {
      *
      * Each TaskMessage is encoded as:
      *  task ... short(2)
+     *  task_src ... short(2) 
      *  len ... int(4)
      *  payload ... byte[]     *  
      */
@@ -108,10 +109,13 @@ class MessageBatch {
             payload_len =  message.message().length;
 
         int task_id = message.task();
-        if (task_id > Short.MAX_VALUE)
+        int task_src = message.taskSrc();
+
+        if (task_id > Short.MAX_VALUE || task_src > Short.MAX_VALUE)
             throw new RuntimeException("Task ID should not exceed "+Short.MAX_VALUE);
         
         bout.writeShort((short)task_id);
+        bout.writeShort((short)task_src);
         bout.writeInt(payload_len);
         if (payload_len >0)
             bout.write(message.message());

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/MessageDecoder.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/MessageDecoder.java
@@ -26,11 +26,13 @@ import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.frame.FrameDecoder;
 
+
 public class MessageDecoder extends FrameDecoder {    
     /*
      * Each ControlMessage is encoded as:
      *  code (<0) ... short(2)
      * Each TaskMessage is encoded as:
+     *  task (>=0) ... short(2)
      *  task (>=0) ... short(2)
      *  len ... int(4)
      *  payload ... byte[]     *  
@@ -101,6 +103,8 @@ public class MessageDecoder extends FrameDecoder {
 
             // case 3: task Message
             short task = code;
+            short task_src = buf.readShort();
+            available-=2;
 
             // Make sure that we have received at least an integer (length)
             if (available < 4) {
@@ -115,7 +119,7 @@ public class MessageDecoder extends FrameDecoder {
             available -= 4;
 
             if (length <= 0) {
-                ret.add(new TaskMessage(task, null));
+                ret.add(new TaskMessage(task, task_src, null));
                 break;
             }
 
@@ -133,7 +137,7 @@ public class MessageDecoder extends FrameDecoder {
 
             // Successfully decoded a frame.
             // Return a TaskMessage object
-            ret.add(new TaskMessage(task, payload.array()));
+            ret.add(new TaskMessage(task, task_src, payload.array()));
         }
 
         if (ret.size() == 0) {

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/Server.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/Server.java
@@ -70,7 +70,7 @@ class Server extends ConnectionWithStatus implements IStatefulObject {
     int roundRobinQueueId;
 	
     private volatile boolean closing = false;
-    List<TaskMessage> closeMessage = Arrays.asList(new TaskMessage(-1, null));
+    List<TaskMessage> closeMessage = Arrays.asList(new TaskMessage(-1, -1, null));
     
     
     @SuppressWarnings("rawtypes")
@@ -265,7 +265,7 @@ class Server extends ConnectionWithStatus implements IStatefulObject {
         }
     }
 
-    public void send(int task, byte[] message) {
+    public void send(int task, int taskSrc, byte[] message) {
         throw new UnsupportedOperationException("Server connection should not send any messages");
     }
     


### PR DESCRIPTION
As part of gathering inputs for Resource Aware Scheduler, understanding the tuple network characteristics between tasks would be helpful. 
The present implementation of TaskMessage includes only the destination task id and message. Including the source task id to it would help us understand the task-task (component/component) network bandwidth characteristics. It shall also avoid the deserialization of message to retrieve the source task id from the serialized tuple message.
