### PR TITLE
[YSTORM-1433] - normalize the scales of CPU/Mem/Net when choosing the best node

### DIFF
--- a/storm-core/src/jvm/backtype/storm/scheduler/resource/strategies/ResourceAwareStrategy.java
+++ b/storm-core/src/jvm/backtype/storm/scheduler/resource/strategies/ResourceAwareStrategy.java
@@ -209,18 +209,18 @@ public class ResourceAwareStrategy implements IStrategy {
         for (RAS_Node n : nodes) {
             if(n.getFreeSlots().size()>0) {
                 if (n.getAvailableMemoryResources() >= taskMem
-                      && n.getAvailableCpuResources() >= taskCPU) {
-                  double a = Math.pow((taskCPU - n.getAvailableCpuResources())
-                          * this.CPU_WEIGHT, 2);
-                  double b = Math.pow((taskMem - n.getAvailableMemoryResources())
-                          * this.MEM_WEIGHT, 2);
-                  double c = 0.0;
-                  if(this.refNode != null) {
-                      c = Math.pow(this.distToNode(this.refNode, n)
-                              * this.NETWORK_WEIGHT, 2);
-                  }
-                  double distance = Math.sqrt(a + b + c);
-                  nodeRankMap.put(distance, n);
+                        && n.getAvailableCpuResources() >= taskCPU) {
+                    double a = Math.pow(((taskCPU - n.getAvailableCpuResources())/n.getAvailableCpuResources())
+                            * this.CPU_WEIGHT, 2);
+                    double b = Math.pow(((taskMem - n.getAvailableMemoryResources())/n.getAvailableMemoryResources())
+                            * this.MEM_WEIGHT, 2);
+                    double c = 0.0;
+                    if(this.refNode != null) {
+                        c = Math.pow(this.distToNode(this.refNode, n)
+                                * this.NETWORK_WEIGHT, 2);
+                    }
+                    double distance = Math.sqrt(a + b + c);
+                    nodeRankMap.put(distance, n);
                 }
             }
         }
@@ -262,12 +262,12 @@ public class ResourceAwareStrategy implements IStrategy {
     }
 
     private Double distToNode(RAS_Node src, RAS_Node dest) {
-        if (src.getId().equals(dest.getId())==true) {
-            return 1.0;
+        if (src.getId().equals(dest.getId()) == true) {
+            return 0.0;
         }else if (this.NodeToCluster(src) == this.NodeToCluster(dest)) {
-            return 2.0;
+            return 0.5;
         } else {
-            return 3.0;
+            return 1.0;
         }
     }
 


### PR DESCRIPTION
So instead of using actual values for CPU and Memory when finding the best node for a executor, lets use ratios. We can calculate what percentage of free resources an executor will consume if scheduled on the node. By using this ratio we still use the best fit strategy however all values will be between 0-1 thus normalizing the scales between CPU and Memory. I also changed the scale when calculating network distance. The values for distance will be represented by a number from 0-1 as well. Now, all the values we use to calculate "distance" will be from 0-1, with 0 signifying the best fit for this resources and 1 as being the worst fit for this resource.