### PR TITLE
STORM-1209 - Generalize `StringMultiSchemeWithTopic`

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
@@ -223,8 +223,8 @@ public class KafkaUtils {
         if (key != null && kafkaConfig.scheme instanceof KeyValueSchemeAsMultiScheme) {
             tups = ((KeyValueSchemeAsMultiScheme) kafkaConfig.scheme).deserializeKeyAndValue(key, payload);
         } else {
-            if (kafkaConfig.scheme instanceof StringMultiSchemeWithTopic) {
-                tups = ((StringMultiSchemeWithTopic)kafkaConfig.scheme).deserializeWithTopic(topic, payload);
+            if (kafkaConfig.scheme instanceof MultiSchemeWithTopic) {
+                tups = ((MultiSchemeWithTopic)kafkaConfig.scheme).deserializeWithTopic(topic, payload);
             } else {
                 tups = kafkaConfig.scheme.deserialize(payload);
             }

--- a/external/storm-kafka/src/jvm/storm/kafka/MultiSchemeWithTopic.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/MultiSchemeWithTopic.java
@@ -17,32 +17,11 @@
  */
 package storm.kafka;
 
-import backtype.storm.spout.MultiScheme;
-import backtype.storm.tuple.Fields;
-import backtype.storm.tuple.Values;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.List;
 
-public class StringMultiSchemeWithTopic
-        implements MultiScheme {
-    public static final String STRING_SCHEME_KEY = "str";
+import backtype.storm.spout.MultiScheme;
 
-    public static final String TOPIC_KEY = "topic";
-
-    @Override
-    public Iterable<List<Object>> deserialize(ByteBuffer bytes) {
-        throw new NotImplementedException();
-    }
-
-    public Iterable<List<Object>> deserializeWithTopic(String topic, ByteBuffer bytes) {
-        List<Object> items = new Values(StringScheme.deserializeString(bytes), topic);
-        return Collections.singletonList(items);
-    }
-
-    public Fields getOutputFields() {
-        return new Fields(STRING_SCHEME_KEY, TOPIC_KEY);
-    }
+public interface MultiSchemeWithTopic extends MultiScheme {
+    public Iterable<List<Object>> deserializeWithTopic(String topic, ByteBuffer bytes);
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/SchemeAsMultiSchemeWithTopic.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/SchemeAsMultiSchemeWithTopic.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package storm.kafka;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import backtype.storm.spout.MultiScheme;
+import backtype.storm.spout.Scheme;
+import backtype.storm.spout.SchemeAsMultiScheme;
+import backtype.storm.tuple.Fields;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+public class SchemeAsMultiSchemeWithTopic implements MultiSchemeWithTopic {
+    public static final String TOPIC_KEY = "topic";
+
+    MultiScheme impl;
+    String topicKey;
+
+    public SchemeAsMultiSchemeWithTopic(Scheme impl) {
+        this(impl, TOPIC_KEY);
+    }
+    public SchemeAsMultiSchemeWithTopic(Scheme impl, String topicKey) {
+        this(new SchemeAsMultiScheme(impl), topicKey);
+    }
+    public SchemeAsMultiSchemeWithTopic(MultiScheme impl) {
+        this(impl, TOPIC_KEY);
+    }
+    public SchemeAsMultiSchemeWithTopic(MultiScheme impl, String topicKey) {
+        this.impl = impl;
+        this.topicKey = topicKey;
+    }
+
+
+    @Override
+    public Iterable<List<Object>> deserialize(ByteBuffer ser) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Iterable<List<Object>> deserializeWithTopic(final String topic, final ByteBuffer bytes) {
+        return new Iterable<List<Object>>() {
+            Iterable<List<Object>> baseIterable = impl.deserialize(bytes);
+            @Override
+            public Iterator<List<Object>> iterator() {
+                final Iterator<List<Object>> baseIterator = baseIterable.iterator();
+                return new Iterator<List<Object>>() {
+                    @Override
+                    public boolean hasNext() {
+                        return baseIterator.hasNext();
+                    }
+                    @Override
+                    public List<Object> next() {
+                        List<Object> ret = new ArrayList<>();
+                        ret.addAll(baseIterator.next());
+                        ret.add(topic);
+                        return ret;                        
+                    }
+                    @Override
+                    public void remove() {
+                        baseIterator.remove();
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    public Fields getOutputFields() {
+        List<String> fields = new ArrayList<>();
+        fields.addAll(impl.getOutputFields().toList());
+        fields.add(topicKey);
+        return new Fields(fields);
+    }
+}

--- a/external/storm-kafka/src/test/storm/kafka/KafkaUtilsTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/KafkaUtilsTest.java
@@ -162,8 +162,8 @@ public class KafkaUtilsTest {
     }
 
     @Test
-    public void generateTuplesWithValueAndStringMultiSchemeWithTopic() {
-        config.scheme = new StringMultiSchemeWithTopic();
+    public void generateTuplesWithValueAndTopic() {
+        config.scheme = new SchemeAsMultiSchemeWithTopic(new StringScheme());
         String value = "value";
         createTopicAndSendMessage(value);
         ByteBufferMessageSet messageAndOffsets = getLastMessage();


### PR DESCRIPTION
Receiving the topic name is useful (https://github.com/apache/storm/pull/561);
Unfortunately, my messages are not plain strings.
Let's generalize it!

For convenience, an existing Scheme/MultiScheme can be wrapped on a `SchemeAsMultiSchemeWithTopic`. This will add a new fields "topic" at the received tuples.

The class `StringMultiSchemeWithTopic` has been removed, but can be replaced with `new SchemeAsMultiSchemeWithTopic(new StringScheme())`
