### PR TITLE
Fix typo in get_jars_full

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -108,7 +108,7 @@ def get_jars_full(adir):
     if os.path.isdir(adir):
         files = os.listdir(adir)
     elif os.path.exists(adir):
-        files = [aidr]
+        files = [adir]
 
     ret = []
     for f in files:


### PR DESCRIPTION
I was considering writing a python unit test to go with this change, but given the discussion in STORM-904 that doesn't seem useful if this will be migrated to java soon.