### PR TITLE
STORM-1219: Fix HDFS and Hive bolt flush/acking

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -48,6 +48,11 @@ import java.util.TimerTask;
 public abstract class AbstractHdfsBolt extends BaseRichBolt {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractHdfsBolt.class);
     private static final Integer DEFAULT_RETRY_COUNT = 3;
+    /**
+     * A low default value so that tuples are flushed and acked as soon as possible to avoid
+     * replay and spouts can continue emitting without hitting TOPOLOGY_MAX_SPOUT_PENDING.
+     */
+    private static final int DEFAULT_TICK_TUPLE_INTERVAL_SECS = 1;
 
     protected ArrayList<RotationAction> rotationActions = new ArrayList<RotationAction>();
     private Path currentFile;
@@ -64,7 +69,7 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
     private List<Tuple> tupleBatch = new LinkedList<>();
     protected long offset = 0;
     protected Integer fileRetryCount = DEFAULT_RETRY_COUNT;
-    protected Integer tickTupleInterval = 0;
+    protected Integer tickTupleInterval = DEFAULT_TICK_TUPLE_INTERVAL_SECS;
 
     protected transient Configuration hdfsConfig;
 
@@ -108,14 +113,6 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
             for(String key : map.keySet()){
                 this.hdfsConfig.set(key, String.valueOf(map.get(key)));
             }
-        }
-
-        // If interval is non-zero then it has already been explicitly set and we should not default it
-        if (conf.containsKey("topology.message.timeout.secs") && tickTupleInterval == 0)
-        {
-            Integer topologyTimeout = Utils.getInt(conf.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
-            tickTupleInterval = (int)(Math.floor(topologyTimeout / 2));
-            LOG.debug("Setting tick tuple interval to [{}] based on topology timeout", tickTupleInterval);
         }
 
         try{

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -49,10 +49,9 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractHdfsBolt.class);
     private static final Integer DEFAULT_RETRY_COUNT = 3;
     /**
-     * A low default value so that tuples are flushed and acked as soon as possible to avoid
-     * replay and spouts can continue emitting without hitting TOPOLOGY_MAX_SPOUT_PENDING.
+     * Half of the default Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS
      */
-    private static final int DEFAULT_TICK_TUPLE_INTERVAL_SECS = 1;
+    private static final int DEFAULT_TICK_TUPLE_INTERVAL_SECS = 15;
 
     protected ArrayList<RotationAction> rotationActions = new ArrayList<RotationAction>();
     private Path currentFile;

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
@@ -94,14 +94,6 @@ public class HiveBolt extends  BaseRichBolt {
             heartBeatTimer = new Timer();
             setupHeartBeatTimer();
 
-            // If interval is non-zero then it has already been explicitly set and we should not default it
-            if (conf.containsKey("topology.message.timeout.secs") && options.getTickTupleInterval() == 0)
-            {
-                Integer topologyTimeout = Integer.parseInt(conf.get("topology.message.timeout.secs").toString());
-                int tickTupleInterval = (int) (Math.floor(topologyTimeout / 2));
-                options.withTickTupleInterval(tickTupleInterval);
-                LOG.debug("Setting tick tuple interval to [" + tickTupleInterval + "] based on topology timeout");
-            }
         } catch(Exception e) {
             LOG.warn("unable to make connection to hive ", e);
         }

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveOptions.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveOptions.java
@@ -27,10 +27,9 @@ import org.apache.hive.hcatalog.streaming.*;
 
 public class HiveOptions implements Serializable {
     /**
-     * A low default value so that tuples are flushed and acked as soon as possible to avoid
-     * replay and spouts can continue emitting without hitting TOPOLOGY_MAX_SPOUT_PENDING.
+     * Half of the default Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS
      */
-    private static final int DEFAULT_TICK_TUPLE_INTERVAL_SECS = 1;
+    private static final int DEFAULT_TICK_TUPLE_INTERVAL_SECS = 15;
 
     protected HiveMapper mapper;
     protected String databaseName;

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveOptions.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveOptions.java
@@ -26,6 +26,12 @@ import org.apache.hive.hcatalog.streaming.*;
 
 
 public class HiveOptions implements Serializable {
+    /**
+     * A low default value so that tuples are flushed and acked as soon as possible to avoid
+     * replay and spouts can continue emitting without hitting TOPOLOGY_MAX_SPOUT_PENDING.
+     */
+    private static final int DEFAULT_TICK_TUPLE_INTERVAL_SECS = 1;
+
     protected HiveMapper mapper;
     protected String databaseName;
     protected String tableName;
@@ -39,7 +45,7 @@ public class HiveOptions implements Serializable {
     protected Boolean autoCreatePartitions = true;
     protected String kerberosPrincipal;
     protected String kerberosKeytab;
-    protected Integer tickTupleInterval = 0;
+    protected Integer tickTupleInterval = DEFAULT_TICK_TUPLE_INTERVAL_SECS;
 
     public HiveOptions(String metaStoreURI,String databaseName,String tableName,HiveMapper mapper) {
         this.metaStoreURI = metaStoreURI;


### PR DESCRIPTION
HDFS and Hive bolts were setting the default tick tuple interval in the
prepare() method, which was not taking effect. Correctly set a default
and return from getComponentConfiguration if the user does not
explicitly set a value.