### PR TITLE
STORM-756 Handle taskids response as soon as possible

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -205,6 +205,7 @@ topology.tasks: null
 # maximum amount of time a message has to complete before it's considered failed
 topology.message.timeout.secs: 30
 topology.multilang.serializer: "backtype.storm.multilang.JsonSerializer"
+topology.shellbolt.max.pending: 100
 topology.skip.missing.kryo.registrations: false
 topology.max.task.parallelism: null
 topology.max.spout.pending: null

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1652,6 +1652,7 @@ public class Config extends HashMap<String, Object> {
     /**
      * Max pending tuples in one ShellBolt
      */
+    @NotNull
     @isInteger
     @isPositiveNumber
     public static final String TOPOLOGY_SHELLBOLT_MAX_PENDING="topology.shellbolt.max.pending";

--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -385,10 +385,6 @@ public class ShellBolt implements IBolt {
                         write = _pendingWrites.poll();
                         _process.writeBoltMsg(write);
                     }
-                    /*
-                } catch (InterruptedException e) {
-                    // NOOP
-                    */
                 } catch (Throwable t) {
                     die(t);
                 }

--- a/storm-core/src/jvm/backtype/storm/utils/ShellBoltMessageQueue.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ShellBoltMessageQueue.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backtype.storm.utils;
+
+import backtype.storm.multilang.BoltMsg;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A data structure for ShellBolt which includes two queues (FIFO),
+ * which one is for task ids (unbounded), another one is for bolt msg (bounded).
+ */
+public class ShellBoltMessageQueue implements Serializable {
+    private final LinkedList<List<Integer>> taskIdsQueue = new LinkedList<>();
+    private final LinkedBlockingQueue<BoltMsg> boltMsgQueue;
+
+    private final ReentrantLock takeLock = new ReentrantLock();
+    private final Condition notEmpty = takeLock.newCondition();
+
+    public ShellBoltMessageQueue(int boltMsgCapacity) {
+        if (boltMsgCapacity <= 0) {
+            throw new IllegalArgumentException();
+        }
+        this.boltMsgQueue = new LinkedBlockingQueue<>(boltMsgCapacity);
+    }
+
+    public ShellBoltMessageQueue() {
+        this(Integer.MAX_VALUE);
+    }
+
+    /**
+     * put list of task id to its queue
+     * @param taskIds task ids that received the tuples
+     */
+    public void putTaskIds(List<Integer> taskIds) {
+        taskIdsQueue.add(taskIds);
+        takeLock.lock();
+        try {
+            notEmpty.signal();
+        } finally {
+            takeLock.unlock();
+        }
+    }
+
+    /**
+     * put bolt message to its queue
+     * @param boltMsg BoltMsg to pass to subprocess
+     * @throws InterruptedException
+     */
+    public void putBoltMsg(BoltMsg boltMsg) throws InterruptedException {
+        boltMsgQueue.put(boltMsg);
+        takeLock.lock();
+        try {
+            notEmpty.signal();
+        } finally {
+            takeLock.unlock();
+        }
+    }
+
+    /**
+     * poll() is a core feature of ShellBoltMessageQueue.
+     * It retrieves and removes the head of one queues, waiting up to the
+     * specified wait time if necessary for an element to become available.
+     * There's priority that what queue it retrieves first, taskIds is higher than boltMsgQueue.
+     *
+     * @param timeout how long to wait before giving up, in units of unit
+     * @param unit a TimeUnit determining how to interpret the timeout parameter
+     * @return List\<Integer\> if task id is available,
+     * BoltMsg if task id is not available but bolt message is available,
+     * null if the specified waiting time elapses before an element is available.
+     * @throws InterruptedException
+     */
+    public Object poll(long timeout, TimeUnit unit) throws InterruptedException {
+        takeLock.lockInterruptibly();
+        long nanos = unit.toNanos(timeout);
+        try {
+            // wait for available queue
+            while (taskIdsQueue.peek() == null && boltMsgQueue.peek() == null) {
+                if (nanos <= 0) {
+                    return null;
+                }
+                nanos = notEmpty.awaitNanos(nanos);
+            }
+
+            // taskIds first
+            List<Integer> taskIds = taskIdsQueue.peek();
+            if (taskIds != null) {
+                taskIds = taskIdsQueue.poll();
+                return taskIds;
+            }
+
+            // boltMsgQueue should have at least one entry at the moment
+            return boltMsgQueue.poll();
+        } finally {
+            takeLock.unlock();
+        }
+    }
+
+}

--- a/storm-core/test/clj/backtype/storm/multilang_test.clj
+++ b/storm-core/test/clj/backtype/storm/multilang_test.clj
@@ -47,7 +47,7 @@
                "test"
                {TOPOLOGY-WORKERS 20 TOPOLOGY-MESSAGE-TIMEOUT-SECS 3 TOPOLOGY-DEBUG true}
                topology)
-       (Thread/sleep 11000)
+       (Thread/sleep 31000)
        (.killTopology nimbus "test")
        (Thread/sleep 11000)
        )))

--- a/storm-core/test/jvm/backtype/storm/utils/ShellBoltMessageQueueTest.java
+++ b/storm-core/test/jvm/backtype/storm/utils/ShellBoltMessageQueueTest.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package backtype.storm.utils;
 
 import backtype.storm.multilang.BoltMsg;

--- a/storm-core/test/jvm/backtype/storm/utils/ShellBoltMessageQueueTest.java
+++ b/storm-core/test/jvm/backtype/storm/utils/ShellBoltMessageQueueTest.java
@@ -1,0 +1,67 @@
+package backtype.storm.utils;
+
+import backtype.storm.multilang.BoltMsg;
+import com.google.common.collect.Lists;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class ShellBoltMessageQueueTest extends TestCase {
+    @Test
+    public void testPollTaskIdsFirst() throws InterruptedException {
+        ShellBoltMessageQueue queue = new ShellBoltMessageQueue();
+
+        // put bolt message first, then put task ids
+        queue.putBoltMsg(new BoltMsg());
+        ArrayList<Integer> taskIds = Lists.newArrayList(1, 2, 3);
+        queue.putTaskIds(taskIds);
+
+        Object msg = queue.poll(10, TimeUnit.SECONDS);
+
+        // task ids should be pulled first
+        assertTrue(msg instanceof List<?>);
+        assertEquals(msg, taskIds);
+    }
+
+    @Test
+    public void testPollWhileThereAreNoDataAvailable() throws InterruptedException {
+        ShellBoltMessageQueue queue = new ShellBoltMessageQueue();
+
+        long start = System.currentTimeMillis();
+        Object msg = queue.poll(1, TimeUnit.SECONDS);
+        long finish = System.currentTimeMillis();
+
+        assertNull(msg);
+        assertTrue(finish - start > 1000);
+    }
+
+    @Test
+    public void testPollShouldReturnASAPWhenDataAvailable() throws InterruptedException {
+        final ShellBoltMessageQueue queue = new ShellBoltMessageQueue();
+        final List<Integer> taskIds = Lists.newArrayList(1, 2, 3);
+
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    // NOOP
+                }
+
+                queue.putTaskIds(taskIds);
+            }
+        });
+        t.start();
+
+        long start = System.currentTimeMillis();
+        Object msg = queue.poll(10, TimeUnit.SECONDS);
+        long finish = System.currentTimeMillis();
+
+        assertEquals(msg, taskIds);
+        assertTrue(finish - start < (10 * 1000));
+    }
+}


### PR DESCRIPTION
This is the implementation of https://github.com/apache/storm/pull/532#issuecomment-158578419
Please refer comment to see purpose of this PR.

Message's priority was heartbeat > taskids = BoltMsg, but in this PR, I changed priority to heartbeat > taskids > BoltMsg.
In order to accomplish this, taskids and BoltMsgs use their own queue. Queue for taskids is unbounded but queue for BoltMsgs is bounded (fixed size) so that executor thread can be blocked and ABP comes into play.

Please note that BoltWriterRunnable polls message from both queues when it is only available. It's for minimizing wait for taskids, but it can spin CPU so CPU usage will be a bit higher than current.
I'd like to discuss about better / safer approach, for example, adding potential lag via poll with timeout.

@revans2 It's alternative approach of #532. Please review and comment. Thanks!