### PR TITLE
STORM-1074: Add Avro HDFS bolt

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -236,7 +236,10 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
     }
 
     /**
-     * writes a tuple to the underlying filesystem but makes no guarantees about syncing data
+     * writes a tuple to the underlying filesystem but makes no guarantees about syncing data.
+     *
+     * this.offset is also updated to reflect additional data written
+     *
      * @param tuple
      * @throws IOException
      */

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBolt.java
@@ -1,0 +1,128 @@
+package org.apache.storm.hdfs.bolt;
+
+import backtype.storm.Config;
+import backtype.storm.Constants;
+import backtype.storm.task.OutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.tuple.Tuple;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+
+import org.apache.storm.hdfs.bolt.format.FileNameFormat;
+import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
+import org.apache.storm.hdfs.bolt.sync.SyncPolicy;
+import org.apache.storm.hdfs.common.rotation.RotationAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.net.URI;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.Map;
+
+public class AvroGenericRecordBolt extends AbstractHdfsBolt{
+
+    private static final Logger LOG = LoggerFactory.getLogger(AvroGenericRecordBolt.class);
+
+    private transient FSDataOutputStream out;
+    private Schema schema;
+    private String schemaAsString;
+    private DataFileWriter<GenericRecord> avroWriter;
+
+    public AvroGenericRecordBolt withSchemaAsString(String schemaAsString)
+    {
+        this.schemaAsString = schemaAsString;
+        return this;
+    }
+
+    public AvroGenericRecordBolt withFsUrl(String fsUrl){
+        this.fsUrl = fsUrl;
+        return this;
+    }
+
+    public AvroGenericRecordBolt withConfigKey(String configKey){
+        this.configKey = configKey;
+        return this;
+    }
+
+    public AvroGenericRecordBolt withFileNameFormat(FileNameFormat fileNameFormat){
+        this.fileNameFormat = fileNameFormat;
+        return this;
+    }
+
+    public AvroGenericRecordBolt withSyncPolicy(SyncPolicy syncPolicy){
+        this.syncPolicy = syncPolicy;
+        return this;
+    }
+
+    public AvroGenericRecordBolt withRotationPolicy(FileRotationPolicy rotationPolicy){
+        this.rotationPolicy = rotationPolicy;
+        return this;
+    }
+
+    public AvroGenericRecordBolt addRotationAction(RotationAction action){
+        this.rotationActions.add(action);
+        return this;
+    }
+
+    public AvroGenericRecordBolt withTickTupleIntervalSeconds(int interval) {
+        this.tickTupleInterval = interval;
+        return this;
+    }
+
+    @Override
+    void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException {
+        LOG.info("Preparing AvroGenericRecord Bolt...");
+        this.fs = FileSystem.get(URI.create(this.fsUrl), hdfsConfig);
+        Schema.Parser parser = new Schema.Parser();
+        this.schema = parser.parse(this.schemaAsString);
+    }
+
+    @Override
+    void writeTuple(Tuple tuple) throws IOException {
+        GenericRecord avroRecord = (GenericRecord) tuple.getValue(0);
+        avroWriter.append(avroRecord);
+        offset = this.out.getPos();
+    }
+
+    @Override
+    void syncTuples() throws IOException {
+        avroWriter.flush();
+
+        LOG.debug("Attempting to sync all data to filesystem");
+        if (this.out instanceof HdfsDataOutputStream) {
+            ((HdfsDataOutputStream) this.out).hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.UPDATE_LENGTH));
+        } else {
+            this.out.hsync();
+        }
+        this.syncPolicy.reset();
+    }
+
+    @Override
+    protected void closeOutputFile() throws IOException
+    {
+        avroWriter.close();
+        this.out.close();
+    }
+
+    @Override
+    Path createOutputFile() throws IOException {
+        Path path = new Path(this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
+        this.out = this.fs.create(path);
+
+        //Initialize writer
+        DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
+        avroWriter = new DataFileWriter<>(datumWriter);
+        avroWriter.create(this.schema, this.out);
+
+        return path;
+    }
+}

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBoltTest.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBoltTest.java
@@ -1,0 +1,203 @@
+package org.apache.storm.hdfs.bolt;
+
+import backtype.storm.Config;
+import backtype.storm.task.GeneralTopologyContext;
+import backtype.storm.task.OutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.TopologyBuilder;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.tuple.TupleImpl;
+import backtype.storm.tuple.Values;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.file.DataFileReader;
+import org.apache.storm.hdfs.bolt.format.DefaultFileNameFormat;
+import org.apache.storm.hdfs.bolt.format.FileNameFormat;
+import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
+import org.apache.storm.hdfs.bolt.rotation.FileSizeRotationPolicy;
+import org.apache.storm.hdfs.bolt.sync.CountSyncPolicy;
+import org.apache.storm.hdfs.bolt.sync.SyncPolicy;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.Assert;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+
+public class AvroGenericRecordBoltTest {
+
+    private String hdfsURI;
+    private DistributedFileSystem fs;
+    private MiniDFSCluster hdfsCluster;
+    private static final String testRoot = "/unittest";
+    private static final Schema schema;
+    private static final Tuple tuple1;
+    private static final Tuple tuple2;
+    private static final String userSchema = "{\"type\":\"record\"," +
+            "\"name\":\"myrecord\"," +
+            "\"fields\":[{\"name\":\"foo1\",\"type\":\"string\"}," +
+            "{ \"name\":\"int1\", \"type\":\"int\" }]}";
+
+    static {
+
+        Schema.Parser parser = new Schema.Parser();
+        schema = parser.parse(userSchema);
+
+        GenericRecord record1 = new GenericData.Record(schema);
+        record1.put("foo1", "bar1");
+        record1.put("int1", 1);
+        tuple1 = generateTestTuple(record1);
+
+        GenericRecord record2 = new GenericData.Record(schema);
+        record2.put("foo1", "bar2");
+        record2.put("int1", 2);
+        tuple2 = generateTestTuple(record2);
+    }
+
+    @Mock private OutputCollector collector;
+    @Mock private TopologyContext topologyContext;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        Configuration conf = new Configuration();
+        conf.set("fs.trash.interval", "10");
+        conf.setBoolean("dfs.permissions", true);
+        File baseDir = new File("./target/hdfs/").getAbsoluteFile();
+        FileUtil.fullyDelete(baseDir);
+        conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+
+        MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
+        hdfsCluster = builder.build();
+        fs = hdfsCluster.getFileSystem();
+        hdfsURI = fs.getUri() + "/";
+    }
+
+    @After
+    public void shutDown() throws IOException {
+        fs.close();
+        hdfsCluster.shutdown();
+    }
+
+    @Test public void multipleTuplesOneFile() throws IOException
+    {
+        AvroGenericRecordBolt bolt = makeAvroBolt(hdfsURI, 1, 1f, userSchema);
+
+        bolt.prepare(new Config(), topologyContext, collector);
+        bolt.execute(tuple1);
+        bolt.execute(tuple2);
+        bolt.execute(tuple1);
+        bolt.execute(tuple2);
+
+        Assert.assertEquals(1, countNonZeroLengthFiles(testRoot));
+        verifyAllAvroFiles(testRoot, schema);
+    }
+
+    @Test public void multipleTuplesMutliplesFiles() throws IOException
+    {
+        AvroGenericRecordBolt bolt = makeAvroBolt(hdfsURI, 1, .0001f, userSchema);
+
+        bolt.prepare(new Config(), topologyContext, collector);
+        bolt.execute(tuple1);
+        bolt.execute(tuple2);
+        bolt.execute(tuple1);
+        bolt.execute(tuple2);
+
+        Assert.assertEquals(4, countNonZeroLengthFiles(testRoot));
+        verifyAllAvroFiles(testRoot, schema);
+    }
+
+    private AvroGenericRecordBolt makeAvroBolt(String nameNodeAddr, int countSync, float rotationSizeMB, String schemaAsString) {
+
+        SyncPolicy fieldsSyncPolicy = new CountSyncPolicy(countSync);
+
+        FileNameFormat fieldsFileNameFormat = new DefaultFileNameFormat().withPath(testRoot);
+
+        FileRotationPolicy rotationPolicy =
+                new FileSizeRotationPolicy(rotationSizeMB, FileSizeRotationPolicy.Units.MB);
+
+        return new AvroGenericRecordBolt()
+                .withFsUrl(nameNodeAddr)
+                .withFileNameFormat(fieldsFileNameFormat)
+                .withSchemaAsString(schemaAsString)
+                .withRotationPolicy(rotationPolicy)
+                .withSyncPolicy(fieldsSyncPolicy);
+    }
+
+    private static Tuple generateTestTuple(GenericRecord record) {
+        TopologyBuilder builder = new TopologyBuilder();
+        GeneralTopologyContext topologyContext = new GeneralTopologyContext(builder.createTopology(),
+                new Config(), new HashMap(), new HashMap(), new HashMap(), "") {
+            @Override
+            public Fields getComponentOutputFields(String componentId, String streamId) {
+                return new Fields("record");
+            }
+        };
+        return new TupleImpl(topologyContext, new Values(record), 1, "");
+    }
+
+    private void verifyAllAvroFiles(String path, Schema schema) throws IOException {
+        Path p = new Path(path);
+
+        for (FileStatus file : fs.listStatus(p)) {
+            if (file.getLen() > 0) {
+                fileIsGoodAvro(file.getPath(), schema);
+            }
+        }
+    }
+
+    private int countNonZeroLengthFiles(String path) throws IOException {
+        Path p = new Path(path);
+        int nonZero = 0;
+
+        for (FileStatus file : fs.listStatus(p)) {
+            if (file.getLen() > 0) {
+                nonZero++;
+            }
+        }
+
+        return nonZero;
+    }
+
+    private void fileIsGoodAvro (Path path, Schema schema) throws IOException {
+        DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(schema);
+        FSDataInputStream in = fs.open(path, 0);
+        FileOutputStream out = new FileOutputStream("target/FOO.avro");
+
+        byte[] buffer = new byte[100];
+        int bytesRead;
+        while ((bytesRead = in.read(buffer)) > 0) {
+            out.write(buffer, 0, bytesRead);
+        }
+        out.close();
+
+        java.io.File file = new File("target/FOO.avro");
+
+        DataFileReader<GenericRecord> dataFileReader = new DataFileReader<>(file, datumReader);
+        GenericRecord user = null;
+        while (dataFileReader.hasNext()) {
+            user = dataFileReader.next(user);
+            System.out.println(user);
+        }
+
+        file.delete();
+    }
+}


### PR DESCRIPTION
This creates a new concrete subtype of AbstractHdfsBolt that can write avro Generic Records directly to HDFS.