### PR TITLE
STORM-162: Load Aware Shuffle Grouping

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -226,6 +226,7 @@ topology.bolts.outgoing.overflow.buffer.enable: false
 topology.disruptor.wait.timeout.millis: 1000
 topology.disruptor.batch.size: 100
 topology.disruptor.batch.timeout.millis: 1
+topology.disable.loadaware: false
 
 # Configs for Resource Aware Scheduler
 topology.component.resources.onheap.memory.mb: 128.0

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -42,7 +42,8 @@
   (:require [backtype.storm.daemon.builtin-metrics :as builtin-metrics])
   (:require [clojure.set :as set]))
 
-(defn- mk-fields-grouper [^Fields out-fields ^Fields group-fields ^List target-tasks]
+(defn- mk-fields-grouper
+  [^Fields out-fields ^Fields group-fields ^List target-tasks]
   (let [num-tasks (count target-tasks)
         task-getter (fn [i] (.get target-tasks i))]
     (fn [task-id ^List values load]
@@ -51,7 +52,8 @@
           (mod num-tasks)
           task-getter))))
 
-(defn- mk-custom-grouper [^CustomStreamGrouping grouping ^WorkerTopologyContext context ^String component-id ^String stream-id target-tasks]
+(defn- mk-custom-grouper
+  [^CustomStreamGrouping grouping ^WorkerTopologyContext context ^String component-id ^String stream-id target-tasks]
   (.prepare grouping context (GlobalStreamId. component-id stream-id) target-tasks)
   (if (instance? LoadAwareCustomStreamGrouping grouping)
     (fn [task-id ^List values load]
@@ -59,7 +61,8 @@
     (fn [task-id ^List values load]
       (.chooseTasks grouping task-id values))))
 
-(defn mk-shuffle-grouper [^List target-tasks topo-conf ^WorkerTopologyContext context ^String component-id ^String stream-id]
+(defn mk-shuffle-grouper
+  [^List target-tasks topo-conf ^WorkerTopologyContext context ^String component-id ^String stream-id]
   (if (.get topo-conf TOPOLOGY-DISABLE-LOADAWARE-MESSAGING)
     (mk-custom-grouper (ShuffleGrouping.) context component-id stream-id target-tasks)
     (mk-custom-grouper (LoadAwareShuffleGrouping.) context component-id stream-id target-tasks)))
@@ -105,7 +108,8 @@
         :direct
       )))
 
-(defn- outbound-groupings [^WorkerTopologyContext worker-context this-component-id stream-id out-fields component->grouping topo-conf]
+(defn- outbound-groupings
+  [^WorkerTopologyContext worker-context this-component-id stream-id out-fields component->grouping topo-conf]
   (->> component->grouping
        (filter-key #(-> worker-context
                         (.getComponentTasks %)

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -55,7 +55,7 @@
   (.prepare grouping context (GlobalStreamId. component-id stream-id) target-tasks)
   (if (instance? LoadAwareCustomStreamGrouping grouping)
     (fn [task-id ^List values load]
-        (.chooseTasks grouping task-id values load))
+      (.chooseTasks grouping task-id values load))
     (fn [task-id ^List values load]
       (.chooseTasks grouping task-id values))))
 

--- a/storm-core/src/clj/backtype/storm/daemon/task.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/task.clj
@@ -18,6 +18,7 @@
   (:use [backtype.storm config util log])
   (:import [backtype.storm.hooks ITaskHook])
   (:import [backtype.storm.tuple Tuple TupleImpl])
+  (:import [backtype.storm.grouping LoadMapping])
   (:import [backtype.storm.generated SpoutSpec Bolt StateSpoutSpec StormTopology])
   (:import [backtype.storm.hooks.info SpoutAckInfo SpoutFailInfo
             EmitInfo BoltFailInfo BoltAckInfo])
@@ -119,6 +120,7 @@
 (defn mk-tasks-fn [task-data]
   (let [task-id (:task-id task-data)
         executor-data (:executor-data task-data)
+        ^LoadMapping load-mapping (:load-mapping (:worker executor-data))
         component-id (:component-id executor-data)
         ^WorkerTopologyContext worker-context (:worker-context executor-data)
         storm-conf (:storm-conf executor-data)
@@ -152,7 +154,7 @@
                (when (= :direct grouper)
                   ;;  TODO: this is wrong, need to check how the stream was declared
                   (throw (IllegalArgumentException. "Cannot do regular emit to direct stream")))
-               (let [comp-tasks (grouper task-id values)]
+               (let [comp-tasks (grouper task-id values load-mapping)]
                  (if (or (sequential? comp-tasks) (instance? Collection comp-tasks))
                    (.addAll out-tasks comp-tasks)
                    (.add out-tasks comp-tasks)

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -313,6 +313,8 @@
     [node (Integer/valueOf port-str)]
     ))
 
+(def LOAD-REFRESH-INTERVAL-MS 5000)
+
 (defn mk-refresh-load [worker]
   (let [local-tasks (set (:task-ids worker))
         remote-tasks (set/difference (worker-outbound-tasks worker) local-tasks)
@@ -331,7 +333,7 @@
           (.setRemote load-mapping remote-load)
           (when (> now @next-update)
             (.sendLoadMetrics (:receiver worker) local-pop)
-            (reset! next-update (+ 5000 now))))))))
+            (reset! next-update (+ LOAD-REFRESH-INTERVAL-MS now))))))))
 
 (defn mk-refresh-connections [worker]
   (let [outbound-tasks (worker-outbound-tasks worker)

--- a/storm-core/src/clj/backtype/storm/daemon/worker.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/worker.clj
@@ -25,6 +25,7 @@
   (:import [java.util.concurrent Executors])
   (:import [java.util ArrayList HashMap])
   (:import [backtype.storm.utils Utils TransferDrainer ThriftTopologyUtils WorkerBackpressureThread DisruptorQueue])
+  (:import [backtype.storm.grouping LoadMapping])
   (:import [backtype.storm.messaging TransportFactory])
   (:import [backtype.storm.messaging TaskMessage IContext IConnection ConnectionWithStatus ConnectionWithStatus$Status])
   (:import [backtype.storm.daemon Shutdownable])
@@ -269,6 +270,7 @@
       :topology topology
       :system-topology (system-topology! storm-conf topology)
       :heartbeat-timer (mk-halting-timer "heartbeat-timer")
+      :refresh-load-timer (mk-halting-timer "refresh-load-timer")
       :refresh-connections-timer (mk-halting-timer "refresh-connections-timer")
       :refresh-credentials-timer (mk-halting-timer "refresh-credentials-timer")
       :reset-log-levels-timer (mk-halting-timer "reset-log-levels-timer")
@@ -295,6 +297,7 @@
       :transfer-local-fn (mk-transfer-local-fn <>)
       :receiver-thread-count (get storm-conf WORKER-RECEIVER-THREAD-COUNT)
       :transfer-fn (mk-transfer-fn <>)
+      :load-mapping (LoadMapping.)
       :assignment-versions assignment-versions
       :backpressure (atom false) ;; whether this worker is going slow
       :transfer-backpressure (atom false) ;; if the transfer queue is backed-up
@@ -309,6 +312,26 @@
   (let [[port-str node] (.split s "/" 2)]
     [node (Integer/valueOf port-str)]
     ))
+
+(defn mk-refresh-load [worker]
+  (let [local-tasks (set (:task-ids worker))
+        remote-tasks (set/difference (worker-outbound-tasks worker) local-tasks)
+        short-executor-receive-queue-map (:short-executor-receive-queue-map worker)
+        next-update (atom 0)]
+    (fn this
+      ([]
+        (let [^LoadMapping load-mapping (:load-mapping worker)
+              local-pop (map-val (fn [queue]
+                                   (let [q-metrics (.getMetrics queue)]
+                                     (/ (double (.population q-metrics)) (.capacity q-metrics))))
+                                 short-executor-receive-queue-map)
+              remote-load (reduce merge (for [[np conn] @(:cached-node+port->socket worker)] (into {} (.getLoad conn remote-tasks))))
+              now (System/currentTimeMillis)]
+          (.setLocal load-mapping local-pop)
+          (.setRemote load-mapping remote-load)
+          (when (> now @next-update)
+            (.sendLoadMetrics (:receiver worker) local-pop)
+            (reset! next-update (+ 5000 now))))))))
 
 (defn mk-refresh-connections [worker]
   (let [outbound-tasks (worker-outbound-tasks worker)
@@ -572,6 +595,7 @@
         receive-thread-shutdown (launch-receive-thread worker)
 
         refresh-connections (mk-refresh-connections worker)
+        refresh-load (mk-refresh-load worker)
 
         _ (refresh-connections nil)
 
@@ -633,6 +657,7 @@
                     (cancel-timer (:refresh-active-timer worker))
                     (cancel-timer (:executor-heartbeat-timer worker))
                     (cancel-timer (:user-timer worker))
+                    (cancel-timer (:refresh-load-timer worker))
 
                     (close-resources worker)
 
@@ -653,6 +678,7 @@
                (and
                  (timer-waiting? (:heartbeat-timer worker))
                  (timer-waiting? (:refresh-connections-timer worker))
+                 (timer-waiting? (:refresh-load-timer worker))
                  (timer-waiting? (:refresh-credentials-timer worker))
                  (timer-waiting? (:refresh-active-timer worker))
                  (timer-waiting? (:executor-heartbeat-timer worker))
@@ -689,6 +715,9 @@
                           (check-credentials-changed)
                           (if ((:storm-conf worker) TOPOLOGY-BACKPRESSURE-ENABLE)
                             (check-throttle-changed))))
+    ;; The jitter allows the clients to get the data at different times, and avoids thundering herd
+    (when-not (.get conf TOPOLOGY-DISABLE-LOADAWARE-MESSAGING)
+      (schedule-recurring-with-jitter (:refresh-load-timer worker) 0 1 500 refresh-load))
     (schedule-recurring (:refresh-connections-timer worker) 0 (conf TASK-REFRESH-POLL-SECS) refresh-connections)
     (schedule-recurring (:reset-log-levels-timer worker) 0 (conf WORKER-LOG-LEVEL-RESET-POLL-SECS) (fn [] (reset-log-levels latest-log-config)))
     (schedule-recurring (:refresh-active-timer worker) 0 (conf TASK-REFRESH-POLL-SECS) (partial refresh-storm-active worker))

--- a/storm-core/src/clj/backtype/storm/messaging/local.clj
+++ b/storm-core/src/clj/backtype/storm/messaging/local.clj
@@ -15,12 +15,17 @@
 ;; limitations under the License.
 (ns backtype.storm.messaging.local
   (:refer-clojure :exclude [send])
-  (:use [backtype.storm log])
+  (:use [backtype.storm log util])
   (:import [backtype.storm.messaging IContext IConnection TaskMessage])
+  (:import [backtype.storm.grouping Load])
   (:import [java.util.concurrent LinkedBlockingQueue])
-  (:import [java.util Map Iterator])
+  (:import [java.util Map Iterator Collection])
   (:import [java.util Iterator ArrayList])
   (:gen-class))
+
+(defn update-load! [cached-task->load lock task->load]
+  (locking lock
+    (swap! cached-task->load merge task->load)))
 
 (defn add-queue! [queues-map lock storm-id port]
   (let [id (str storm-id "-" port)]
@@ -29,7 +34,7 @@
         (swap! queues-map assoc id (LinkedBlockingQueue.))))
     (@queues-map id)))
 
-(deftype LocalConnection [storm-id port queues-map lock queue]
+(deftype LocalConnection [storm-id port queues-map lock queue task->load]
   IConnection
   (^Iterator recv [this ^int flags ^int clientId]
     (when-not queue
@@ -50,24 +55,35 @@
       (while (.hasNext iter) 
          (.put send-queue (.next iter)))
       ))
-  (^void close [this]
-    ))
+  (^void sendLoadMetrics [this ^Map taskToLoad]
+    (update-load! task->load lock taskToLoad))
+  (^Map getLoad [this ^Collection tasks]
+    (locking lock
+      (into {}
+        (for [task tasks
+              :let [load (.get @task->load task)]
+              :when (not-nil? load)]
+          ;; for now we are ignoring the connection load locally
+          [task (Load. true load 0.0)]))))
+  (^void close [this]))
 
 
 (deftype LocalContext [^{:unsynchronized-mutable true} queues-map
-                       ^{:unsynchronized-mutable true} lock]
+                       ^{:unsynchronized-mutable true} lock
+                       ^{:unsynchronized-mutable true} task->load]
   IContext
   (^void prepare [this ^Map storm-conf]
     (set! queues-map (atom {}))
+    (set! task->load (atom {}))
     (set! lock (Object.)))
   (^IConnection bind [this ^String storm-id ^int port]
-    (LocalConnection. storm-id port queues-map lock (add-queue! queues-map lock storm-id port)))
+    (LocalConnection. storm-id port queues-map lock (add-queue! queues-map lock storm-id port) task->load))
   (^IConnection connect [this ^String storm-id ^String host ^int port]
-    (LocalConnection. storm-id port queues-map lock nil))
+    (LocalConnection. storm-id port queues-map lock nil task->load))
   (^void term [this]
     ))
 
 (defn mk-context [] 
-  (let [context  (LocalContext. nil nil)]
+  (let [context  (LocalContext. nil nil nil)]
     (.prepare ^IContext context nil)
     context))

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -239,6 +239,13 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_TUPLE_SERIALIZER = "topology.tuple.serializer";
 
     /**
+     * Disable load aware grouping support.
+     */
+    @isBoolean
+    @NotNull
+    public static final String TOPOLOGY_DISABLE_LOADAWARE_MESSAGING = "topology.disable.loadaware.messaging";
+
+    /**
      * Try to serialize all tuples, even for local transfers.  This should only be used
      * for testing, as a sanity check that all of your tuples are setup properly.
      */

--- a/storm-core/src/jvm/backtype/storm/grouping/Load.java
+++ b/storm-core/src/jvm/backtype/storm/grouping/Load.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.grouping;
+
+import java.io.Serializable;
+
+/**
+ * Represents the load that a Bolt is currently under to help in
+ * deciding where to route a tuple, to help balance the load.
+ */
+public class Load {
+    private boolean hasMetrics = false;
+    private double boltLoad = 0.0; //0 no load to 1 fully loaded
+    private double connectionLoad = 0.0; //0 no load to 1 fully loaded
+
+    /**
+     * Create a new load
+     * @param hasMetrics have metrics been reported yet?
+     * @param boltLoad the load as reported by the bolt 0.0 no load 1.0 fully loaded
+     * @param connectionLoad the load as reported by the connection to the bolt 0.0 no load 1.0 fully loaded.
+     */
+    public Load(boolean hasMetrics, double boltLoad, double connectionLoad) {
+        this.hasMetrics = hasMetrics;
+        this.boltLoad = boltLoad;
+        this.connectionLoad = connectionLoad;
+    }
+
+    /**
+     * @return true if metrics have been reported so far.
+     */
+    public boolean hasMetrics() {
+        return hasMetrics;
+    }
+
+    /**
+     * @return the load as reported by the bolt.
+     */
+    public double getBoltLoad() {
+        return boltLoad;
+    }
+
+    /**
+     * @return the load as reported by the connection
+     */
+    public double getConnectionLoad() {
+        return connectionLoad;
+    }
+
+    /**
+     * @return the load that is a combination of sub loads.
+     */
+    public double getLoad() {
+        if (!hasMetrics) {
+            return 1.0;
+        }
+        return connectionLoad > boltLoad ? connectionLoad : boltLoad;
+    }
+
+    public String toString() {
+        return "[:load "+boltLoad+" "+connectionLoad+"]";
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/grouping/LoadAwareCustomStreamGrouping.java
+++ b/storm-core/src/jvm/backtype/storm/grouping/LoadAwareCustomStreamGrouping.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.grouping;
+
+import java.util.List;
+
+public interface LoadAwareCustomStreamGrouping extends CustomStreamGrouping {
+   List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load);
+}

--- a/storm-core/src/jvm/backtype/storm/grouping/LoadAwareShuffleGrouping.java
+++ b/storm-core/src/jvm/backtype/storm/grouping/LoadAwareShuffleGrouping.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.grouping;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import backtype.storm.generated.GlobalStreamId;
+import backtype.storm.task.WorkerTopologyContext;
+
+public class LoadAwareShuffleGrouping implements LoadAwareCustomStreamGrouping, Serializable {
+    private Random random;
+    private List<Integer>[] rets;
+    private int[] targets;
+    private int[] loads;
+    private int total;
+    private long lastUpdate = 0;
+
+    @Override
+    public void prepare(WorkerTopologyContext context, GlobalStreamId stream, List<Integer> targetTasks) {
+        random = new Random();
+        rets = (List<Integer>[])new List<?>[targetTasks.size()];
+        targets = new int[targetTasks.size()];
+        for (int i = 0; i < targets.length; i++) {
+            rets[i] = Arrays.asList(targetTasks.get(i));
+            targets[i] = targetTasks.get(i);
+        }
+        loads = new int[targets.length];
+    }
+
+    @Override
+    public List<Integer> chooseTasks(int taskId, List<Object> values) {
+        throw new RuntimeException("NOT IMPLEMENTED");
+    }
+
+    @Override
+    public List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load) {
+        if ((lastUpdate + 1000) < System.currentTimeMillis()) {
+            int local_total = 0;
+            for (int i = 0; i < targets.length; i++) {
+                int val = (int)(101 - (load.get(targets[i]) * 100));
+                loads[i] = val;
+                local_total += val;
+            }
+            total = local_total;
+            lastUpdate = System.currentTimeMillis();
+        }
+        int selected = random.nextInt(total);
+        int sum = 0;
+        for (int i = 0; i < targets.length; i++) {
+            sum += loads[i];
+            if (selected < sum) {
+                return rets[i];
+            }
+        }
+        return rets[rets.length-1];
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/grouping/LoadMapping.java
+++ b/storm-core/src/jvm/backtype/storm/grouping/LoadMapping.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.grouping;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+ * Holds a list of the current loads
+ */
+public class LoadMapping {
+    private static final Load NOT_CONNECTED = new Load(false, 1.0, 1.0);
+    private final AtomicReference<Map<Integer,Load>> _local = new AtomicReference<Map<Integer,Load>>(new HashMap<Integer,Load>());
+    private final AtomicReference<Map<Integer,Load>> _remote = new AtomicReference<Map<Integer,Load>>(new HashMap<Integer,Load>());
+
+    public void setLocal(Map<Integer, Double> local) {
+        Map<Integer, Load> newLocal = new HashMap<Integer, Load>();
+        if (local != null) {
+          for (Map.Entry<Integer, Double> entry: local.entrySet()) {
+            newLocal.put(entry.getKey(), new Load(true, entry.getValue(), 0.0));
+          }
+        }
+        _local.set(newLocal);
+    }
+
+    public void setRemote(Map<Integer, Load> remote) {
+        if (remote != null) {
+          _remote.set(new HashMap<Integer, Load>(remote));
+        } else {
+          _remote.set(new HashMap<Integer, Load>());
+        }
+    }
+
+    public Load getLoad(int task) {
+        Load ret = _local.get().get(task);
+        if (ret == null) {
+          ret = _remote.get().get(task);
+        }
+        if (ret == null) {
+          ret = NOT_CONNECTED;
+        }
+        return ret;
+    }
+
+    public double get(int task) {
+        return getLoad(task).getLoad();
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/grouping/ShuffleGrouping.java
+++ b/storm-core/src/jvm/backtype/storm/grouping/ShuffleGrouping.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.grouping;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import backtype.storm.generated.GlobalStreamId;
+import backtype.storm.task.WorkerTopologyContext;
+
+public class ShuffleGrouping implements CustomStreamGrouping, Serializable {
+    private Random random;
+    private ArrayList<List<Integer>> choices;
+    private AtomicInteger current;
+
+    @Override
+    public void prepare(WorkerTopologyContext context, GlobalStreamId stream, List<Integer> targetTasks) {
+        random = new Random();
+        choices = new ArrayList<List<Integer>>(targetTasks.size());
+        for (Integer i: targetTasks) {
+            choices.add(Arrays.asList(i));
+        }
+        Collections.shuffle(choices, random);
+        current = new AtomicInteger(0);
+    }
+
+    @Override
+    public List<Integer> chooseTasks(int taskId, List<Object> values) {
+        int rightNow;
+        int size = choices.size();
+        while (true) {
+            rightNow = current.incrementAndGet();
+            if (rightNow < size) {
+                return choices.get(rightNow);
+            } else if (rightNow == size) {
+                current.set(0);
+                //This should be thread safe so long as ArrayList does not have any internal state that can be messed up by multi-treaded access.
+                Collections.shuffle(choices, random);
+                return choices.get(0);
+            }
+            //race condition with another thread, and we lost
+            // try again
+        }
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/messaging/IConnection.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/IConnection.java
@@ -17,7 +17,10 @@
  */
 package backtype.storm.messaging;
 
+import backtype.storm.grouping.Load;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 
 public interface IConnection {   
     
@@ -27,6 +30,12 @@ public interface IConnection {
      * @return
      */
     public Iterator<TaskMessage> recv(int flags, int clientId);
+
+    /**
+     * Send load metrics to all downstream connections.
+     * @param taskToLoad a map from the task id to the load for that task.
+     */
+    public void sendLoadMetrics(Map<Integer, Double> taskToLoad);
     
     /**
      * send a message with taskId and payload
@@ -42,6 +51,13 @@ public interface IConnection {
 
     public void send(Iterator<TaskMessage> msgs);
     
+    /**
+     * Get the current load for the given tasks
+     * @param tasks the tasks to look for.
+     * @return a Load for each of the tasks it knows about.
+     */
+    public Map<Integer, Load> getLoad(Collection<Integer> tasks);
+
     /**
      * close this connection
      */

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/ISaslClient.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/ISaslClient.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.messaging.netty;
+
+import org.jboss.netty.channel.Channel;
+import backtype.storm.Config;
+
+public interface ISaslClient {
+    void channelConnected(Channel channel);
+    void channelReady();
+    String name();
+    String secretKey();
+}

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/ISaslServer.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/ISaslServer.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.messaging.netty;
+
+import org.jboss.netty.channel.Channel;
+
+public interface ISaslServer extends IServer {
+    String name();
+    String secretKey();
+    void authenticated(Channel c);
+}

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/IServer.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/IServer.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.messaging.netty;
+
+import org.jboss.netty.channel.Channel;
+
+public interface IServer {
+    void channelConnected(Channel c);
+    void received(Object message, String remote, Channel channel) throws InterruptedException;
+    void closeChannel(Channel c);
+}

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/SaslStormClientHandler.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/SaslStormClientHandler.java
@@ -28,19 +28,18 @@ import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.Config;
-
 public class SaslStormClientHandler extends SimpleChannelUpstreamHandler {
 
     private static final Logger LOG = LoggerFactory
             .getLogger(SaslStormClientHandler.class);
-    private Client client;
+
+    private ISaslClient client;
     long start_time;
     /** Used for client or server's token to send or receive from each other. */
     private byte[] token;
-    private String topologyName;
+    private String name;
 
-    public SaslStormClientHandler(Client client) throws IOException {
+    public SaslStormClientHandler(ISaslClient client) throws IOException {
         this.client = client;
         start_time = System.currentTimeMillis();
         getSASLCredentials();
@@ -51,9 +50,7 @@ public class SaslStormClientHandler extends SimpleChannelUpstreamHandler {
             ChannelStateEvent event) {
         // register the newly established channel
         Channel channel = ctx.getChannel();
-
-        LOG.info("Connection established from " + channel.getLocalAddress()
-                + " to " + channel.getRemoteAddress());
+        client.channelConnected(channel);
 
         try {
             SaslNettyClient saslNettyClient = SaslNettyClientState.getSaslNettyClient
@@ -62,10 +59,11 @@ public class SaslStormClientHandler extends SimpleChannelUpstreamHandler {
             if (saslNettyClient == null) {
                 LOG.debug("Creating saslNettyClient now " + "for channel: "
                         + channel);
-                saslNettyClient = new SaslNettyClient(topologyName, token);
+                saslNettyClient = new SaslNettyClient(name, token);
                 SaslNettyClientState.getSaslNettyClient.set(channel,
                         saslNettyClient);
             }
+            LOG.debug("Sending SASL_TOKEN_MESSAGE_REQUEST");
             channel.write(ControlMessage.SASL_TOKEN_MESSAGE_REQUEST);
         } catch (Exception e) {
             LOG.error("Failed to authenticate with server " + "due to error: ",
@@ -96,7 +94,7 @@ public class SaslStormClientHandler extends SimpleChannelUpstreamHandler {
             ControlMessage msg = (ControlMessage) event.getMessage();
             if (msg == ControlMessage.SASL_COMPLETE_REQUEST) {
                 LOG.debug("Server has sent us the SaslComplete "
-                        + "message. Allowing normal work to proceed.");
+                          + "message. Allowing normal work to proceed.");
 
                 if (!saslNettyClient.isComplete()) {
                     LOG.error("Server returned a Sasl-complete message, "
@@ -106,6 +104,8 @@ public class SaslStormClientHandler extends SimpleChannelUpstreamHandler {
                             + "we can tell, we are not authenticated yet.");
                 }
                 ctx.getPipeline().remove(this);
+                this.client.channelReady();
+
                 // We call fireMessageReceived since the client is allowed to
                 // perform this request. The client's request will now proceed
                 // to the next pipeline component namely StormClientHandler.
@@ -116,7 +116,7 @@ public class SaslStormClientHandler extends SimpleChannelUpstreamHandler {
         SaslMessageToken saslTokenMessage = (SaslMessageToken) event
                 .getMessage();
         LOG.debug("Responding to server's token of length: "
-                + saslTokenMessage.getSaslToken().length);
+                  + saslTokenMessage.getSaslToken().length);
 
         // Generate SASL response (but we only actually send the response if
         // it's non-null.
@@ -127,17 +127,18 @@ public class SaslStormClientHandler extends SimpleChannelUpstreamHandler {
             // (if not, warn), and return without sending a response back to the
             // server.
             LOG.debug("Response to server is null: "
-                    + "authentication should now be complete.");
+                      + "authentication should now be complete.");
             if (!saslNettyClient.isComplete()) {
                 LOG.warn("Generated a null response, "
                         + "but authentication is not complete.");
                 throw new Exception("Server reponse is null, but as far as "
                         + "we can tell, we are not authenticated yet.");
             }
+            this.client.channelReady();
             return;
         } else {
             LOG.debug("Response to server token has length:"
-                    + responseToServer.length);
+                      + responseToServer.length);
         }
         // Construct a message containing the SASL response and send it to the
         // server.
@@ -146,12 +147,14 @@ public class SaslStormClientHandler extends SimpleChannelUpstreamHandler {
     }
 
     private void getSASLCredentials() throws IOException {
-        topologyName = (String) this.client.getStormConf().get(Config.TOPOLOGY_NAME);
-        String secretKey = SaslUtils.getSecretKey(this.client.getStormConf());
+        String secretKey;
+        name = client.name();
+        secretKey = client.secretKey();
+
         if (secretKey != null) {
             token = secretKey.getBytes();
         }
-        LOG.debug("SASL credentials for storm topology " + topologyName
+        LOG.debug("SASL credentials for storm topology " + name
                 + " is " + secretKey);
     }
 }

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/StormClientHandler.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/StormClientHandler.java
@@ -17,7 +17,20 @@
  */
 package backtype.storm.messaging.netty;
 
+import backtype.storm.messaging.TaskMessage;
+import backtype.storm.serialization.KryoValuesDeserializer;
+
 import java.net.ConnectException;
+import java.util.Map;
+import java.util.List;
+import java.io.IOException;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 
 import org.jboss.netty.channel.*;
 import org.slf4j.Logger;
@@ -26,9 +39,41 @@ import org.slf4j.LoggerFactory;
 public class StormClientHandler extends SimpleChannelUpstreamHandler  {
     private static final Logger LOG = LoggerFactory.getLogger(StormClientHandler.class);
     private Client client;
-    
-    StormClientHandler(Client client) {
+    private KryoValuesDeserializer _des;
+
+    StormClientHandler(Client client, Map conf) {
         this.client = client;
+        _des = new KryoValuesDeserializer(conf);
+    }
+
+    @Override
+    public void messageReceived(ChannelHandlerContext ctx, MessageEvent event) {
+        //examine the response message from server
+        Object message = event.getMessage();
+        if (message instanceof ControlMessage) {
+            ControlMessage msg = (ControlMessage)message;
+            if (msg==ControlMessage.FAILURE_RESPONSE) {
+                LOG.info("failure response:{}", msg);
+            }
+        } else if (message instanceof List) {
+            try {
+                //This should be the metrics, and there should only be one of them
+                List<TaskMessage> list = (List<TaskMessage>)message;
+                if (list.size() < 1) throw new RuntimeException("Didn't see enough load metrics ("+client.getDstAddress()+") "+list);
+                if (list.size() != 1) LOG.warn("Messages are not being delivered fast enough, got "+list.size()+" metrics messages at once("+client.getDstAddress()+")");
+                TaskMessage tm = ((List<TaskMessage>)message).get(list.size() - 1);
+                if (tm.task() != -1) throw new RuntimeException("Metrics messages are sent to the system task ("+client.getDstAddress()+") "+tm);
+                List metrics = _des.deserialize(tm.message());
+                if (metrics.size() < 1) throw new RuntimeException("No metrics data in the metrics message ("+client.getDstAddress()+") "+metrics);
+                if (!(metrics.get(0) instanceof Map)) throw new RuntimeException("The metrics did not have a map in the first slot ("+client.getDstAddress()+") "+metrics);
+                client.setLoadMetrics((Map<Integer, Double>)metrics.get(0));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            throw new RuntimeException("Don't know how to handle a message of type "
+                                       + message + " (" + client.getDstAddress() + ")");
+        }
     }
 
     @Override
@@ -40,7 +85,7 @@ public class StormClientHandler extends SimpleChannelUpstreamHandler  {
     public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent event) {
         Throwable cause = event.getCause();
         if (!(cause instanceof ConnectException)) {
-            LOG.info("Connection failed " + client.dstAddressPrefixedName, cause);
+            LOG.info("Connection to "+client.getDstAddress()+" failed:", cause);
         }
     }
 }

--- a/storm-core/src/jvm/backtype/storm/messaging/netty/StormClientPipelineFactory.java
+++ b/storm-core/src/jvm/backtype/storm/messaging/netty/StormClientPipelineFactory.java
@@ -22,12 +22,15 @@ import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.Channels;
 
 import backtype.storm.Config;
+import java.util.Map;
 
 class StormClientPipelineFactory implements ChannelPipelineFactory {
     private Client client;
+    private Map conf;
 
-    StormClientPipelineFactory(Client client) {
+    StormClientPipelineFactory(Client client, Map conf) {
         this.client = client;
+        this.conf = conf;
     }
 
     public ChannelPipeline getPipeline() throws Exception {
@@ -39,15 +42,15 @@ class StormClientPipelineFactory implements ChannelPipelineFactory {
         // Encoder
         pipeline.addLast("encoder", new MessageEncoder());
 
-        boolean isNettyAuth = (Boolean) this.client.getStormConf().get(Config.STORM_MESSAGING_NETTY_AUTHENTICATION);
+        boolean isNettyAuth = (Boolean) conf
+                .get(Config.STORM_MESSAGING_NETTY_AUTHENTICATION);
         if (isNettyAuth) {
             // Authenticate: Removed after authentication completes
             pipeline.addLast("saslClientHandler", new SaslStormClientHandler(
                     client));
         }
         // business logic.
-        pipeline.addLast("handler", new StormClientHandler(client));
-
+        pipeline.addLast("handler", new StormClientHandler(client, conf));
         return pipeline;
     }
 }

--- a/storm-core/test/clj/backtype/storm/grouping_test.clj
+++ b/storm-core/test/clj/backtype/storm/grouping_test.clj
@@ -17,27 +17,85 @@
   (:use [clojure test])
   (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount TestAggregatesCounter TestWordBytesCounter NGrouping]
            [backtype.storm.generated JavaObject JavaObjectArg])
-  (:use [backtype.storm testing clojure])
-  (:use [backtype.storm.daemon common])
+  (:import [backtype.storm.grouping LoadMapping])
+  (:use [backtype.storm testing clojure log config])
+  (:use [backtype.storm.daemon common executor])
   (:require [backtype.storm [thrift :as thrift]]))
 
 (deftest test-shuffle
+ (let [shuffle-fn (mk-shuffle-grouper [(int 1) (int 2)] {TOPOLOGY-DISABLE-LOADAWARE-MESSAGING true} nil "comp" "stream")
+       num-messages 100000
+       min-prcnt (int (* num-messages 0.49))
+       max-prcnt (int (* num-messages 0.51))
+       data [1 2]
+       freq (frequencies (for [x (range 0 num-messages)] (shuffle-fn (int 1) data nil)))
+       load1 (.get freq [(int 1)])
+       load2 (.get freq [(int 2)])]
+    (log-message "FREQ:" freq)
+    (is (>= load1 min-prcnt))
+    (is (<= load1 max-prcnt))
+    (is (>= load2 min-prcnt))
+    (is (<= load2 max-prcnt))))
+
+(deftest test-shuffle-load-even
+ (let [shuffle-fn (mk-shuffle-grouper [(int 1) (int 2)] {} nil "comp" "stream")
+       num-messages 100000
+       min-prcnt (int (* num-messages 0.49))
+       max-prcnt (int (* num-messages 0.51))
+       load (LoadMapping.)
+       _ (.setLocal load {(int 1) 0.0 (int 2) 0.0})
+       data [1 2]
+       freq (frequencies (for [x (range 0 num-messages)] (shuffle-fn (int 1) data load)))
+       load1 (.get freq [(int 1)])
+       load2 (.get freq [(int 2)])]
+    (log-message "FREQ:" freq)
+    (is (>= load1 min-prcnt))
+    (is (<= load1 max-prcnt))
+    (is (>= load2 min-prcnt))
+    (is (<= load2 max-prcnt))))
+
+(deftest test-shuffle-load-uneven
+ (let [shuffle-fn (mk-shuffle-grouper [(int 1) (int 2)] {} nil "comp" "stream")
+       num-messages 100000
+       min1-prcnt (int (* num-messages 0.32))
+       max1-prcnt (int (* num-messages 0.34))
+       min2-prcnt (int (* num-messages 0.65))
+       max2-prcnt (int (* num-messages 0.67))
+       load (LoadMapping.)
+       _ (.setLocal load {(int 1) 0.5 (int 2) 0.0})
+       data [1 2]
+       freq (frequencies (for [x (range 0 num-messages)] (shuffle-fn (int 1) data load)))
+       load1 (.get freq [(int 1)])
+       load2 (.get freq [(int 2)])]
+    (log-message "FREQ:" freq)
+    (is (>= load1 min1-prcnt))
+    (is (<= load1 max1-prcnt))
+    (is (>= load2 min2-prcnt))
+    (is (<= load2 max2-prcnt))))
+
+(deftest test-field
   (with-simulated-time-local-cluster [cluster :supervisors 4]
-    (let [topology (thrift/mk-topology
-                    {"1" (thrift/mk-spout-spec (TestWordSpout. true) :parallelism-hint 4)}
-                    {"2" (thrift/mk-bolt-spec {"1" :shuffle} (TestGlobalCount.)
-                                            :parallelism-hint 6)
+    (let [spout-phint 4
+          bolt-phint 6
+          topology (thrift/mk-topology
+                    {"1" (thrift/mk-spout-spec (TestWordSpout. true)
+                                               :parallelism-hint spout-phint)}
+                    {"2" (thrift/mk-bolt-spec {"1" ["word"]}
+                                              (TestWordBytesCounter.)
+                                              :parallelism-hint bolt-phint)
                      })
-          results (complete-topology cluster
-                                     topology
-                                     ;; important for test that
-                                     ;; #tuples = multiple of 4 and 6
-                                     :mock-sources {"1" (->> [["a"] ["b"]]
-                                                             (repeat 12)
-                                                             (apply concat))})]
-      (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
-               (read-tuples results "2")))
-      )))
+          results (complete-topology
+                    cluster
+                    topology
+                    :mock-sources {"1" (->> [[(.getBytes "a")]
+                                             [(.getBytes "b")]]
+                                            (repeat (* spout-phint bolt-phint))
+                                            (apply concat))})]
+      (is (ms= (apply concat
+                      (for [value '("a" "b")
+                            sum (range 1 (inc (* spout-phint bolt-phint)))]
+                        [[value sum]]))
+               (read-tuples results "2"))))))
 
 (deftest test-field
   (with-simulated-time-local-cluster [cluster :supervisors 4]

--- a/storm-core/test/clj/backtype/storm/integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/integration_test.clj
@@ -62,13 +62,13 @@
   (with-simulated-time-local-cluster [cluster :supervisors 4]
     (let [topology (thrift/mk-topology
                     {"1" (thrift/mk-spout-spec (TestWordSpout. true))}
-                    {"2" (thrift/mk-bolt-spec {"1" :shuffle} emit-task-id
+                    {"2" (thrift/mk-bolt-spec {"1" :all} emit-task-id
                       :parallelism-hint 3
                       :conf {TOPOLOGY-TASKS 6})
                      })
           results (complete-topology cluster
                                      topology
-                                     :mock-sources {"1" [["a"] ["a"] ["a"] ["a"] ["a"] ["a"]]})]
+                                     :mock-sources {"1" [["a"]]})]
       (is (ms= [[0] [1] [2] [3] [4] [5]]
                (read-tuples results "2")))
       )))

--- a/storm-core/test/clj/backtype/storm/messaging/netty_integration_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging/netty_integration_test.clj
@@ -54,5 +54,4 @@
                                                          ["a"] ["b"]
                                                          ]}
                                      )]
-      (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
-               (read-tuples results "2"))))))
+        (is (= (* 6 4) (.size (read-tuples results "2")))))))

--- a/storm-core/test/clj/backtype/storm/messaging/netty_unit_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging/netty_unit_test.clj
@@ -16,6 +16,7 @@
 (ns backtype.storm.messaging.netty-unit-test
   (:use [clojure test])
   (:import [backtype.storm.messaging TransportFactory])
+  (:import [backtype.storm.utils Utils])
   (:use [backtype.storm testing util config log])
   (:use [backtype.storm.daemon.worker :only [is-connection-ready]])
   (:import [java.util ArrayList]))
@@ -33,20 +34,37 @@
       (do (log-message "Waiting until all Netty connections are ready...")
           (wait-until-ready connections 0)))
   ([connections waited-ms]
-    (let [interval-ms 10
-          max-wait-ms 5000]
-      (if-not (every? is-connection-ready connections)
-        (if (<= waited-ms max-wait-ms)
-          (do
-            (Thread/sleep interval-ms)
-            (wait-until-ready connections (+ waited-ms interval-ms)))
-          (throw (RuntimeException. (str "Netty connections were not ready within " max-wait-ms " ms"))))
-        (log-message "All Netty connections are ready")))))
+   (loop [connections connections waited-ms waited-ms]
+     (let [interval-ms 10
+           max-wait-ms 5000]
+       (if-not (every? is-connection-ready connections)
+         (if (<= waited-ms max-wait-ms)
+           (do
+             (Thread/sleep interval-ms)
+             (recur connections (+ waited-ms interval-ms)))
+           (throw (RuntimeException. (str "Netty connections were not ready within " max-wait-ms " ms"))))
+         (log-message "All Netty connections are ready"))))))
+
+
+(defn- test-basic-fn [storm-conf]
+  (log-message "1. Should send and receive a basic message")
+  (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
+        context (TransportFactory/makeContext storm-conf)
+        port (available-port 6700)
+        server (.bind context nil port)
+        client (.connect context nil "localhost" port)
+        _ (wait-until-ready [server client])
+        _ (.send client task (.getBytes req_msg))
+        iter (.recv server 0 0)
+        resp (.next iter)]
+    (is (= task (.task resp)))
+    (is (= req_msg (String. (.message resp))))
+    (.close client)
+    (.close server)
+    (.term context)))
 
 (deftest test-basic
-  (log-message "Should send and receive a basic message")
-  (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
-        storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+ (let [storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
                     STORM-MESSAGING-NETTY-AUTHENTICATION false
                     STORM-MESSAGING-NETTY-BUFFER-SIZE 1024
                     STORM-MESSAGING-NETTY-MAX-RETRIES 10
@@ -54,8 +72,64 @@
                     STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
                     STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
                     STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
-                    }
+                    TOPOLOGY-KRYO-FACTORY "backtype.storm.serialization.DefaultKryoFactory"
+                    TOPOLOGY-TUPLE-SERIALIZER "backtype.storm.serialization.types.ListDelegateSerializer"
+                    TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false
+                    TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS false}
+        storm-conf-sasl (assoc storm-conf
+                                    STORM-MESSAGING-NETTY-AUTHENTICATION true
+                                    TOPOLOGY-NAME "topo1-netty-sasl"
+                                    STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD (str (Utils/secureRandomLong) ":" (Utils/secureRandomLong)))]
+   (test-basic-fn storm-conf)          ;; test with sasl authentication disabled
+   (test-basic-fn storm-conf-sasl)))   ;; test with sasl authentication enabled
+
+(defn- test-load-fn [storm-conf]
+  (log-message "2 test load")
+  (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
         context (TransportFactory/makeContext storm-conf)
+        port (available-port 6700)
+        server (.bind context nil port)
+        client (.connect context nil "localhost" port)
+        _ (wait-until-ready [server client])
+        _ (.send client task (.getBytes req_msg))
+        iter (.recv server 0 0)
+        resp (.next iter)
+        _ (.sendLoadMetrics server {(int 1) 0.0 (int 2) 1.0})
+        _ (while-timeout 5000 (empty? (.getLoad client [(int 1) (int 2)])) (Thread/sleep 10))
+        load (.getLoad client [(int 1) (int 2)])]
+    (is (= 0.0 (.getBoltLoad (.get load (int 1)))))
+    (is (= 1.0 (.getBoltLoad (.get load (int 2)))))
+    (is (= task (.task resp)))
+    (is (= req_msg (String. (.message resp))))
+    (.close client)
+    (.close server)
+    (.term context)))
+
+(deftest test-load
+ (let [storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+                    STORM-MESSAGING-NETTY-AUTHENTICATION false
+                    STORM-MESSAGING-NETTY-BUFFER-SIZE 1024
+                    STORM-MESSAGING-NETTY-MAX-RETRIES 10
+                    STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
+                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                    TOPOLOGY-KRYO-FACTORY "backtype.storm.serialization.DefaultKryoFactory"
+                    TOPOLOGY-TUPLE-SERIALIZER "backtype.storm.serialization.types.ListDelegateSerializer"
+                    TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false
+                    TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS false}
+        storm-conf-sasl (assoc storm-conf
+                                    STORM-MESSAGING-NETTY-AUTHENTICATION true
+                                    TOPOLOGY-NAME "topo1-netty-sasl"
+                                    STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD (str (Utils/secureRandomLong) ":" (Utils/secureRandomLong)))]
+   (test-load-fn storm-conf)          ;; test with sasl authentication disabled
+   (test-load-fn storm-conf-sasl)))   ;; test with sasl authentication enabled
+
+(defn test-large-msg-fn [storm-conf]
+  (log-message "3 Should send and receive a large message")
+  (let [req_msg (apply str (repeat 2048000 'c'))
+        context (TransportFactory/makeContext storm-conf)
+        port (available-port 6700)
         server (.bind context nil port)
         client (.connect context nil "localhost" port)
         _ (wait-until-ready [server client])
@@ -69,9 +143,7 @@
     (.term context)))
 
 (deftest test-large-msg
-  (log-message "Should send and receive a large message")
-  (let [req_msg (apply str (repeat 2048000 'c'))
-        storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+ (let [storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
                     STORM-MESSAGING-NETTY-AUTHENTICATION false
                     STORM-MESSAGING-NETTY-BUFFER-SIZE 102400
                     STORM-MESSAGING-NETTY-MAX-RETRIES 10
@@ -79,34 +151,68 @@
                     STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
                     STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
                     STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
-                    }
-        context (TransportFactory/makeContext storm-conf)
-        server (.bind context nil port)
-        client (.connect context nil "localhost" port)
-        _ (wait-until-ready [server client])
-        _ (.send client task (.getBytes req_msg))
-        iter (.recv server 0 0)
-        resp (.next iter)]
-    (is (= task (.task resp)))
-    (is (= req_msg (String. (.message resp))))
-    (.close client)
-    (.close server)
-    (.term context)))
+                    TOPOLOGY-KRYO-FACTORY "backtype.storm.serialization.DefaultKryoFactory"
+                    TOPOLOGY-TUPLE-SERIALIZER "backtype.storm.serialization.types.ListDelegateSerializer"
+                    TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false
+                    TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS false}
+        storm-conf-sasl (assoc storm-conf
+                                    STORM-MESSAGING-NETTY-AUTHENTICATION true
+                                    TOPOLOGY-NAME "topo1-netty-sasl"
+                                    STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD (str (Utils/secureRandomLong) ":" (Utils/secureRandomLong)))]
+   (test-large-msg-fn storm-conf)          ;; test with sasl authentication disabled
+   (test-large-msg-fn storm-conf-sasl)))   ;; test with sasl authentication enabled
 
+(defn- test-server-delayed-fn [storm-conf]
+  (log-message "4. test server delayed")
+    (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
+          context (TransportFactory/makeContext storm-conf)
+          port (available-port 6700)
+          client (.connect context nil "localhost" port)
 
-(deftest test-batch
-  (let [num-messages 100000
-        storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+          server (Thread.
+                  (fn []
+                    (Thread/sleep 1000)
+                    (let [server (.bind context nil port)
+                          iter (.recv server 0 0)
+                          resp (.next iter)]
+                      (is (= task (.task resp)))
+                      (is (= req_msg (String. (.message resp))))
+                      (.close server))))]
+      (.start server)
+      (wait-until-ready [server client])
+      (.send client task (.getBytes req_msg))
+
+      (.join server)
+      (.close client)
+      (.term context)))
+
+(deftest test-server-delayed
+ (let [storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
                     STORM-MESSAGING-NETTY-AUTHENTICATION false
-                    STORM-MESSAGING-NETTY-BUFFER-SIZE 1024000
+                    STORM-MESSAGING-NETTY-BUFFER-SIZE 1024
                     STORM-MESSAGING-NETTY-MAX-RETRIES 10
                     STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
                     STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
                     STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
                     STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
-                    }
+                    TOPOLOGY-KRYO-FACTORY "backtype.storm.serialization.DefaultKryoFactory"
+                    TOPOLOGY-TUPLE-SERIALIZER "backtype.storm.serialization.types.ListDelegateSerializer"
+                    TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false
+                    TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS false}
+        storm-conf-sasl (assoc storm-conf
+                                    STORM-MESSAGING-NETTY-AUTHENTICATION true
+                                    TOPOLOGY-NAME "topo1-netty-sasl"
+                                    STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD (str (Utils/secureRandomLong) ":" (Utils/secureRandomLong)))]
+   (test-server-delayed-fn storm-conf)          ;; test with sasl authentication disabled
+   (test-server-delayed-fn storm-conf-sasl)))   ;; test with sasl authentication enabled
+
+
+(defn- test-batch-fn [storm-conf]
+  (log-message "5. test batch")
+  (let [num-messages 100000
         _ (log-message "Should send and receive many messages (testing with " num-messages " messages)")
         context (TransportFactory/makeContext storm-conf)
+        port (available-port 6700)
         server (.bind context nil port)
         client (.connect context nil "localhost" port)
         _ (wait-until-ready [server client])]
@@ -130,4 +236,78 @@
 
     (.close client)
     (.close server)
-    (.term context)))
+    (.term context))
+
+(deftest test-batch
+ (let [storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+                    STORM-MESSAGING-NETTY-AUTHENTICATION false
+                    STORM-MESSAGING-NETTY-BUFFER-SIZE 1024000
+                    STORM-MESSAGING-NETTY-MAX-RETRIES 10
+                    STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000
+                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                    TOPOLOGY-KRYO-FACTORY "backtype.storm.serialization.DefaultKryoFactory"
+                    TOPOLOGY-TUPLE-SERIALIZER "backtype.storm.serialization.types.ListDelegateSerializer"
+                    TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false
+                    TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS false}
+        storm-conf-sasl (assoc storm-conf
+                                    STORM-MESSAGING-NETTY-AUTHENTICATION true
+                                    TOPOLOGY-NAME "topo1-netty-sasl"
+                                    STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD (str (Utils/secureRandomLong) ":" (Utils/secureRandomLong)))]
+   (test-batch-fn storm-conf)          ;; test with sasl authentication disabled
+   (test-batch-fn storm-conf-sasl)))   ;; test with sasl authentication enabled
+)
+
+(defn- test-server-always-reconnects-fn [storm-conf]
+  (log-message "6. test server always reconnects")
+    (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
+          storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+                      STORM-MESSAGING-NETTY-AUTHENTICATION false
+                      STORM-MESSAGING-NETTY-BUFFER-SIZE 1024
+                      STORM-MESSAGING-NETTY-MAX-RETRIES 2
+                      STORM-MESSAGING-NETTY-MIN-SLEEP-MS 10
+                      STORM-MESSAGING-NETTY-MAX-SLEEP-MS 50
+                      STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                      STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                      TOPOLOGY-KRYO-FACTORY "backtype.storm.serialization.DefaultKryoFactory"
+                      TOPOLOGY-TUPLE-SERIALIZER "backtype.storm.serialization.types.ListDelegateSerializer"
+                      TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false
+                      TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS false}
+          context (TransportFactory/makeContext storm-conf)
+          port (available-port 6700)
+          client (.connect context nil "localhost" port)
+          _ (.send client task (.getBytes req_msg))
+          server (.bind context nil port)
+          _ (wait-until-ready [server client])
+          _ (.send client task (.getBytes req_msg))
+          iter (future (.recv server 0 0))
+          resp (deref iter 5000 nil)
+          resp-val (if resp (.next resp) nil)]
+      (is resp-val)
+      (when resp-val
+        (is (= task (.task resp-val)))
+        (is (= req_msg (String. (.message resp-val)))))
+      (.close client)
+      (.close server)
+      (.term context)))
+
+(deftest test-server-always-reconnects
+ (let [storm-conf {STORM-MESSAGING-TRANSPORT "backtype.storm.messaging.netty.Context"
+                    STORM-MESSAGING-NETTY-AUTHENTICATION false
+                    STORM-MESSAGING-NETTY-BUFFER-SIZE 1024
+                    STORM-MESSAGING-NETTY-MAX-RETRIES 2
+                    STORM-MESSAGING-NETTY-MIN-SLEEP-MS 10
+                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 50
+                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                    TOPOLOGY-KRYO-FACTORY "backtype.storm.serialization.DefaultKryoFactory"
+                    TOPOLOGY-TUPLE-SERIALIZER "backtype.storm.serialization.types.ListDelegateSerializer"
+                    TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false
+                    TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS false}
+        storm-conf-sasl (assoc storm-conf
+                                    STORM-MESSAGING-NETTY-AUTHENTICATION true
+                                    TOPOLOGY-NAME "topo1-netty-sasl"
+                                    STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD (str (Utils/secureRandomLong) ":" (Utils/secureRandomLong)))]
+   (test-server-always-reconnects-fn storm-conf)          ;; test with sasl authentication disabled
+   (test-server-always-reconnects-fn storm-conf-sasl)))   ;; test with sasl authentication enabled

--- a/storm-core/test/clj/backtype/storm/messaging_test.clj
+++ b/storm-core/test/clj/backtype/storm/messaging_test.clj
@@ -51,8 +51,7 @@
                                                            ["a"] ["b"]
                                                            ]}
                                        )]
-        (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
-                 (read-tuples results "2")))))))
+        (is (= (* 6 4) (.size (read-tuples results "2"))))))))
 
 (extend-type TestEventLogSpout
   CompletableSpout


### PR DESCRIPTION
I am recreating this pull request. Originally there was discussion about using the velocity of a bolt in addition to the queue size in determining the routing, but I didn't have time to implement that, and we have been running with this code in production for quite a while, so I decided to just put it up, as it has a really positive impact.  This is most pronounced on heterogeneous clusters where not all nodes have the same CPU.  But also this improves the performance of the groupings implementations significantly dropping the 99th and 99.9th %-lie latencies significantly for the Latency vs Throughput test case.

I would still like to explore using velocity and network distance in the routing calculations, but in a follow on JIRA.