### PR TITLE
MINOR: Use /usr/bin/env to find bash

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
This is a minor change to the shell scripts in the bin directory that use bash which switches them to find bash via /usr/bin/env which should provide more cross platform compatibility. Specifically it will allow these scripts to work out of the box on the various BSDs with bash is installed in the default manner, in /usr/local/bin instead of /bin and should remain compatible with other OSes that typically put most things in /bin