### PR TITLE
STORM-1378:  Use File.separator for OS independence in Blobstore LocalizerTest

### DIFF
--- a/storm-core/src/jvm/backtype/storm/blobstore/BlobStore.java
+++ b/storm-core/src/jvm/backtype/storm/blobstore/BlobStore.java
@@ -298,7 +298,9 @@ public abstract class BlobStore implements Shutdownable {
     public byte[] readBlob(String key, Subject who) throws IOException, KeyNotFoundException, AuthorizationException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         readBlobTo(key, out, who);
-        return out.toByteArray();
+        byte[] bytes = out.toByteArray();
+        out.close();
+        return bytes;
     }
 
     /**

--- a/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
+++ b/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
@@ -126,15 +126,15 @@ public class LocalizerTest {
   }
 
   public String constructUserCacheDir(String base, String user) {
-    return base + "/" + Localizer.USERCACHE + "/" + user;
+    return base + File.separator + Localizer.USERCACHE + File.separator + user;
   }
 
   public String constructExpectedFilesDir(String base, String user) {
-    return constructUserCacheDir(base, user) + "/" + Localizer.FILECACHE + "/" + Localizer.FILESDIR;
+    return constructUserCacheDir(base, user) + File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
   }
 
   public String constructExpectedArchivesDir(String base, String user) {
-    return constructUserCacheDir(base, user) + "/" + Localizer.FILECACHE + "/" + Localizer
+    return constructUserCacheDir(base, user) + File.separator + Localizer.FILECACHE + File.separator + Localizer
         .ARCHIVESDIR;
   }
 
@@ -147,7 +147,7 @@ public class LocalizerTest {
     assertEquals("get local user dir doesn't return right value",
         expectedDir, localizer.getLocalUserDir(user1).toString());
 
-    String expectedFileDir = expectedDir + "/" + Localizer.FILECACHE;
+    String expectedFileDir = expectedDir + File.separator + Localizer.FILECACHE;
     assertEquals("get local user file dir doesn't return right value",
         expectedFileDir, localizer.getLocalUserFileCacheDir(user1).toString());
   }
@@ -287,8 +287,8 @@ public class LocalizerTest {
         user1Dir);
     long timeAfter = System.nanoTime();
 
-    String expectedUserDir = baseDir + "/" + Localizer.USERCACHE + "/" + user1;
-    String expectedFileDir = expectedUserDir + "/" + Localizer.FILECACHE + "/" + Localizer.ARCHIVESDIR;
+    String expectedUserDir = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1;
+    String expectedFileDir = expectedUserDir + File.separator + Localizer.FILECACHE + File.separator + Localizer.ARCHIVESDIR;
     assertTrue("user filecache dir not created", new File(expectedFileDir).exists());
     File keyFile = new File(expectedFileDir, key1 + ".0");
     assertTrue("blob not created", keyFile.exists());
@@ -364,8 +364,8 @@ public class LocalizerTest {
         user1Dir);
     long timeAfter = System.nanoTime();
 
-    String expectedUserDir = baseDir + "/" + Localizer.USERCACHE + "/" + user1;
-    String expectedFileDir = expectedUserDir + "/" + Localizer.FILECACHE + "/" + Localizer.FILESDIR;
+    String expectedUserDir = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1;
+    String expectedFileDir = expectedUserDir + File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
     assertTrue("user filecache dir not created", new File(expectedFileDir).exists());
     File keyFile = new File(expectedFileDir, key1);
     File keyFileCurrentSymlink = new File(expectedFileDir, key1 + Utils.DEFAULT_CURRENT_BLOB_SUFFIX);
@@ -437,8 +437,8 @@ public class LocalizerTest {
     LocalizedResource lrsrc2 = lrsrcs.get(1);
     LocalizedResource lrsrc3 = lrsrcs.get(2);
 
-    String expectedFileDir = baseDir + "/" + Localizer.USERCACHE + "/" + user1 +
-        "/" + Localizer.FILECACHE + "/" + Localizer.FILESDIR;
+    String expectedFileDir = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1 +
+            File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
     assertTrue("user filecache dir not created", new File(expectedFileDir).exists());
     File keyFile = new File(expectedFileDir, key1 + Utils.DEFAULT_CURRENT_BLOB_SUFFIX);
     File keyFile2 = new File(expectedFileDir, key2 + Utils.DEFAULT_CURRENT_BLOB_SUFFIX);
@@ -570,13 +570,13 @@ public class LocalizerTest {
     LocalizedResource lrsrc1_user3 = localizer.getBlob(new LocalResource(key1, false), user3,
         topo3, user3Dir);
 
-    String expectedUserDir1 = baseDir + "/" + Localizer.USERCACHE + "/" + user1;
-    String expectedFileDirUser1 = expectedUserDir1 + "/" + Localizer.FILECACHE + "/" +
+    String expectedUserDir1 = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1;
+    String expectedFileDirUser1 = expectedUserDir1 + File.separator + Localizer.FILECACHE + File.separator +
         Localizer.FILESDIR;
-    String expectedFileDirUser2 = baseDir + "/" + Localizer.USERCACHE + "/" + user2 +
-        "/" + Localizer.FILECACHE + "/" + Localizer.FILESDIR;
-    String expectedFileDirUser3 = baseDir + "/" + Localizer.USERCACHE + "/" + user3 +
-        "/" + Localizer.FILECACHE + "/" + Localizer.FILESDIR;
+    String expectedFileDirUser2 = baseDir + File.separator + Localizer.USERCACHE + File.separator + user2 +
+            File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
+    String expectedFileDirUser3 = baseDir + File.separator + Localizer.USERCACHE + File.separator + user3 +
+            File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
     assertTrue("user filecache dir user1 not created", new File(expectedFileDirUser1).exists());
     assertTrue("user filecache dir user2 not created", new File(expectedFileDirUser2).exists());
     assertTrue("user filecache dir user3 not created", new File(expectedFileDirUser3).exists());
@@ -637,8 +637,8 @@ public class LocalizerTest {
     LocalizedResource lrsrc = localizer.getBlob(new LocalResource(key1, false), user1, topo1,
         user1Dir);
 
-    String expectedUserDir = baseDir + "/" + Localizer.USERCACHE + "/" + user1;
-    String expectedFileDir = expectedUserDir + "/" + Localizer.FILECACHE + "/" + Localizer.FILESDIR;
+    String expectedUserDir = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1;
+    String expectedFileDir = expectedUserDir + File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
     assertTrue("user filecache dir not created", new File(expectedFileDir).exists());
     File keyFile = new File(expectedFileDir, key1);
     File keyFileCurrentSymlink = new File(expectedFileDir, key1 + Utils.DEFAULT_CURRENT_BLOB_SUFFIX);

--- a/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
+++ b/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
@@ -237,35 +237,30 @@ public class LocalizerTest {
 
   @Test
   public void testArchivesTgz() throws Exception {
-    testArchives("test/jvm/backtype/storm/localizer/localtestwithsymlink.tgz", true,
-        21344);
+    testArchives(joinPath("test", "jvm", "backtype", "storm", "localizer", "localtestwithsymlink.tgz"), true, 21344);
   }
 
   @Test
   public void testArchivesZip() throws Exception {
-    testArchives("test/jvm/backtype/storm/localizer/localtest.zip", false,
-        21348);
+    testArchives(joinPath("test", "jvm", "backtype", "storm", "localizer", "localtest.zip"), false, 21348);
   }
 
   @Test
   public void testArchivesTarGz() throws Exception {
-    testArchives("test/jvm/backtype/storm/localizer/localtestwithsymlink.tar.gz",
-        true, 21344);
+    testArchives(joinPath("test", "jvm", "backtype", "storm", "localizer", "localtestwithsymlink.tar.gz"), true, 21344);
   }
 
   @Test
   public void testArchivesTar() throws Exception {
-    testArchives("test/jvm/backtype/storm/localizer/localtestwithsymlink.tar", true,
-        21344);
+    testArchives(joinPath("test", "jvm", "backtype", "storm", "localizer", "localtestwithsymlink.tar"), true, 21344);
   }
 
   @Test
   public void testArchivesJar() throws Exception {
-    testArchives("test/jvm/backtype/storm/localizer/localtestwithsymlink.jar", false,
-        21416);
+    testArchives(joinPath("test", "jvm", "backtype", "storm", "localizer", "localtestwithsymlink.jar"), false, 21416);
   }
 
-  // archive passed in must contain symlink named tmptestsymlink is not a zip file
+  // archive passed in must contain symlink named tmptestsymlink if not a zip file
   public void testArchives(String archivePath, boolean supportSymlinks, int size) throws Exception {
     Map conf = new HashMap();
     // set clean time really high so doesn't kick in

--- a/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
+++ b/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
@@ -31,6 +31,7 @@ import backtype.storm.generated.SettableBlobMeta;
 import backtype.storm.utils.Utils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import com.google.common.base.Joiner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -125,17 +126,20 @@ public class LocalizerTest {
     FileUtils.deleteDirectory(baseDir);
   }
 
+  protected String joinPath(String... pathList) {
+      return Joiner.on(File.separator).join(pathList);
+  }
+
   public String constructUserCacheDir(String base, String user) {
-    return base + File.separator + Localizer.USERCACHE + File.separator + user;
+    return joinPath(base, Localizer.USERCACHE, user);
   }
 
   public String constructExpectedFilesDir(String base, String user) {
-    return constructUserCacheDir(base, user) + File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
+    return joinPath(constructUserCacheDir(base, user), Localizer.FILECACHE, Localizer.FILESDIR);
   }
 
   public String constructExpectedArchivesDir(String base, String user) {
-    return constructUserCacheDir(base, user) + File.separator + Localizer.FILECACHE + File.separator + Localizer
-        .ARCHIVESDIR;
+    return joinPath(constructUserCacheDir(base, user), Localizer.FILECACHE, Localizer.ARCHIVESDIR);
   }
 
   @Test
@@ -147,7 +151,7 @@ public class LocalizerTest {
     assertEquals("get local user dir doesn't return right value",
         expectedDir, localizer.getLocalUserDir(user1).toString());
 
-    String expectedFileDir = expectedDir + File.separator + Localizer.FILECACHE;
+    String expectedFileDir = joinPath(expectedDir, Localizer.FILECACHE);
     assertEquals("get local user file dir doesn't return right value",
         expectedFileDir, localizer.getLocalUserFileCacheDir(user1).toString());
   }
@@ -287,8 +291,8 @@ public class LocalizerTest {
         user1Dir);
     long timeAfter = System.nanoTime();
 
-    String expectedUserDir = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1;
-    String expectedFileDir = expectedUserDir + File.separator + Localizer.FILECACHE + File.separator + Localizer.ARCHIVESDIR;
+    String expectedUserDir = joinPath(baseDir.toString(), Localizer.USERCACHE, user1);
+    String expectedFileDir = joinPath(expectedUserDir, Localizer.FILECACHE, Localizer.ARCHIVESDIR);
     assertTrue("user filecache dir not created", new File(expectedFileDir).exists());
     File keyFile = new File(expectedFileDir, key1 + ".0");
     assertTrue("blob not created", keyFile.exists());
@@ -364,8 +368,8 @@ public class LocalizerTest {
         user1Dir);
     long timeAfter = System.nanoTime();
 
-    String expectedUserDir = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1;
-    String expectedFileDir = expectedUserDir + File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
+    String expectedUserDir = joinPath(baseDir.toString(), Localizer.USERCACHE, user1);
+    String expectedFileDir = joinPath(expectedUserDir, Localizer.FILECACHE, Localizer.FILESDIR);
     assertTrue("user filecache dir not created", new File(expectedFileDir).exists());
     File keyFile = new File(expectedFileDir, key1);
     File keyFileCurrentSymlink = new File(expectedFileDir, key1 + Utils.DEFAULT_CURRENT_BLOB_SUFFIX);
@@ -437,8 +441,8 @@ public class LocalizerTest {
     LocalizedResource lrsrc2 = lrsrcs.get(1);
     LocalizedResource lrsrc3 = lrsrcs.get(2);
 
-    String expectedFileDir = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1 +
-            File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
+    String expectedFileDir = joinPath(baseDir.toString(), Localizer.USERCACHE, user1,
+        Localizer.FILECACHE, Localizer.FILESDIR);
     assertTrue("user filecache dir not created", new File(expectedFileDir).exists());
     File keyFile = new File(expectedFileDir, key1 + Utils.DEFAULT_CURRENT_BLOB_SUFFIX);
     File keyFile2 = new File(expectedFileDir, key2 + Utils.DEFAULT_CURRENT_BLOB_SUFFIX);
@@ -570,13 +574,12 @@ public class LocalizerTest {
     LocalizedResource lrsrc1_user3 = localizer.getBlob(new LocalResource(key1, false), user3,
         topo3, user3Dir);
 
-    String expectedUserDir1 = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1;
-    String expectedFileDirUser1 = expectedUserDir1 + File.separator + Localizer.FILECACHE + File.separator +
-        Localizer.FILESDIR;
-    String expectedFileDirUser2 = baseDir + File.separator + Localizer.USERCACHE + File.separator + user2 +
-            File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
-    String expectedFileDirUser3 = baseDir + File.separator + Localizer.USERCACHE + File.separator + user3 +
-            File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
+    String expectedUserDir1 = joinPath(baseDir.toString(), Localizer.USERCACHE, user1);
+    String expectedFileDirUser1 = joinPath(expectedUserDir1, Localizer.FILECACHE, Localizer.FILESDIR);
+    String expectedFileDirUser2 = joinPath(baseDir.toString(), Localizer.USERCACHE, user2,
+        Localizer.FILECACHE, Localizer.FILESDIR);
+    String expectedFileDirUser3 = joinPath(baseDir.toString(), Localizer.USERCACHE, user3,
+        Localizer.FILECACHE, Localizer.FILESDIR);
     assertTrue("user filecache dir user1 not created", new File(expectedFileDirUser1).exists());
     assertTrue("user filecache dir user2 not created", new File(expectedFileDirUser2).exists());
     assertTrue("user filecache dir user3 not created", new File(expectedFileDirUser3).exists());
@@ -637,8 +640,8 @@ public class LocalizerTest {
     LocalizedResource lrsrc = localizer.getBlob(new LocalResource(key1, false), user1, topo1,
         user1Dir);
 
-    String expectedUserDir = baseDir + File.separator + Localizer.USERCACHE + File.separator + user1;
-    String expectedFileDir = expectedUserDir + File.separator + Localizer.FILECACHE + File.separator + Localizer.FILESDIR;
+    String expectedUserDir = joinPath(baseDir.toString(), Localizer.USERCACHE, user1);
+    String expectedFileDir = joinPath(expectedUserDir, Localizer.FILECACHE, Localizer.FILESDIR);
     assertTrue("user filecache dir not created", new File(expectedFileDir).exists());
     File keyFile = new File(expectedFileDir, key1);
     File keyFileCurrentSymlink = new File(expectedFileDir, key1 + Utils.DEFAULT_CURRENT_BLOB_SUFFIX);

--- a/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
+++ b/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
@@ -123,7 +123,9 @@ public class LocalizerTest {
 
   @After
   public void tearDown() throws Exception {
-    FileUtils.deleteDirectory(baseDir);
+    try {
+      FileUtils.deleteDirectory(baseDir);
+    } catch (IOException ignore) {}
   }
 
   protected String joinPath(String... pathList) {


### PR DESCRIPTION
This clears up one incidental issue shown on STORM-1378, the one test failure due solely to "/" vs "\" in the path comparison.  This does _not_ solve the larger issue on STORM-1378.