### PR TITLE
[STORM-40] Turn worker garbage collection and heapdump on by default

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -142,7 +142,7 @@ supervisor.cpu.capacity: 400.0
 
 ### worker.* configs are for task workers
 worker.heap.memory.mb: 768
-worker.childopts: "-Xmx%HEAP-MEM%m"
+worker.childopts: "-Xmx%HEAP-MEM%m -XX:+PrintGCDetails -Xloggc:artifacts/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"
 worker.gc.childopts: ""
 worker.heartbeat.frequency.secs: 1
 


### PR DESCRIPTION
Since STORM-901 worker artifacts directory just gets merged in, it provides a private place for us to turn on the garbage collection and heapdump for each worker by default. 
Since user can easily view and download gc log and heapdump file from logviewer UI, this will greatly improve the debugging of storm. 

Welcome discussion on the setting details (default gc rollover size, number of files, whether we want pid in the gc log file name, etc.), 