### PR TITLE
STORM-1179: Create Maven Profiles for Integration Tests

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -118,6 +118,25 @@ GitHub.
     3. Storm committers will iterate with you on the design to make sure you are on the right track.
     4. Implement your issue, create a pull request (see below), and iterate from there.
 
+### Testing
+
+Unit tests and Integration tests are an essential part of code contributions.
+
+To mark a Java test as a Java integration test, add the annotation `@Category(IntegrationTest.class)` to the test class definition as well as to its hierarchy of superclasses. Java integration tests can be in the same package as Java unit tests.
+ 
+```java
+    @Category(IntegrationTest.class)
+    public class MyIntegrationTest {
+    ...
+    }
+```
+ 
+To mark a Clojure test as Clojure integration test, the test source must be located in a package with name prefixed by `integration.`
+
+For example, the test `test/clj/backtype.storm.drpc_test.clj` is considered a clojure unit test, whereas
+ `test/clj/integration.backtype.storm.drpc_test.clj` is considered a clojure integration test.
+
+Please refer to section <a href="#building">Build the code and run the tests</a> for how to run integration tests, and the info on the build phase each test runs. 
 
 <a name="contribute-documentation"></a>
 
@@ -258,6 +277,29 @@ sh genthrift.sh
 
 ## Testing
 
+Tests are separated in two groups, Unit tests, and Integration tests. Java unit tests, Clojure unit tests, and Clojure integration tests (for reasons inherent to the clojure-maven-plugin) run in the maven `test` phase. Java integration tests run in the maven `integration-test` or `verify` phases. 
+ 
+To run Clojure and Java unit tests but no integration tests execute the command
+ 
+    mvn test
+
+Integration tests require that you activate the profile `integration-test` and that you specify the `maven-failsafe-plugin` in the module pom file.
+ 
+To run all Java and Clojure integration tests but no unit tests execute one of the commands
+ 
+    mvn -P  integration-tests-only verify
+    mvn -P  integration-tests-only integration-test
+
+To run all unit tests plus Clojure integration tests but no Java integration tests execute the command
+ 
+    mvn -P all-tests test
+
+To run all unit tests and all integration tests execute one of the commands
+ 
+    mvn -P all-tests verify
+    mvn -P all-tests integration-test
+ 
+ 
 You can also run tests selectively via the Clojure REPL.  The following example runs the tests in
 [auth_test.clj](storm-core/test/clj/backtype/storm/security/auth/auth_test.clj), which has the namespace
 `backtype.storm.security.auth.auth-test`.
@@ -269,6 +311,10 @@ You can also run tests selectively with `-Dtest=<test_name>`.  This works for bo
 > can be helpful to narrow down errors.
 
 Unfortunately you might experience failures in clojure tests which are wrapped in the `maven-clojure-plugin` and thus doesn't provide too much useful output at first sight - you might end up with a maven test failure with an error message as unhelpful as `Clojure failed.`. In this case it's recommended to look into `target/test-reports` of the failed project to see what actual tests have failed or scroll through the maven output looking for obvious issues like missing binaries.
+
+By default integration tests are not run in the test phase. To run Java and Clojure integration tests you must enable the profile
+ 
+
 
 <a name="packaging"></a>
 
@@ -310,7 +356,7 @@ You can verify whether the digital signatures match their corresponding files:
 
 ## Testing
 
-Tests should never rely on timing in order to pass.  In Storm can properly test functionality that depends on time by
+Tests should never rely on timing in order to pass.  Storm can properly test functionality that depends on time by
 simulating time, which means we do not have to worry about e.g. random delays failing our tests indeterministically.
 
 If you are testing topologies that do not do full tuple acking, then you should be testing using the "tracked

--- a/external/storm-elasticsearch/pom.xml
+++ b/external/storm-elasticsearch/pom.xml
@@ -15,7 +15,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -101,6 +102,10 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/bolt/AbstractEsBoltIntegrationTest.java
+++ b/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/bolt/AbstractEsBoltIntegrationTest.java
@@ -17,8 +17,7 @@
  */
 package org.apache.storm.elasticsearch.bolt;
 
-import java.io.File;
-
+import backtype.storm.testing.IntegrationTest;
 import org.apache.commons.io.FileUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;
@@ -33,10 +32,14 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Category(IntegrationTest.class)
 public abstract class AbstractEsBoltIntegrationTest<Bolt extends AbstractEsBolt> extends AbstractEsBoltTest<Bolt> {
 
     protected static Node node;

--- a/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/bolt/EsIndexBoltTest.java
+++ b/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/bolt/EsIndexBoltTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.elasticsearch.bolt;
 
+import backtype.storm.testing.IntegrationTest;
 import backtype.storm.tuple.Tuple;
 import org.apache.storm.elasticsearch.common.EsConfig;
 import org.apache.storm.elasticsearch.common.EsTestUtil;
@@ -25,9 +26,11 @@ import org.elasticsearch.action.count.CountResponse;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.mockito.Mockito.verify;
 
+@Category(IntegrationTest.class)
 public class EsIndexBoltTest extends AbstractEsBoltIntegrationTest<EsIndexBolt> {
 
     @Test

--- a/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/bolt/EsLookupBoltIntegrationTest.java
+++ b/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/bolt/EsLookupBoltIntegrationTest.java
@@ -17,10 +17,11 @@
  */
 package org.apache.storm.elasticsearch.bolt;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.UUID;
-
+import backtype.storm.testing.IntegrationTest;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.ITuple;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.tuple.Values;
 import org.apache.storm.elasticsearch.ElasticsearchGetRequest;
 import org.apache.storm.elasticsearch.EsLookupResultOutput;
 import org.apache.storm.elasticsearch.common.EsConfig;
@@ -29,21 +30,22 @@ import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import backtype.storm.tuple.Fields;
-import backtype.storm.tuple.ITuple;
-import backtype.storm.tuple.Tuple;
-import backtype.storm.tuple.Values;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 
+@Category(IntegrationTest.class)
 @RunWith(MockitoJUnitRunner.class)
 public class EsLookupBoltIntegrationTest extends AbstractEsBoltIntegrationTest<EsLookupBolt> {
 

--- a/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/bolt/EsPercolateBoltTest.java
+++ b/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/bolt/EsPercolateBoltTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.elasticsearch.bolt;
 
+import backtype.storm.testing.IntegrationTest;
 import backtype.storm.tuple.Tuple;
 import backtype.storm.tuple.Values;
 import org.apache.storm.elasticsearch.common.EsConfig;
@@ -24,10 +25,12 @@ import org.apache.storm.elasticsearch.common.EsTestUtil;
 import org.apache.storm.elasticsearch.common.EsTupleMapper;
 import org.elasticsearch.action.percolate.PercolateResponse;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-import static org.mockito.Mockito.verify;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
 
+@Category(IntegrationTest.class)
 public class EsPercolateBoltTest extends AbstractEsBoltIntegrationTest<EsPercolateBolt> {
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,13 @@
         <hdrhistogram.version>2.1.7</hdrhistogram.version>
         <calcite.version>1.4.0-incubating</calcite.version>
         <jackson.version>2.6.3</jackson.version>
+        <maven-surefire.version>2.18.1</maven-surefire.version>
+
+        <!-- Java and clojure build lifecycle test properties are defined here to avoid having to create a default profile -->
+        <java.unit.test.exclude>backtype.storm.testing.IntegrationTest</java.unit.test.exclude>
+        <java.unit.test.include>**/Test*.java, **/*Test.java, **/*TestCase.java</java.unit.test.include>    <!--maven surefire plugin default test list-->
+        <!-- by default the clojure test set are all clojure tests that are not integration tests. This property is overridden in the profiles -->
+        <clojure.test.set>!integration.*</clojure.test.set>
     </properties>
 
     <modules>
@@ -253,7 +260,6 @@
         <module>external/storm-cassandra</module>
         <module>examples/storm-starter</module>
     </modules>
-
 
     <profiles>
         <profile>
@@ -334,7 +340,26 @@
                 </plugins>
             </build>
         </profile>
-
+        <profile>
+            <id>all-tests</id>
+            <properties>
+                <java.integration.test.include>**/*.java</java.integration.test.include>
+                <java.integration.test.group>backtype.storm.testing.IntegrationTest</java.integration.test.group>
+                <clojure.test.set>*.*</clojure.test.set>
+            </properties>
+        </profile>
+        <profile>
+            <id>integration-tests-only</id>
+            <properties>
+                <!--Java-->
+                <java.unit.test.include>no.unit.tests</java.unit.test.include>
+                <java.integration.test.include>**/*.java</java.integration.test.include>
+                <java.integration.test.group>backtype.storm.testing.IntegrationTest</java.integration.test.group>
+                <!--Clojure-->
+                <clojure.test.set>integration.*</clojure.test.set>
+                <clojure.test.declared.namespace.only>true</clojure.test.declared.namespace.only>
+            </properties>
+        </profile>
     </profiles>
 
     <distributionManagement>
@@ -727,16 +752,38 @@
     </repositories>
 
     <build>
-
         <pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
+                    <version>${maven-surefire.version}</version>
                     <configuration>
-                      <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <excludedGroups>${java.unit.test.exclude}</excludedGroups>
+                        <includes>
+                            <include>${java.unit.test.include}</include>
+                        </includes>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-surefire.version}</version>
+                    <configuration>
+                        <includes>
+                            <include>${java.integration.test.include}</include>
+                        </includes>
+                        <groups>${java.integration.test.group}</groups>  <!--set in integration-test the profile-->
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -412,6 +412,11 @@
                             <testScript>test/resources/test_runner.clj</testScript>
                             <!-- argLine is set by JaCoCo for code coverage -->
                             <vmargs>${argLine} ${test.extra.args}</vmargs>
+                            <!-- Run clojure unit tests or all tests (including integration tests) depending on the profile enabled -->
+                            <testNamespaces>
+                                <testNamespace>${clojure.test.set}</testNamespace>
+                            </testNamespaces>
+                            <testDeclaredNamespaceOnly>${clojure.test.declared.namespace.only}</testDeclaredNamespaceOnly>
                         </configuration>
                     </execution>
                 </executions>
@@ -423,6 +428,13 @@
                     <reportsDirectories>
                         <file>${project.build.directory}/test-reports</file>
                     </reportsDirectories>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-core/src/jvm/backtype/storm/testing/IntegrationTest.java
+++ b/storm-core/src/jvm/backtype/storm/testing/IntegrationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package backtype.storm.testing;
+
+/**
+ * Marker interface used to mark integration tests. Integration tests will be run during the Maven
+ * <b><i>integration-test</i></b> phase, whereas unit tests will be run during the Maven <b><i>test</i></b> phase.
+ * <p/>
+ * Integration tests can be in the same package as unit tests. To mark a test as integration test,
+ * add the annotation @Category(IntegrationTest.class) to the class definition as well as to its hierarchy of superclasses.
+ * For example:
+ * <p/>
+ *
+ *
+ * @ Category(IntegrationTest.class)<br/>
+ * public class MyIntegrationTest {<br/>
+ *  ...<br/>
+ * }
+ *
+ */
+public interface IntegrationTest {
+}

--- a/storm-core/test/clj/integration/backtype/storm/integration_test.clj
+++ b/storm-core/test/clj/integration/backtype/storm/integration_test.clj
@@ -13,7 +13,7 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-(ns backtype.storm.integration-test
+(ns integration.backtype.storm.integration-test
   (:use [clojure test])
   (:import [backtype.storm Config])
   (:import [backtype.storm.topology TopologyBuilder])

--- a/storm-core/test/clj/integration/backtype/storm/testing4j_test.clj
+++ b/storm-core/test/clj/integration/backtype/storm/testing4j_test.clj
@@ -13,10 +13,10 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-(ns backtype.storm.testing4j-test
+(ns integration.backtype.storm.testing4j-test
   (:use [clojure.test])
   (:use [backtype.storm config clojure testing util])
-  (:require [backtype.storm.integration-test :as it])
+  (:require [integration.backtype.storm.integration-test :as it])
   (:require [backtype.storm.thrift :as thrift])
   (:import [backtype.storm Testing Config ILocalCluster])
   (:import [backtype.storm.tuple Values Tuple])

--- a/storm-core/test/clj/integration/storm/trident/integration_test.clj
+++ b/storm-core/test/clj/integration/storm/trident/integration_test.clj
@@ -13,7 +13,7 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-(ns storm.trident.integration-test
+(ns integration.storm.trident.integration-test
   (:use [clojure test])
   (:require [backtype.storm [testing :as t]])
   (:import [storm.trident.testing Split CountAsAggregator StringLength TrueFilter

--- a/storm-multilang/javascript/pom.xml
+++ b/storm-multilang/javascript/pom.xml
@@ -16,7 +16,8 @@
  limitations under the License.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>storm</artifactId>
@@ -29,4 +30,13 @@
     <packaging>jar</packaging>
     <name>multilang-javascript</name>
 
+    <dependencies>
+        <!-- The JUnit dependency is required for this submodule by the maven-surefire-plugin <excludedGroups> configuration -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/storm-multilang/python/pom.xml
+++ b/storm-multilang/python/pom.xml
@@ -29,4 +29,13 @@
     <packaging>jar</packaging>
     <name>multilang-python</name>
 
+    <dependencies>
+        <!-- The JUnit dependency is required for this submodule by the maven-surefire-plugin <excludedGroups> configuration -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/storm-multilang/ruby/pom.xml
+++ b/storm-multilang/ruby/pom.xml
@@ -28,5 +28,14 @@
     <artifactId>multilang-ruby</artifactId>
     <packaging>jar</packaging>
     <name>multilang-ruby</name>
-    
+
+    <dependencies>
+        <!-- The JUnit dependency is required for this submodule by the maven-surefire-plugin <excludedGroups> configuration -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
This patch has 3 commits. 
-  POM changes implementing profiles to separate integration tests and unit tests
- Two separate commits that illustrate how to migrate existing tests currently running as unit tests  to run as integration tests