### PR TITLE
[STORM-1177] Build fails because DISCLAIMER file is missing

### DIFF
--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -316,10 +316,6 @@
             <source>${project.basedir}/../../README.markdown</source>
             <outputDirectory>/</outputDirectory>
         </file>
-        <file>
-            <source>${project.basedir}/../../DISCLAIMER</source>
-            <outputDirectory>/</outputDirectory>
-        </file>
 
         <file>
             <source>${project.basedir}/../../CHANGELOG.md</source>


### PR DESCRIPTION
apache/storm@4a57e500b3e0c3f3256e776357d1e1de1c7f5e49 removed the DISCLAIMER file, which causes `mvn package` to fail (as that file is required in [binary.xml#L320](https://github.com/apache/storm/blob/master/storm-dist/binary/src/main/assembly/binary.xml#L320)).