### PR TITLE
STORM-1190: System Load too high after recent changes

### DIFF
--- a/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DisruptorQueue.java
@@ -65,7 +65,7 @@ public class DisruptorQueue implements IStatefulObject {
 
     private static class FlusherPool { 
         private Timer _timer = new Timer("disruptor-flush-trigger", true);
-        private ThreadPoolExecutor _exec = new ThreadPoolExecutor(1, 100, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1024));
+        private ThreadPoolExecutor _exec = new ThreadPoolExecutor(1, 100, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1024), new ThreadPoolExecutor.DiscardPolicy());
         private HashMap<Long, ArrayList<Flusher>> _pendingFlush = new HashMap<>();
         private HashMap<Long, TimerTask> _tt = new HashMap<>();
 
@@ -92,8 +92,8 @@ public class DisruptorQueue implements IStatefulObject {
                 if (tasks != null) {
                     _exec.invokeAll(tasks);
                 }
-            } catch (Exception e) {
-               LOG.error("Could not invoke all ", e); 
+            } catch (InterruptedException e) {
+               //Ignored
             }
         }
 

--- a/storm-core/test/clj/backtype/storm/metrics_test.clj
+++ b/storm-core/test/clj/backtype/storm/metrics_test.clj
@@ -47,7 +47,7 @@
             ))))))
 
 (defn assert-loop [afn ids]
-  (while (not (every? afn ids))
+  (while-timeout TEST-TIMEOUT-MS (not (every? afn ids))
     (Thread/sleep 1)))
 
 (defn assert-acked [tracker & ids]

--- a/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueTest.java
+++ b/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueTest.java
@@ -54,8 +54,7 @@ public class DisruptorQueueTest extends TestCase {
             }
         });
 
-        run(producer, consumer);
-        queue.haltWithInterrupt();
+        run(producer, consumer, queue);
         Assert.assertEquals("We expect to receive first published message first, but received " + result.get(),
                 "FIRST", result.get());
       }
@@ -80,8 +79,7 @@ public class DisruptorQueueTest extends TestCase {
             }
         });
 
-        run(producer, consumer, 1000, 1);
-        queue.haltWithInterrupt();
+        run(producer, consumer, queue, 1000, 1);
         Assert.assertTrue("Messages delivered out of order",
                 allInOrder.get());
     }
@@ -105,19 +103,18 @@ public class DisruptorQueueTest extends TestCase {
             }
         });
 
-        run(producer, consumer, 1000, 1);
-        queue.haltWithInterrupt();
+        run(producer, consumer, queue, 1000, 1);
         Assert.assertTrue("Messages delivered out of order",
                 allInOrder.get());
     }
 
 
-    private void run(Runnable producer, Runnable consumer)
+    private void run(Runnable producer, Runnable consumer, DisruptorQueue queue)
             throws InterruptedException {
-        run(producer, consumer, 10, PRODUCER_NUM);
+        run(producer, consumer, queue, 10, PRODUCER_NUM);
     }
 
-    private void run(Runnable producer, Runnable consumer, int sleepMs, int producerNum)
+    private void run(Runnable producer, Runnable consumer, DisruptorQueue queue, int sleepMs, int producerNum)
             throws InterruptedException {
 
         Thread[] producerThreads = new Thread[producerNum];
@@ -132,12 +129,12 @@ public class DisruptorQueueTest extends TestCase {
         for (int i = 0; i < producerNum; i++) {
             producerThreads[i].interrupt();
         }
-        consumerThread.interrupt();
         
         for (int i = 0; i < producerNum; i++) {
             producerThreads[i].join(TIMEOUT);
             assertFalse("producer "+i+" is still alive", producerThreads[i].isAlive());
         }
+        queue.haltWithInterrupt();
         consumerThread.join(TIMEOUT);
         assertFalse("consumer is still alive", consumerThread.isAlive());
     }

--- a/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueTest.java
+++ b/storm-core/test/jvm/backtype/storm/utils/DisruptorQueueTest.java
@@ -55,6 +55,7 @@ public class DisruptorQueueTest extends TestCase {
         });
 
         run(producer, consumer);
+        queue.haltWithInterrupt();
         Assert.assertEquals("We expect to receive first published message first, but received " + result.get(),
                 "FIRST", result.get());
       }
@@ -80,6 +81,7 @@ public class DisruptorQueueTest extends TestCase {
         });
 
         run(producer, consumer, 1000, 1);
+        queue.haltWithInterrupt();
         Assert.assertTrue("Messages delivered out of order",
                 allInOrder.get());
     }
@@ -104,6 +106,7 @@ public class DisruptorQueueTest extends TestCase {
         });
 
         run(producer, consumer, 1000, 1);
+        queue.haltWithInterrupt();
         Assert.assertTrue("Messages delivered out of order",
                 allInOrder.get());
     }


### PR DESCRIPTION
This helps a fair amount at the low end, but not as much as I had hoped.  The spout seems to sleeping more with batching enabled which is offsetting some of the gains from updating the DisruptorQueue code.  I really have not idea why at this point.