### PR TITLE
[STORM-1376] Performance slowdown due excessive zk connections and log-debugging

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -179,7 +179,7 @@ task.refresh.poll.secs: 10
 task.credentials.poll.secs: 30
 
 # now should be null by default
-topology.backpressure.enable: false
+topology.backpressure.enable: true
 backpressure.disruptor.high.watermark: 0.9
 backpressure.disruptor.low.watermark: 0.4
 

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -179,7 +179,7 @@ task.refresh.poll.secs: 10
 task.credentials.poll.secs: 30
 
 # now should be null by default
-topology.backpressure.enable: true
+topology.backpressure.enable: false
 backpressure.disruptor.high.watermark: 0.9
 backpressure.disruptor.low.watermark: 0.4
 

--- a/log4j2/worker.xml
+++ b/log4j2/worker.xml
@@ -22,7 +22,7 @@
     <property name="patternNoTime">%msg%n</property>
 </properties>
 <appenders>
-    <RollingFile name="A1" immediateFlush="false"
+    <RollingFile name="A1"
 		fileName="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}"
 		filePattern="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.%i.gz">
         <PatternLayout>
@@ -33,7 +33,7 @@
         </Policies>
         <DefaultRolloverStrategy max="9"/>
     </RollingFile>
-    <RollingFile name="STDOUT" immediateFlush="false"
+    <RollingFile name="STDOUT"
 		fileName="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.out"
 		filePattern="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.out.%i.gz">
         <PatternLayout>
@@ -44,7 +44,7 @@
         </Policies>
         <DefaultRolloverStrategy max="4"/>
     </RollingFile>
-    <RollingFile name="STDERR" immediateFlush="false"
+    <RollingFile name="STDERR"
 		fileName="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.err"
 		filePattern="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.err.%i.gz">
         <PatternLayout>
@@ -58,7 +58,7 @@
     <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"
         protocol="UDP" appName="[${sys:storm.id}:${sys:worker.port}]" mdcId="mdc" includeMDC="true"
         facility="LOCAL5" enterpriseNumber="18060" newLine="true" exceptionPattern="%rEx{full}"
-        messageId="[${sys:user.name}:${sys:logging.sensitivity}]" id="storm" immediateFlush="false" immediateFail="true"/>
+        messageId="[${sys:user.name}:${sys:logging.sensitivity}]" id="storm" immediateFail="true"/>
 </appenders>
 <loggers>
     <root level="info"> <!-- We log everything -->

--- a/storm-core/src/jvm/backtype/storm/blobstore/BlobSynchronizer.java
+++ b/storm-core/src/jvm/backtype/storm/blobstore/BlobSynchronizer.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;;
+import java.util.Set;
 
 /**
  * Is called periodically and updates the nimbus with blobs based on the state stored inside the zookeeper

--- a/storm-core/src/jvm/backtype/storm/blobstore/KeySequenceNumber.java
+++ b/storm-core/src/jvm/backtype/storm/blobstore/KeySequenceNumber.java
@@ -130,7 +130,7 @@ public class KeySequenceNumber {
         this.nimbusInfo = nimbusInfo;
     }
 
-    public int getKeySequenceNumber(Map conf) {
+    public synchronized int getKeySequenceNumber(Map conf) {
         TreeSet<Integer> sequenceNumbers = new TreeSet<Integer>();
         CuratorFramework zkClient = BlobStoreUtils.createZKClient(conf);
         try {

--- a/storm-core/src/jvm/backtype/storm/blobstore/LocalFsBlobStore.java
+++ b/storm-core/src/jvm/backtype/storm/blobstore/LocalFsBlobStore.java
@@ -268,7 +268,6 @@ public class LocalFsBlobStore extends BlobStore {
         SettableBlobMeta meta = getStoredBlobMeta(key);
         _aclHandler.hasPermissions(meta.get_acl(), READ, who, key);
         if (zkClient.checkExists().forPath(BLOBSTORE_SUBTREE + key) == null) {
-            zkClient.close();
             return 0;
         }
         replicationCount = zkClient.getChildren().forPath(BLOBSTORE_SUBTREE + key).size();

--- a/storm-core/src/jvm/backtype/storm/blobstore/LocalFsBlobStore.java
+++ b/storm-core/src/jvm/backtype/storm/blobstore/LocalFsBlobStore.java
@@ -74,11 +74,13 @@ public class LocalFsBlobStore extends BlobStore {
     private FileBlobStoreImpl fbs;
     private final int allPermissions = READ | WRITE | ADMIN;
     private Map conf;
+    private CuratorFramework zkClient;
 
     @Override
     public void prepare(Map conf, String overrideBase, NimbusInfo nimbusInfo) {
         this.conf = conf;
         this.nimbusInfo = nimbusInfo;
+        zkClient = BlobStoreUtils.createZKClient(conf);
         if (overrideBase == null) {
             overrideBase = (String)conf.get(Config.BLOBSTORE_DIR);
             if (overrideBase == null) {
@@ -254,27 +256,22 @@ public class LocalFsBlobStore extends BlobStore {
 
     @Override
     public void shutdown() {
+        if (zkClient != null) {
+            zkClient.close();
+        }
     }
 
     @Override
     public int getBlobReplication(String key, Subject who) throws Exception {
-        CuratorFramework zkClient = null;
         int replicationCount = 0;
-        try {
-            validateKey(key);
-            SettableBlobMeta meta = getStoredBlobMeta(key);
-            _aclHandler.hasPermissions(meta.get_acl(), READ, who, key);
-            zkClient = BlobStoreUtils.createZKClient(conf);
-            if (zkClient.checkExists().forPath(BLOBSTORE_SUBTREE + key) == null) {
-                zkClient.close();
-                return 0;
-            }
-            replicationCount = zkClient.getChildren().forPath(BLOBSTORE_SUBTREE + key).size();
-        } finally {
-            if (zkClient != null) {
-                zkClient.close();
-            }
+        validateKey(key);
+        SettableBlobMeta meta = getStoredBlobMeta(key);
+        _aclHandler.hasPermissions(meta.get_acl(), READ, who, key);
+        if (zkClient.checkExists().forPath(BLOBSTORE_SUBTREE + key) == null) {
+            zkClient.close();
+            return 0;
         }
+        replicationCount = zkClient.getChildren().forPath(BLOBSTORE_SUBTREE + key).size();
         return replicationCount;
     }
 
@@ -287,11 +284,9 @@ public class LocalFsBlobStore extends BlobStore {
     //This additional check and download is for nimbus high availability in case you have more than one nimbus
     public boolean checkForBlobOrDownload(String key) {
         boolean checkBlobDownload = false;
-        CuratorFramework zkClient = null;
         try {
             List<String> keyList = BlobStoreUtils.getKeyListFromBlobStore(this);
             if (!keyList.contains(key)) {
-                zkClient = BlobStoreUtils.createZKClient(conf);
                 if (zkClient.checkExists().forPath(BLOBSTORE_SUBTREE + key) != null) {
                     Set<NimbusInfo> nimbusSet = BlobStoreUtils.getNimbodesWithLatestSequenceNumberOfBlob(zkClient, key);
                     if (BlobStoreUtils.downloadMissingBlob(conf, this, key, nimbusSet)) {
@@ -303,18 +298,12 @@ public class LocalFsBlobStore extends BlobStore {
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
-        } finally {
-            if (zkClient != null) {
-                zkClient.close();
-            }
         }
         return checkBlobDownload;
     }
 
     public void checkForBlobUpdate(String key) {
-        CuratorFramework zkClient = BlobStoreUtils.createZKClient(conf);
         BlobStoreUtils.updateKeyForBlobStore(conf, this, zkClient, key, nimbusInfo);
-        zkClient.close();
     }
 
     public void fullCleanup(long age) throws IOException {

--- a/storm-core/src/jvm/backtype/storm/blobstore/LocalFsBlobStore.java
+++ b/storm-core/src/jvm/backtype/storm/blobstore/LocalFsBlobStore.java
@@ -281,7 +281,7 @@ public class LocalFsBlobStore extends BlobStore {
     }
 
     //This additional check and download is for nimbus high availability in case you have more than one nimbus
-    public boolean checkForBlobOrDownload(String key) {
+    public synchronized boolean checkForBlobOrDownload(String key) {
         boolean checkBlobDownload = false;
         try {
             List<String> keyList = BlobStoreUtils.getKeyListFromBlobStore(this);
@@ -301,7 +301,7 @@ public class LocalFsBlobStore extends BlobStore {
         return checkBlobDownload;
     }
 
-    public void checkForBlobUpdate(String key) {
+    public synchronized void checkForBlobUpdate(String key) {
         BlobStoreUtils.updateKeyForBlobStore(conf, this, zkClient, key, nimbusInfo);
     }
 

--- a/storm-core/test/clj/backtype/storm/nimbus_test.clj
+++ b/storm-core/test/clj/backtype/storm/nimbus_test.clj
@@ -1238,10 +1238,11 @@
   (testing "nimbus-data uses correct ACLs"
     (let [scheme "digest"
           digest "storm:thisisapoorpassword"
-          auth-conf {STORM-ZOOKEEPER-AUTH-SCHEME scheme
+          auth-conf (merge (read-storm-config)
+                    {STORM-ZOOKEEPER-AUTH-SCHEME scheme
                      STORM-ZOOKEEPER-AUTH-PAYLOAD digest
                      STORM-PRINCIPAL-TO-LOCAL-PLUGIN "backtype.storm.security.auth.DefaultPrincipalToLocal"
-                     NIMBUS-THRIFT-PORT 6666}
+                     NIMBUS-THRIFT-PORT 6666})
           expected-acls nimbus/NIMBUS-ZK-ACLS
           fake-inimbus (reify INimbus (getForcedScheduler [this] nil))]
       (stubbing [nimbus-topo-history-state nil

--- a/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
+++ b/storm-core/test/jvm/backtype/storm/localizer/LocalizerTest.java
@@ -517,11 +517,9 @@ public class LocalizerTest {
 
   @Test(expected = KeyNotFoundException.class)
   public void testKeyNotFoundException() throws Exception {
-    Map conf = new HashMap();
+    Map conf = Utils.readStormConfig();
     String key1 = "key1";
     conf.put(Config.STORM_LOCAL_DIR, "local");
-    conf.put(Config.BLOBSTORE_SUPERUSER, "superuser");
-    conf.put(Config.STORM_PRINCIPAL_TO_LOCAL_PLUGIN, "backtype.storm.security.auth.DefaultPrincipalToLocal");
     LocalFsBlobStore bs = new LocalFsBlobStore();
     LocalFsBlobStore spy = spy(bs);
     Mockito.doReturn(true).when(spy).checkForBlobOrDownload(key1);


### PR DESCRIPTION
 Uneccessary creation of client and closing of connections puts load on zookeeper.
Having a single client connection to perform reads helps