### PR TITLE
STORM-1129: Use topology name instead of id in UI calls.

### DIFF
--- a/docs/STORM-UI-REST-API.md
+++ b/docs/STORM-UI-REST-API.md
@@ -46,8 +46,8 @@ are used by nimbus.
 Examples:
 
 ```no-highlight
- 1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount-1-1425844354\?doAsUser=testUSer1
- 2. curl 'http://localhost:8080/api/v1/topology/wordcount-1-1425844354/activate' -X POST -H 'doAsUser:testUSer1'
+ 1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount\?doAsUser=testUSer1
+ 2. curl 'http://localhost:8080/api/v1/topology/wordcount/activate' -X POST -H 'doAsUser:testUSer1'
 ```
 
 ## GET Operations
@@ -264,7 +264,7 @@ Sample response:
 
 ### /api/v1/topology-workers/:id (GET)
 
-Returns the worker' information (host and port) for a topology.
+Returns the worker' information (host and port) for a topology. id can be name or id of the topology
 
 Response fields:
 
@@ -297,13 +297,13 @@ Sample response:
 
 ### /api/v1/topology/:id (GET)
 
-Returns topology information and statistics.  Substitute id with topology id.
+Returns topology information and statistics.  Substitute id with topology id or name.
 
 Request parameters:
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name |
 |window    |String. Default value :all-time| Window duration for metrics in seconds|
 |sys       |String. Values 1 or 0. Default value 0| Controls including sys stats part of the response|
 
@@ -361,9 +361,9 @@ Response fields:
 Examples:
 
 ```no-highlight
- 1. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3-1-1402960825
- 2. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3-1-1402960825?sys=1
- 3. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3-1-1402960825?window=600
+ 1. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3
+ 2. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3?sys=1
+ 3. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3?window=600
 ```
 
 Sample response:
@@ -517,7 +517,7 @@ Returns detailed metrics and executor information
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name |
 |component |String (required)| Component Id |
 |window    |String. Default value :all-time| window duration for metrics in seconds|
 |sys       |String. Values 1 or 0. Default value 0| controls including sys stats part of the response|
@@ -563,9 +563,9 @@ Response fields:
 Examples:
 
 ```no-highlight
-1. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3-1-1402960825/component/spout
-2. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3-1-1402960825/component/spout?sys=1
-3. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3-1-1402960825/component/spout?window=600
+1. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3/component/spout
+2. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3/component/spout?sys=1
+3. http://ui-daemon-host-name:8080/api/v1/topology/WordCount3/component/spout?window=600
 ```
 
 Sample response:
@@ -731,7 +731,7 @@ Request to start profiler on worker with timeout. Returns status and link to pro
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name  |
 |host-port |String (required)| Worker Id |
 |timeout |String (required)| Time out for profiler to stop in minutes |
 
@@ -747,9 +747,9 @@ Response fields:
 Examples:
 
 ```no-highlight
-1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount-1-1446614150/profiling/start/10.11.1.7:6701/10
-2. http://ui-daemon-host-name:8080/api/v1/topology/wordcount-1-1446614150/profiling/start/10.11.1.7:6701/5
-3. http://ui-daemon-host-name:8080/api/v1/topology/wordcount-1-1446614150/profiling/start/10.11.1.7:6701/20
+1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount/profiling/start/10.11.1.7:6701/10
+2. http://ui-daemon-host-name:8080/api/v1/topology/wordcount/profiling/start/10.11.1.7:6701/5
+3. http://ui-daemon-host-name:8080/api/v1/topology/wordcount/profiling/start/10.11.1.7:6701/20
 ```
 
 Sample response:
@@ -769,7 +769,7 @@ Request to dump profiler recording on worker. Returns status and worker id for t
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name |
 |host-port |String (required)| Worker Id |
 
 Response fields:
@@ -782,7 +782,7 @@ Response fields:
 Examples:
 
 ```no-highlight
-1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount-1-1446614150/profiling/dumpprofile/10.11.1.7:6701
+1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount/profiling/dumpprofile/10.11.1.7:6701
 ```
 
 Sample response:
@@ -800,7 +800,7 @@ Request to stop profiler on worker. Returns status and worker id for the request
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name |
 |host-port |String (required)| Worker Id |
 
 Response fields:
@@ -813,7 +813,7 @@ Response fields:
 Examples:
 
 ```no-highlight
-1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount-1-1446614150/profiling/stop/10.11.1.7:6701
+1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount/profiling/stop/10.11.1.7:6701
 ```
 
 Sample response:
@@ -831,7 +831,7 @@ Request to dump jstack on worker. Returns status and worker id for the request.
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name |
 |host-port |String (required)| Worker Id |
 
 Response fields:
@@ -844,7 +844,7 @@ Response fields:
 Examples:
 
 ```no-highlight
-1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount-1-1446614150/profiling/dumpjstack/10.11.1.7:6701
+1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount/profiling/dumpjstack/10.11.1.7:6701
 ```
 
 Sample response:
@@ -862,7 +862,7 @@ Request to dump heap (jmap) on worker. Returns status and worker id for the requ
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name  |
 |host-port |String (required)| Worker Id |
 
 Response fields:
@@ -875,7 +875,7 @@ Response fields:
 Examples:
 
 ```no-highlight
-1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount-1-1446614150/profiling/dumpheap/10.11.1.7:6701
+1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount/profiling/dumpheap/10.11.1.7:6701
 ```
 
 Sample response:
@@ -893,7 +893,7 @@ Request to request the worker. Returns status and worker id for the request.
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name |
 |host-port |String (required)| Worker Id |
 
 Response fields:
@@ -906,7 +906,7 @@ Response fields:
 Examples:
 
 ```no-highlight
-1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount-1-1446614150/profiling/restartworker/10.11.1.7:6701
+1. http://ui-daemon-host-name:8080/api/v1/topology/wordcount/profiling/restartworker/10.11.1.7:6701
 ```
 
 Sample response:
@@ -926,7 +926,7 @@ Activates a topology.
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name  |
 
 Sample Response:
 
@@ -941,7 +941,7 @@ Deactivates a topology.
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name |
 
 Sample Response:
 
@@ -956,7 +956,7 @@ Rebalances a topology.
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name |
 |wait-time |String (required)| Wait time before rebalance happens |
 |rebalanceOptions| Json (optional) | topology rebalance options |
 
@@ -973,7 +973,7 @@ Examples:
 curl  -i -b ~/cookiejar.txt -c ~/cookiejar.txt -X POST  
 -H "Content-Type: application/json" 
 -d  '{"rebalanceOptions": {"numWorkers": 2, "executors": { "spout" : "5", "split": 7, "count": 5 }}, "callback":"foo"}' 
-http://localhost:8080/api/v1/topology/wordcount-1-1420308665/rebalance/0
+http://localhost:8080/api/v1/topology/wordcount/rebalance/0
 ```
 
 Sample Response:
@@ -990,7 +990,7 @@ Kills a topology.
 
 |Parameter |Value   |Description  |
 |----------|--------|-------------|
-|id   	   |String (required)| Topology Id  |
+|id   	   |String (required)| Topology Id or Name |
 |wait-time |String (required)| Wait time before rebalance happens |
 
 Caution: Small wait times (0-5 seconds) may increase the probability of triggering the bug reported in

--- a/storm-core/src/ui/public/component.html
+++ b/storm-core/src/ui/public/component.html
@@ -132,12 +132,13 @@ function workerActionSelectedClicked() {
 workerActionSelected = {};
 
 $(document).ready(function() {
+    var topologyId;
     var componentId = $.url("?id");
-    var topologyId = $.url("?topology_id");
-    var tableStateKey = ":".concat(topologyId, ":", componentId);
+    var topologyName = $.url("?topology_name");
+    var tableStateKey = ":".concat(topologyName, ":", componentId);
     var window = $.url("?window");
     var sys = $.cookies.get("sys") || "false";
-    var url = "/api/v1/topology/"+topologyId+"/component/"+componentId+"?sys="+sys;
+    var url = "/api/v1/topology/"+topologyName+"/component/"+componentId+"?sys="+sys;
     if(window) url += "&window="+window;
 
     $.extend( $.fn.dataTable.defaults, {
@@ -186,6 +187,7 @@ $(document).ready(function() {
     }
 
     $.getJSON(url,function(response,status,jqXHR) {
+        topologyId = response["topologyId"];
         var uiUser = $("#ui-user");
         $.get("/templates/user-template.html", function(template) {
             uiUser.append(Mustache.render($(template).filter("#user-template").html(),response));
@@ -194,7 +196,7 @@ $(document).ready(function() {
 
         var componentSummary = $("#component-summary");
         var componentActions = $("#component-actions");
-        var buttonJsonData = componentActionJson(response["encodedTopologyId"], response["encodedId"], response["id"],
+        var buttonJsonData = componentActionJson(response["name"], response["encodedId"], response["id"],
                                                  response["topologyStatus"], response["debug"], response["samplingPct"]);
         var componentStatsDetail = $("#component-stats-detail")
         var inputStats = $("#component-input-stats");
@@ -328,7 +330,7 @@ $(document).ready(function() {
 });
 
 function start_profiling() {
-    var topologyId = $.url("?topology_id");
+    var topologyName = $.url("?topology_name");
     var timeout = $("#timeout").val();
 
     if(timeout == "") { timeout = 10; }
@@ -340,7 +342,7 @@ function start_profiling() {
     var failed = {}
     var passed = {}
     Object.keys(workerActionSelected).forEach(function (id) {
-        var url = "/api/v1/topology/"+topologyId+"/profiling/start/" + id + "/" + timeout;
+        var url = "/api/v1/topology/"+topologyName+"/profiling/start/" + id + "/" + timeout;
         $.get(url, function(response,status,jqXHR) {
             jsError(function() {
                 $.get("/templates/component-page-template.html", function(template) {
@@ -376,8 +378,8 @@ function start_profiling() {
 }
 
 function stop_profiling(id) {
-    var topologyId = $.url("?topology_id");
-    var url = "/api/v1/topology/"+topologyId+"/profiling/stop/" + id;
+    var topologyName = $.url("?topology_name");
+    var url = "/api/v1/topology/"+topologyName+"/profiling/stop/" + id;
 
     $("#stop_" + id).prop('disabled', true);
     setTimeout(function(){ $("#stop_" + id).prop('disabled', false); }, 5000);
@@ -392,8 +394,8 @@ function stop_profiling(id) {
 }
 
 function dump_profile(id) {
-    var topologyId = $.url("?topology_id");
-    var url = "/api/v1/topology/"+topologyId+"/profiling/dumpprofile/" + id;
+    var topologyName = $.url("?topology_name");
+    var url = "/api/v1/topology/"+topologyName+"/profiling/dumpprofile/" + id;
 
     $("#dump_profile_" + id).prop('disabled', true);
     setTimeout(function(){ $("#dump_profile_" + id).prop('disabled', false); }, 5000);
@@ -408,12 +410,12 @@ function dump_profile(id) {
 
 // Create jstack output for all selected workers.
 function dump_jstacks() {
-    var topologyId = $.url("?topology_id");
+    var topologyName = $.url("?topology_name");
 
     var failed = {}
     var passed = {}
     Object.keys(workerActionSelected).forEach(function (id) {
-        var url = "/api/v1/topology/"+topologyId+"/profiling/dumpjstack/" + id;
+        var url = "/api/v1/topology/"+topologyName+"/profiling/dumpjstack/" + id;
 
         $("#dump_jstack_" + id).prop('disabled', true);
         setTimeout(function(){ $("#dump_jstack_" + id).prop('disabled', false); }, 5000);
@@ -437,8 +439,8 @@ function dump_jstacks() {
 
 // Create jstack output for the worker with the given id.
 function dump_jstack(id) {
-    var topologyId = $.url("?topology_id");
-    var url = "/api/v1/topology/"+topologyId+"/profiling/dumpjstack/" + id;
+    var topologyName = $.url("?topology_name");
+    var url = "/api/v1/topology/"+topologyName+"/profiling/dumpjstack/" + id;
 
     $("#dump_jstack_" + id).prop('disabled', true);
     setTimeout(function(){ $("#dump_jstack_" + id).prop('disabled', false); }, 5000);
@@ -452,11 +454,11 @@ function dump_jstack(id) {
 }
 
 function restart_worker_jvms() {
-    var topologyId = $.url("?topology_id");
+    var topologyName = $.url("?topology_name");
     var failed = {}
     var passed = {}
     Object.keys(workerActionSelected).forEach(function (id) {
-        var url = "/api/v1/topology/"+topologyId+"/profiling/restartworker/" + id;
+        var url = "/api/v1/topology/"+topologyName+"/profiling/restartworker/" + id;
 
         $("#restart_worker_jvm_" + id).prop('disabled', true);
         setTimeout(function(){ $("#restart_worker_jvm_" + id).prop('disabled', false); }, 5000);
@@ -480,11 +482,11 @@ function restart_worker_jvms() {
 
 // Create java heap output for all selected workers.
 function dump_heaps() {
-    var topologyId = $.url("?topology_id");
+    var topologyName = $.url("?topology_name");
     var failed = {}
     var passed = {}
     Object.keys(workerActionSelected).forEach(function (id) {
-        var url = "/api/v1/topology/"+topologyId+"/profiling/dumpheap/" + id;
+        var url = "/api/v1/topology/"+topologyName+"/profiling/dumpheap/" + id;
         var heap = $("#dump_heap_" + id);
         $("#dump_heap_" + id).prop('disabled', true);
         setTimeout(function(){ $("#dump_heap_" + id).prop('disabled', false); }, 5000);
@@ -508,8 +510,8 @@ function dump_heaps() {
 
 // Create java heap output for the worker with the given id.
 function dump_heap(id) {
-    var topologyId = $.url("?topology_id");
-    var url = "/api/v1/topology/"+topologyId+"/profiling/dumpheap/" + id;
+    var topologyName = $.url("?topology_name");
+    var url = "/api/v1/topology/"+topologyName+"/profiling/dumpheap/" + id;
     var heap = $("#dump_heap_" + id);
     $("#dump_heap_" + id).prop('disabled', true);
     setTimeout(function(){ $("#dump_heap_" + id).prop('disabled', false); }, 5000);

--- a/storm-core/src/ui/public/js/script.js
+++ b/storm-core/src/ui/public/js/script.js
@@ -81,10 +81,10 @@ function ensureInt(n) {
     return isInt;
 }
 
-function sendRequest(id, action, extra, body, cb){
+function sendRequest(name, action, extra, body, cb){
    var opts = {
         type:'POST',
-        url:'/api/v1/topology/' + id + '/' + action
+        url:'/api/v1/topology/' + name + '/' + action
     };
 
     if (body) {
@@ -101,10 +101,10 @@ function sendRequest(id, action, extra, body, cb){
     });
 }
 
-function confirmComponentAction(topologyId, componentId, componentName, action, param, defaultParamValue, paramText, actionText) {
+function confirmComponentAction(name, componentId, componentName, action, param, defaultParamValue, paramText, actionText) {
     var opts = {
         type:'POST',
-        url:'/api/v1/topology/' + topologyId + '/component/' + componentId + '/' + action
+        url:'/api/v1/topology/' + name + '/component/' + componentId + '/' + action
     };
     if (actionText === undefined) {
         actionText = action;
@@ -140,7 +140,7 @@ function confirmComponentAction(topologyId, componentId, componentName, action, 
 function confirmAction(id, name, action, param, defaultParamValue, paramText, actionText) {
     var opts = {
         type:'POST',
-        url:'/api/v1/topology/' + id + '/' + action
+        url:'/api/v1/topology/' + name + '/' + action
     };
     if (actionText === undefined) {
         actionText = action;
@@ -226,9 +226,9 @@ function topologyActionJson(id, encodedId, name, status, msgTimeout, debug, samp
     return jsonData;
 }
 
-function componentActionJson(encodedTopologyId, encodedId, componentName, status, debug, samplingPct) {
+function componentActionJson(topologyName, encodedId, componentName, status, debug, samplingPct) {
     var jsonData = {};
-    jsonData["encodedTopologyId"] = encodedTopologyId;
+    jsonData["topologyName"] = topologyName;
     jsonData["encodedId"] = encodedId;
     jsonData["componentName"] = componentName;
     jsonData["startDebugStatus"] = (status === "ACTIVE" && !debug) ? "enabled" : "disabled";

--- a/storm-core/src/ui/public/js/visualization.js
+++ b/storm-core/src/ui/public/js/visualization.js
@@ -387,7 +387,7 @@ function jsError(other) {
 
 var should_update;
 function show_visualization(sys) {
-    $.getJSON("/api/v1/topology/"+$.url("?id")+"/visualization-init",function(response,status,jqXHR) {
+    $.getJSON("/api/v1/topology/"+$.url("?name")+"/visualization-init",function(response,status,jqXHR) {
         $.get("/templates/topology-page-template.html", function(template) {
             jsError(function() {
                 var topologyVisualization = $("#visualization-container");
@@ -412,7 +412,7 @@ function show_visualization(sys) {
             var update = function(should_rechoose){
               if(should_update) {
                 $.ajax({
-                    url: "/api/v1/topology/"+$.url("?id")+"/visualization",
+                    url: "/api/v1/topology/"+$.url("?name")+"/visualization",
                     success: function(data, status, jqXHR) {
                         topology_data = data;
                         update_data(topology_data, sys);

--- a/storm-core/src/ui/public/templates/component-page-template.html
+++ b/storm-core/src/ui/public/templates/component-page-template.html
@@ -49,7 +49,7 @@
     <tbody>
       <tr>
         <td>{{id}}</td>
-        <td><a href="/topology.html?id={{encodedTopologyId}}">{{name}}</a></td>
+        <td><a href="/topology.html?name={{name}}">{{name}}</a></td>
         <td>{{executors}}</td>
         <td>{{tasks}}</td>
         <td><a href="{{eventLogLink}}">events</a></td>
@@ -96,7 +96,7 @@
     <tbody>
       {{#spoutSummary}}
       <tr>
-        <td><a href="/component.html?id={{encodedId}}&topology_id={{encodedTopologyId}}&window={{window}}">{{windowPretty}}</a></td>
+        <td><a href="/component.html?id={{encodedId}}&topology_name={{name}}&window={{window}}">{{windowPretty}}</a></td>
         <td>{{emitted}}</td>
         <td>{{transferred}}</td>
         <td>{{completeLatency}}</td>
@@ -331,7 +331,7 @@
     <tbody>
       {{#boltStats}}
       <tr>
-        <td><a href="/component.html?id={{encodedId}}&topology_id={{encodedTopologyId}}&window={{window}}">{{windowPretty}}</a></td>
+        <td><a href="/component.html?id={{encodedId}}&topology_name={{name}}&window={{window}}">{{windowPretty}}</a></td>
         <td>{{emitted}}</td>
         <td>{{transferred}}</td>
         <td>{{executeLatency}}</td>
@@ -557,7 +557,9 @@
 <script id="component-actions-template" type="text/html">
   <h2>Component actions</h2>
   <p id="component-actions">
-    <input {{startDebugStatus}} onclick="confirmComponentAction('{{encodedTopologyId}}', '{{encodedId}}', '{{componentName}}', 'debug/enable', true, {{currentSamplingPct}}, 'sampling percentage', 'debug')" type="button" value="Debug" class="btn btn-default">
-    <input {{stopDebugStatus}} onclick="confirmComponentAction('{{encodedTopologyId}}', '{{encodedId}}', '{{componentName}}', 'debug/disable', false, 0, 'sampling percentage', 'stop debugging')" type="button" value="Stop Debug" class="btn btn-default">
+    <input {{startDebugStatus}}
+           onclick="confirmComponentAction('{{topologyName}}', '{{encodedId}}', '{{componentName}}', 'debug/enable', true, {{currentSamplingPct}}, 'sampling percentage', 'debug')" type="button" value="Debug" class="btn btn-default">
+    <input {{stopDebugStatus}}
+           onclick="confirmComponentAction('{{topologyName}}', '{{encodedId}}', '{{componentName}}', 'debug/disable', false, 0, 'sampling percentage', 'stop debugging')" type="button" value="Stop Debug" class="btn btn-default">
   </p>
 </script>

--- a/storm-core/src/ui/public/templates/index-page-template.html
+++ b/storm-core/src/ui/public/templates/index-page-template.html
@@ -171,7 +171,7 @@
     <tbody>
       {{#topologies}}
       <tr>
-        <td><a href="/topology.html?id={{encodedId}}">{{name}}</a></td>
+        <td><a href="/topology.html?name={{name}}">{{name}}</a></td>
         <td>{{owner}}</td>
         <td>{{status}}</td>
         <td>{{uptime}}</td>

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -192,7 +192,7 @@
     <tbody>
       {{#topologyStats}}
       <tr>
-        <td><a href="/topology.html?id={{encodedId}}&window={{window}}">{{windowPretty}}</td>
+        <td><a href="/topology.html?name={{name}}&window={{window}}">{{windowPretty}}</td>
         <td>{{emitted}}</td>
         <td>{{transferred}}</td>
         <td>{{completeLatency}}</td>
@@ -309,7 +309,7 @@
     <tbody>
       {{#spouts}}
       <tr>
-        <td><a href="/component.html?id={{encodedSpoutId}}&topology_id={{encodedId}}">{{spoutId}}</a></td>
+        <td><a href="/component.html?id={{encodedSpoutId}}&topology_name={{name}}">{{spoutId}}</a></td>
         <td>{{executors}}</td>
         <td>{{tasks}}</td>
         <td>{{emitted}}</td>
@@ -402,7 +402,7 @@
     <tbody>
       {{#bolts}}
       <tr>
-        <td><a href="/component.html?id={{encodedBoltId}}&topology_id={{encodedId}}">{{boltId}}</a></td>
+        <td><a href="/component.html?id={{encodedBoltId}}&topology_name={{name}}">{{boltId}}</a></td>
         <td>{{executors}}</td>
         <td>{{tasks}}</td>
         <td>{{emitted}}</td>

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -107,7 +107,7 @@ function clearLoggerLevel(id){
 }
 
 function sendLoggerLevel(id){
-    var topologyId = $.url("?id");
+    var topologyName = $.url("?name");
     var shouldRemove = $("#loggerRemove-" + id).val() === "true";
     var level = $("#loggerLevel-" + id).val();
     var timeout = parseInt($("#loggerTimeout-" + id).val());
@@ -143,11 +143,11 @@ function sendLoggerLevel(id){
     loggerSetting.reset_level  = "INFO";
     loggerSetting.timeout = timeout;
 
-    sendRequest (topologyId, "logconfig", null, data, toggleChangeLogLevel);
+    sendRequest (topologyName, "logconfig", null, data, toggleChangeLogLevel);
 };
 
 function renderLogLevelForm (template, responseData){
-    var topologyId = $.url("?id");
+    var topologyName = $.url("?name");
     var container = $("#change-log-level");
 
     var levels = [
@@ -226,8 +226,8 @@ function renderLogLevelForm (template, responseData){
         container.show('fast');
     };
     if (!responseData) {
-        var topologyId = $.url("?id");
-        $.get ('/api/v1/topology/' + topologyId + '/logconfig', renderImpl);
+        var topologyName = $.url("?name");
+        $.get ('/api/v1/topology/' + topologyName + '/logconfig', renderImpl);
     } else {
         renderImpl (responseData);
     }
@@ -239,11 +239,11 @@ $(document).ajaxStart(function(){
     }
 });
 $(document).ready(function() {
-    var topologyId = $.url("?id");
-    var tableStateKey = ":".concat(topologyId);
+    var topologyName = $.url("?name");
+    var tableStateKey = ":".concat(topologyName);
     var window = $.url("?window");
     var sys = $.cookies.get("sys") || "false";
-    var url = "/api/v1/topology/"+topologyId+"?sys="+sys;
+    var url = "/api/v1/topology/"+topologyName+"?sys="+sys;
     if(window) url += "&window="+window;
     $.extend( $.fn.dataTable.defaults, {
       stateSave: true,
@@ -290,7 +290,7 @@ $(document).ready(function() {
             toggleChangeLogLevel = function (data) {
               renderLogLevelForm (template, data);
             }
-            searchForm.append(Mustache.render($(template).filter("#search-form-template").html(),{id: topologyId}));
+            searchForm.append(Mustache.render($(template).filter("#search-form-template").html(),{id: response["encodedId"]}));
             topologySummary.append(Mustache.render($(template).filter("#topology-summary-template").html(),response));
             topologyResources.append(Mustache.render($(template).filter("#topology-resources-template").html(),response));
             var displayResource = response["schedulerDisplayResource"];


### PR DESCRIPTION
Note that all-topologies-summary has been used to get topology id from a topology name. That involves a few calls to zookeeper which is not ideal. However, UI does not seem to take any significant performance hit. If needed we can handle it possibly using one of the options below. Since its a separate performance issue we can handle it in a separate JIRA.
1. Have nimbus thrift server cache summary for topologies so it does not hit zookeeper every time we try to get topology id from name.
2. Update nimbus thrift api with a method that takes options and use that to do only the minimal necessary interaction with zookeeper for a given option.
