### PR TITLE
STORM-1221. Create a common interface for all Trident spout.

### DIFF
--- a/storm-core/src/jvm/storm/trident/TridentTopology.java
+++ b/storm-core/src/jvm/storm/trident/TridentTopology.java
@@ -63,6 +63,7 @@ import storm.trident.spout.BatchSpoutExecutor;
 import storm.trident.spout.IBatchSpout;
 import storm.trident.spout.IOpaquePartitionedTridentSpout;
 import storm.trident.spout.IPartitionedTridentSpout;
+import storm.trident.spout.ITridentDataSource;
 import storm.trident.spout.ITridentSpout;
 import storm.trident.spout.OpaquePartitionedTridentSpoutExecutor;
 import storm.trident.spout.PartitionedTridentSpoutExecutor;
@@ -127,7 +128,21 @@ public class TridentTopology {
     public Stream newStream(String txId, IOpaquePartitionedTridentSpout spout) {
         return newStream(txId, new OpaquePartitionedTridentSpoutExecutor(spout));
     }
-    
+
+    public Stream newStream(String txId, ITridentDataSource dataSource) {
+        if (dataSource instanceof IBatchSpout) {
+            return newStream(txId, (IBatchSpout) dataSource);
+        } else if (dataSource instanceof ITridentSpout) {
+            return newStream(txId, (ITridentSpout) dataSource);
+        } else if (dataSource instanceof IPartitionedTridentSpout) {
+            return newStream(txId, (IPartitionedTridentSpout) dataSource);
+        } else if (dataSource instanceof IOpaquePartitionedTridentSpout) {
+            return newStream(txId, (IOpaquePartitionedTridentSpout) dataSource);
+        } else {
+            throw new UnsupportedOperationException("Unsupported stream");
+        }
+    }
+
     public Stream newDRPCStream(String function) {
         return newDRPCStream(new DRPCSpout(function));
     }

--- a/storm-core/src/jvm/storm/trident/spout/IOpaquePartitionedTridentSpout.java
+++ b/storm-core/src/jvm/storm/trident/spout/IOpaquePartitionedTridentSpout.java
@@ -30,7 +30,8 @@ import storm.trident.topology.TransactionAttempt;
  * replay the same batch every time it emits a batch for a transaction id.
  * 
  */
-public interface IOpaquePartitionedTridentSpout<Partitions, Partition extends ISpoutPartition, M> extends Serializable {
+public interface IOpaquePartitionedTridentSpout<Partitions, Partition extends ISpoutPartition, M>
+    extends ITridentDataSource {
     public interface Coordinator<Partitions> {
         boolean isReady(long txid);
         Partitions getPartitionsForBatch();

--- a/storm-core/src/jvm/storm/trident/spout/IPartitionedTridentSpout.java
+++ b/storm-core/src/jvm/storm/trident/spout/IPartitionedTridentSpout.java
@@ -30,7 +30,7 @@ import storm.trident.topology.TransactionAttempt;
  * brokers. It automates the storing of metadata for each partition to ensure that the same batch
  * is always emitted for the same transaction id. The partition metadata is stored in Zookeeper.
  */
-public interface IPartitionedTridentSpout<Partitions, Partition extends ISpoutPartition, T> extends Serializable {
+public interface IPartitionedTridentSpout<Partitions, Partition extends ISpoutPartition, T> extends ITridentDataSource {
     public interface Coordinator<Partitions> {
         /**
          * Return the partitions currently in the source of data. The idea is

--- a/storm-core/src/jvm/storm/trident/spout/ITridentDataSource.java
+++ b/storm-core/src/jvm/storm/trident/spout/ITridentDataSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,17 +17,10 @@
  */
 package storm.trident.spout;
 
-import backtype.storm.task.TopologyContext;
-import backtype.storm.tuple.Fields;
 import java.io.Serializable;
-import java.util.Map;
-import storm.trident.operation.TridentCollector;
 
-public interface IBatchSpout extends ITridentDataSource {
-    void open(Map conf, TopologyContext context);
-    void emitBatch(long batchId, TridentCollector collector);
-    void ack(long batchId);
-    void close();
-    Map<String, Object> getComponentConfiguration();
-    Fields getOutputFields();
+/**
+ * ITridentDataSource marks all spouts that provide data into Trident.
+ */
+public interface ITridentDataSource extends Serializable {
 }

--- a/storm-core/src/jvm/storm/trident/spout/ITridentSpout.java
+++ b/storm-core/src/jvm/storm/trident/spout/ITridentSpout.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import storm.trident.operation.TridentCollector;
 
 
-public interface ITridentSpout<T> extends Serializable {
+public interface ITridentSpout<T> extends ITridentDataSource {
     interface BatchCoordinator<X> {
         /**
          * Create metadata for this particular transaction id which has never


### PR DESCRIPTION
This PR marks the trident spouts with a common interface. Such a common interface allows StormSQL to manage external data sources with a unified interface.