### PR TITLE
[STORM-1208] Guard against NPE, and avoid using NaN values

### DIFF
--- a/storm-core/src/clj/backtype/storm/stats.clj
+++ b/storm-core/src/clj/backtype/storm/stats.clj
@@ -288,10 +288,11 @@
       rate)))
 
 (defn valid-number?
-  "Returns true if x is a number that is not NaN, false otherwise"
+  "Returns true if x is a number that is not NaN or Infinity, false otherwise"
   [x]
   (and (number? x)
-       (not (Double/isNaN x))))
+       (not (Double/isNaN x))
+       (not (Double/isInfinite x))))
 
 (defn apply-default
   [f defaulting-fn & args]

--- a/storm-core/src/clj/backtype/storm/stats.clj
+++ b/storm-core/src/clj/backtype/storm/stats.clj
@@ -287,18 +287,42 @@
       specific-stats
       rate)))
 
+(defn valid-number?
+  "Returns true if x is a number that is not NaN, false otherwise"
+  [x]
+  (and (number? x)
+       (not (Double/isNaN x))))
+
+(defn apply-default
+  [f defaulting-fn & args]
+  (apply f (map defaulting-fn args)))
+
+(defn apply-or-0
+  [f & args]
+  (apply apply-default
+         f
+         #(if (valid-number? %) % 0)
+         args))
+
+(defn sum-or-0
+  [& args]
+  (apply apply-or-0 + args))
+
+(defn product-or-0
+  [& args]
+  (apply apply-or-0 * args))
+
+(defn max-or-0
+  [& args]
+  (apply apply-or-0 max args))
+
 (defn- agg-bolt-lat-and-count
   "Aggregates number executed, process latency, and execute latency across all
   streams."
   [idk->exec-avg idk->proc-avg idk->num-executed]
-  {:pre (apply = (map #(set (keys %))
-                      [idk->exec-avg
-                       idk->proc-avg
-                       idk->num-executed]))}
-  (letfn [(weight-avg [[id avg]] (let [num-e (get idk->num-executed id)]
-                                   (if (and avg num-e)
-                                     (* avg num-e)
-                                     0)))]
+  (letfn [(weight-avg [[id avg]]
+            (let [num-e (get idk->num-executed id)]
+              (product-or-0 avg num-e)))]
     {:executeLatencyTotal (sum (map weight-avg idk->exec-avg))
      :processLatencyTotal (sum (map weight-avg idk->proc-avg))
      :executed (sum (vals idk->num-executed))}))
@@ -306,10 +330,8 @@
 (defn- agg-spout-lat-and-count
   "Aggregates number acked and complete latencies across all streams."
   [sid->comp-avg sid->num-acked]
-  {:pre (apply = (map #(set (keys %))
-                      [sid->comp-avg
-                       sid->num-acked]))}
-  (letfn [(weight-avg [[id avg]] (* avg (get sid->num-acked id)))]
+  (letfn [(weight-avg [[id avg]]
+            (product-or-0 avg (get sid->num-acked id)))]
     {:completeLatencyTotal (sum (map weight-avg sid->comp-avg))
      :acked (sum (vals sid->num-acked))}))
 
@@ -335,30 +357,21 @@
 (defn- agg-bolt-streams-lat-and-count
   "Aggregates number executed and process & execute latencies."
   [idk->exec-avg idk->proc-avg idk->executed]
-  {:pre (apply = (map #(set (keys %))
-                      [idk->exec-avg
-                       idk->proc-avg
-                       idk->executed]))}
-  (letfn [(weight-avg [id avg] (let [num-e (idk->executed id)]
-                                   (if (and avg num-e)
-                                     (* avg num-e)
-                                     0)))]
+  (letfn [(weight-avg [id avg]
+            (let [num-e (idk->executed id)]
+              (product-or-0 avg num-e)))]
     (into {}
       (for [k (keys idk->exec-avg)]
-        [k {:executeLatencyTotal (weight-avg k (idk->exec-avg k))
-            :processLatencyTotal (weight-avg k (idk->proc-avg k))
+        [k {:executeLatencyTotal (weight-avg k (get idk->exec-avg k))
+            :processLatencyTotal (weight-avg k (get idk->proc-avg k))
             :executed (idk->executed k)}]))))
 
 (defn- agg-spout-streams-lat-and-count
   "Aggregates number acked and complete latencies."
   [idk->comp-avg idk->acked]
-  {:pre (apply = (map #(set (keys %))
-                      [idk->comp-avg
-                       idk->acked]))}
-  (letfn [(weight-avg [id avg] (let [num-e (get idk->acked id)]
-                                   (if (and avg num-e)
-                                     (* avg num-e)
-                                     0)))]
+  (letfn [(weight-avg [id avg]
+            (let [num-e (get idk->acked id)]
+              (product-or-0 avg num-e)))]
     (into {}
       (for [k (keys idk->comp-avg)]
         [k {:completeLatencyTotal (weight-avg k (get idk->comp-avg k))
@@ -595,22 +608,6 @@
                     (get window)
                     vals
                     sum)})}))
-
-(defn apply-default
-  [f defaulting-fn & args]
-  (apply f (map defaulting-fn args)))
-
-(defn apply-or-0
-  [f & args]
-  (apply apply-default f #(or % 0) args))
-
-(defn sum-or-0
-  [& args]
-  (apply apply-or-0 + args))
-
-(defn max-or-0
-  [& args]
-  (apply apply-or-0 max args))
 
 (defn merge-agg-comp-stats-comp-page-bolt
   [{acc-in :cid+sid->input-stats

--- a/storm-core/src/jvm/backtype/storm/metric/internal/LatencyStatAndMetric.java
+++ b/storm-core/src/jvm/backtype/storm/metric/internal/LatencyStatAndMetric.java
@@ -145,7 +145,10 @@ public class LatencyStatAndMetric implements IMetric {
         }
 
         long timeSpent = now - _bucketStart;
-        double ret = ((double)(lat + _exactExtraLat))/(count + _exactExtraCount);
+        long exactExtraCountSum = count + _exactExtraCount;
+        double ret = exactExtraCountSum > 0 ?
+                ((double)(lat + _exactExtraLat))/exactExtraCountSum :
+                0.0;
         _bucketStart = now;
         _exactExtraLat = 0;
         _exactExtraCount = 0;
@@ -227,7 +230,10 @@ public class LatencyStatAndMetric implements IMetric {
         ret.put("600", readApproximateLatAvg(lat, count, timeSpent, _tmTime, _tmLatBuckets, _tmCountBuckets, 600 * 1000));
         ret.put("10800", readApproximateLatAvg(lat, count, timeSpent, _thTime, _thLatBuckets, _thCountBuckets, 10800 * 1000));
         ret.put("86400", readApproximateLatAvg(lat, count, timeSpent, _odTime, _odLatBuckets, _odCountBuckets, 86400 * 1000));
-        ret.put(":all-time", ((double)lat + _allTimeLat)/(count + _allTimeCount));
+        long allTimeCountSum = count + _allTimeCount;
+        ret.put(":all-time", allTimeCountSum > 0 ?
+                ((double)lat + _allTimeLat)/allTimeCountSum :
+                0.0);
         return ret;
     }
 
@@ -242,7 +248,7 @@ public class LatencyStatAndMetric implements IMetric {
             totalCount += countBuckets[i];
             timeNeeded -= bucketTime[i];
         }
-        return ((double)totalLat)/totalCount;
+        return totalCount > 0 ? ((double)totalLat)/totalCount : 0.0;
     }
 
     public void close() {

--- a/storm-core/src/jvm/backtype/storm/metric/internal/LatencyStatAndMetric.java
+++ b/storm-core/src/jvm/backtype/storm/metric/internal/LatencyStatAndMetric.java
@@ -19,11 +19,10 @@ package backtype.storm.metric.internal;
 
 import java.util.Map;
 import java.util.HashMap;
-import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.atomic.AtomicLong;
 
 import backtype.storm.metric.api.IMetric;
+import backtype.storm.utils.Utils;
 
 /**
  * Acts as a Latency Metric, but also keeps track of approximate latency
@@ -146,9 +145,8 @@ public class LatencyStatAndMetric implements IMetric {
 
         long timeSpent = now - _bucketStart;
         long exactExtraCountSum = count + _exactExtraCount;
-        double ret = exactExtraCountSum > 0 ?
-                ((double)(lat + _exactExtraLat))/exactExtraCountSum :
-                0.0;
+        double ret = Utils.zeroIfNaNOrInf(
+                ((double) (lat + _exactExtraLat)) / exactExtraCountSum);
         _bucketStart = now;
         _exactExtraLat = 0;
         _exactExtraCount = 0;
@@ -231,9 +229,8 @@ public class LatencyStatAndMetric implements IMetric {
         ret.put("10800", readApproximateLatAvg(lat, count, timeSpent, _thTime, _thLatBuckets, _thCountBuckets, 10800 * 1000));
         ret.put("86400", readApproximateLatAvg(lat, count, timeSpent, _odTime, _odLatBuckets, _odCountBuckets, 86400 * 1000));
         long allTimeCountSum = count + _allTimeCount;
-        ret.put(":all-time", allTimeCountSum > 0 ?
-                ((double)lat + _allTimeLat)/allTimeCountSum :
-                0.0);
+        ret.put(":all-time", Utils.zeroIfNaNOrInf(
+                (double) lat + _allTimeLat)/allTimeCountSum);
         return ret;
     }
 
@@ -248,7 +245,7 @@ public class LatencyStatAndMetric implements IMetric {
             totalCount += countBuckets[i];
             timeNeeded -= bucketTime[i];
         }
-        return totalCount > 0 ? ((double)totalLat)/totalCount : 0.0;
+        return Utils.zeroIfNaNOrInf(((double) totalLat) / totalCount);
     }
 
     public void close() {

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -760,5 +760,9 @@ public class Utils {
         raf.close();
         return val;
     }
+
+    public static double zeroIfNaNOrInf(double x) {
+        return (Double.isNaN(x) || Double.isInfinite(x)) ? 0.0 : x;
+    }
 }
 


### PR DESCRIPTION
* Removes malformed preconditions that don't do anything, and if they did work would throw Errors that would crash nimbus.
* When reading and writing average-type metrics, use `0` instead of `NaN`
* Avoid NPE accessing some maps by doing `(get m k)` instead of `(m k)`.