### PR TITLE
[STORM-1121] Remove method call to avoid overhead during topology submission time

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -65,7 +65,6 @@ nimbus.cleanup.inbox.freq.secs: 600
 nimbus.inbox.jar.expiration.secs: 3600
 nimbus.code.sync.freq.secs: 300
 nimbus.task.launch.secs: 120
-nimbus.reassign: true
 nimbus.file.copy.expiration.secs: 600
 nimbus.topology.validator: "backtype.storm.nimbus.DefaultTopologyValidator"
 topology.min.replication.count: 1

--- a/storm-core/src/clj/backtype/storm/config.clj
+++ b/storm-core/src/clj/backtype/storm/config.clj
@@ -25,6 +25,7 @@
   (:use [backtype.storm log util]))
 
 (def RESOURCES-SUBDIR "resources")
+(def NIMBUS-DO-NOT-REASSIGN "NIMBUS-DO-NOT-REASSIGN")
 
 (defn- clojure-config-name [name]
   (.replace (.toUpperCase name) "_" "-"))

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -1166,7 +1166,7 @@
                         0
                         (conf NIMBUS-MONITOR-FREQ-SECS)
                         (fn []
-                          (when (conf NIMBUS-REASSIGN)
+                          (when-not (conf NIMBUS-DO-NOT-REASSIGN)
                             (locking (:submit-lock nimbus)
                               (mk-assignments nimbus)))
                           (do-cleanup nimbus)

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -1263,8 +1263,7 @@
               (.setup-backpressure! storm-cluster-state storm-id)
               (let [thrift-status->kw-status {TopologyInitialStatus/INACTIVE :inactive
                                               TopologyInitialStatus/ACTIVE :active}]
-                (start-storm nimbus storm-name storm-id (thrift-status->kw-status (.get_initial_status submitOptions))))
-              (mk-assignments nimbus)))
+                (start-storm nimbus storm-name storm-id (thrift-status->kw-status (.get_initial_status submitOptions))))))
           (catch Throwable e
             (log-warn-error e "Topology submission exception. (topology name='" storm-name "')")
             (throw e))))

--- a/storm-core/src/clj/backtype/storm/testing.clj
+++ b/storm-core/src/clj/backtype/storm/testing.clj
@@ -612,7 +612,7 @@
                 ;; (log-message "Transferring: " transfer-args#)
                 (increment-global! id# "transferred" 1)
                 (apply transferrer# args2#)))))]
-       (with-local-cluster [~cluster-sym ~@cluster-args]
+       (with-simulated-time-local-cluster [~cluster-sym ~@cluster-args]
                            (let [~cluster-sym (assoc-track-id ~cluster-sym id#)]
                              ~@body)))
      (RegisteredGlobalState/clearState id#)))

--- a/storm-core/src/clj/backtype/storm/testing.clj
+++ b/storm-core/src/clj/backtype/storm/testing.clj
@@ -515,6 +515,7 @@
       (startup spout))
 
     (submit-local-topology (:nimbus cluster-map) storm-name storm-conf topology)
+    (advance-cluster-time cluster-map 11)
 
     (let [storm-id (common/get-storm-id state storm-name)]
       ;;Give the topology time to come up without using it to wait for the spouts to complete

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -470,13 +470,6 @@ public class Config extends HashMap<String, Object> {
     public static final String NIMBUS_TASK_LAUNCH_SECS = "nimbus.task.launch.secs";
 
     /**
-     * Whether or not nimbus should reassign tasks if it detects that a task goes down.
-     * Defaults to true, and it's not recommended to change this value.
-     */
-    @isBoolean
-    public static final String NIMBUS_REASSIGN = "nimbus.reassign";
-
-    /**
      * During upload/download with the master, how long an upload or download connection is idle
      * before nimbus considers it dead and drops the connection.
      */

--- a/storm-core/test/clj/backtype/storm/integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/integration_test.clj
@@ -237,9 +237,7 @@
                              "acking-test1"
                              {}
                              (:topology tracked))
-      ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
-      (.rebalance (:nimbus cluster)
-                             "acking-test1" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+      (advance-cluster-time cluster 11)
       (.feed feeder1 [1])
       (tracked-wait tracked 1)
       (checker1 0)
@@ -282,9 +280,7 @@
                              "test-acking2"
                              {}
                              (:topology tracked))
-      ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
-      (.rebalance (:nimbus cluster)
-                             "test-acking2" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+      (advance-cluster-time cluster 11)
       (.feed feeder [1])
       (tracked-wait tracked 1)
       (checker 0)
@@ -355,9 +351,7 @@
                              "test"
                              {}
                              (:topology tracked))
-      ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
-      (.rebalance (:nimbus cluster)
-                             "test" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+      (advance-cluster-time cluster 11)
       (.feed feeder [1])
       (tracked-wait tracked 1)
       (checker 1)
@@ -579,9 +573,7 @@
                                               TOPOLOGY-DEBUG true
                                               }
                                              (:topology tracked))
-            ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
-            _ (.rebalance (:nimbus cluster)
-                                             "test-errors" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+            _ (advance-cluster-time cluster 11)
             storm-id (get-storm-id state "test-errors")
             errors-count (fn [] (count (.errors state storm-id "2")))]
 

--- a/storm-core/test/clj/backtype/storm/integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/integration_test.clj
@@ -105,6 +105,7 @@
                              "timeout-tester"
                              {TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
                              topology)
+      (advance-cluster-time cluster 11)
       (.feed feeder ["a"] 1)
       (.feed feeder ["b"] 2)
       (.feed feeder ["c"] 3)
@@ -236,6 +237,7 @@
                              "acking-test1"
                              {}
                              (:topology tracked))
+      (Thread/sleep 11000)
       (.feed feeder1 [1])
       (tracked-wait tracked 1)
       (checker1 0)
@@ -278,6 +280,7 @@
                              "test-acking2"
                              {}
                              (:topology tracked))
+      (Thread/sleep 11000)
       (.feed feeder [1])
       (tracked-wait tracked 1)
       (checker 0)
@@ -323,6 +326,7 @@
         {TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
         topology
         (SubmitOptions. TopologyInitialStatus/INACTIVE))
+      (Thread/sleep 11000)
       (.feed feeder ["a"] 1)
       (advance-cluster-time cluster 9)
       (is (not @bolt-prepared?))
@@ -347,6 +351,7 @@
                              "test"
                              {}
                              (:topology tracked))
+      (Thread/sleep 11000)
       (.feed feeder [1])
       (tracked-wait tracked 1)
       (checker 1)
@@ -568,6 +573,7 @@
                                               TOPOLOGY-DEBUG true
                                               }
                                              (:topology tracked))
+            _ (advance-cluster-time cluster 11)
             storm-id (get-storm-id state "test-errors")
             errors-count (fn [] (count (.errors state storm-id "2")))]
 

--- a/storm-core/test/clj/backtype/storm/multilang_test.clj
+++ b/storm-core/test/clj/backtype/storm/multilang_test.clj
@@ -47,9 +47,9 @@
                "test"
                {TOPOLOGY-WORKERS 20 TOPOLOGY-MESSAGE-TIMEOUT-SECS 3 TOPOLOGY-DEBUG true}
                topology)
-       (Thread/sleep 10000)
+       (Thread/sleep 11000)
        (.killTopology nimbus "test")
-       (Thread/sleep 10000)
+       (Thread/sleep 11000)
        )))
 
 

--- a/storm-core/test/clj/backtype/storm/nimbus_test.clj
+++ b/storm-core/test/clj/backtype/storm/nimbus_test.clj
@@ -206,7 +206,9 @@
                       "4" (thrift/mk-bolt-spec {"1" :global "2" :none} (TestPlannerBolt.) :parallelism-hint 4)}
                      )
           _ (submit-local-topology nimbus "mystorm" {TOPOLOGY-WORKERS 4} topology)
-          _ (Thread/sleep 11000)
+          ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
+          _ (.rebalance nimbus "mystorm" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+          _ (Thread/sleep 1000)
           task-info (storm-component->task-info cluster "mystorm")]
       (check-consistency cluster "mystorm")
       ;; 3 should be assigned once (if it were optimized, we'd have
@@ -217,7 +219,9 @@
       (is (= 1 (count (task-info "3"))))
       (is (= 4 (storm-num-workers state "mystorm")))
       (submit-local-topology nimbus "storm2" {TOPOLOGY-WORKERS 20} topology2)
-      (Thread/sleep 11000)
+      ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
+      (.rebalance nimbus "storm2" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+      (Thread/sleep 1000)
       (check-consistency cluster "storm2")
       (is (= 2 (count (.assignments state nil))))
       (let [task-info (storm-component->task-info cluster "storm2")]
@@ -342,7 +346,9 @@
                     {"2" (thrift/mk-bolt-spec {"1" :none} (TestPlannerBolt.) :parallelism-hint 1 :conf {TOPOLOGY-TASKS 2})
                      "3" (thrift/mk-bolt-spec {"2" :none} (TestPlannerBolt.) :conf {TOPOLOGY-TASKS 5})})
           _ (submit-local-topology nimbus "mystorm" {TOPOLOGY-WORKERS 4} topology)
-          _ (Thread/sleep 11000)
+          ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
+          _ (.rebalance nimbus "mystorm" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+          _ (Thread/sleep 1000)
           task-info (storm-component->task-info cluster "mystorm")]
       (check-consistency cluster "mystorm")
       (is (= 0 (count (task-info "1"))))
@@ -359,7 +365,9 @@
                     {"2" (thrift/mk-bolt-spec {"1" :none} (TestPlannerBolt.) :parallelism-hint 8 :conf {TOPOLOGY-TASKS 2})
                      "3" (thrift/mk-bolt-spec {"2" :none} (TestPlannerBolt.) :parallelism-hint 3)})
           _ (submit-local-topology nimbus "mystorm" {TOPOLOGY-WORKERS 4} topology)
-          _ (Thread/sleep 11000)
+          ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
+          _ (.rebalance nimbus "mystorm" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+          _ (Thread/sleep 1000)
           task-info (storm-component->task-info cluster "mystorm")
           executor-info (->> (storm-component->executor-info cluster "mystorm")
                              (map-val #(map executor-id->tasks %)))]
@@ -386,7 +394,9 @@
                       "4" (thrift/mk-bolt-spec {"1" :none} (TestPlannerBolt.) :parallelism-hint 10)}
                      )
           _ (submit-local-topology nimbus "test" {TOPOLOGY-WORKERS 7} topology)
-          _ (Thread/sleep 11000)
+          ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
+          _ (.rebalance nimbus "test" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+          _ (Thread/sleep 1000)
           task-info (storm-component->task-info cluster "test")]
       (check-consistency cluster "test")
       (is (= 21 (count (task-info "1"))))
@@ -1038,7 +1048,9 @@
 
               ;first we verify that the master nimbus can perform all actions, even with another nimbus present.
               (submit-local-topology nimbus "t1" {} topology)
-              (Thread/sleep 11000)
+              ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
+              (.rebalance nimbus "t1" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+              (Thread/sleep 1000)
               (.deactivate nimbus "t1")
               (.activate nimbus "t1")
               (.rebalance nimbus "t1" (RebalanceOptions.))

--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -103,6 +103,7 @@
                          ["sup1" 2] [0.0 0.0 0.0]
                          ["sup1" 3] [0.0 0.0 0.0]
                          })
+                      ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
                       (.rebalance (:nimbus cluster) "test" (doto (RebalanceOptions.) (.set_wait_secs 0)))
                       (advance-cluster-time cluster 2)
                       (heartbeat-workers cluster "sup1" [1 2 3])
@@ -159,6 +160,7 @@
                          ["sup1" 2] [0.0 0.0 0.0]
                          ["sup2" 1] [0.0 0.0 0.0]
                          })
+                      ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
                       (.rebalance (:nimbus cluster) "test" (doto (RebalanceOptions.) (.set_wait_secs 0)))
                       (advance-cluster-time cluster 2)
                       (heartbeat-workers cluster "sup1" [1 2])
@@ -183,6 +185,7 @@
                         {["sup1" 3] [0.0 0.0 0.0]
                          ["sup2" 2] [0.0 0.0 0.0]
                          })
+                      ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
                       (.rebalance (:nimbus cluster) "test2" (doto (RebalanceOptions.) (.set_wait_secs 0)))
                       (advance-cluster-time cluster 2)
                       (heartbeat-workers cluster "sup1" [3])
@@ -696,6 +699,7 @@
                      {["sup1" 1] [0.0 0.0 0.0]
                       ["sup1" 2] [0.0 0.0 0.0]
                       })
+                    ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
                     (.rebalance (:nimbus cluster) "topology1" (doto (RebalanceOptions.) (.set_wait_secs 0)))
                     ))
      (is (empty? (:launched changed)))

--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -75,7 +75,7 @@
 
 (deftest launches-assignment
   (with-simulated-time-local-cluster [cluster :supervisors 0
-    :daemon-conf {NIMBUS-REASSIGN false
+    :daemon-conf {NIMBUS-DO-NOT-REASSIGN true
                   SUPERVISOR-WORKER-START-TIMEOUT-SECS 5
                   SUPERVISOR-WORKER-TIMEOUT-SECS 15
                   SUPERVISOR-MONITOR-FREQUENCY-SECS 3}]
@@ -128,7 +128,7 @@
 
 (deftest test-multiple-active-storms-multiple-supervisors
   (with-simulated-time-local-cluster [cluster :supervisors 0
-    :daemon-conf {NIMBUS-REASSIGN false
+    :daemon-conf {NIMBUS-DO-NOT-REASSIGN true
                   SUPERVISOR-WORKER-START-TIMEOUT-SECS 5
                   SUPERVISOR-WORKER-TIMEOUT-SECS 15
                   SUPERVISOR-MONITOR-FREQUENCY-SECS 3}]
@@ -659,7 +659,7 @@
   (with-simulated-time-local-cluster [cluster
                                       :supervisors 0
                                       :ports-per-supervisor 2
-                                      :daemon-conf {NIMBUS-REASSIGN false
+                                      :daemon-conf {NIMBUS-DO-NOT-REASSIGN true
                                                     NIMBUS-MONITOR-FREQ-SECS 10
                                                     TOPOLOGY-MESSAGE-TIMEOUT-SECS 30
                                                     TOPOLOGY-ACKER-EXECUTORS 0}]

--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -103,6 +103,7 @@
                          ["sup1" 2] [0.0 0.0 0.0]
                          ["sup1" 3] [0.0 0.0 0.0]
                          })
+                      (.rebalance (:nimbus cluster) "test" (doto (RebalanceOptions.) (.set_wait_secs 0)))
                       (advance-cluster-time cluster 2)
                       (heartbeat-workers cluster "sup1" [1 2 3])
                       (advance-cluster-time cluster 10)))
@@ -158,6 +159,7 @@
                          ["sup1" 2] [0.0 0.0 0.0]
                          ["sup2" 1] [0.0 0.0 0.0]
                          })
+                      (.rebalance (:nimbus cluster) "test" (doto (RebalanceOptions.) (.set_wait_secs 0)))
                       (advance-cluster-time cluster 2)
                       (heartbeat-workers cluster "sup1" [1 2])
                       (heartbeat-workers cluster "sup2" [1])
@@ -181,6 +183,7 @@
                         {["sup1" 3] [0.0 0.0 0.0]
                          ["sup2" 2] [0.0 0.0 0.0]
                          })
+                      (.rebalance (:nimbus cluster) "test2" (doto (RebalanceOptions.) (.set_wait_secs 0)))
                       (advance-cluster-time cluster 2)
                       (heartbeat-workers cluster "sup1" [3])
                       (heartbeat-workers cluster "sup2" [2])
@@ -693,7 +696,7 @@
                      {["sup1" 1] [0.0 0.0 0.0]
                       ["sup1" 2] [0.0 0.0 0.0]
                       })
-                    (advance-cluster-time cluster 10)
+                    (.rebalance (:nimbus cluster) "topology1" (doto (RebalanceOptions.) (.set_wait_secs 0)))
                     ))
      (is (empty? (:launched changed)))
      (bind options (RebalanceOptions.))

--- a/storm-core/test/clj/backtype/storm/testing4j_test.clj
+++ b/storm-core/test/clj/backtype/storm/testing4j_test.clj
@@ -20,7 +20,6 @@
   (:require [backtype.storm.thrift :as thrift])
   (:import [backtype.storm Testing Config ILocalCluster])
   (:import [backtype.storm.tuple Values Tuple])
-  (:import [backtype.storm.generated RebalanceOptions])
   (:import [backtype.storm.utils Time Utils])
   (:import [backtype.storm.testing MkClusterParam TestJob MockedSources TestWordSpout
             TestWordCounter TestGlobalCount TestAggregatesCounter CompleteTopologyParam
@@ -119,10 +118,7 @@
                           "test-acking2"
                           (Config.)
                           (.getTopology tracked))
-         ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
-         (.rebalance cluster
-                          "test-acking2" (doto (RebalanceOptions.) (.set_wait_secs 0)))
-         (Thread/sleep 1000)
+         (advance-cluster-time (.getState cluster) 11)
          (.feed feeder [1])
          (Testing/trackedWait tracked (int 1))
          (checker 0)

--- a/storm-core/test/clj/backtype/storm/testing4j_test.clj
+++ b/storm-core/test/clj/backtype/storm/testing4j_test.clj
@@ -20,6 +20,7 @@
   (:require [backtype.storm.thrift :as thrift])
   (:import [backtype.storm Testing Config ILocalCluster])
   (:import [backtype.storm.tuple Values Tuple])
+  (:import [backtype.storm.generated RebalanceOptions])
   (:import [backtype.storm.utils Time Utils])
   (:import [backtype.storm.testing MkClusterParam TestJob MockedSources TestWordSpout
             TestWordCounter TestGlobalCount TestAggregatesCounter CompleteTopologyParam
@@ -118,6 +119,10 @@
                           "test-acking2"
                           (Config.)
                           (.getTopology tracked))
+         ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
+         (.rebalance cluster
+                          "test-acking2" (doto (RebalanceOptions.) (.set_wait_secs 0)))
+         (Thread/sleep 1000)
          (.feed feeder [1])
          (Testing/trackedWait tracked (int 1))
          (checker 0)

--- a/storm-core/test/clj/backtype/storm/transactional_test.clj
+++ b/storm-core/test/clj/backtype/storm/transactional_test.clj
@@ -412,12 +412,7 @@
                               "transactional-test"
                               {TOPOLOGY-MAX-SPOUT-PENDING 2}
                               (:topology topo-info))
-       ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
-       (.rebalance (:nimbus cluster)
-                   "test-acking2" 
-                   (doto (RebalanceOptions.) (.set_wait_secs 0)))
-
-
+       (advance-cluster-time cluster 11)
        (bind ack-tx! (fn [txid]
                        (let [[to-ack not-to-ack] (separate
                                                   #(-> %
@@ -672,11 +667,7 @@
                               {TOPOLOGY-MAX-SPOUT-PENDING 2
                                }
                               (:topology topo-info))
-       ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
-       (.rebalance (:nimbus cluster)
-                   "test-acking2" 
-                   (doto (RebalanceOptions.) (.set_wait_secs 0)))
-
+       (advance-cluster-time cluster 11)
        (bind ack-tx! (fn [txid]
                        (let [[to-ack not-to-ack] (separate
                                                   #(-> %

--- a/storm-core/test/clj/backtype/storm/transactional_test.clj
+++ b/storm-core/test/clj/backtype/storm/transactional_test.clj
@@ -20,6 +20,7 @@
   (:import [backtype.storm.transactional TransactionalSpoutCoordinator ITransactionalSpout ITransactionalSpout$Coordinator TransactionAttempt
             TransactionalTopologyBuilder])
   (:import [backtype.storm.transactional.state TransactionalState TestTransactionalState RotatingTransactionalState RotatingTransactionalState$StateInitializer])
+  (:import [backtype.storm.generated RebalanceOptions])
   (:import [backtype.storm.spout SpoutOutputCollector ISpoutOutputCollector])
   (:import [backtype.storm.task OutputCollector IOutputCollector])
   (:import [backtype.storm.coordination BatchBoltExecutor])
@@ -411,7 +412,11 @@
                               "transactional-test"
                               {TOPOLOGY-MAX-SPOUT-PENDING 2}
                               (:topology topo-info))
-       (Thread/sleep 11000)
+       ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
+       (.rebalance (:nimbus cluster)
+                   "test-acking2" 
+                   (doto (RebalanceOptions.) (.set_wait_secs 0)))
+
 
        (bind ack-tx! (fn [txid]
                        (let [[to-ack not-to-ack] (separate
@@ -667,7 +672,10 @@
                               {TOPOLOGY-MAX-SPOUT-PENDING 2
                                }
                               (:topology topo-info))
-       (Thread/sleep 11000)
+       ;; Instead of sleeping until topology is scheduled, rebalance topology so mk-assignments is called.
+       (.rebalance (:nimbus cluster)
+                   "test-acking2" 
+                   (doto (RebalanceOptions.) (.set_wait_secs 0)))
 
        (bind ack-tx! (fn [txid]
                        (let [[to-ack not-to-ack] (separate

--- a/storm-core/test/clj/backtype/storm/transactional_test.clj
+++ b/storm-core/test/clj/backtype/storm/transactional_test.clj
@@ -411,6 +411,7 @@
                               "transactional-test"
                               {TOPOLOGY-MAX-SPOUT-PENDING 2}
                               (:topology topo-info))
+       (Thread/sleep 11000)
 
        (bind ack-tx! (fn [txid]
                        (let [[to-ack not-to-ack] (separate
@@ -666,6 +667,7 @@
                               {TOPOLOGY-MAX-SPOUT-PENDING 2
                                }
                               (:topology topo-info))
+       (Thread/sleep 11000)
 
        (bind ack-tx! (fn [txid]
                        (let [[to-ack not-to-ack] (separate


### PR DESCRIPTION
Nimbus calls mk-assignments from SubmitTopology within lock is causing it to wait for processing of all heartbeats. This conflicts with recurring mk-assignments call. Topology can be submitted without making assignments, since for new topology the assignments would be made available as part of next scheduling cycle.). This gives more consistent response time as avoid locking within nimbus.
