### PR TITLE
STORM-1202: Migrate APIs to org.apache.storm, but try to provide some form of backwards compatability

### DIFF
--- a/dev-tools/cleanup.sh
+++ b/dev-tools/cleanup.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BASE="$1"
+git reset HEAD -- "$BASE"
+git checkout -- "$BASE"
+git clean -fdx

--- a/dev-tools/move_package.sh
+++ b/dev-tools/move_package.sh
@@ -18,8 +18,9 @@ set -u
 set -e
 
 BASE="$1"
-find "$BASE" -type f -print0 | xargs -0 egrep -l 'backtype.storm|storm.trident|storm.starter|storm.kafka|"backtype", "storm"' | egrep -v '.git/|docs/|CHANGELOG.md|dev-tools/move_package.sh|StormShadeRequest.java' | xargs sed -i '' -e 's/storm\(.\)trident/org\1apache\1storm\1trident/g' -e 's/backtype\(.\)storm/org\1apache\1storm/g' -e 's/storm\([\.\\]\)starter/org\1apache\1storm\1starter/g' -e 's/storm\([\.\\]\)kafka/org\1apache\1storm\1kafka/g' -e 's/"backtype", "storm"/"org", "apache", "storm"/g'
+find "$BASE" -type f -print0 | xargs -0 egrep -l 'backtype.storm|storm.trident|storm.starter|storm.kafka|"backtype", "storm"' | egrep -v '.git/|docs/|CHANGELOG.md|dev-tools/move_package.sh|StormShadeRequest.java' | xargs sed -i.back -e 's/storm\(.\)trident/org\1apache\1storm\1trident/g' -e 's/backtype\(.\)storm/org\1apache\1storm/g' -e 's/storm\([\.\\]\)starter/org\1apache\1storm\1starter/g' -e 's/storm\([\.\\]\)kafka/org\1apache\1storm\1kafka/g' -e 's/"backtype", "storm"/"org", "apache", "storm"/g'
 #find "$BASE" -type f -print0 | xargs -0 egrep -l 'backtype.storm|storm.trident' | egrep -v '.git/|docs/|CHANGELOG.md' | xargs sed -i '' -e 's/storm\(.\)trident/org\1apache\1storm\1trident/g' -e 's/backtype\(.\)storm/org\1apache\1storm/g'
+find "$BASE" -iname \*.back | xargs rm
 mkdir -p "$BASE"/storm-core/src/jvm/org/apache/storm/ "$BASE"/storm-core/src/clj/org/apache/storm/ "$BASE"/storm-core/test/jvm/org/apache/storm/ "$BASE"/storm-core/test/clj/org/apache/storm/
 #STORM-CORE
 #SRC JVM

--- a/dev-tools/move_package.sh
+++ b/dev-tools/move_package.sh
@@ -45,8 +45,10 @@ git mv "$BASE"/storm-core/test/clj/backtype/storm/* "$BASE"/storm-core/test/clj/
 rm -rf "$BASE"/storm-core/test/clj/backtype
 git mv "$BASE"/storm-core/test/clj/storm/trident "$BASE"/storm-core/test/clj/org/apache/storm
 rm -rf "$BASE"/storm-core/test/clj/storm
-git mv "$BASE"/storm-core/test/clj/integration/storm "$BASE"/storm-core/test/clj/integration/org/apache/storm
+git mv "$BASE"/storm-core/test/clj/integration/storm/* "$BASE"/storm-core/test/clj/integration/org/apache/storm
 rm -rf "$BASE"/storm-core/test/clj/integration/storm
+git mv "$BASE"/storm-core/test/clj/integration/backtype/storm/* "$BASE"/storm-core/test/clj/integration/org/apache/storm
+rm -rf "$BASE"/storm-core/test/clj/integration/backtype
 
 #STORM-STARTER
 mkdir -p "$BASE"/examples/storm-starter/src/jvm/org/apache/ "$BASE"/examples/storm-starter/src/clj/org/apache/ "$BASE"/examples/storm-starter/test/jvm/org/apache/

--- a/dev-tools/move_package.sh
+++ b/dev-tools/move_package.sh
@@ -1,0 +1,69 @@
+#!/bin/sh -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -u
+set -e
+
+BASE="$1"
+find "$BASE" -type f -print0 | xargs -0 egrep -l 'backtype.storm|storm.trident|storm.starter|storm.kafka|"backtype", "storm"' | egrep -v '.git/|docs/|CHANGELOG.md|dev-tools/move_package.sh|StormShadeRequest.java' | xargs sed -i '' -e 's/storm\(.\)trident/org\1apache\1storm\1trident/g' -e 's/backtype\(.\)storm/org\1apache\1storm/g' -e 's/storm\([\.\\]\)starter/org\1apache\1storm\1starter/g' -e 's/storm\([\.\\]\)kafka/org\1apache\1storm\1kafka/g' -e 's/"backtype", "storm"/"org", "apache", "storm"/g'
+#find "$BASE" -type f -print0 | xargs -0 egrep -l 'backtype.storm|storm.trident' | egrep -v '.git/|docs/|CHANGELOG.md' | xargs sed -i '' -e 's/storm\(.\)trident/org\1apache\1storm\1trident/g' -e 's/backtype\(.\)storm/org\1apache\1storm/g'
+mkdir -p "$BASE"/storm-core/src/jvm/org/apache/storm/ "$BASE"/storm-core/src/clj/org/apache/storm/ "$BASE"/storm-core/test/jvm/org/apache/storm/ "$BASE"/storm-core/test/clj/org/apache/storm/
+#STORM-CORE
+#SRC JVM
+git mv "$BASE"/storm-core/src/jvm/backtype/storm/* "$BASE"/storm-core/src/jvm/org/apache/storm/
+rm -rf "$BASE"/storm-core/src/jvm/backtype
+git mv "$BASE"/storm-core/src/jvm/storm/trident "$BASE"/storm-core/src/jvm/org/apache/storm
+rm -rf "$BASE"/storm-core/src/jvm/storm
+
+#SRC CLJ
+git mv "$BASE"/storm-core/src/clj/backtype/storm/* "$BASE"/storm-core/src/clj/org/apache/storm/
+rm -rf "$BASE"/storm-core/src/clj/backtype
+git mv "$BASE"/storm-core/src/clj/storm/trident "$BASE"/storm-core/src/clj/org/apache/storm
+rm -rf "$BASE"/storm-core/src/clj/storm
+
+#TEST JVM
+git mv "$BASE"/storm-core/test/jvm/backtype/storm/* "$BASE"/storm-core/test/jvm/org/apache/storm/
+rm -rf "$BASE"/storm-core/test/jvm/backtype
+#git mv "$BASE"/storm-core/test/jvm/storm/trident "$BASE"/storm-core/test/jvm/org/apache/storm
+#rm -rf "$BASE"/storm-core/test/jvm/storm
+
+#TEST CLJ
+git mv "$BASE"/storm-core/test/clj/backtype/storm/* "$BASE"/storm-core/test/clj/org/apache/storm/
+rm -rf "$BASE"/storm-core/test/clj/backtype
+git mv "$BASE"/storm-core/test/clj/storm/trident "$BASE"/storm-core/test/clj/org/apache/storm
+rm -rf "$BASE"/storm-core/test/clj/storm
+
+#STORM-STARTER
+mkdir -p "$BASE"/examples/storm-starter/src/jvm/org/apache/ "$BASE"/examples/storm-starter/src/clj/org/apache/ "$BASE"/examples/storm-starter/test/jvm/org/apache/
+#SRC JVM
+git mv "$BASE"/examples/storm-starter/src/jvm/storm "$BASE"/examples/storm-starter/src/jvm/org/apache/
+
+#SRC CLJ
+git mv "$BASE"/examples/storm-starter/src/clj/storm "$BASE"/examples/storm-starter/src/clj/org/apache/
+
+#TEST JVM
+git mv "$BASE"/examples/storm-starter/test/jvm/storm "$BASE"/examples/storm-starter/test/jvm/org/apache/
+
+
+#STORM-KAFKA
+mkdir -p "$BASE"/external/storm-kafka/src/jvm/org/apache/ "$BASE"/external/storm-kafka/src/test/org/apache/
+
+#SRC JVM
+git mv "$BASE"/external/storm-kafka/src/jvm/storm "$BASE"/external/storm-kafka/src/jvm/org/apache/
+
+#TEST JVM
+git mv "$BASE"/external/storm-kafka/src/test/storm "$BASE"/external/storm-kafka/src/test/org/apache/
+

--- a/dev-tools/move_package.sh
+++ b/dev-tools/move_package.sh
@@ -19,9 +19,8 @@ set -e
 
 BASE="$1"
 find "$BASE" -type f -print0 | xargs -0 egrep -l 'backtype.storm|storm.trident|storm.starter|storm.kafka|"backtype", "storm"' | egrep -v '.git/|docs/|CHANGELOG.md|dev-tools/move_package.sh|StormShadeRequest.java' | xargs sed -i.back -e 's/storm\(.\)trident/org\1apache\1storm\1trident/g' -e 's/backtype\(.\)storm/org\1apache\1storm/g' -e 's/storm\([\.\\]\)starter/org\1apache\1storm\1starter/g' -e 's/storm\([\.\\]\)kafka/org\1apache\1storm\1kafka/g' -e 's/"backtype", "storm"/"org", "apache", "storm"/g'
-#find "$BASE" -type f -print0 | xargs -0 egrep -l 'backtype.storm|storm.trident' | egrep -v '.git/|docs/|CHANGELOG.md' | xargs sed -i '' -e 's/storm\(.\)trident/org\1apache\1storm\1trident/g' -e 's/backtype\(.\)storm/org\1apache\1storm/g'
 find "$BASE" -iname \*.back | xargs rm
-mkdir -p "$BASE"/storm-core/src/jvm/org/apache/storm/ "$BASE"/storm-core/src/clj/org/apache/storm/ "$BASE"/storm-core/test/jvm/org/apache/storm/ "$BASE"/storm-core/test/clj/org/apache/storm/
+mkdir -p "$BASE"/storm-core/src/jvm/org/apache/storm/ "$BASE"/storm-core/src/clj/org/apache/storm/ "$BASE"/storm-core/test/jvm/org/apache/storm/ "$BASE"/storm-core/test/clj/org/apache/storm/ "$BASE"/storm-core/test/clj/integration/org/apache/storm/
 #STORM-CORE
 #SRC JVM
 git mv "$BASE"/storm-core/src/jvm/backtype/storm/* "$BASE"/storm-core/src/jvm/org/apache/storm/
@@ -46,6 +45,8 @@ git mv "$BASE"/storm-core/test/clj/backtype/storm/* "$BASE"/storm-core/test/clj/
 rm -rf "$BASE"/storm-core/test/clj/backtype
 git mv "$BASE"/storm-core/test/clj/storm/trident "$BASE"/storm-core/test/clj/org/apache/storm
 rm -rf "$BASE"/storm-core/test/clj/storm
+git mv "$BASE"/storm-core/test/clj/integration/storm "$BASE"/storm-core/test/clj/integration/org/apache/storm
+rm -rf "$BASE"/storm-core/test/clj/integration/storm
 
 #STORM-STARTER
 mkdir -p "$BASE"/examples/storm-starter/src/jvm/org/apache/ "$BASE"/examples/storm-starter/src/clj/org/apache/ "$BASE"/examples/storm-starter/test/jvm/org/apache/

--- a/dev-tools/travis/travis-install.sh
+++ b/dev-tools/travis/travis-install.sh
@@ -19,7 +19,7 @@ STORM_SRC_ROOT_DIR=$1
 TRAVIS_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 cd ${STORM_SRC_ROOT_DIR}
-
+./dev-tools/move_package.sh "${STORM_SRC_ROOT_DIR}"
 python ${TRAVIS_SCRIPT_DIR}/save-logs.py "install.txt" mvn clean install -DskipTests -Pnative --batch-mode
 BUILD_RET_VAL=$?
 

--- a/dev-tools/travis/travis-install.sh
+++ b/dev-tools/travis/travis-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
@@ -19,7 +19,7 @@ STORM_SRC_ROOT_DIR=$1
 TRAVIS_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 cd ${STORM_SRC_ROOT_DIR}
-./dev-tools/move_package.sh "${STORM_SRC_ROOT_DIR}"
+./dev-tools/move_package.sh "${STORM_SRC_ROOT_DIR}" || exit 1
 python ${TRAVIS_SCRIPT_DIR}/save-logs.py "install.txt" mvn clean install -DskipTests -Pnative --batch-mode
 BUILD_RET_VAL=$?
 

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
         <module>storm-buildtools/maven-shade-clojure-transformer</module>
         <module>storm-buildtools/storm-maven-plugins</module>
         <module>storm-core</module>
+        <module>storm-rename-hack</module>
         <module>external/storm-kafka</module>
         <module>external/storm-hdfs</module>
         <module>external/storm-hbase</module>

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -2066,6 +2066,13 @@ public class Config extends HashMap<String, Object> {
     @isInteger
     public static final String NIMBUS_CODE_SYNC_FREQ_SECS = "nimbus.code.sync.freq.secs";
 
+    /**
+     * An implementation of @{link backtype.storm.daemon.JarTransformer} that will can be used to transform a jar
+     * file before storm jar runs with it. Use with extreme caution.
+     */
+    @isString
+    public static final Object CLIENT_JAR_TRANSFORMER = "client.jartransformer.class";
+
     public static void setClasspath(Map conf, String cp) {
         conf.put(Config.TOPOLOGY_CLASSPATH, cp);
     }

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -2069,6 +2069,9 @@ public class Config extends HashMap<String, Object> {
     /**
      * An implementation of @{link backtype.storm.daemon.JarTransformer} that will can be used to transform a jar
      * file before storm jar runs with it. Use with extreme caution.
+     * If you want to enable a transition between backtype.storm and org.apache.storm to run older topologies
+     * you can set this to org.apache.storm.hack.StormShadeTransformer.  But this is likely to be deprecated in
+     * future releases.
      */
     @isString
     public static final Object CLIENT_JAR_TRANSFORMER = "client.jartransformer.class";

--- a/storm-core/src/jvm/backtype/storm/daemon/ClientJarTransformerRunner.java
+++ b/storm-core/src/jvm/backtype/storm/daemon/ClientJarTransformerRunner.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backtype.storm.daemon;
+
+import backtype.storm.utils.Utils;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.InputStream;
+
+/**
+ * Main executable to load and run a jar transformer
+ */
+public class ClientJarTransformerRunner {
+    public static void main(String [] args) throws IOException {
+        JarTransformer transformer = Utils.jarTransformer(args[0]);
+        InputStream in = new FileInputStream(args[1]);
+        OutputStream out = new FileOutputStream(args[2]);
+        transformer.transform(in, out);
+        in.close();
+        out.close();
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/daemon/JarTransformer.java
+++ b/storm-core/src/jvm/backtype/storm/daemon/JarTransformer.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backtype.storm.daemon;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * A plugin that can be used to transform a jar file in nimbus before it
+ * is used by a topology.
+ */
+public interface JarTransformer {
+    public void transform(InputStream input, OutputStream output) throws IOException;
+}

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -596,7 +596,7 @@ public class Utils {
     }
 
 
-    public static IFn loadClojureFn(String namespace, String name) {
+    public static synchronized IFn loadClojureFn(String namespace, String name) {
         try {
             clojure.lang.Compiler.eval(RT.readString("(require '" + namespace + ")"));
         } catch (Exception e) {

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -23,6 +23,7 @@ import backtype.storm.blobstore.BlobStoreAclHandler;
 import backtype.storm.blobstore.ClientBlobStore;
 import backtype.storm.blobstore.InputStreamWithMeta;
 import backtype.storm.blobstore.LocalFsBlobStore;
+import backtype.storm.daemon.JarTransformer;
 import backtype.storm.generated.*;
 import backtype.storm.localizer.Localizer;
 import backtype.storm.nimbus.NimbusInfo;
@@ -126,6 +127,14 @@ public class Utils {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static JarTransformer jarTransformer(String klass) {
+        JarTransformer ret = null;
+        if (klass != null) {
+            ret = (JarTransformer)newInstance(klass);
+        }
+        return ret;
     }
 
     public static byte[] serialize(Object obj) {

--- a/storm-dist/binary/pom.xml
+++ b/storm-dist/binary/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>storm-sql-runtime</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-rename-hack</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/storm-rename-hack/pom.xml
+++ b/storm-rename-hack/pom.xml
@@ -18,10 +18,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-      <artifactId>storm</artifactId>
-      <groupId>org.apache.storm</groupId>
-      <version>0.11.0-SNAPSHOT</version>
-      <relativePath>../pom.xml</relativePath>
+    <artifactId>storm</artifactId>
+    <groupId>org.apache.storm</groupId>
+    <version>0.11.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.apache.storm</groupId>
@@ -60,48 +60,48 @@
 
   <build>
     <plugins>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-shade-plugin</artifactId>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
+          <createDependencyReducedPom>true</createDependencyReducedPom>
+          <artifactSet>
+            <includes>
+              <include>com.google.guava:guava</include>
+              <include>org.ow2.asm:asm</include>
+              <include>org.ow2.asm:asm-commons</include>
+            </includes>
+          </artifactSet>
+          <relocations>
+            <relocation>
+              <pattern>com.google</pattern>
+              <shadedPattern>org.apache.storm.hack.shade.com.google</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.objectweb.asm</pattern>
+              <shadedPattern>org.apache.storm.hack.shade.org.objectweb.asm</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
             <configuration>
-                <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
-                <createDependencyReducedPom>true</createDependencyReducedPom>
-                <artifactSet>
-                    <includes>
-                        <include>com.google.guava:guava</include>
-                        <include>org.ow2.asm:asm</include>
-                        <include>org.ow2.asm:asm-commons</include>
-                    </includes>
-                </artifactSet>
-                <relocations>
-                    <relocation>
-                        <pattern>com.google</pattern>
-                        <shadedPattern>org.apache.storm.hack.shade.com.google</shadedPattern>
-                    </relocation>
-                    <relocation>
-                        <pattern>org.objectweb.asm</pattern>
-                        <shadedPattern>org.apache.storm.hack.shade.org.objectweb.asm</shadedPattern>
-                    </relocation>
-                </relocations>
+              <transformers>
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer
+                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                </transformer>
+              </transformers>
             </configuration>
-            <executions>
-                <execution>
-                    <phase>package</phase>
-                    <goals>
-                        <goal>shade</goal>
-                    </goals>
-                    <configuration>
-                        <transformers>
-                            <transformer
-                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                            <transformer
-                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            </transformer>
-                        </transformers>
-                    </configuration>
-                </execution>
-            </executions>
-        </plugin>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/storm-rename-hack/pom.xml
+++ b/storm-rename-hack/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+      <artifactId>storm</artifactId>
+      <groupId>org.apache.storm</groupId>
+      <version>0.11.0-SNAPSHOT</version>
+      <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <groupId>org.apache.storm</groupId>
+  <artifactId>storm-rename-hack</artifactId>
+  <packaging>jar</packaging>
+
+  <name>storm-rename-hack</name>
+
+  <properties>
+    <mavenVersion>3.0</mavenVersion>
+    <asmVersion>5.0.2</asmVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.storm</groupId>
+      <artifactId>storm-core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>${asmVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>${asmVersion}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <configuration>
+                <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
+                <createDependencyReducedPom>true</createDependencyReducedPom>
+                <artifactSet>
+                    <includes>
+                        <include>com.google.guava:guava</include>
+                        <include>org.ow2.asm:asm</include>
+                        <include>org.ow2.asm:asm-commons</include>
+                    </includes>
+                </artifactSet>
+                <relocations>
+                    <relocation>
+                        <pattern>com.google</pattern>
+                        <shadedPattern>org.apache.storm.hack.shade.com.google</shadedPattern>
+                    </relocation>
+                    <relocation>
+                        <pattern>org.objectweb.asm</pattern>
+                        <shadedPattern>org.apache.storm.hack.shade.org.objectweb.asm</shadedPattern>
+                    </relocation>
+                </relocations>
+            </configuration>
+            <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>shade</goal>
+                    </goals>
+                    <configuration>
+                        <transformers>
+                            <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            </transformer>
+                        </transformers>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+  </build>
+</project>

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/DefaultShader.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/DefaultShader.java
@@ -129,6 +129,15 @@ public class DefaultShader {
         }
 
         jarFile.close();
+
+        for ( ResourceTransformer transformer : transformers )
+        {
+            if ( transformer.hasTransformedResource() )
+            {
+                transformer.modifyOutputStream( jos );
+            }
+        }
+
         jos.close();
     }
 

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/DefaultShader.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/DefaultShader.java
@@ -1,0 +1,382 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.storm.hack;
+
+import org.apache.storm.hack.relocation.Relocator;
+import org.apache.storm.hack.resource.ResourceTransformer;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.commons.Remapper;
+import org.objectweb.asm.commons.RemappingClassAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipException;
+
+/**
+ * This is based off of
+ *
+ * https://github.com/apache/maven-plugins.git
+ *
+ * maven-shade-plugin-2.4.1
+ */
+public class DefaultShader {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultShader.class);
+
+    public void shadeJarStream(ShadeRequest shadeRequest, InputStream in, final OutputStream fileOutputStream)
+            throws IOException {
+        Set<String> resources = new HashSet<>();
+
+        List<ResourceTransformer> transformers =
+                new ArrayList<>( shadeRequest.getResourceTransformers() );
+        LOG.debug("Transformers {}", transformers);
+
+        RelocatorRemapper remapper = new RelocatorRemapper( shadeRequest.getRelocators() );
+        LOG.debug("Remapper {}", remapper);
+
+        JarOutputStream jos = new JarOutputStream( new BufferedOutputStream( fileOutputStream ) );
+
+        JarInputStream jarFile = new JarInputStream(in);
+
+        for ( JarEntry entry = jarFile.getNextJarEntry(); entry != null; entry = jarFile.getNextJarEntry())
+        {
+            String name = entry.getName();
+            LOG.debug("Processing " + name);
+            remapper.setClassName(name);
+            if ( "META-INF/INDEX.LIST".equals( name ) )
+            {
+                LOG.debug("Skipping INDEX.LIST...");
+                // we cannot allow the jar indexes to be copied over or the
+                // jar is useless. Ideally, we could create a new one
+                // later
+                continue;
+            }
+
+            if ( !entry.isDirectory() )
+            {
+                InputStream is = jarFile;
+
+                String mappedName = remapper.map( name );
+                LOG.debug(name + " -> " + mappedName);
+
+                int idx = mappedName.lastIndexOf( '/' );
+                if ( idx != -1 )
+                {
+                    // make sure dirs are created
+                    String dir = mappedName.substring( 0, idx );
+                    if ( !resources.contains( dir ) )
+                    {
+                        addDirectory( resources, jos, dir );
+                    }
+                }
+
+                if ( name.endsWith( ".class" ) )
+                {
+                    addRemappedClass( remapper, jos, name, is );
+                }
+                else if ( name.endsWith( ".java" ) )
+                {
+                    // Avoid duplicates
+                    if ( resources.contains( mappedName ) )
+                    {
+                        continue;
+                    }
+
+                    addJavaSource( resources, jos, mappedName, is, shadeRequest.getRelocators() );
+                }
+                else
+                {
+                    if ( !resourceTransformed( transformers, mappedName, is, shadeRequest.getRelocators() ) )
+                    {
+                        // Avoid duplicates that aren't accounted for by the resource transformers
+                        if ( resources.contains( mappedName ) )
+                        {
+                            continue;
+                        }
+
+                        addResource( resources, jos, mappedName, is );
+                    }
+                }
+            }
+        }
+
+        jarFile.close();
+        jos.close();
+    }
+
+    private void addDirectory( Set<String> resources, JarOutputStream jos, String name )
+        throws IOException {
+        if (name.lastIndexOf('/') > 0) {
+            String parent = name.substring(0, name.lastIndexOf('/'));
+            if (!resources.contains(parent)) {
+                addDirectory(resources, jos, parent);
+            }
+        }
+
+        // directory entries must end in "/"
+        JarEntry entry = new JarEntry(name + "/");
+        LOG.debug("Adding JAR directory " + entry);
+        jos.putNextEntry(entry);
+
+        resources.add(name);
+    }
+
+    private void addRemappedClass( RelocatorRemapper remapper, JarOutputStream jos, String name,
+                                   InputStream is )
+        throws IOException
+    {
+        LOG.debug("Remapping class... "+name);
+        if ( !remapper.hasRelocators() )
+        {
+            try
+            {
+                LOG.debug("Just copy class...");
+                jos.putNextEntry( new JarEntry( name ) );
+                IOUtil.copy( is, jos );
+            }
+            catch ( ZipException e )
+            {
+                LOG.info( "zip exception ", e);
+            }
+
+            return;
+        }
+
+        ClassReader cr = new ClassReader( is );
+
+        // We don't pass the ClassReader here. This forces the ClassWriter to rebuild the constant pool.
+        // Copying the original constant pool should be avoided because it would keep references
+        // to the original class names. This is not a problem at runtime (because these entries in the
+        // constant pool are never used), but confuses some tools such as Felix' maven-bundle-plugin
+        // that use the constant pool to determine the dependencies of a class.
+        ClassWriter cw = new ClassWriter( 0 );
+
+        final String pkg = name.substring( 0, name.lastIndexOf( '/' ) + 1 );
+        ClassVisitor cv = new RemappingClassAdapter( cw, remapper )
+        {
+            @Override
+            public void visitSource( final String source, final String debug )
+            {
+                LOG.debug("visitSource "+source);
+                if ( source == null )
+                {
+                    super.visitSource( source, debug );
+                }
+                else
+                {
+                    final String fqSource = pkg + source;
+                    final String mappedSource = remapper.map( fqSource );
+                    final String filename = mappedSource.substring( mappedSource.lastIndexOf( '/' ) + 1 );
+                    LOG.debug("Remapped to "+filename);
+                    super.visitSource( filename, debug );
+                }
+            }
+        };
+
+        try
+        {
+            cr.accept( cv, ClassReader.EXPAND_FRAMES );
+        }
+        catch ( Throwable ise )
+        {
+            throw new IOException( "Error in ASM processing class " + name, ise );
+        }
+
+        byte[] renamedClass = cw.toByteArray();
+
+        // Need to take the .class off for remapping evaluation
+        String mappedName = remapper.map( name.substring( 0, name.indexOf( '.' ) ) );
+        LOG.debug("Remapped class name to "+mappedName);
+
+        try
+        {
+            // Now we put it back on so the class file is written out with the right extension.
+            jos.putNextEntry( new JarEntry( mappedName + ".class" ) );
+            jos.write(renamedClass);
+        }
+        catch ( ZipException e )
+        {
+            LOG.info( "zip exception ", e);
+        }
+    }
+
+    private boolean resourceTransformed( List<ResourceTransformer> resourceTransformers, String name, InputStream is,
+                                         List<Relocator> relocators )
+        throws IOException
+    {
+        boolean resourceTransformed = false;
+
+        for ( ResourceTransformer transformer : resourceTransformers )
+        {
+            if ( transformer.canTransformResource( name ) )
+            {
+                LOG.debug( "Transforming " + name + " using " + transformer.getClass().getName() );
+
+                transformer.processResource( name, is, relocators );
+
+                resourceTransformed = true;
+
+                break;
+            }
+        }
+        return resourceTransformed;
+    }
+
+    private void addJavaSource( Set<String> resources, JarOutputStream jos, String name, InputStream is,
+                                List<Relocator> relocators )
+        throws IOException
+    {
+        jos.putNextEntry( new JarEntry( name ) );
+
+        String sourceContent = IOUtil.toString( new InputStreamReader( is, "UTF-8" ) );
+
+        for ( Relocator relocator : relocators )
+        {
+            sourceContent = relocator.applyToSourceContent( sourceContent );
+        }
+
+        OutputStreamWriter writer = new OutputStreamWriter( jos, "UTF-8" );
+        writer.append(sourceContent);
+        writer.flush();
+
+        resources.add( name );
+    }
+
+    private void addResource( Set<String> resources, JarOutputStream jos, String name, InputStream is )
+        throws IOException
+    {
+        jos.putNextEntry( new JarEntry( name ) );
+
+        IOUtil.copy( is, jos );
+
+        resources.add( name );
+    }
+
+    class RelocatorRemapper extends Remapper
+    {
+
+        private final Pattern classPattern = Pattern.compile( "(\\[*)?L(.+);" );
+
+        private final List<Relocator> relocators;
+
+        private final HashSet<String> warned = new HashSet<>();
+
+        private String className = "UNKNOWN";
+
+        public RelocatorRemapper( List<Relocator> relocators)
+        {
+            this.relocators = relocators;
+        }
+
+        public boolean hasRelocators()
+        {
+            return !relocators.isEmpty();
+        }
+
+        public void setClassName(String className) {
+            this.className = className;
+        }
+
+        @Override
+        public Object mapValue( Object object )
+        {
+            if ( object instanceof String )
+            {
+                String name = (String) object;
+                String value = name;
+
+                String prefix = "";
+                String suffix = "";
+
+                Matcher m = classPattern.matcher( name );
+                if ( m.matches() )
+                {
+                    prefix = m.group( 1 ) + "L";
+                    suffix = ";";
+                    name = m.group( 2 );
+                }
+
+                for ( Relocator r : relocators )
+                {
+                    if ( r.canRelocateClass( name ) )
+                    {
+                        value = prefix + r.relocateClass( name ) + suffix;
+                        break;
+                    }
+                    else if ( r.canRelocatePath( name ) )
+                    {
+                        value = prefix + r.relocatePath( name ) + suffix;
+                        break;
+                    }
+                }
+
+                return value;
+            }
+
+            return super.mapValue( object );
+        }
+
+        @Override
+        public String map( String name )
+        {
+            String orig = name;
+            String value = name;
+
+            String prefix = "";
+            String suffix = "";
+
+            Matcher m = classPattern.matcher( name );
+            if ( m.matches() )
+            {
+                prefix = m.group( 1 ) + "L";
+                suffix = ";";
+                name = m.group( 2 );
+            }
+
+            for ( Relocator r : relocators )
+            {
+                if ( r.canRelocatePath( name ) )
+                {
+                    value = prefix + r.relocatePath( name ) + suffix;
+                    if (!warned.contains(orig)) {
+                        LOG.warn("Relocating {} to {} in {} please modify your code to use the new namespace", orig, value, className);
+                        warned.add(orig);
+                    }
+                    break;
+                }
+            }
+
+            return value;
+        }
+
+    }
+
+}

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/IOUtil.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/IOUtil.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hack;
+
+import java.io.*;
+
+public class IOUtil {
+    public static void copy(InputStream in, OutputStream out) throws IOException {
+        byte [] buffer = new byte[4096];
+        int read;
+        while ((read = in.read(buffer)) > 0) {
+            out.write(buffer, 0, read);
+        }
+    }
+
+    public static String toString(Reader reader) throws IOException {
+        StringWriter ret = new StringWriter();
+        char [] buffer = new char[4096];
+        int read;
+        while ((read = reader.read(buffer)) > 0) {
+            ret.write(buffer, 0, read);
+        }
+        return ret.toString();
+    }
+}

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/ShadeRequest.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/ShadeRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.storm.hack;
+
+import org.apache.storm.hack.relocation.Relocator;
+import org.apache.storm.hack.resource.ResourceTransformer;
+
+import java.util.List;
+
+/**
+ * This is based off of
+ *
+ * https://github.com/apache/maven-plugins.git
+ *
+ * maven-shade-plugin-2.4.1
+ */
+public class ShadeRequest
+{
+    private List<Relocator> relocators;
+
+    private List<ResourceTransformer> resourceTransformers;
+
+    public List<Relocator> getRelocators()
+    {
+        return relocators;
+    }
+
+    /**
+     * The relocators.
+     *
+     * @param relocators
+     */
+    public void setRelocators( List<Relocator> relocators )
+    {
+        this.relocators = relocators;
+    }
+
+    public List<ResourceTransformer> getResourceTransformers()
+    {
+        return resourceTransformers;
+    }
+
+    /**
+     * The transformers.
+     *
+     * @param resourceTransformers
+     */
+    public void setResourceTransformers( List<ResourceTransformer> resourceTransformers )
+    {
+        this.resourceTransformers = resourceTransformers;
+    }
+}

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/StormShadeRequest.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/StormShadeRequest.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hack;
+
+import org.apache.storm.hack.relocation.Relocator;
+import org.apache.storm.hack.relocation.SimpleRelocator;
+import org.apache.storm.hack.resource.ClojureTransformer;
+import org.apache.storm.hack.resource.ResourceTransformer;
+
+import java.util.Arrays;
+
+public class StormShadeRequest {
+    public static ShadeRequest makeRequest() {
+        ShadeRequest request = new ShadeRequest();
+        request.setRelocators(Arrays.asList(
+                (Relocator)new SimpleRelocator("backtype.storm", "org.apache.storm"),
+                (Relocator)new SimpleRelocator("storm.trident", "org.apache.storm.trident")
+        ));
+        request.setResourceTransformers(Arrays.asList(
+                (ResourceTransformer)new ClojureTransformer()
+        ));
+        return request;
+    }
+}

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/StormShadeTransformer.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/StormShadeTransformer.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hack;
+
+import backtype.storm.daemon.JarTransformer;
+import org.apache.storm.hack.relocation.Relocator;
+import org.apache.storm.hack.relocation.SimpleRelocator;
+import org.apache.storm.hack.resource.ClojureTransformer;
+import org.apache.storm.hack.resource.ResourceTransformer;
+
+import java.io.*;
+import java.util.Arrays;
+
+public class StormShadeTransformer implements JarTransformer {
+    @Override
+    public void transform(InputStream input, OutputStream output) throws IOException {
+        DefaultShader shader = new DefaultShader();
+        ShadeRequest request = StormShadeRequest.makeRequest();
+        shader.shadeJarStream(request,input, output);
+    }
+}

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/relocation/Relocator.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/relocation/Relocator.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.storm.hack.relocation;
+
+/**
+ * This is based off of
+ *
+ * https://github.com/apache/maven-plugins.git
+ *
+ * maven-shade-plugin-2.4.1
+ */
+public interface Relocator
+{
+    boolean canRelocatePath( String clazz );
+
+    String relocatePath( String clazz );
+
+    boolean canRelocateClass( String clazz );
+
+    String relocateClass( String clazz );
+    
+    String applyToSourceContent( String sourceContent );
+}

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/relocation/SimpleRelocator.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/relocation/SimpleRelocator.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.storm.hack.relocation;
+
+/**
+ * This is based off of
+ *
+ * https://github.com/apache/maven-plugins.git
+ *
+ * maven-shade-plugin-2.4.1
+ */
+public class SimpleRelocator
+    implements Relocator
+{
+
+    private final String pattern;
+
+    private final String pathPattern;
+
+    private final String shadedPattern;
+
+    private final String shadedPathPattern;
+
+    public SimpleRelocator( String patt, String shadedPattern)
+    {
+        if ( patt == null )
+        {
+            this.pattern = "";
+            this.pathPattern = "";
+        }
+        else
+        {
+            this.pattern = patt.replace( '/', '.' );
+            this.pathPattern = patt.replace( '.', '/' );
+        }
+
+        if ( shadedPattern != null )
+        {
+            this.shadedPattern = shadedPattern.replace( '/', '.' );
+            this.shadedPathPattern = shadedPattern.replace( '.', '/' );
+        }
+        else
+        {
+            this.shadedPattern = "hidden." + this.pattern;
+            this.shadedPathPattern = "hidden/" + this.pathPattern;
+        }
+    }
+
+    public boolean canRelocatePath( String path )
+    {
+        if ( path.endsWith( ".class" ) )
+        {
+            path = path.substring( 0, path.length() - 6 );
+        }
+
+        // Allow for annoying option of an extra / on the front of a path. See MSHADE-119; comes from
+        // getClass().getResource("/a/b/c.properties").
+        return path.startsWith( pathPattern ) || path.startsWith ( "/" + pathPattern );
+    }
+
+    public boolean canRelocateClass( String clazz )
+    {
+        return clazz.indexOf( '/' ) < 0 && canRelocatePath( clazz.replace( '.', '/' ) );
+    }
+
+    public String relocatePath( String path )
+    {
+        return path.replaceFirst( pathPattern, shadedPathPattern );
+    }
+
+    public String relocateClass( String clazz )
+    {
+        return clazz.replaceFirst( pattern, shadedPattern );
+    }
+
+    public String applyToSourceContent( String sourceContent )
+    {
+        return sourceContent.replaceAll( "\\b" + pattern, shadedPattern );
+    }
+}

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ClojureTransformer.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ClojureTransformer.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hack.resource;
+
+import org.apache.storm.hack.relocation.Relocator;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+
+public class ClojureTransformer implements ResourceTransformer {
+
+    private final HashMap<String, String> entries = new HashMap<>();
+
+    @Override
+    public boolean canTransformResource(String s) {
+        if(s.endsWith(".clj")){
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void processResource(String s, InputStream inputStream, List<Relocator> relocators) throws IOException {
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int b;
+        while((b = inputStream.read()) != -1){
+            out.write(b);
+        }
+        String data = out.toString();
+
+        for(Relocator rel : relocators){
+            data = rel.applyToSourceContent(data);
+        }
+        this.entries.put(s, data);
+    }
+}

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ClojureTransformer.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ClojureTransformer.java
@@ -53,4 +53,12 @@ public class ClojureTransformer implements ResourceTransformer {
         }
         this.entries.put(s, data);
     }
+
+    @Override
+    public void modifyOutputStream(JarOutputStream jarOut) throws IOException {
+        for(String key : this.entries.keySet()){
+            jarOut.putNextEntry(new JarEntry(key));
+            jarOut.write(this.entries.get(key).getBytes());
+        }
+    }
 }

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ClojureTransformer.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ClojureTransformer.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
+import java.util.jar.JarOutputStream;
 
 public class ClojureTransformer implements ResourceTransformer {
 

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ClojureTransformer.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ClojureTransformer.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.jar.JarOutputStream;
+import java.util.jar.JarEntry;
 
 public class ClojureTransformer implements ResourceTransformer {
 
@@ -53,6 +54,11 @@ public class ClojureTransformer implements ResourceTransformer {
             data = rel.applyToSourceContent(data);
         }
         this.entries.put(s, data);
+    }
+
+    @Override
+    public boolean hasTransformedResource() {
+        return !entries.isEmpty();
     }
 
     @Override

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ResourceTransformer.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ResourceTransformer.java
@@ -39,4 +39,6 @@ public interface ResourceTransformer
 
     void processResource( String resource, InputStream is, List<Relocator> relocators )
         throws IOException;
+
+    public void modifyOutputStream(JarOutputStream jarOut) throws IOException;
 }

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ResourceTransformer.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ResourceTransformer.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.storm.hack.resource;
+
+import org.apache.storm.hack.relocation.Relocator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.jar.JarOutputStream;
+
+/**
+ * This is based off of
+ *
+ * https://github.com/apache/maven-plugins.git
+ *
+ * maven-shade-plugin-2.4.1
+ */
+public interface ResourceTransformer
+{
+    boolean canTransformResource( String resource );
+
+    void processResource( String resource, InputStream is, List<Relocator> relocators )
+        throws IOException;
+}

--- a/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ResourceTransformer.java
+++ b/storm-rename-hack/src/main/java/org/apache/storm/hack/resource/ResourceTransformer.java
@@ -40,5 +40,7 @@ public interface ResourceTransformer
     void processResource( String resource, InputStream is, List<Relocator> relocators )
         throws IOException;
 
-    public void modifyOutputStream(JarOutputStream jarOut) throws IOException;
+    boolean hasTransformedResource();
+
+    void modifyOutputStream(JarOutputStream jarOut) throws IOException;
 }


### PR DESCRIPTION
This is not a typical pull request, because changing the packages is a huge task, and keeping it upmerged while this is reviewed and other patches goes in is a huge task, and error prone.

Instead the actual changes to the package/namespace is done by running

 ```./dev-tools/move_packages.sh ./```

you can wipe all of the changes clean again (Including any modifications on your branch that you have not checked in) by running
```./dev-tools/cleanup.sh ./```

once the changes are approved/committed these two scripts should be removed.

The other code is intended to provide a single executable that can shade a user jar so instead of using `backtype.storm` and `storm.trident` it uses `org.apache.storm` and `org.apache.storm.trident`.

These are off by default by can be enabled by adding
```
client.jartransformer.class: "org.apache.storm.hack.StormShadeTransformer"
```
to storm.yaml.  I would expect all of the code related to this to be removed when we go to the 2.0 release.

I have tested this by running a 0.10.0-SNAPSHOT storm starter topologies against a cluster running this patch (along with the move_package.sh executed).