### PR TITLE
STORM-1357. Support writing to Kafka streams in Storm SQL.

### DIFF
--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/parser/SqlCreateTable.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/parser/SqlCreateTable.java
@@ -113,13 +113,19 @@ public class SqlCreateTable extends SqlCall {
   }
 
   public String inputFormatClass() {
-    return inputFormatClass == null ? null : SqlLiteral.stringValue(
-        inputFormatClass);
+    return getString(inputFormatClass);
   }
 
   public String outputFormatClass() {
-    return outputFormatClass == null ? null : SqlLiteral.stringValue
-        (outputFormatClass);
+    return getString(outputFormatClass);
+  }
+
+  public String properties() {
+    return getString(properties);
+  }
+
+  private String getString(SqlNode n) {
+    return n == null ? null : SqlLiteral.stringValue(n);
   }
 
   @SuppressWarnings("unchecked")

--- a/external/sql/storm-sql-core/src/test/org/apache/storm/sql/TestStormSql.java
+++ b/external/sql/storm-sql-core/src/test/org/apache/storm/sql/TestStormSql.java
@@ -44,7 +44,7 @@ public class TestStormSql {
 
     @Override
     public ISqlTridentDataSource constructTrident(URI uri, String inputFormatClass, String outputFormatClass,
-         List<FieldInfo> fields) {
+                                                  String properties, List<FieldInfo> fields) {
       throw new UnsupportedOperationException();
     }
   }

--- a/external/sql/storm-sql-kafka/src/jvm/org/apache/storm/sql/kafka/JsonSerializer.java
+++ b/external/sql/storm-sql-kafka/src/jvm/org/apache/storm/sql/kafka/JsonSerializer.java
@@ -20,14 +20,12 @@ package org.apache.storm.sql.kafka;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.common.base.Preconditions;
-import org.apache.commons.io.Charsets;
-import org.apache.commons.lang.CharSet;
 import org.apache.storm.sql.runtime.IOutputSerializer;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 class JsonSerializer implements IOutputSerializer {
@@ -53,6 +51,6 @@ class JsonSerializer implements IOutputSerializer {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    return ByteBuffer.wrap(sw.toString().getBytes(Charsets.UTF_8));
+    return ByteBuffer.wrap(sw.toString().getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/external/sql/storm-sql-kafka/src/test/org/apache/storm/sql/kafka/TestKafkaDataSourcesProvider.java
+++ b/external/sql/storm-sql-kafka/src/test/org/apache/storm/sql/kafka/TestKafkaDataSourcesProvider.java
@@ -17,10 +17,9 @@
  */
 package org.apache.storm.sql.kafka;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import kafka.javaapi.producer.Producer;
-import kafka.producer.KeyedMessage;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.storm.sql.kafka.KafkaDataSourcesProvider.KafkaTridentSink;
@@ -49,12 +48,20 @@ public class TestKafkaDataSourcesProvider {
       new FieldInfo("val", String.class, false));
   private static final List<String> FIELD_NAMES = ImmutableList.of("ID", "val");
   private static final JsonSerializer SERIALIZER = new JsonSerializer(FIELD_NAMES);
-
+  private static final String TBL_PROPERTIES = Joiner.on('\n').join(
+      "{\"producer\": {",
+      "\"bootstrap.servers\": \"localhost:9092\",",
+      "\"acks\": \"1\",",
+      "\"key.serializer\": \"org.apache.kafka.common.serialization.StringSerializer\",",
+      "\"value.serializer\": \"org.apache.kafka.common.serialization.StringSerializer\"",
+      "}",
+      "}"
+  );
   @SuppressWarnings("unchecked")
   @Test
   public void testKafkaSink() {
     ISqlTridentDataSource ds = DataSourcesRegistry.constructTridentDataSource(
-        URI.create("kafka://mock?topic=foo"), null, null, FIELDS);
+        URI.create("kafka://mock?topic=foo"), null, null, TBL_PROPERTIES, FIELDS);
     Assert.assertNotNull(ds);
     KafkaTridentSink sink = (KafkaTridentSink) ds.getConsumer();
     sink.prepare(null, null);

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/DataSourcesProvider.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/DataSourcesProvider.java
@@ -22,7 +22,6 @@ package org.apache.storm.sql.runtime;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Map;
 
 public interface DataSourcesProvider {
   /**
@@ -46,5 +45,5 @@ public interface DataSourcesProvider {
 
   ISqlTridentDataSource constructTrident(
       URI uri, String inputFormatClass, String outputFormatClass,
-      List<FieldInfo> fields);
+      String properties, List<FieldInfo> fields);
 }

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/DataSourcesRegistry.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/DataSourcesRegistry.java
@@ -61,13 +61,13 @@ public class DataSourcesRegistry {
 
   public static ISqlTridentDataSource constructTridentDataSource(
       URI uri, String inputFormatClass, String outputFormatClass,
-      List<FieldInfo> fields) {
+      String properties, List<FieldInfo> fields) {
     DataSourcesProvider provider = providers.get(uri.getScheme());
     if (provider == null) {
       return null;
     }
 
-    return provider.constructTrident(uri, inputFormatClass, outputFormatClass, fields);
+    return provider.constructTrident(uri, inputFormatClass, outputFormatClass, properties, fields);
   }
 
   /**

--- a/external/storm-kafka/src/jvm/storm/kafka/ByteBufferSerializer.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/ByteBufferSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package storm.kafka;
+
+import backtype.storm.utils.Utils;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+public class ByteBufferSerializer implements Serializer<ByteBuffer> {
+  @Override
+  public void configure(Map<String, ?> map, boolean b) {
+
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public byte[] serialize(String s, ByteBuffer b) {
+    return Utils.toByteArray(b);
+  }
+}

--- a/external/storm-kafka/src/jvm/storm/kafka/IntSerializer.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/IntSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package storm.kafka;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.util.Map;
+
+public class IntSerializer implements Serializer<Integer> {
+  @Override
+  public void configure(Map<String, ?> map, boolean b) {
+  }
+
+  @Override
+  public byte[] serialize(String topic, Integer val) {
+    byte[] r = new byte[4];
+    IntBuffer b = ByteBuffer.wrap(r).asIntBuffer();
+    b.put(val);
+    return r;
+  }
+
+  @Override
+  public void close() {
+  }
+}


### PR DESCRIPTION
This PR adds supports to stream the results from Storm SQL to `KafkaProducer`. 

It contains two main components:

* Allow plugging in producer config in `CREATE TABLE`.
* Add serializers for primitive SQL fields.