### PR TITLE
[STORM-1163] use rmr rather than rmpath for remove worker-root

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -243,7 +243,7 @@
           (do
             (rmr (worker-heartbeats-root conf id))
             ;; this avoids a race condition with worker or subprocess writing pid around same time
-            (rmpath (worker-pids-root conf id))
+            (rmr (worker-pids-root conf id))
             (rmr (worker-root conf id))))
         (remove-worker-user! conf id)
         (remove-dead-worker id)

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -244,7 +244,7 @@
             (rmr (worker-heartbeats-root conf id))
             ;; this avoids a race condition with worker or subprocess writing pid around same time
             (rmpath (worker-pids-root conf id))
-            (rmpath (worker-root conf id))))
+            (rmr (worker-root conf id))))
         (remove-worker-user! conf id)
         (remove-dead-worker id)
       ))


### PR DESCRIPTION
In supervisor/try-cleaup-worker