### PR TITLE
STORM-1360:  storm.py issues with python 3

### DIFF
--- a/storm-multilang/python/src/main/resources/resources/storm.py
+++ b/storm-multilang/python/src/main/resources/resources/storm.py
@@ -196,7 +196,7 @@ class Bolt(object):
                     sync()
                 else:
                     self.process(tup)
-        except Exception, e:
+        except Exception as e:
             reportError(traceback.format_exc(e))
 
 class BasicBolt(object):
@@ -222,10 +222,10 @@ class BasicBolt(object):
                     try:
                         self.process(tup)
                         ack(tup)
-                    except Exception, e:
+                    except Exception as e:
                         reportError(traceback.format_exc(e))
                         fail(tup)
-        except Exception, e:
+        except Exception as e:
             reportError(traceback.format_exc(e))
 
 class Spout(object):
@@ -256,5 +256,5 @@ class Spout(object):
                 if msg["command"] == "fail":
                     self.fail(msg["id"])
                 sync()
-        except Exception, e:
+        except Exception as e:
             reportError(traceback.format_exc(e))

--- a/storm-multilang/python/src/main/resources/resources/storm.py
+++ b/storm-multilang/python/src/main/resources/resources/storm.py
@@ -75,8 +75,8 @@ def readTuple():
     return Tuple(cmd["id"], cmd["comp"], cmd["stream"], cmd["task"], cmd["tuple"])
 
 def sendMsgToParent(msg):
-    print json_encode(msg)
-    print "end"
+    print(json_encode(msg))
+    print("end")
     sys.stdout.flush()
 
 def sync():


### PR DESCRIPTION
This changes the "print" and "except" syntax usages such that they test fine for me on Python 2.6.6 (RHEL) and 3.5.0 (Win7).