### PR TITLE
STORM-1199 : HDFS Spout Functionally complete. Not well tested. Some UTs

### DIFF
--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -135,6 +135,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.storm</groupId>
+      <artifactId>storm-hdfs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.10</artifactId>
       <version>0.8.2.1</version>

--- a/examples/storm-starter/src/jvm/storm/starter/HdfsSpoutTopology.java
+++ b/examples/storm-starter/src/jvm/storm/starter/HdfsSpoutTopology.java
@@ -18,18 +18,20 @@
 
 package storm.starter;
 
-import backtype.storm.Config;
-import backtype.storm.StormSubmitter;
-import backtype.storm.generated.Nimbus;
-import backtype.storm.topology.TopologyBuilder;
-import backtype.storm.utils.NimbusClient;
-import backtype.storm.utils.Utils;
+import org.apache.storm.Config;
+import org.apache.storm.StormSubmitter;
+import org.apache.storm.generated.Nimbus;
+import org.apache.storm.metric.LoggingMetricsConsumer;
+import org.apache.storm.starter.FastWordCountTopology;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.utils.NimbusClient;
+import org.apache.storm.utils.Utils;
 import org.apache.storm.hdfs.spout.Configs;
 import org.apache.storm.hdfs.spout.HdfsSpout;
-import backtype.storm.topology.base.BaseRichBolt;
-import backtype.storm.topology.*;
-import backtype.storm.tuple.*;
-import backtype.storm.task.*;
+import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.topology.*;
+import org.apache.storm.tuple.*;
+import org.apache.storm.task.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +123,7 @@ public class HdfsSpoutTopology {
     // 3 - Create and configure topology
     conf.setDebug(true);
     conf.setNumWorkers(WORKER_NUM);
-    conf.registerMetricsConsumer(backtype.storm.metric.LoggingMetricsConsumer.class);
+    conf.registerMetricsConsumer(LoggingMetricsConsumer.class);
 
     TopologyBuilder builder = new TopologyBuilder();
     builder.setSpout(SPOUT_ID, spout, spoutNum);

--- a/examples/storm-starter/src/jvm/storm/starter/HdfsSpoutTopology.java
+++ b/examples/storm-starter/src/jvm/storm/starter/HdfsSpoutTopology.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package storm.starter;
+
+import backtype.storm.Config;
+import backtype.storm.StormSubmitter;
+import backtype.storm.generated.Nimbus;
+import backtype.storm.topology.TopologyBuilder;
+import backtype.storm.utils.NimbusClient;
+import backtype.storm.utils.Utils;
+import org.apache.storm.hdfs.bolt.HdfsBolt;
+import org.apache.storm.hdfs.bolt.format.DefaultFileNameFormat;
+import org.apache.storm.hdfs.bolt.format.DelimitedRecordFormat;
+import org.apache.storm.hdfs.bolt.format.RecordFormat;
+import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
+import org.apache.storm.hdfs.bolt.rotation.TimedRotationPolicy;
+import org.apache.storm.hdfs.bolt.sync.CountSyncPolicy;
+import org.apache.storm.hdfs.spout.Configs;
+import org.apache.storm.hdfs.spout.HdfsSpout;
+
+import java.util.Map;
+
+
+public class HdfsSpoutTopology {
+
+  public static final String SPOUT_ID = "hdfsspout";
+  public static final String BOLT_ID = "hdfsbolt";
+
+  public static final int SPOUT_NUM = 4;
+  public static final int BOLT_NUM = 4;
+  public static final int WORKER_NUM = 4;
+
+
+  private static HdfsBolt makeHdfsBolt(String arg, String destinationDir) {
+    DefaultFileNameFormat fileNameFormat = new DefaultFileNameFormat()
+            .withPath(destinationDir)
+            .withExtension(".txt");
+    RecordFormat format = new DelimitedRecordFormat();
+    FileRotationPolicy rotationPolicy = new TimedRotationPolicy(5.0f, TimedRotationPolicy.TimeUnit.MINUTES);
+
+    return new HdfsBolt()
+            .withConfigKey("hdfs.config")
+            .withFsUrl(arg)
+            .withFileNameFormat(fileNameFormat)
+            .withRecordFormat(format)
+            .withRotationPolicy(rotationPolicy)
+            .withSyncPolicy(new CountSyncPolicy(1000));
+  }
+
+  /** Copies text file content from sourceDir to destinationDir. Moves source files into sourceDir after its done consuming
+   *    args: sourceDir sourceArchiveDir badDir destinationDir
+   */
+  public static void main(String[] args) throws Exception {
+    // 0 - validate args
+    if (args.length < 6) {
+      System.err.println("Please check command line arguments.");
+      System.err.println("Usage :");
+      System.err.println(HdfsSpoutTopology.class.toString() + " topologyName fileFormat sourceDir sourceArchiveDir badDir destinationDir.");
+      System.err.println(" topologyName - topology name.");
+      System.err.println(" fileFormat -  Set to 'TEXT' for reading text files or 'SEQ' for sequence files.");
+      System.err.println(" sourceDir  - read files from this HDFS dir using HdfsSpout.");
+      System.err.println(" sourceArchiveDir - after a file in sourceDir is read completely, it is moved to this HDFS location.");
+      System.err.println(" badDir - files that cannot be read properly will be moved to this HDFS location.");
+      System.err.println(" destinationDir - write data out to this HDFS location using HDFS bolt.");
+
+      System.err.println();
+      System.exit(-1);
+    }
+
+    // 1 - parse cmd line args
+    String topologyName = args[0];
+    String fileFormat = args[1];
+    String sourceDir = args[2];
+    String sourceArchiveDir = args[3];
+    String badDir = args[4];
+    String destinationDir = args[5];
+
+    // 2 - create and configure spout and bolt
+    HdfsBolt bolt = makeHdfsBolt(args[0], destinationDir);
+    HdfsSpout spout = new HdfsSpout().withOutputFields("line");
+
+    Config conf = new Config();
+    conf.put(Configs.SOURCE_DIR, sourceDir);
+    conf.put(Configs.ARCHIVE_DIR, sourceArchiveDir);
+    conf.put(Configs.BAD_DIR, badDir);
+    conf.put(Configs.READER_TYPE, fileFormat);
+
+    // 3 - Create and configure topology
+    conf.setDebug(true);
+    conf.setNumWorkers(WORKER_NUM);
+    conf.registerMetricsConsumer(backtype.storm.metric.LoggingMetricsConsumer.class);
+
+    TopologyBuilder builder = new TopologyBuilder();
+    builder.setSpout(SPOUT_ID, spout, SPOUT_NUM);
+    builder.setBolt(BOLT_ID, bolt, BOLT_NUM).shuffleGrouping(SPOUT_ID);
+
+    // 4 - submit topology, wait for few min and terminate it
+    Map clusterConf = Utils.readStormConfig();
+    StormSubmitter.submitTopologyWithProgressBar(topologyName, conf, builder.createTopology());
+    Nimbus.Client client = NimbusClient.getConfiguredClient(clusterConf).getClient();
+
+    // 5 - Print metrics every 30 sec, kill topology after 5 min
+    for (int i = 0; i < 10; i++) {
+      Thread.sleep(30 * 1000);
+      FastWordCountTopology.printMetrics(client, topologyName);
+    }
+    FastWordCountTopology.kill(client, topologyName);
+  } // main
+
+}

--- a/external/storm-hdfs/README.md
+++ b/external/storm-hdfs/README.md
@@ -1,11 +1,50 @@
 # Storm HDFS
 
 Storm components for interacting with HDFS file systems
- - HDFS Bolt
  - HDFS Spout
- 
+ - HDFS Bolt 
 
 # HDFS Spout
+
+Hdfs spout is intended to allow feeding data into Storm from a HDFS directory. 
+It will actively monitor the directory to consume any new files that appear in the directory.
+
+**Impt**: Hdfs spout assumes that the files being made visible to it in the monitored directory 
+are NOT actively being written to. Only after a files is completely written should it be made
+visible to the spout. This can be achieved by either writing the files out to another directory 
+and once completely written, move it to the monitored directory. Alternatively the file
+can be created with a '.ignore' suffix in the monitored directory and after data is completely 
+written, rename it without the suffix. File names with a '.ignore' suffix are ignored
+by the spout.
+
+When the spout is actively consuming a file, ite renames the file with a '.inprogress' suffix.
+After consuming all the contents in the file, the file will be moved to a configurable *done* 
+directory and the '.inprogress' suffix will be dropped.
+
+**Concurrency** If multiple spout instances are used in the topology, each instance will consume
+a different file. Synchronization among spout instances is done using a lock files created in 
+(by default) a '.lock' subdirectory under the monitored directory. A file with the same name
+as the file being consumed (with the in progress suffix) is created in the lock directory.
+Once the file is completely consumed, the corresponding lock file is deleted.
+
+**Recovery from failure**
+Periodically, the spout also records progress information wrt to how much of the file has been
+consumed in the lock file. In case of an crash of the spout instance (or force kill of topology) 
+another spout can take over the file and resume from the location recorded in the lock file.
+
+Certain error conditions can cause lock files to go stale. Basically the lock file exists, 
+but no spout actively owns and therefore will the file will not be deleted. Usually this indicates 
+that the corresponding input file has also not been completely processed. A configuration
+'hdfsspout.lock.timeout.sec' can be set to specify the duration of inactivity that a lock file
+should be considered stale. Stale lock files are candidates for automatic transfer of ownership to 
+another spout.
+
+**Lock on .lock Directory**
+The .lock directory contains another DIRLOCK file which is used to co-ordinate accesses to the 
+.lock dir itself among spout instances. A spout will try to create it when it needs access to
+the .lock directory and then delete it when done.  In case of a topology crash or force kill,
+if this file still exists, it should be deleted to allow the new topology instance to regain 
+full access to the  .lock directory and resume normal processing. 
 
 ## Usage
 
@@ -13,8 +52,10 @@ The following example creates an HDFS spout that reads text files from HDFS path
 
 ```java
 // Instantiate spout
-HdfsSpout textReaderSpout = new HdfsSpout().withOutputFields("line");
-// HdfsSpout seqFileReaderSpout = new HdfsSpout().withOutputFields("key","value");
+HdfsSpout textReaderSpout = new HdfsSpout().withOutputFields(TextFileReader.defaultFields);
+// HdfsSpout seqFileReaderSpout = new HdfsSpout().withOutputFields(SequenceFileReader.defaultFields);
+
+// textReaderSpout.withConfigKey("custom.keyname"); // Optional. Not required normally unless you need to change the keyname use to provide hds settings. This keyname defaults to 'hdfs.config' 
 
 // Configure it
 Config conf = new Config();
@@ -34,21 +75,34 @@ builder.setSpout("hdfsspout", textReaderSpout, SPOUT_NUM);
 StormSubmitter.submitTopologyWithProgressBar("topologyName", conf, builder.createTopology());
 ```
 
-## HDFS Spout Configuration Settings
+## Configuration Settings
+Class HdfsSpout provided following methods for configuration:
 
-| Setting                  | Default     | Description |
-|--------------------------|-------------|-------------|
-|**hdfsspout.reader.type** |             | Indicates the reader for the file format. Set to 'seq' for reading sequence files or 'text' for text files. Set to a fully qualified class name if using a custom type (that implements interface org.apache.storm.hdfs.spout.FileReader)|
-|**hdfsspout.source.dir**  |             | HDFS location from where to read.  E.g. hdfs://localhost:54310/inputfiles       |
-|**hdfsspout.archive.dir** |             | After a file is processed completely it will be moved to this directory. E.g. hdfs://localhost:54310/done|
-|**hdfsspout.badfiles.dir**|             | if there is an error parsing a file's contents, the file is moved to this location.  E.g. hdfs://localhost:54310/badfiles  |
-|hdfsspout.ignore.suffix   |   .ignore   | File names with this suffix in the in the hdfsspout.source.dir location will not be processed|
-|hdfsspout.lock.dir        | '.lock' subdirectory under hdfsspout.source.dir | Dir in which lock files will be created. Concurrent HDFS spout instances synchronize using *lock*. Before processing a file the spout instance creates a lock file in this directory with same name as input file and deletes this lock file after processing the file. Spout also periodically makes a note of its progress (wrt reading the input file) in the lock file so that another spout instance can resume progress on the same file if the spout dies for any reason.|
-|hdfsspout.commit.count    |    20000    | Record progress in the lock file after these many records are processed. If set to 0, this criterion will not be used. |
-|hdfsspout.commit.sec      |    10       | Record progress in the lock file after these many seconds have elapsed. Must be greater than 0 |
-|hdfsspout.max.outstanding |   10000     | Limits the number of unACKed tuples by pausing tuple generation (if ACKers are used in the topology) |
-|hdfsspout.lock.timeout.sec|  5 minutes  | Duration of inactivity after which a lock file is considered to be abandoned and ready for another spout to take ownership |
-|hdfsspout.clocks.insync   |    true     | Indicates whether clocks on the storm machines are in sync (using services like NTP)       |
+`HdfsSpout withOutputFields(String... fields)` : This sets the names for the output fields. 
+The number of fields depends upon the reader being used. For convenience, built-in reader types 
+expose a static member called `defaultFields` that can be used for this. 
+ 
+ `HdfsSpout withConfigKey(String configKey)`
+Allows overriding the default key name (hdfs.config) with new name for specifying HDFS configs. Typicallly used
+to provide kerberos keytabs.
+
+Only settings mentioned in **bold** are required.
+
+| Setting                      | Default     | Description |
+|------------------------------|-------------|-------------|
+|**hdfsspout.reader.type**     |             | Indicates the reader for the file format. Set to 'seq' for reading sequence files or 'text' for text files. Set to a fully qualified class name if using a custom type (that implements interface org.apache.storm.hdfs.spout.FileReader)|
+|**hdfsspout.hdfs**            |             | HDFS URI. Example:  hdfs://namenodehost:8020
+|**hdfsspout.source.dir**      |             | HDFS location from where to read.  E.g. /data/inputfiles  |
+|**hdfsspout.archive.dir**     |             | After a file is processed completely it will be moved to this directory. E.g. /data/done|
+|**hdfsspout.badfiles.dir**    |             | if there is an error parsing a file's contents, the file is moved to this location.  E.g. /data/badfiles  |
+|hdfsspout.lock.dir            | '.lock' subdirectory under hdfsspout.source.dir | Dir in which lock files will be created. Concurrent HDFS spout instances synchronize using *lock* files. Before processing a file the spout instance creates a lock file in this directory with same name as input file and deletes this lock file after processing the file. Spout also periodically makes a note of its progress (wrt reading the input file) in the lock file so that another spout instance can resume progress on the same file if the spout dies for any reason. When a toplogy is killed, if a .lock/DIRLOCK file is left behind it can be safely deleted to allow normal resumption of the topology on restart.|
+|hdfsspout.ignore.suffix       |   .ignore   | File names with this suffix in the in the hdfsspout.source.dir location will not be processed|
+|hdfsspout.commit.count        |    20000    | Record progress in the lock file after these many records are processed. If set to 0, this criterion will not be used. |
+|hdfsspout.commit.sec          |    10       | Record progress in the lock file after these many seconds have elapsed. Must be greater than 0 |
+|hdfsspout.max.outstanding     |   10000     | Limits the number of unACKed tuples by pausing tuple generation (if ACKers are used in the topology) |
+|hdfsspout.lock.timeout.sec    |  5 minutes  | Duration of inactivity after which a lock file is considered to be abandoned and ready for another spout to take ownership |
+|hdfsspout.clocks.insync       |    true     | Indicates whether clocks on the storm machines are in sync (using services like NTP)       |
+|hdfs.config (unless changed)  |             | Set it to a Map of Key/value pairs indicating the HDFS settigns to be used. For example, keytab and principle could be set using this. See section **Using keytabs on all worker hosts** under HDFS bolt below.| 
 
 
 # HDFS Bolt

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/CmpFilesByModificationTime.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/CmpFilesByModificationTime.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.storm.hdfs.common;
 
 import org.apache.hadoop.fs.LocatedFileStatus;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/CmpFilesByModificationTime.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/CmpFilesByModificationTime.java
@@ -1,0 +1,14 @@
+package org.apache.storm.hdfs.common;
+
+import org.apache.hadoop.fs.LocatedFileStatus;
+
+import java.util.Comparator;
+
+
+public class CmpFilesByModificationTime
+        implements Comparator<LocatedFileStatus> {
+   @Override
+    public int compare(LocatedFileStatus o1, LocatedFileStatus o2) {
+      return new Long(o1.getModificationTime()).compareTo( o1.getModificationTime() );
+    }
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/CmpFilesByModificationTime.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/CmpFilesByModificationTime.java
@@ -18,15 +18,15 @@
 
 package org.apache.storm.hdfs.common;
 
-import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.FileStatus;
 
 import java.util.Comparator;
 
 
 public class CmpFilesByModificationTime
-        implements Comparator<LocatedFileStatus> {
+        implements Comparator<FileStatus> {
    @Override
-    public int compare(LocatedFileStatus o1, LocatedFileStatus o2) {
+    public int compare(FileStatus o1, FileStatus o2) {
       return new Long(o1.getModificationTime()).compareTo( o1.getModificationTime() );
     }
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.storm.hdfs.common;
 
 import org.apache.hadoop.fs.FileSystem;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
@@ -29,13 +29,12 @@ import org.apache.hadoop.ipc.RemoteException;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 
 public class HdfsUtils {
   /** list files sorted by modification time that have not been modified since 'olderThan'. if
    * 'olderThan' is <= 0 then the filtering is disabled */
-  public static Collection<Path> listFilesByModificationTime(FileSystem fs, Path directory, long olderThan)
+  public static ArrayList<Path> listFilesByModificationTime(FileSystem fs, Path directory, long olderThan)
           throws IOException {
     ArrayList<LocatedFileStatus> fstats = new ArrayList<>();
 
@@ -43,7 +42,7 @@ public class HdfsUtils {
     while( itr.hasNext() ) {
       LocatedFileStatus fileStatus = itr.next();
       if(olderThan>0) {
-        if( fileStatus.getModificationTime()<olderThan )
+        if( fileStatus.getModificationTime()<=olderThan )
           fstats.add(fileStatus);
       }
       else {
@@ -69,14 +68,13 @@ public class HdfsUtils {
     } catch (FileAlreadyExistsException e) {
       return null;
     } catch (RemoteException e) {
-      if( e.getClassName().contentEquals(AlreadyBeingCreatedException.class.getName()) ) {
+      if( e.unwrapRemoteException() instanceof AlreadyBeingCreatedException ) {
         return null;
       } else { // unexpected error
         throw e;
       }
     }
   }
-
 
   public static class Pair<K,V> {
     private K key;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
@@ -38,10 +38,13 @@ public class HdfsUtils {
     RemoteIterator<LocatedFileStatus> itr = fs.listFiles(directory, false);
     while( itr.hasNext() ) {
       LocatedFileStatus fileStatus = itr.next();
-      if(olderThan>0 && fileStatus.getModificationTime()<olderThan )
+      if(olderThan>0) {
+        if( fileStatus.getModificationTime()<olderThan )
+          fstats.add(fileStatus);
+      }
+      else {
         fstats.add(fileStatus);
-      else
-        fstats.add(fileStatus);
+      }
     }
     Collections.sort(fstats, new CmpFilesByModificationTime() );
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
@@ -1,0 +1,57 @@
+package org.apache.storm.hdfs.common;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+public class HdfsUtils {
+  /** list files sorted by modification time that have not been modified since 'olderThan'. if
+   * 'olderThan' is <= 0 then the filtering is disabled */
+  public static Collection<Path> listFilesByModificationTime(FileSystem fs, Path directory, long olderThan)
+          throws IOException {
+    ArrayList<LocatedFileStatus> fstats = new ArrayList<>();
+
+    RemoteIterator<LocatedFileStatus> itr = fs.listFiles(directory, false);
+    while( itr.hasNext() ) {
+      LocatedFileStatus fileStatus = itr.next();
+      if(olderThan>0 && fileStatus.getModificationTime()<olderThan )
+        fstats.add(fileStatus);
+      else
+        fstats.add(fileStatus);
+    }
+    Collections.sort(fstats, new CmpFilesByModificationTime() );
+
+    ArrayList<Path> result = new ArrayList<>(fstats.size());
+    for (LocatedFileStatus fstat : fstats) {
+      result.add(fstat.getPath());
+    }
+    return result;
+  }
+
+  public static class Pair<K,V> {
+    private K key;
+    private V value;
+    public Pair(K key, V value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public K getKey() {
+      return key;
+    }
+
+    public V getValue() {
+      return value;
+    }
+
+    public static <K,V> Pair of(K key, V value) {
+      return new Pair(key,value);
+    }
+  }  // class Pair
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.protocol.AlreadyBeingCreatedException;
 import org.apache.hadoop.ipc.RemoteException;
-import org.apache.storm.hdfs.spout.DirLock;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
@@ -49,7 +49,7 @@ public class HdfsUtils {
         fstats.add(fileStatus);
       }
     }
-    Collections.sort(fstats, new CmpFilesByModificationTime() );
+    Collections.sort(fstats, new ModifTimeComparator() );
 
     ArrayList<Path> result = new ArrayList<>(fstats.size());
     for (LocatedFileStatus fstat : fstats) {
@@ -59,7 +59,7 @@ public class HdfsUtils {
   }
 
   /**
-   * Returns true if succeeded. False if file already exists. throws if there was unexpected problem
+   * Returns null if file already exists. throws if there was unexpected problem
    */
   public static FSDataOutputStream tryCreateFile(FileSystem fs, Path file) throws IOException {
     try {

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HdfsUtils.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.protocol.AlreadyBeingCreatedException;
 import org.apache.hadoop.ipc.RemoteException;
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/ModifTimeComparator.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/ModifTimeComparator.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.fs.FileStatus;
 import java.util.Comparator;
 
 
-public class CmpFilesByModificationTime
+public class ModifTimeComparator
         implements Comparator<FileStatus> {
    @Override
     public int compare(FileStatus o1, FileStatus o2) {

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/AbstractFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/AbstractFileReader.java
@@ -26,13 +26,11 @@ import org.apache.hadoop.fs.Path;
 abstract class AbstractFileReader implements FileReader {
 
   private final Path file;
-  private final FileSystem fs;
   private Fields fields;
 
   public AbstractFileReader(FileSystem fs, Path file, Fields fieldNames) {
     if (fs == null || file == null)
       throw new IllegalArgumentException("file and filesystem args cannot be null");
-    this.fs = fs;
     this.file = file;
     this.fields = fieldNames;
   }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/AbstractFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/AbstractFileReader.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+import backtype.storm.tuple.Fields;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+
+abstract class AbstractFileReader implements FileReader {
+
+  private final Path file;
+  private final FileSystem fs;
+  private Fields fields;
+
+  public AbstractFileReader(FileSystem fs, Path file, Fields fieldNames) {
+    if (fs == null || file == null)
+      throw new IllegalArgumentException("file and filesystem args cannot be null");
+    this.fs = fs;
+    this.file = file;
+    this.fields = fieldNames;
+  }
+
+  @Override
+  public Path getFilePath() {
+    return file;
+  }
+
+
+  @Override
+  public Fields getOutputFields() {
+    return fields;
+  }
+
+  @Override
+  public void setFields(String... fieldNames) {
+    this.fields = new Fields(fieldNames);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    AbstractFileReader that = (AbstractFileReader) o;
+
+    return !(file != null ? !file.equals(that.file) : that.file != null);
+  }
+
+  @Override
+  public int hashCode() {
+    return file != null ? file.hashCode() : 0;
+  }
+
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/AbstractFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/AbstractFileReader.java
@@ -28,11 +28,10 @@ abstract class AbstractFileReader implements FileReader {
   private final Path file;
   private Fields fields;
 
-  public AbstractFileReader(FileSystem fs, Path file, Fields fieldNames) {
+  public AbstractFileReader(FileSystem fs, Path file) {
     if (fs == null || file == null)
       throw new IllegalArgumentException("file and filesystem args cannot be null");
     this.file = file;
-    this.fields = fieldNames;
   }
 
   @Override
@@ -40,16 +39,6 @@ abstract class AbstractFileReader implements FileReader {
     return file;
   }
 
-
-  @Override
-  public Fields getOutputFields() {
-    return fields;
-  }
-
-  @Override
-  public void setFields(String... fieldNames) {
-    this.fields = new Fields(fieldNames);
-  }
 
   @Override
   public boolean equals(Object o) {

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/AbstractFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/AbstractFileReader.java
@@ -18,7 +18,6 @@
 
 package org.apache.storm.hdfs.spout;
 
-import backtype.storm.tuple.Fields;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -26,11 +25,14 @@ import org.apache.hadoop.fs.Path;
 abstract class AbstractFileReader implements FileReader {
 
   private final Path file;
-  private Fields fields;
 
   public AbstractFileReader(FileSystem fs, Path file) {
-    if (fs == null || file == null)
-      throw new IllegalArgumentException("file and filesystem args cannot be null");
+    if (fs == null ) {
+      throw new IllegalArgumentException("filesystem arg cannot be null for reader");
+    }
+    if (file == null ) {
+      throw new IllegalArgumentException("file arg cannot be null for reader");
+    }
     this.file = file;
   }
 
@@ -42,8 +44,8 @@ abstract class AbstractFileReader implements FileReader {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
 
     AbstractFileReader that = (AbstractFileReader) o;
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
@@ -23,15 +23,16 @@ public class Configs {
   public static final String TEXT = "text";
   public static final String SEQ = "seq";
 
-  public static final String SOURCE_DIR = "hdfsspout.source.dir";         // dir from which to read files
-  public static final String ARCHIVE_DIR = "hdfsspout.archive.dir";        // completed files will be moved here
-  public static final String BAD_DIR = "hdfsspout.badfiles.dir";       // unpraseable files will be moved here
-  public static final String LOCK_DIR = "hdfsspout.lock.dir";           // dir in which lock files will be created
-  public static final String COMMIT_FREQ_COUNT = "hdfsspout.commit.count";       // commit after N records
-  public static final String COMMIT_FREQ_SEC = "hdfsspout.commit.sec";         // commit after N secs
+  public static final String SOURCE_DIR = "hdfsspout.source.dir";           // dir from which to read files
+  public static final String ARCHIVE_DIR = "hdfsspout.archive.dir";         // completed files will be moved here
+  public static final String BAD_DIR = "hdfsspout.badfiles.dir";            // unpraseable files will be moved here
+  public static final String LOCK_DIR = "hdfsspout.lock.dir";               // dir in which lock files will be created
+  public static final String COMMIT_FREQ_COUNT = "hdfsspout.commit.count";  // commit after N records
+  public static final String COMMIT_FREQ_SEC = "hdfsspout.commit.sec";      // commit after N secs
   public static final String MAX_DUPLICATE = "hdfsspout.max.duplicate";
   public static final String LOCK_TIMEOUT = "hdfsspout.lock.timeout.sec";   // inactivity duration after which locks are considered candidates for being reassigned to another spout
-  public static final String CLOCKS_INSYNC = "hdfsspout.clocks.insync"; // if clocks on machines in the Storm cluster are in sync
+  public static final String CLOCKS_INSYNC = "hdfsspout.clocks.insync";     // if clocks on machines in the Storm cluster are in sync
+  public static final String IGNORE_SUFFIX = "hdfsspout.ignore.suffix";     // filenames with this suffix will be ignored by the Spout
 
   public static final String DEFAULT_LOCK_DIR = ".lock";
   public static final int DEFAULT_COMMIT_FREQ_COUNT = 10000;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+public class Configs {
+  public static final String READER_TYPE = "hdfsspout.reader.type";
+  public static final String TEXT = "text";
+  public static final String SEQ = "seq";
+
+  public static final String SOURCE_DIR = "hdfsspout.source.dir";         // dir from which to read files
+  public static final String ARCHIVE_DIR = "hdfsspout.archive.dir";        // completed files will be moved here
+  public static final String BAD_DIR = "hdfsspout.badfiles.dir";       // unpraseable files will be moved here
+  public static final String LOCK_DIR = "hdfsspout.lock.dir";           // dir in which lock files will be created
+  public static final String COMMIT_FREQ_COUNT = "hdfsspout.commit.count";       // commit after N records
+  public static final String COMMIT_FREQ_SEC = "hdfsspout.commit.sec";         // commit after N secs
+  public static final String MAX_DUPLICATE = "hdfsspout.max.duplicate";
+  public static final String LOCK_TIMEOUT = "hdfsspout.lock.timeout.sec";   // inactivity duration after which locks are considered candidates for being reassigned to another spout
+  public static final String CLOCKS_INSYNC = "hdfsspout.clocks.insync"; // if clocks on machines in the Storm cluster are in sync
+
+  public static final String DEFAULT_LOCK_DIR = ".lock";
+  public static final int DEFAULT_COMMIT_FREQ_COUNT = 10000;
+  public static final int DEFAULT_COMMIT_FREQ_SEC = 10;
+  public static final int DEFAULT_MAX_DUPLICATES = 100;
+  public static final int DEFAULT_LOCK_TIMEOUT = 5 * 60; // 5 min
+  public static final String DEFAULT_HDFS_CONFIG_KEY = "hdfs.config";
+
+
+} // class Configs

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
@@ -27,8 +27,8 @@ public class Configs {
   public static final String ARCHIVE_DIR = "hdfsspout.archive.dir";         // completed files will be moved here
   public static final String BAD_DIR = "hdfsspout.badfiles.dir";            // unpraseable files will be moved here
   public static final String LOCK_DIR = "hdfsspout.lock.dir";               // dir in which lock files will be created
-  public static final String COMMIT_FREQ_COUNT = "hdfsspout.commit.count";  // commit after N records
-  public static final String COMMIT_FREQ_SEC = "hdfsspout.commit.sec";      // commit after N secs
+  public static final String COMMIT_FREQ_COUNT = "hdfsspout.commit.count";  // commit after N records. 0 disables this.
+  public static final String COMMIT_FREQ_SEC = "hdfsspout.commit.sec";      // commit after N secs. cannot be disabled.
   public static final String MAX_DUPLICATE = "hdfsspout.max.duplicate";
   public static final String LOCK_TIMEOUT = "hdfsspout.lock.timeout.sec";   // inactivity duration after which locks are considered candidates for being reassigned to another spout
   public static final String CLOCKS_INSYNC = "hdfsspout.clocks.insync";     // if clocks on machines in the Storm cluster are in sync

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
@@ -23,6 +23,7 @@ public class Configs {
   public static final String TEXT = "text";
   public static final String SEQ = "seq";
 
+  public static final String HDFS_URI = "hdfsspout.hdfs";                   // Required - HDFS name node
   public static final String SOURCE_DIR = "hdfsspout.source.dir";           // Required - dir from which to read files
   public static final String ARCHIVE_DIR = "hdfsspout.archive.dir";         // Required - completed files will be moved here
   public static final String BAD_DIR = "hdfsspout.badfiles.dir";            // Required - unparsable files will be moved here

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/Configs.java
@@ -19,25 +19,25 @@
 package org.apache.storm.hdfs.spout;
 
 public class Configs {
-  public static final String READER_TYPE = "hdfsspout.reader.type";
+  public static final String READER_TYPE = "hdfsspout.reader.type";        // Required - chose the file type being consumed
   public static final String TEXT = "text";
   public static final String SEQ = "seq";
 
-  public static final String SOURCE_DIR = "hdfsspout.source.dir";           // dir from which to read files
-  public static final String ARCHIVE_DIR = "hdfsspout.archive.dir";         // completed files will be moved here
-  public static final String BAD_DIR = "hdfsspout.badfiles.dir";            // unpraseable files will be moved here
+  public static final String SOURCE_DIR = "hdfsspout.source.dir";           // Required - dir from which to read files
+  public static final String ARCHIVE_DIR = "hdfsspout.archive.dir";         // Required - completed files will be moved here
+  public static final String BAD_DIR = "hdfsspout.badfiles.dir";            // Required - unparsable files will be moved here
   public static final String LOCK_DIR = "hdfsspout.lock.dir";               // dir in which lock files will be created
   public static final String COMMIT_FREQ_COUNT = "hdfsspout.commit.count";  // commit after N records. 0 disables this.
   public static final String COMMIT_FREQ_SEC = "hdfsspout.commit.sec";      // commit after N secs. cannot be disabled.
-  public static final String MAX_DUPLICATE = "hdfsspout.max.duplicate";
+  public static final String MAX_OUTSTANDING = "hdfsspout.max.outstanding";
   public static final String LOCK_TIMEOUT = "hdfsspout.lock.timeout.sec";   // inactivity duration after which locks are considered candidates for being reassigned to another spout
   public static final String CLOCKS_INSYNC = "hdfsspout.clocks.insync";     // if clocks on machines in the Storm cluster are in sync
-  public static final String IGNORE_SUFFIX = "hdfsspout.ignore.suffix";     // filenames with this suffix will be ignored by the Spout
+  public static final String IGNORE_SUFFIX = "hdfsspout.ignore.suffix";     // filenames with this suffix in archive dir will be ignored by the Spout
 
   public static final String DEFAULT_LOCK_DIR = ".lock";
-  public static final int DEFAULT_COMMIT_FREQ_COUNT = 10000;
+  public static final int DEFAULT_COMMIT_FREQ_COUNT = 20000;
   public static final int DEFAULT_COMMIT_FREQ_SEC = 10;
-  public static final int DEFAULT_MAX_DUPLICATES = 100;
+  public static final int DEFAULT_MAX_OUTSTANDING = 10000;
   public static final int DEFAULT_LOCK_TIMEOUT = 5 * 60; // 5 min
   public static final String DEFAULT_HDFS_CONFIG_KEY = "hdfs.config";
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/DirLock.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/DirLock.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class DirLock {
+  private FileSystem fs;
+  private final Path lockFile;
+  public static final String DIR_LOCK_FILE = "DIRLOCK";
+  private static final Logger log = LoggerFactory.getLogger(DirLock.class);
+  private DirLock(FileSystem fs, Path lockFile) throws IOException {
+    if( fs.isDirectory(lockFile) )
+      throw new IllegalArgumentException(lockFile.toString() + " is not a directory");
+    this.fs = fs;
+    this.lockFile = lockFile;
+  }
+
+  /** Returns null if somebody else has a lock
+   *
+   * @param fs
+   * @param dir  the dir on which to get a lock
+   * @return lock object
+   * @throws IOException if there were errors
+   */
+  public static DirLock tryLock(FileSystem fs, Path dir) throws IOException {
+    Path lockFile = new Path(dir.toString() + Path.SEPARATOR_CHAR + DIR_LOCK_FILE );
+    try {
+      FSDataOutputStream os = fs.create(lockFile, false);
+      if(log.isInfoEnabled()) {
+        log.info("Thread acquired dir lock  " + threadInfo() + " - lockfile " + lockFile);
+      }
+      os.close();
+      return new DirLock(fs, lockFile);
+    } catch (FileAlreadyExistsException e) {
+      return null;
+    }
+  }
+
+  private static String threadInfo () {
+    return "ThdId=" + Thread.currentThread().getId() + ", ThdName=" + Thread.currentThread().getName();
+  }
+  public void release() throws IOException {
+    fs.delete(lockFile, false);
+    log.info("Thread {} released dir lock {} ", threadInfo(), lockFile);
+  }
+
+  public Path getLockFile() {
+    return lockFile;
+  }
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/DirLock.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/DirLock.java
@@ -81,8 +81,12 @@ public class DirLock {
 
   /** Release lock on dir by deleting the lock file */
   public void release() throws IOException {
-    fs.delete(lockFile, false);
-    log.info("Thread {} released dir lock {} ", threadInfo(), lockFile);
+    if(!fs.delete(lockFile, false)) {
+      log.error("Thread {} could not delete dir lock {} ", threadInfo(), lockFile);
+    }
+    else {
+      log.info("Thread {} released dir lock {} ", threadInfo(), lockFile);
+    }
   }
 
   /** if the lock on the directory is stale, take ownership */

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileLock.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileLock.java
@@ -1,0 +1,263 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.storm.hdfs.common.HdfsUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collection;
+
+public class FileLock {
+
+  private final FileSystem fs;
+  private final String componentID;
+  private final Path lockFile;
+  private final FSDataOutputStream stream;
+  private LogEntry lastEntry;
+
+  private static final Logger log = LoggerFactory.getLogger(DirLock.class);
+
+  private FileLock(FileSystem fs, Path fileToLock, Path lockDirPath, String spoutId)
+          throws IOException {
+    this.fs = fs;
+    String lockFileName = lockDirPath.toString() + Path.SEPARATOR_CHAR + fileToLock.getName();
+    this.lockFile = new Path(lockFileName);
+    this.stream =  fs.create(lockFile);
+    this.componentID = spoutId;
+    logProgress("0", false);
+  }
+
+  private FileLock(FileSystem fs, Path lockFile, String spoutId, LogEntry entry)
+          throws IOException {
+    this.fs = fs;
+    this.lockFile = lockFile;
+    this.stream =  fs.append(lockFile);
+    this.componentID = spoutId;
+    log.debug("Acquired abandoned lockFile {}", lockFile);
+    logProgress(entry.fileOffset, true);
+  }
+
+  public void heartbeat(String fileOffset) throws IOException {
+    logProgress(fileOffset, true);
+  }
+
+  // new line is at beginning of each line (instead of end) for better recovery from
+  // partial writes of prior lines
+  private void logProgress(String fileOffset, boolean prefixNewLine)
+          throws IOException {
+    long now = System.currentTimeMillis();
+    LogEntry entry = new LogEntry(now, componentID, fileOffset);
+    String line = entry.toString();
+    if(prefixNewLine)
+      stream.writeBytes(System.lineSeparator() + line);
+    else
+      stream.writeBytes(line);
+    stream.flush();
+    lastEntry = entry; // update this only after writing to hdfs
+  }
+
+  public void release() throws IOException {
+    stream.close();
+    fs.delete(lockFile, false);
+  }
+
+  // throws exception immediately if not able to acquire lock
+  public static FileLock tryLock(FileSystem hdfs, Path fileToLock, Path lockDirPath, String spoutId)
+          throws IOException {
+    return new FileLock(hdfs, fileToLock, lockDirPath, spoutId);
+  }
+
+  /**
+   * checks if lockFile is older than 'olderThan' UTC time by examining the modification time
+   * on file and (if necessary) the timestamp in last log entry in the file. If its stale, then
+   * returns the last log entry, else returns null.
+   * @param fs
+   * @param lockFile
+   * @param olderThan  time (millis) in UTC.
+   * @return the last entry in the file if its too old. null if last entry is not too old
+   * @throws IOException
+   */
+  public static LogEntry getLastEntryIfStale(FileSystem fs, Path lockFile, long olderThan)
+          throws IOException {
+    if( fs.getFileStatus(lockFile).getModificationTime() >= olderThan ) {
+      // HDFS timestamp may not reflect recent updates, so we double check the
+      // timestamp in last line of file to see when the last update was made
+      LogEntry lastEntry =  getLastEntry(fs, lockFile);
+      if(lastEntry==null) {
+        throw new RuntimeException(lockFile.getName() + " is empty. this file is invalid.");
+      }
+      if( lastEntry.eventTime <= olderThan )
+        return lastEntry;
+    }
+    return null;
+  }
+
+  /**
+   * returns the last log entry
+   * @param fs
+   * @param lockFile
+   * @return
+   * @throws IOException
+   */
+  public static LogEntry getLastEntry(FileSystem fs, Path lockFile)
+          throws IOException {
+    FSDataInputStream in = fs.open(lockFile);
+    BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+    String lastLine = null;
+    for(String line = reader.readLine(); line!=null; line = reader.readLine() ) {
+      lastLine=line;
+    }
+    return LogEntry.deserialize(lastLine);
+  }
+
+  // takes ownership of the lock file
+
+  /**
+   * Takes ownership of the lock file.
+   * @param lockFile
+   * @param lastEntry   last entry in the lock file. this param is an optimization.
+   *                    we dont scan the lock file again to find its last entry here since
+   *                    its already been done once by the logic used to check if the lock
+   *                    file is stale. so this value comes from that earlier scan.
+   * @param spoutId     spout id
+   * @return
+   */
+  public static FileLock takeOwnership(FileSystem fs, Path lockFile, LogEntry lastEntry, String spoutId)
+          throws IOException {
+    return new FileLock(fs, lockFile, spoutId, lastEntry);
+  }
+
+  /**
+   * Finds a oldest expired lock file (using modification timestamp), then takes
+   * ownership of the lock file
+   * Impt: Assumes access to lockFilesDir has been externally synchronized such that
+   *       only one thread accessing the same thread
+   * @param fs
+   * @param lockFilesDir
+   * @param locktimeoutSec
+   * @return
+   */
+  public static FileLock acquireOldestExpiredLock(FileSystem fs, Path lockFilesDir, int locktimeoutSec, String spoutId)
+          throws IOException {
+    // list files
+    long olderThan = System.currentTimeMillis() - (locktimeoutSec*1000);
+    Collection<Path> listing = HdfsUtils.listFilesByModificationTime(fs, lockFilesDir, olderThan);
+
+    // locate oldest expired lock file (if any) and take ownership
+    for (Path file : listing) {
+      if(file.getName().equalsIgnoreCase( DirLock.DIR_LOCK_FILE) )
+        continue;
+      LogEntry lastEntry = getLastEntryIfStale(fs, file, olderThan);
+      if(lastEntry!=null)
+        return FileLock.takeOwnership(fs, file, lastEntry, spoutId);
+    }
+    log.info("No abandoned files found");
+    return null;
+  }
+
+
+  /**
+   * Finds oldest expired lock file (using modification timestamp), then takes
+   * ownership of the lock file
+   * Impt: Assumes access to lockFilesDir has been externally synchronized such that
+   *       only one thread accessing the same thread
+   * @param fs
+   * @param lockFilesDir
+   * @param locktimeoutSec
+   * @param spoutId
+   * @return a Pair<lock file path, last entry in lock file> .. if expired lock file found
+   * @throws IOException
+   */
+  public static HdfsUtils.Pair<Path,LogEntry> locateOldestExpiredLock(FileSystem fs, Path lockFilesDir, int locktimeoutSec, String spoutId)
+          throws IOException {
+    // list files
+    long olderThan = System.currentTimeMillis() - (locktimeoutSec*1000);
+    Collection<Path> listing = HdfsUtils.listFilesByModificationTime(fs, lockFilesDir, olderThan);
+
+    // locate oldest expired lock file (if any) and take ownership
+    for (Path file : listing) {
+      if(file.getName().equalsIgnoreCase( DirLock.DIR_LOCK_FILE) )
+        continue;
+      LogEntry lastEntry = getLastEntryIfStale(fs, file, olderThan);
+      if(lastEntry!=null)
+        return new HdfsUtils.Pair<>(file, lastEntry);
+    }
+    log.info("No abandoned files found");
+    return null;
+  }
+
+  public LogEntry getLastLogEntry() {
+    return lastEntry;
+  }
+
+  public Path getLockFile() {
+    return lockFile;
+  }
+
+  public static class LogEntry {
+    private static final int NUM_FIELDS = 3;
+    public final long eventTime;
+    public final String componentID;
+    public final String fileOffset;
+
+    public LogEntry(long eventtime, String componentID, String fileOffset) {
+      this.eventTime = eventtime;
+      this.componentID = componentID;
+      this.fileOffset = fileOffset;
+    }
+
+    public String toString() {
+      return eventTime + "," + componentID + "," + fileOffset;
+    }
+    public static LogEntry deserialize(String line) {
+      String[] fields = line.split(",", NUM_FIELDS);
+      return new LogEntry(Long.parseLong(fields[0]), fields[1], fields[2]);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof LogEntry)) return false;
+
+      LogEntry logEntry = (LogEntry) o;
+
+      if (eventTime != logEntry.eventTime) return false;
+      if (!componentID.equals(logEntry.componentID)) return false;
+      return fileOffset.equals(logEntry.fileOffset);
+
+    }
+
+    @Override
+    public int hashCode() {
+      int result = (int) (eventTime ^ (eventTime >>> 32));
+      result = 31 * result + componentID.hashCode();
+      result = 31 * result + fileOffset.hashCode();
+      return result;
+    }
+  }
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileOffset.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileOffset.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+/**
+ * Represents the notion of an offset in a file. Idea is accommodate representing file
+ * offsets other than simple byte offset as it may be insufficient for certain formats.
+ * Reader for each format implements this as appropriate for its needs.
+ * Note: Derived types must :
+ *       - implement equals() & hashCode() appropriately.
+ *       - implement Comparable<> appropriately.
+ *       - implement toString() appropriately for serialization.
+ *       - constructor(string) for deserialization
+ */
+
+interface FileOffset extends Comparable<FileOffset>, Cloneable {
+  /** tests if rhs == currOffset+1 */
+  boolean isNextOffset(FileOffset rhs);
+  public FileOffset clone();
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileOffset.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileOffset.java
@@ -32,5 +32,5 @@ package org.apache.storm.hdfs.spout;
 interface FileOffset extends Comparable<FileOffset>, Cloneable {
   /** tests if rhs == currOffset+1 */
   boolean isNextOffset(FileOffset rhs);
-  public FileOffset clone();
+  FileOffset clone();
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileReader.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+import backtype.storm.tuple.Fields;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.List;
+
+interface FileReader {
+  public Path getFilePath();
+
+  /**
+   * A simple numeric value may not be sufficient for certain formats consequently
+   * this is a String.
+   */
+  public FileOffset getFileOffset();
+
+  /**
+   * Get the next tuple from the file
+   *
+   * @return null if no more data
+   * @throws IOException
+   */
+  public List<Object> next() throws IOException, ParseException;
+
+  public Fields getOutputFields();
+
+  public void setFields(String... fieldNames);
+
+  public void close();
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileReader.java
@@ -25,13 +25,13 @@ import java.io.IOException;
 import java.util.List;
 
 interface FileReader {
-  public Path getFilePath();
+  Path getFilePath();
 
   /**
    * A simple numeric value may not be sufficient for certain formats consequently
    * this is a String.
    */
-  public FileOffset getFileOffset();
+  FileOffset getFileOffset();
 
   /**
    * Get the next tuple from the file
@@ -39,11 +39,7 @@ interface FileReader {
    * @return null if no more data
    * @throws IOException
    */
-  public List<Object> next() throws IOException, ParseException;
+  List<Object> next() throws IOException, ParseException;
 
-  public Fields getOutputFields();
-
-  public void setFields(String... fieldNames);
-
-  public void close();
+  void close();
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileReader.java
@@ -18,7 +18,6 @@
 
 package org.apache.storm.hdfs.spout;
 
-import backtype.storm.tuple.Fields;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
@@ -504,7 +504,7 @@ public class HdfsSpout extends BaseRichSpout {
       // 3 - if clocks are not in sync ..
       if( lastExpiredLock == null ) {
         // just make a note of the oldest expired lock now and check if its still unmodified after lockTimeoutSec
-        lastExpiredLock = FileLock.locateOldestExpiredLock(hdfs, lockDirPath, lockTimeoutSec, spoutId);
+        lastExpiredLock = FileLock.locateOldestExpiredLock(hdfs, lockDirPath, lockTimeoutSec);
         lastExpiredLockTime = System.currentTimeMillis();
         return null;
       }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
@@ -1,0 +1,645 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import backtype.storm.Config;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.storm.hdfs.common.HdfsUtils;
+import org.apache.storm.hdfs.common.security.HdfsSecurityUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.topology.base.BaseRichSpout;
+import backtype.storm.tuple.Fields;
+
+public class HdfsSpout extends BaseRichSpout {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HdfsSpout.class);
+
+  private Path sourceDirPath;
+  private Path archiveDirPath;
+  private Path badFilesDirPath;
+  private Path lockDirPath;
+
+  private int commitFrequencyCount = Configs.DEFAULT_COMMIT_FREQ_COUNT;
+  private int commitFrequencySec = Configs.DEFAULT_COMMIT_FREQ_SEC;
+  private int maxDuplicates = Configs.DEFAULT_MAX_DUPLICATES;
+  private int lockTimeoutSec = Configs.DEFAULT_LOCK_TIMEOUT;
+  private boolean clocksInSync = true;
+
+  private ProgressTracker tracker = new ProgressTracker();
+
+  private FileSystem hdfs;
+  private FileReader reader;
+
+  private SpoutOutputCollector collector;
+  HashMap<MessageId, List<Object> > inflight = new HashMap<>();
+  LinkedBlockingQueue<HdfsUtils.Pair<MessageId, List<Object>>> retryList = new LinkedBlockingQueue<>();
+
+  private String inprogress_suffix = ".inprogress";
+
+  private Configuration hdfsConfig;
+  private String readerType;
+
+  private Map conf = null;
+  private FileLock lock;
+  private String spoutId = null;
+
+  HdfsUtils.Pair<Path,FileLock.LogEntry> lastExpiredLock = null;
+  private long lastExpiredLockTime = 0;
+
+  private long tupleCounter = 0;
+  private boolean ackEnabled = false;
+  private int acksSinceLastCommit = 0 ;
+  private final AtomicBoolean commitTimeElapsed = new AtomicBoolean(false);
+  private final Timer commitTimer = new Timer();
+  private boolean fileReadCompletely = false;
+
+  private String configKey = Configs.DEFAULT_HDFS_CONFIG_KEY; // key for hdfs kerberos configs
+
+  public HdfsSpout() {
+  }
+
+  public Path getLockDirPath() {
+    return lockDirPath;
+  }
+
+  public SpoutOutputCollector getCollector() {
+    return collector;
+  }
+
+  public HdfsSpout withConfigKey(String configKey){
+    this.configKey = configKey;
+    return this;
+  }
+
+  public void nextTuple() {
+    LOG.debug("Next Tuple");
+    // 1) First re-emit any previously failed tuples (from retryList)
+    if (!retryList.isEmpty()) {
+      LOG.debug("Sending from retry list");
+      HdfsUtils.Pair<MessageId, List<Object>> pair = retryList.remove();
+      emitData(pair.getValue(), pair.getKey());
+      return;
+    }
+
+    if( ackEnabled  &&  tracker.size()>=maxDuplicates ) {
+      LOG.warn("Waiting for more ACKs before generating new tuples. " +
+               "Progress tracker size has reached limit {}"
+              , maxDuplicates);
+      // Don't emit anything .. allow configured spout wait strategy to kick in
+      return;
+    }
+
+    // 2) If no failed tuples, then send tuples from hdfs
+    while (true) {
+      try {
+        // 3) Select a new file if one is not open already
+        if (reader == null) {
+          reader = pickNextFile();
+          if (reader == null) {
+            LOG.info("Currently no new files to process under : " + sourceDirPath);
+            return;
+          }
+        }
+
+        // 4) Read record from file, emit to collector and record progress
+        List<Object> tuple = reader.next();
+        if (tuple != null) {
+          fileReadCompletely= false;
+          ++tupleCounter;
+          MessageId msgId = new MessageId(tupleCounter, reader.getFilePath(), reader.getFileOffset());
+          emitData(tuple, msgId);
+
+          if(!ackEnabled) {
+            ++acksSinceLastCommit; // assume message is immediately acked in non-ack mode
+            commitProgress(reader.getFileOffset());
+          } else {
+            commitProgress(tracker.getCommitPosition());
+          }
+          return;
+        } else {
+          fileReadCompletely = true;
+          if(!ackEnabled) {
+            markFileAsDone(reader.getFilePath());
+          }
+        }
+      } catch (IOException e) {
+        LOG.error("I/O Error processing at file location " + getFileProgress(reader), e);
+        // don't emit anything .. allow configured spout wait strategy to kick in
+        return;
+      } catch (ParseException e) {
+        LOG.error("Parsing error when processing at file location " + getFileProgress(reader) +
+                ". Skipping remainder of file.", e);
+        markFileAsBad(reader.getFilePath());
+        // note: Unfortunately not emitting anything here due to parse error
+        // will trigger the configured spout wait strategy which is unnecessary
+      }
+    }
+
+  }
+
+  // will commit progress into lock file if commit threshold is reached
+  private void commitProgress(FileOffset position) {
+    if ( lock!=null && canCommitNow() ) {
+      try {
+        lock.heartbeat(position.toString());
+        acksSinceLastCommit = 0;
+        commitTimeElapsed.set(false);
+        setupCommitElapseTimer();
+      } catch (IOException e) {
+        LOG.error("Unable to commit progress Will retry later.", e);
+      }
+    }
+  }
+
+  private void setupCommitElapseTimer() {
+    if(commitFrequencySec<=0)
+      return;
+    TimerTask timerTask = new TimerTask() {
+      @Override
+      public void run() {
+        commitTimeElapsed.set(false);
+      }
+    };
+    commitTimer.schedule(timerTask, commitFrequencySec * 1000);
+  }
+
+
+  private static String getFileProgress(FileReader reader) {
+    return reader.getFilePath() + " " + reader.getFileOffset();
+  }
+
+  private void markFileAsDone(Path filePath) {
+    fileReadCompletely = false;
+    try {
+      renameCompletedFile(reader.getFilePath());
+    } catch (IOException e) {
+      LOG.error("Unable to archive completed file" + filePath, e);
+    }
+    unlockAndCloseReader();
+
+  }
+
+  private void markFileAsBad(Path file) {
+    String fileName = file.toString();
+    String fileNameMinusSuffix = fileName.substring(0, fileName.indexOf(inprogress_suffix));
+    String originalName = new Path(fileNameMinusSuffix).getName();
+    Path  newFile = new Path( badFilesDirPath + Path.SEPARATOR + originalName);
+
+    LOG.info("Moving bad file to " + newFile);
+    try {
+      if (!hdfs.rename(file, newFile) ) { // seems this can fail by returning false or throwing exception
+        throw new IOException("Move failed for bad file: " + file); // convert false ret value to exception
+      }
+    } catch (IOException e) {
+      LOG.warn("Error moving bad file: " + file + ". to destination :  " + newFile);
+    }
+
+    unlockAndCloseReader();
+  }
+
+  private void unlockAndCloseReader() {
+    reader.close();
+    reader = null;
+    try {
+      lock.release();
+    } catch (IOException e) {
+      LOG.error("Unable to delete lock file : " + this.lock.getLockFile(), e);
+    }
+    lock = null;
+  }
+
+
+
+  protected void emitData(List<Object> tuple, MessageId id) {
+    LOG.debug("Emitting - {}", id);
+    this.collector.emit(tuple, id);
+    inflight.put(id, tuple);
+  }
+
+  public void open(Map conf, TopologyContext context,  SpoutOutputCollector collector) {
+    this.conf = conf;
+    final String FILE_SYSTEM = "filesystem";
+    LOG.info("Opening");
+    this.collector = collector;
+    this.hdfsConfig = new Configuration();
+    this.tupleCounter = 0;
+
+    for( Object k : conf.keySet() ) {
+      String key = k.toString();
+      if( ! FILE_SYSTEM.equalsIgnoreCase( key ) ) { // to support unit test only
+        String val = conf.get(key).toString();
+        LOG.info("Config setting : " + key + " = " + val);
+        this.hdfsConfig.set(key, val);
+      }
+      else
+        this.hdfs = (FileSystem) conf.get(key);
+
+      if(key.equalsIgnoreCase(Configs.READER_TYPE)) {
+        readerType = conf.get(key).toString();
+        checkValidReader(readerType);
+      }
+    }
+
+    // - Hdfs configs
+    this.hdfsConfig = new Configuration();
+    Map<String, Object> map = (Map<String, Object>)conf.get(this.configKey);
+    if(map != null){
+      for(String key : map.keySet()){
+        this.hdfsConfig.set(key, String.valueOf(map.get(key)));
+      }
+    }
+
+    try {
+      HdfsSecurityUtil.login(conf, hdfsConfig);
+    } catch (IOException e) {
+      LOG.error("Failed to open " + sourceDirPath);
+      throw new RuntimeException(e);
+    }
+
+    // -- source dir config
+    if ( !conf.containsKey(Configs.SOURCE_DIR) ) {
+      LOG.error(Configs.SOURCE_DIR + " setting is required");
+      throw new RuntimeException(Configs.SOURCE_DIR + " setting is required");
+    }
+    this.sourceDirPath = new Path( conf.get(Configs.SOURCE_DIR).toString() );
+
+    // -- archive dir config
+    if ( !conf.containsKey(Configs.ARCHIVE_DIR) ) {
+      LOG.error(Configs.ARCHIVE_DIR + " setting is required");
+      throw new RuntimeException(Configs.ARCHIVE_DIR + " setting is required");
+    }
+    this.archiveDirPath = new Path( conf.get(Configs.ARCHIVE_DIR).toString() );
+
+    try {
+      if(hdfs.exists(archiveDirPath)) {
+        if(! hdfs.isDirectory(archiveDirPath) ) {
+          LOG.error("Archive directory is a file. " + archiveDirPath);
+          throw new RuntimeException("Archive directory is a file. " + archiveDirPath);
+        }
+      } else if(! hdfs.mkdirs(archiveDirPath) ) {
+        LOG.error("Unable to create archive directory. " + archiveDirPath);
+        throw new RuntimeException("Unable to create archive directory " + archiveDirPath);
+      }
+    } catch (IOException e) {
+      LOG.error("Unable to create archive dir ", e);
+      throw new RuntimeException("Unable to create archive directory ", e);
+    }
+
+    // -- bad files dir config
+    if ( !conf.containsKey(Configs.BAD_DIR) ) {
+      LOG.error(Configs.BAD_DIR + " setting is required");
+      throw new RuntimeException(Configs.BAD_DIR + " setting is required");
+    }
+
+    this.badFilesDirPath = new Path(conf.get(Configs.BAD_DIR).toString());
+
+    try {
+      if(hdfs.exists(badFilesDirPath)) {
+        if(! hdfs.isDirectory(badFilesDirPath) ) {
+          LOG.error("Bad files directory is a file: " + badFilesDirPath);
+          throw new RuntimeException("Bad files directory is a file: " + badFilesDirPath);
+        }
+      } else if(! hdfs.mkdirs(badFilesDirPath) ) {
+        LOG.error("Unable to create directory for bad files: " + badFilesDirPath);
+        throw new RuntimeException("Unable to create a directory for bad files: " + badFilesDirPath);
+      }
+    } catch (IOException e) {
+      LOG.error("Unable to create archive dir ", e);
+      throw new RuntimeException(e.getMessage(), e);
+    }
+
+    // -- lock dir config
+    String lockDir = !conf.containsKey(Configs.LOCK_DIR) ? getDefaultLockDir(sourceDirPath) : conf.get(Configs.LOCK_DIR).toString() ;
+    this.lockDirPath = new Path(lockDir);
+
+    try {
+      if(hdfs.exists(lockDirPath)) {
+        if(! hdfs.isDirectory(lockDirPath) ) {
+          LOG.error("Lock directory is a file: " + lockDirPath);
+          throw new RuntimeException("Lock directory is a file: " + lockDirPath);
+        }
+      } else if(! hdfs.mkdirs(lockDirPath) ) {
+        LOG.error("Unable to create lock directory: " + lockDirPath);
+        throw new RuntimeException("Unable to create lock directory: " + lockDirPath);
+      }
+    } catch (IOException e) {
+      LOG.error("Unable to create lock dir: " + lockDirPath, e);
+      throw new RuntimeException(e.getMessage(), e);
+    }
+
+    // -- lock timeout
+    if( conf.get(Configs.LOCK_TIMEOUT) !=null )
+      this.lockTimeoutSec =  Integer.parseInt(conf.get(Configs.LOCK_TIMEOUT).toString());
+
+    // -- enable/disable ACKing
+    Object ackers = conf.get(Config.TOPOLOGY_ACKER_EXECUTORS);
+    if( ackers!=null )
+      this.ackEnabled = ( Integer.parseInt( ackers.toString() ) > 0 );
+    else
+      this.ackEnabled = false;
+
+    // -- commit frequency - count
+    if( conf.get(Configs.COMMIT_FREQ_COUNT) != null )
+      commitFrequencyCount = Integer.parseInt( conf.get(Configs.COMMIT_FREQ_COUNT).toString() );
+
+    // -- commit frequency - seconds
+    if( conf.get(Configs.COMMIT_FREQ_SEC) != null )
+      commitFrequencySec = Integer.parseInt( conf.get(Configs.COMMIT_FREQ_SEC).toString() );
+
+    // -- max duplicate
+    if( conf.get(Configs.MAX_DUPLICATE) !=null )
+      maxDuplicates = Integer.parseInt( conf.get(Configs.MAX_DUPLICATE).toString() );
+
+    // -- clocks in sync
+    if( conf.get(Configs.CLOCKS_INSYNC) !=null )
+      clocksInSync = Boolean.parseBoolean(conf.get(Configs.CLOCKS_INSYNC).toString());
+
+    // -- spout id
+    spoutId = context.getThisComponentId();
+
+    // setup timer for commit elapse time tracking
+    setupCommitElapseTimer();
+  }
+
+  private String getDefaultLockDir(Path sourceDirPath) {
+    return sourceDirPath.toString() + Path.SEPARATOR + Configs.DEFAULT_LOCK_DIR;
+  }
+
+  private static void checkValidReader(String readerType) {
+    if(readerType.equalsIgnoreCase(Configs.TEXT)  || readerType.equalsIgnoreCase(Configs.SEQ) )
+      return;
+    try {
+      Class<?> classType = Class.forName(readerType);
+      classType.getConstructor(FileSystem.class, Path.class, Map.class);
+      return;
+    } catch (ClassNotFoundException e) {
+      LOG.error(readerType + " not found in classpath.", e);
+      throw new IllegalArgumentException(readerType + " not found in classpath.", e);
+    } catch (NoSuchMethodException e) {
+      LOG.error(readerType + " is missing the expected constructor for Readers.", e);
+      throw new IllegalArgumentException(readerType + " is missing the expected constuctor for Readers.");
+    }
+  }
+
+  @Override
+  public void ack(Object msgId) {
+    MessageId id = (MessageId) msgId;
+    inflight.remove(id);
+    ++acksSinceLastCommit;
+    tracker.recordAckedOffset(id.offset);
+    commitProgress(tracker.getCommitPosition());
+    if(fileReadCompletely) {
+      markFileAsDone(reader.getFilePath());
+      reader = null;
+    }
+    super.ack(msgId);
+  }
+
+  private boolean canCommitNow() {
+    if( acksSinceLastCommit >= commitFrequencyCount )
+      return true;
+    return commitTimeElapsed.get();
+  }
+
+  @Override
+  public void fail(Object msgId) {
+    super.fail(msgId);
+    HdfsUtils.Pair<MessageId, List<Object>> item = HdfsUtils.Pair.of(msgId, inflight.remove(msgId));
+    retryList.add(item);
+  }
+
+  private FileReader pickNextFile()  {
+    try {
+      // 1) If there are any abandoned files, pick oldest one
+      lock = getOldestExpiredLock();
+      if (lock != null) {
+        Path file = getFileForLockFile(lock.getLockFile(), sourceDirPath);
+        String resumeFromOffset = lock.getLastLogEntry().fileOffset;
+        LOG.info("Processing abandoned file : {}", file);
+        return createFileReader(file, resumeFromOffset);
+      }
+
+      // 2) If no abandoned files, then pick oldest file in sourceDirPath, lock it and rename it
+      Collection<Path> listing = HdfsUtils.listFilesByModificationTime(hdfs, sourceDirPath, 0);
+
+      for (Path file : listing) {
+        if( file.getName().contains(inprogress_suffix) )
+          continue;
+        LOG.info("Processing : {} ", file);
+        lock = FileLock.tryLock(hdfs, file, lockDirPath, spoutId);
+        if( lock==null ) {
+          LOG.info("Unable to get lock, so skipping file: {}", file);
+          continue; // could not lock, so try another file.
+        }
+        Path newFile = renameSelectedFile(file);
+        return createFileReader(newFile);
+      }
+
+      return null;
+    } catch (IOException e) {
+      LOG.error("Unable to select next file for consumption " + sourceDirPath, e);
+      return null;
+    }
+  }
+
+  /**
+   * If clocks in sync, then acquires the oldest expired lock
+   * Else, on first call, just remembers the oldest expired lock, on next call check if the lock is updated. if not updated then acquires the lock
+   * @return
+   * @throws IOException
+   */
+  private FileLock getOldestExpiredLock() throws IOException {
+    // 1 - acquire lock on dir
+    DirLock dirlock = DirLock.tryLock(hdfs, lockDirPath);
+    if (dirlock == null)
+      return null;
+    try {
+      // 2 - if clocks are in sync then simply take ownership of the oldest expired lock
+      if (clocksInSync)
+        return FileLock.acquireOldestExpiredLock(hdfs, lockDirPath, lockTimeoutSec, spoutId);
+
+      // 3 - if clocks are not in sync ..
+      if( lastExpiredLock == null ) {
+        // just make a note of the oldest expired lock now and check if its still unmodified after lockTimeoutSec
+        lastExpiredLock = FileLock.locateOldestExpiredLock(hdfs, lockDirPath, lockTimeoutSec, spoutId);
+        lastExpiredLockTime = System.currentTimeMillis();
+        return null;
+      }
+      // see if lockTimeoutSec time has elapsed since we last selected the lock file
+      if( hasExpired(lastExpiredLockTime) )
+        return null;
+
+      // If lock file has expired, then own it
+      FileLock.LogEntry lastEntry = FileLock.getLastEntry(hdfs, lastExpiredLock.getKey());
+      if( lastEntry.equals(lastExpiredLock.getValue()) ) {
+        FileLock result = FileLock.takeOwnership(hdfs, lastExpiredLock.getKey(), lastEntry, spoutId);
+        lastExpiredLock = null;
+        return  result;
+      } else {
+        // if lock file has been updated since last time, then leave this lock file alone
+        lastExpiredLock = null;
+        return null;
+      }
+    } finally {
+      dirlock.release();
+    }
+  }
+
+  private boolean hasExpired(long lastModifyTime) {
+    return (System.currentTimeMillis() - lastModifyTime ) < lockTimeoutSec*1000;
+  }
+
+  /**
+   * Creates a reader that reads from beginning of file
+   * @param file file to read
+   * @return
+   * @throws IOException
+   */
+  private FileReader createFileReader(Path file)
+          throws IOException {
+    if(readerType.equalsIgnoreCase(Configs.SEQ))
+      return new SequenceFileReader(this.hdfs, file, conf);
+    if(readerType.equalsIgnoreCase(Configs.TEXT))
+      return new TextFileReader(this.hdfs, file, conf);
+
+    try {
+      Class<?> clsType = Class.forName(readerType);
+      Constructor<?> constructor = clsType.getConstructor(FileSystem.class, Path.class, Map.class);
+      return (FileReader) constructor.newInstance(this.hdfs, file, conf);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new RuntimeException("Unable to instantiate " + readerType, e);
+    }
+  }
+
+
+  /**
+   * Creates a reader that starts reading from 'offset'
+   * @param file the file to read
+   * @param offset the offset string should be understandable by the reader type being used
+   * @return
+   * @throws IOException
+   */
+  private FileReader createFileReader(Path file, String offset)
+          throws IOException {
+    if(readerType.equalsIgnoreCase(Configs.SEQ))
+      return new SequenceFileReader(this.hdfs, file, conf, offset);
+    if(readerType.equalsIgnoreCase(Configs.TEXT))
+      return new TextFileReader(this.hdfs, file, conf, offset);
+
+    try {
+      Class<?> clsType = Class.forName(readerType);
+      Constructor<?> constructor = clsType.getConstructor(FileSystem.class, Path.class, Map.class, String.class);
+      return (FileReader) constructor.newInstance(this.hdfs, file, conf, offset);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new RuntimeException("Unable to instantiate " + readerType, e);
+    }
+  }
+
+  // returns new path of renamed file
+  private Path renameSelectedFile(Path file)
+          throws IOException {
+    Path newFile =  new Path( file.toString() + inprogress_suffix );
+    if( ! hdfs.rename(file, newFile) ) {
+      throw new IOException("Rename failed for file: " + file);
+    }
+    return newFile;
+  }
+
+  /** Returns the corresponding input file in the 'sourceDirPath' for the specified lock file.
+   *  If no such file is found then returns null
+   */
+  private Path getFileForLockFile(Path lockFile, Path sourceDirPath)
+          throws IOException {
+    String lockFileName = lockFile.getName();
+    Path dataFile = new Path(sourceDirPath + lockFileName + inprogress_suffix);
+    if( hdfs.exists(dataFile) )
+      return dataFile;
+    dataFile = new Path(sourceDirPath + lockFileName);
+    if(hdfs.exists(dataFile))
+      return dataFile;
+    return null;
+  }
+
+
+  private Path renameCompletedFile(Path file) throws IOException {
+    String fileName = file.toString();
+    String fileNameMinusSuffix = fileName.substring(0, fileName.indexOf(inprogress_suffix));
+    String newName = new Path(fileNameMinusSuffix).getName();
+
+    Path  newFile = new Path( archiveDirPath + Path.SEPARATOR + newName );
+    LOG.debug("Renaming complete file to " + newFile);
+    LOG.info("Completed file " + fileNameMinusSuffix );
+    if (!hdfs.rename(file, newFile) ) {
+      throw new IOException("Rename failed for file: " + file);
+    }
+    return newFile;
+  }
+
+  public void declareOutputFields(OutputFieldsDeclarer declarer) {
+    Fields fields = reader.getOutputFields();
+    declarer.declare(fields);
+  }
+
+  static class MessageId implements  Comparable<MessageId> {
+    public long msgNumber; // tracks order in which msg came in
+    public String fullPath;
+    public FileOffset offset;
+
+    public MessageId(long msgNumber, Path fullPath, FileOffset offset) {
+      this.msgNumber = msgNumber;
+      this.fullPath = fullPath.toString();
+      this.offset = offset;
+    }
+
+    @Override
+    public String toString() {
+      return "{'" +  fullPath + "':" + offset + "}";
+    }
+
+    @Override
+    public int compareTo(MessageId rhs) {
+      if (msgNumber<rhs.msgNumber)
+        return -1;
+      if(msgNumber>rhs.msgNumber)
+        return 1;
+      return 0;
+    }
+  }
+
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
@@ -130,10 +130,11 @@ public class HdfsSpout extends BaseRichSpout {
         // 3) Select a new file if one is not open already
         if (reader == null) {
           reader = pickNextFile();
-          fileReadCompletely=false;
           if (reader == null) {
             LOG.debug("Currently no new files to process under : " + sourceDirPath);
             return;
+          } else {
+            fileReadCompletely=false;
           }
         }
         if( fileReadCompletely ) { // wait for more ACKs before proceeding

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/ParseException.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/ParseException.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+public class ParseException extends Exception {
+  public ParseException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/ProgressTracker.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/ProgressTracker.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+import java.io.PrintStream;
+import java.util.TreeSet;
+
+public class ProgressTracker {
+
+  TreeSet<FileOffset> offsets = new TreeSet<>();
+
+  public void recordAckedOffset(FileOffset newOffset) {
+    if(newOffset==null)
+      return;
+    offsets.add(newOffset);
+
+    FileOffset currHead = offsets.first();
+
+    if( currHead.isNextOffset(newOffset) ) { // check is a minor optimization
+      trimHead();
+    }
+  }
+
+  // remove contiguous elements from the head of the heap
+  // e.g.:  1,2,3,4,10,11,12,15  =>  4,10,11,12,15
+  private void trimHead() {
+    if(offsets.size()<=1)
+      return;
+    FileOffset head = offsets.first();
+    FileOffset head2 = offsets.higher(head);
+    if( head.isNextOffset(head2) ) {
+      offsets.pollFirst();
+      trimHead();
+    }
+    return;
+  }
+
+  public FileOffset getCommitPosition() {
+    if(!offsets.isEmpty())
+      return offsets.first().clone();
+    return null;
+  }
+
+  public void dumpState(PrintStream stream) {
+    stream.println(offsets);
+  }
+
+  public int size() {
+    return offsets.size();
+  }
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/ProgressTracker.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/ProgressTracker.java
@@ -25,7 +25,7 @@ public class ProgressTracker {
 
   TreeSet<FileOffset> offsets = new TreeSet<>();
 
-  public void recordAckedOffset(FileOffset newOffset) {
+  public synchronized void recordAckedOffset(FileOffset newOffset) {
     if(newOffset==null) {
       return;
     }
@@ -40,7 +40,7 @@ public class ProgressTracker {
 
   // remove contiguous elements from the head of the heap
   // e.g.:  1,2,3,4,10,11,12,15  =>  4,10,11,12,15
-  private void trimHead() {
+  private synchronized void trimHead() {
     if(offsets.size()<=1) {
       return;
     }
@@ -53,18 +53,18 @@ public class ProgressTracker {
     return;
   }
 
-  public FileOffset getCommitPosition() {
+  public synchronized FileOffset getCommitPosition() {
     if(!offsets.isEmpty()) {
       return offsets.first().clone();
     }
     return null;
   }
 
-  public void dumpState(PrintStream stream) {
+  public synchronized void dumpState(PrintStream stream) {
     stream.println(offsets);
   }
 
-  public int size() {
+  public synchronized int size() {
     return offsets.size();
   }
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/ProgressTracker.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/ProgressTracker.java
@@ -26,8 +26,9 @@ public class ProgressTracker {
   TreeSet<FileOffset> offsets = new TreeSet<>();
 
   public void recordAckedOffset(FileOffset newOffset) {
-    if(newOffset==null)
+    if(newOffset==null) {
       return;
+    }
     offsets.add(newOffset);
 
     FileOffset currHead = offsets.first();
@@ -40,8 +41,9 @@ public class ProgressTracker {
   // remove contiguous elements from the head of the heap
   // e.g.:  1,2,3,4,10,11,12,15  =>  4,10,11,12,15
   private void trimHead() {
-    if(offsets.size()<=1)
+    if(offsets.size()<=1) {
       return;
+    }
     FileOffset head = offsets.first();
     FileOffset head2 = offsets.higher(head);
     if( head.isNextOffset(head2) ) {
@@ -52,8 +54,9 @@ public class ProgressTracker {
   }
 
   public FileOffset getCommitPosition() {
-    if(!offsets.isEmpty())
+    if(!offsets.isEmpty()) {
       return offsets.first().clone();
+    }
     return null;
   }
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
@@ -1,0 +1,227 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+import backtype.storm.tuple.Fields;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+// Todo: Track file offsets instead of line number
+public class SequenceFileReader<Key extends Writable,Value extends Writable>
+        extends AbstractFileReader {
+  private static final Logger LOG = LoggerFactory
+          .getLogger(SequenceFileReader.class);
+  private static final int DEFAULT_BUFF_SIZE = 4096;
+  public static final String BUFFER_SIZE = "hdfsspout.reader.buffer.bytes";
+
+  private final SequenceFile.Reader reader;
+
+  private final SequenceFileReader.Offset offset;
+
+  private static final String DEFAULT_KEYNAME = "key";
+  private static final String DEFAULT_VALNAME = "value";
+
+  private String keyName;
+  private String valueName;
+
+
+  private final Key key;
+  private final Value value;
+
+
+  public SequenceFileReader(FileSystem fs, Path file, Map conf)
+          throws IOException {
+    super(fs, file, new Fields(DEFAULT_KEYNAME, DEFAULT_VALNAME));
+    this.keyName = DEFAULT_KEYNAME;
+    this.valueName = DEFAULT_VALNAME;
+    int bufferSize = !conf.containsKey(BUFFER_SIZE) ? DEFAULT_BUFF_SIZE : Integer.parseInt( conf.get(BUFFER_SIZE).toString() );
+    this.reader = new SequenceFile.Reader(fs.getConf(),  SequenceFile.Reader.file(file), SequenceFile.Reader.bufferSize(bufferSize) );
+    this.key = (Key) ReflectionUtils.newInstance(reader.getKeyClass(), fs.getConf() );
+    this.value = (Value) ReflectionUtils.newInstance(reader.getValueClass(), fs.getConf() );
+    this.offset = new SequenceFileReader.Offset(0,0,0);
+  }
+
+  public SequenceFileReader(FileSystem fs, Path file, Map conf, String offset)
+          throws IOException {
+    super(fs, file, new Fields(DEFAULT_KEYNAME, DEFAULT_VALNAME));
+    this.keyName = DEFAULT_KEYNAME;
+    this.valueName = DEFAULT_VALNAME;
+    int bufferSize = !conf.containsKey(BUFFER_SIZE) ? DEFAULT_BUFF_SIZE : Integer.parseInt( conf.get(BUFFER_SIZE).toString() );
+    this.offset = new SequenceFileReader.Offset(offset);
+    this.reader = new SequenceFile.Reader(fs.getConf(),  SequenceFile.Reader.file(file), SequenceFile.Reader.bufferSize(bufferSize) );
+    this.reader.sync(this.offset.lastSyncPoint);
+    this.key = (Key) ReflectionUtils.newInstance(reader.getKeyClass(), fs.getConf() );
+    this.value = (Value) ReflectionUtils.newInstance(reader.getValueClass(), fs.getConf() );
+  }
+
+  public String getKeyName() {
+    return keyName;
+  }
+
+  public void setKeyName(String name) {
+    if (name == null)
+      throw new IllegalArgumentException("keyName cannot be null");
+    this.keyName = name;
+    setFields(keyName, valueName);
+
+  }
+
+  public String getValueName() {
+    return valueName;
+  }
+
+  public void setValueName(String name) {
+    if (name == null)
+      throw new IllegalArgumentException("valueName cannot be null");
+    this.valueName = name;
+    setFields(keyName, valueName);
+  }
+
+  public List<Object> next() throws IOException, ParseException {
+    if( reader.next(key, value) ) {
+      ArrayList<Object> result = new ArrayList<Object>(2);
+      Collections.addAll(result, key, value);
+      offset.increment(reader.syncSeen(), reader.getPosition() );
+      return result;
+    }
+    return null;
+  }
+
+  @Override
+  public void close() {
+    try {
+      reader.close();
+    } catch (IOException e) {
+      LOG.warn("Ignoring error when closing file " + getFilePath(), e);
+    }
+  }
+
+  public Offset getFileOffset() {
+      return offset;
+  }
+
+
+  public static class Offset implements  FileOffset {
+    private long lastSyncPoint;
+    private long recordsSinceLastSync;
+    private long currentRecord;
+    private long currRecordEndOffset;
+    private long prevRecordEndOffset;
+
+    public Offset(long lastSyncPoint, long recordsSinceLastSync, long currentRecord) {
+      this(lastSyncPoint, recordsSinceLastSync, currentRecord, 0, 0 );
+    }
+
+    public Offset(long lastSyncPoint, long recordsSinceLastSync, long currentRecord
+                  , long currRecordEndOffset, long prevRecordEndOffset) {
+      this.lastSyncPoint = lastSyncPoint;
+      this.recordsSinceLastSync = recordsSinceLastSync;
+      this.currentRecord = currentRecord;
+      this.prevRecordEndOffset = prevRecordEndOffset;
+      this.currRecordEndOffset = currRecordEndOffset;
+    }
+
+    public Offset(String offset) {
+      try {
+        String[] parts = offset.split(",");
+        this.lastSyncPoint = Long.parseLong(parts[0].split("=")[1]);
+        this.recordsSinceLastSync = Long.parseLong(parts[1].split("=")[1]);
+        this.currentRecord = Long.parseLong(parts[2].split("=")[1]);
+        this.prevRecordEndOffset = 0;
+        this.currRecordEndOffset = 0;
+      } catch (Exception e) {
+        throw new IllegalArgumentException("'" + offset +
+                "' cannot be interpreted. It is not in expected format for SequenceFileReader." +
+                " Format e.g. {sync=123:afterSync=345:record=67}");
+      }
+    }
+
+    @Override
+    public String toString() {
+      return '{' +
+              "sync=" + lastSyncPoint +
+              ":afterSync=" + recordsSinceLastSync +
+              ":record=" + currentRecord +
+              '}';
+    }
+
+    @Override
+    public boolean isNextOffset(FileOffset rhs) {
+      if(rhs instanceof Offset) {
+        Offset other = ((Offset) rhs);
+        return  other.currentRecord > currentRecord+1;
+      }
+      return false;
+    }
+
+    @Override
+    public int compareTo(FileOffset o) {
+      Offset rhs = ((Offset) o);
+      if(currentRecord<rhs.currentRecord)
+        return -1;
+      if(currentRecord==rhs.currentRecord)
+        return 0;
+      return 1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Offset)) return false;
+
+      Offset offset = (Offset) o;
+
+      return currentRecord == offset.currentRecord;
+    }
+
+    @Override
+    public int hashCode() {
+      return (int) (currentRecord ^ (currentRecord >>> 32));
+    }
+    
+    void increment(boolean syncSeen, long newBytePosition) {
+      if(!syncSeen) {
+        ++recordsSinceLastSync;
+      }  else {
+        recordsSinceLastSync = 1;
+        lastSyncPoint = prevRecordEndOffset;
+      }
+      ++currentRecord;
+      prevRecordEndOffset = currRecordEndOffset;
+      currentRecord = newBytePosition;
+    }
+
+    @Override
+    public Offset clone() {
+      return new Offset(lastSyncPoint, recordsSinceLastSync, currentRecord, currRecordEndOffset, prevRecordEndOffset);
+    }
+
+  } //class Offset
+} //class

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
@@ -18,7 +18,6 @@
 
 package org.apache.storm.hdfs.spout;
 
-import backtype.storm.tuple.Fields;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile;
@@ -35,7 +34,7 @@ import java.util.Map;
 
 public class SequenceFileReader<Key extends Writable,Value extends Writable>
         extends AbstractFileReader {
-  private static final Logger log = LoggerFactory
+  private static final Logger LOG = LoggerFactory
           .getLogger(SequenceFileReader.class);
   public static final String[] defaultFields = {"key", "value"};
   private static final int DEFAULT_BUFF_SIZE = 4096;
@@ -93,7 +92,7 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
     try {
       reader.close();
     } catch (IOException e) {
-      log.warn("Ignoring error when closing file " + getFilePath(), e);
+      LOG.warn("Ignoring error when closing file " + getFilePath(), e);
     }
   }
 
@@ -124,8 +123,9 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
 
     public Offset(String offset) {
       try {
-        if(offset==null)
+        if(offset==null) {
           throw new IllegalArgumentException("offset cannot be null");
+        }
         if(offset.equalsIgnoreCase("0")) {
           this.lastSyncPoint = 0;
           this.recordsSinceLastSync = 0;
@@ -168,17 +168,19 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
     @Override
     public int compareTo(FileOffset o) {
       Offset rhs = ((Offset) o);
-      if(currentRecord<rhs.currentRecord)
+      if(currentRecord<rhs.currentRecord) {
         return -1;
-      if(currentRecord==rhs.currentRecord)
+      }
+      if(currentRecord==rhs.currentRecord) {
         return 0;
+      }
       return 1;
     }
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof Offset)) return false;
+      if (this == o) { return true; }
+      if (!(o instanceof Offset)) { return false; }
 
       Offset offset = (Offset) o;
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
@@ -150,6 +150,8 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
 
     public Offset(String offset) {
       try {
+        if(offset==null)
+          throw new IllegalArgumentException("offset cannot be null");
         String[] parts = offset.split(",");
         this.lastSyncPoint = Long.parseLong(parts[0].split("=")[1]);
         this.recordsSinceLastSync = Long.parseLong(parts[1].split("=")[1]);
@@ -169,7 +171,7 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
               "sync=" + lastSyncPoint +
               ":afterSync=" + recordsSinceLastSync +
               ":record=" + currentRecord +
-              '}';
+              ":}";
     }
 
     @Override

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
@@ -37,6 +37,7 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
         extends AbstractFileReader {
   private static final Logger log = LoggerFactory
           .getLogger(SequenceFileReader.class);
+  public static final String[] defaultFields = {"key", "value"};
   private static final int DEFAULT_BUFF_SIZE = 4096;
   public static final String BUFFER_SIZE = "hdfsspout.reader.buffer.bytes";
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
@@ -33,10 +33,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-// Todo: Track file offsets instead of line number
 public class SequenceFileReader<Key extends Writable,Value extends Writable>
         extends AbstractFileReader {
-  private static final Logger LOG = LoggerFactory
+  private static final Logger log = LoggerFactory
           .getLogger(SequenceFileReader.class);
   private static final int DEFAULT_BUFF_SIZE = 4096;
   public static final String BUFFER_SIZE = "hdfsspout.reader.buffer.bytes";
@@ -45,12 +44,6 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
 
   private final SequenceFileReader.Offset offset;
 
-  private static final String DEFAULT_KEYNAME = "key";
-  private static final String DEFAULT_VALNAME = "value";
-
-  private String keyName;
-  private String valueName;
-
 
   private final Key key;
   private final Value value;
@@ -58,9 +51,7 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
 
   public SequenceFileReader(FileSystem fs, Path file, Map conf)
           throws IOException {
-    super(fs, file, new Fields(DEFAULT_KEYNAME, DEFAULT_VALNAME));
-    this.keyName = DEFAULT_KEYNAME;
-    this.valueName = DEFAULT_VALNAME;
+    super(fs, file);
     int bufferSize = !conf.containsKey(BUFFER_SIZE) ? DEFAULT_BUFF_SIZE : Integer.parseInt( conf.get(BUFFER_SIZE).toString() );
     this.reader = new SequenceFile.Reader(fs.getConf(),  SequenceFile.Reader.file(file), SequenceFile.Reader.bufferSize(bufferSize) );
     this.key = (Key) ReflectionUtils.newInstance(reader.getKeyClass(), fs.getConf() );
@@ -70,9 +61,7 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
 
   public SequenceFileReader(FileSystem fs, Path file, Map conf, String offset)
           throws IOException {
-    super(fs, file, new Fields(DEFAULT_KEYNAME, DEFAULT_VALNAME));
-    this.keyName = DEFAULT_KEYNAME;
-    this.valueName = DEFAULT_VALNAME;
+    super(fs, file);
     int bufferSize = !conf.containsKey(BUFFER_SIZE) ? DEFAULT_BUFF_SIZE : Integer.parseInt( conf.get(BUFFER_SIZE).toString() );
     this.offset = new SequenceFileReader.Offset(offset);
     this.reader = new SequenceFile.Reader(fs.getConf(),  SequenceFile.Reader.file(file), SequenceFile.Reader.bufferSize(bufferSize) );
@@ -86,29 +75,6 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
     for(int i=0; i<offset.recordsSinceLastSync; ++i) {
       reader.next(key);
     }
-  }
-
-  public String getKeyName() {
-    return keyName;
-  }
-
-  public void setKeyName(String name) {
-    if (name == null)
-      throw new IllegalArgumentException("keyName cannot be null");
-    this.keyName = name;
-    setFields(keyName, valueName);
-
-  }
-
-  public String getValueName() {
-    return valueName;
-  }
-
-  public void setValueName(String name) {
-    if (name == null)
-      throw new IllegalArgumentException("valueName cannot be null");
-    this.valueName = name;
-    setFields(keyName, valueName);
   }
 
   public List<Object> next() throws IOException, ParseException {
@@ -126,7 +92,7 @@ public class SequenceFileReader<Key extends Writable,Value extends Writable>
     try {
       reader.close();
     } catch (IOException e) {
-      LOG.warn("Ignoring error when closing file " + getFilePath(), e);
+      log.warn("Ignoring error when closing file " + getFilePath(), e);
     }
   }
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+import backtype.storm.tuple.Fields;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+// Todo: Track file offsets instead of line number
+class TextFileReader extends AbstractFileReader {
+  public static final String CHARSET = "hdfsspout.reader.charset";
+  public static final String BUFFER_SIZE = "hdfsspout.reader.buffer.bytes";
+
+  public static final String DEFAULT_FIELD_NAME = "line";
+
+  private static final int DEFAULT_BUFF_SIZE = 4096;
+
+  private BufferedReader reader;
+  private final Logger LOG = LoggerFactory.getLogger(TextFileReader.class);
+  private TextFileReader.Offset offset;
+
+  public TextFileReader(FileSystem fs, Path file, Map conf) throws IOException {
+    super(fs, file, new Fields(DEFAULT_FIELD_NAME));
+    FSDataInputStream in = fs.open(file);
+    String charSet = (conf==null || !conf.containsKey(CHARSET) ) ? "UTF-8" : conf.get(CHARSET).toString();
+    int buffSz = (conf==null || !conf.containsKey(BUFFER_SIZE) ) ? DEFAULT_BUFF_SIZE : Integer.parseInt( conf.get(BUFFER_SIZE).toString() );
+    reader = new BufferedReader(new InputStreamReader(in, charSet), buffSz);
+    offset = new TextFileReader.Offset(0,0);
+  }
+
+  public TextFileReader(FileSystem fs, Path file, Map conf, String startOffset) throws IOException {
+    super(fs, file, new Fields(DEFAULT_FIELD_NAME));
+    offset = new TextFileReader.Offset(startOffset);
+    FSDataInputStream in = fs.open(file);
+    in.seek(offset.byteOffset);
+    String charSet = (conf==null || !conf.containsKey(CHARSET) ) ? "UTF-8" : conf.get(CHARSET).toString();
+    int buffSz = (conf==null || !conf.containsKey(BUFFER_SIZE) ) ? DEFAULT_BUFF_SIZE : Integer.parseInt( conf.get(BUFFER_SIZE).toString() );
+    reader = new BufferedReader(new InputStreamReader(in, charSet), buffSz);
+  }
+
+  public Offset getFileOffset() {
+    return offset.clone();
+  }
+
+  public List<Object> next() throws IOException, ParseException {
+    String line =  reader.readLine();
+    if(line!=null) {
+      int strByteSize = line.getBytes().length;
+      offset.increment(strByteSize);
+      return Collections.singletonList((Object) line);
+    }
+    return null;
+  }
+
+  @Override
+  public void close() {
+    try {
+      reader.close();
+    } catch (IOException e) {
+      LOG.warn("Ignoring error when closing file " + getFilePath(), e);
+    }
+  }
+
+  public static class Offset implements FileOffset {
+    long byteOffset;
+    long lineNumber;
+
+    public Offset(long byteOffset, long lineNumber) {
+      this.byteOffset = byteOffset;
+      this.lineNumber = lineNumber;
+    }
+
+    public Offset(String offset) {
+      try {
+        String[] parts = offset.split(":");
+        this.byteOffset = Long.parseLong(parts[0].split("=")[1]);
+        this.lineNumber = Long.parseLong(parts[1].split("=")[1]);
+      } catch (Exception e) {
+        throw new IllegalArgumentException("'" + offset +
+                "' cannot be interpreted. It is not in expected format for TextFileReader." +
+                " Format e.g.  {byte=123:line=5}");
+      }
+    }
+
+    @Override
+    public String toString() {
+      return '{' +
+              "byte=" + byteOffset +
+              ":line=" + lineNumber +
+              '}';
+    }
+
+    @Override
+    public boolean isNextOffset(FileOffset rhs) {
+      if(rhs instanceof Offset) {
+        Offset other = ((Offset) rhs);
+        return  other.byteOffset > byteOffset    &&
+                other.lineNumber == lineNumber+1;
+      }
+      return false;
+    }
+
+    @Override
+    public int compareTo(FileOffset o) {
+      Offset rhs = ((Offset)o);
+      if(lineNumber < rhs.lineNumber)
+        return -1;
+      if(lineNumber == rhs.lineNumber)
+        return 0;
+      return 1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Offset)) return false;
+
+      Offset that = (Offset) o;
+
+      if (byteOffset != that.byteOffset)
+        return false;
+      return lineNumber == that.lineNumber;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = (int) (byteOffset ^ (byteOffset >>> 32));
+      result = 31 * result + (int) (lineNumber ^ (lineNumber >>> 32));
+      return result;
+    }
+
+    void increment(int delta) {
+      ++lineNumber;
+      byteOffset += delta;
+    }
+
+    @Override
+    public Offset clone() {
+      return new Offset(byteOffset, lineNumber);
+    }
+  } //class Offset
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
@@ -18,7 +18,6 @@
 
 package org.apache.storm.hdfs.spout;
 
-import backtype.storm.tuple.Fields;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -41,7 +40,7 @@ class TextFileReader extends AbstractFileReader {
   private static final int DEFAULT_BUFF_SIZE = 4096;
 
   private BufferedReader reader;
-  private final Logger log = LoggerFactory.getLogger(TextFileReader.class);
+  private final Logger LOG = LoggerFactory.getLogger(TextFileReader.class);
   private TextFileReader.Offset offset;
 
   public TextFileReader(FileSystem fs, Path file, Map conf) throws IOException {
@@ -61,8 +60,9 @@ class TextFileReader extends AbstractFileReader {
     String charSet = (conf==null || !conf.containsKey(CHARSET) ) ? "UTF-8" : conf.get(CHARSET).toString();
     int buffSz = (conf==null || !conf.containsKey(BUFFER_SIZE) ) ? DEFAULT_BUFF_SIZE : Integer.parseInt( conf.get(BUFFER_SIZE).toString() );
     reader = new BufferedReader(new InputStreamReader(in, charSet), buffSz);
-    if(offset.charOffset >0)
+    if(offset.charOffset >0) {
       reader.skip(offset.charOffset);
+    }
 
   }
 
@@ -91,8 +91,9 @@ class TextFileReader extends AbstractFileReader {
         sb.append((char)ch);
       }
     }
-    if(before==offset.charOffset) // reached EOF, didnt read anything
+    if(before==offset.charOffset) { // reached EOF, didnt read anything
       return null;
+    }
     return sb.toString();
   }
 
@@ -101,7 +102,7 @@ class TextFileReader extends AbstractFileReader {
     try {
       reader.close();
     } catch (IOException e) {
-      log.warn("Ignoring error when closing file " + getFilePath(), e);
+      LOG.warn("Ignoring error when closing file " + getFilePath(), e);
     }
   }
 
@@ -115,8 +116,9 @@ class TextFileReader extends AbstractFileReader {
     }
 
     public Offset(String offset) {
-      if(offset==null)
+      if(offset==null) {
         throw new IllegalArgumentException("offset cannot be null");
+      }
       try {
         if(offset.equalsIgnoreCase("0")) {
           this.charOffset = 0;
@@ -154,17 +156,19 @@ class TextFileReader extends AbstractFileReader {
     @Override
     public int compareTo(FileOffset o) {
       Offset rhs = ((Offset)o);
-      if(lineNumber < rhs.lineNumber)
+      if(lineNumber < rhs.lineNumber) {
         return -1;
-      if(lineNumber == rhs.lineNumber)
+      }
+      if(lineNumber == rhs.lineNumber) {
         return 0;
+      }
       return 1;
     }
 
     @Override
     public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof Offset)) return false;
+      if (this == o) { return true; }
+      if (!(o instanceof Offset)) { return false; }
 
       Offset that = (Offset) o;
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
@@ -37,12 +37,10 @@ class TextFileReader extends AbstractFileReader {
   public static final String CHARSET = "hdfsspout.reader.charset";
   public static final String BUFFER_SIZE = "hdfsspout.reader.buffer.bytes";
 
-  public static final String DEFAULT_FIELD_NAME = "line";
-
   private static final int DEFAULT_BUFF_SIZE = 4096;
 
   private BufferedReader reader;
-  private final Logger LOG = LoggerFactory.getLogger(TextFileReader.class);
+  private final Logger log = LoggerFactory.getLogger(TextFileReader.class);
   private TextFileReader.Offset offset;
 
   public TextFileReader(FileSystem fs, Path file, Map conf) throws IOException {
@@ -55,7 +53,7 @@ class TextFileReader extends AbstractFileReader {
 
   private TextFileReader(FileSystem fs, Path file, Map conf, TextFileReader.Offset startOffset)
           throws IOException {
-    super(fs, file, new Fields(DEFAULT_FIELD_NAME));
+    super(fs, file);
     offset = startOffset;
     FSDataInputStream in = fs.open(file);
 
@@ -102,7 +100,7 @@ class TextFileReader extends AbstractFileReader {
     try {
       reader.close();
     } catch (IOException e) {
-      LOG.warn("Ignoring error when closing file " + getFilePath(), e);
+      log.warn("Ignoring error when closing file " + getFilePath(), e);
     }
   }
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 // Todo: Track file offsets instead of line number
 class TextFileReader extends AbstractFileReader {
+  public static final String[] defaultFields = {"line"};
   public static final String CHARSET = "hdfsspout.reader.charset";
   public static final String BUFFER_SIZE = "hdfsspout.reader.buffer.bytes";
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
@@ -119,9 +119,14 @@ class TextFileReader extends AbstractFileReader {
       if(offset==null)
         throw new IllegalArgumentException("offset cannot be null");
       try {
-        String[] parts = offset.split(":");
-        this.charOffset = Long.parseLong(parts[0].split("=")[1]);
-        this.lineNumber = Long.parseLong(parts[1].split("=")[1]);
+        if(offset.equalsIgnoreCase("0")) {
+          this.charOffset = 0;
+          this.lineNumber = 0;
+        } else {
+          String[] parts = offset.split(":");
+          this.charOffset = Long.parseLong(parts[0].split("=")[1]);
+          this.lineNumber = Long.parseLong(parts[1].split("=")[1]);
+        }
       } catch (Exception e) {
         throw new IllegalArgumentException("'" + offset +
                 "' cannot be interpreted. It is not in expected format for TextFileReader." +

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
@@ -76,7 +76,7 @@ public class TestDirLock {
     fs.delete(lockDir, true);
   }
 
-  @Test
+//  @Test
   public void testConcurrentLocking() throws Exception {
 //    -Dlog4j.configuration=config
     Logger.getRootLogger().setLevel(Level.ERROR);

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+public class TestDirLock {
+
+
+  static MiniDFSCluster.Builder builder;
+  static MiniDFSCluster hdfsCluster;
+  static FileSystem fs;
+  static String hdfsURI;
+  static Configuration conf = new  HdfsConfiguration();
+
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+  private Path lockDir = new Path("/tmp/lockdir");
+
+
+  @BeforeClass
+  public static void setupClass() throws IOException {
+    builder = new MiniDFSCluster.Builder(new Configuration());
+    hdfsCluster = builder.build();
+    fs  = hdfsCluster.getFileSystem();
+    hdfsURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/";
+  }
+
+  @AfterClass
+  public static void teardownClass() throws IOException {
+    fs.close();
+    hdfsCluster.shutdown();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    assert fs.mkdirs(lockDir) ;
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    fs.delete(lockDir, true);
+  }
+
+  @Test
+  public void testConcurrentLocking() throws Exception {
+//    -Dlog4j.configuration=config
+    Logger.getRootLogger().setLevel(Level.ERROR);
+    DirLockingThread[] thds = startThreads(10, lockDir );
+    for (DirLockingThread thd : thds) {
+      thd.start();
+    }
+    System.err.println("Thread creation complete");
+    Thread.sleep(5000);
+    for (DirLockingThread thd : thds) {
+      thd.join(1000);
+      if(thd.isAlive() && thd.cleanExit)
+        System.err.println(thd.getName() + " did not exit cleanly");
+      Assert.assertTrue(thd.cleanExit);
+    }
+
+    Path lockFile = new Path(lockDir + Path.SEPARATOR + DirLock.DIR_LOCK_FILE);
+    Assert.assertFalse(fs.exists(lockFile));
+  }
+
+
+
+  private DirLockingThread[] startThreads(int thdCount, Path dir)
+          throws IOException {
+    DirLockingThread[] result = new DirLockingThread[thdCount];
+    for (int i = 0; i < thdCount; i++) {
+      result[i] = new DirLockingThread(i, fs, dir);
+    }
+    return result;
+  }
+
+
+  class DirLockingThread extends Thread {
+
+    private final FileSystem fs;
+    private final Path dir;
+    public boolean cleanExit = false;
+
+    public DirLockingThread(int thdNum,FileSystem fs, Path dir) throws IOException {
+      this.fs = fs;
+      this.dir = dir;
+      Thread.currentThread().setName("DirLockingThread-" + thdNum);
+    }
+
+    @Override
+    public void run() {
+      try {
+        DirLock lock;
+        do {
+          lock = DirLock.tryLock(fs, dir);
+          if(lock==null) {
+            System.out.println("Retrying lock - " + Thread.currentThread().getId());
+          }
+        } while (lock==null);
+        lock.release();
+        cleanExit= true;
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+
+    }
+
+  }
+}

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
@@ -127,18 +127,21 @@ public class TestDirLock {
 
   class DirLockingThread extends Thread {
 
+    private int thdNum;
     private final FileSystem fs;
     private final Path dir;
     public boolean cleanExit = false;
 
-    public DirLockingThread(int thdNum,FileSystem fs, Path dir) throws IOException {
+    public DirLockingThread(int thdNum,FileSystem fs, Path dir)
+            throws IOException {
+      this.thdNum = thdNum;
       this.fs = fs;
       this.dir = dir;
-      Thread.currentThread().setName("DirLockingThread-" + thdNum);
     }
 
     @Override
     public void run() {
+      Thread.currentThread().setName("DirLockingThread-" + thdNum);
       DirLock lock = null;
       try {
         do {
@@ -146,7 +149,7 @@ public class TestDirLock {
           lock = DirLock.tryLock(fs, dir);
           System.err.println("Acquired lock " + getName());
           if(lock==null) {
-            System.out.println("Retrying lock - " + Thread.currentThread().getId());
+            System.out.println("Retrying lock - " + getName());
           }
         } while (lock==null);
         cleanExit= true;
@@ -164,7 +167,7 @@ public class TestDirLock {
           }
       }
       System.err.println("Thread exiting " + getName());
-    }
+    } // run()
 
-  }
+  } // class DirLockingThread
 }

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
@@ -40,18 +40,13 @@ import java.io.IOException;
 
 public class TestDirLock {
 
-
   static MiniDFSCluster.Builder builder;
   static MiniDFSCluster hdfsCluster;
   static FileSystem fs;
   static String hdfsURI;
   static HdfsConfiguration conf = new  HdfsConfiguration();
 
-
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
   private Path lockDir = new Path("/tmp/lockdir");
-
 
   @BeforeClass
   public static void setupClass() throws IOException {

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestDirLock.java
@@ -98,8 +98,9 @@ public class TestDirLock {
     DirLockingThread[] thds = startThreads(100, locksDir);
     for (DirLockingThread thd : thds) {
       thd.join();
-      if( !thd.cleanExit)
+      if( !thd.cleanExit ) {
         System.err.println(thd.getName() + " did not exit cleanly");
+      }
       Assert.assertTrue(thd.cleanExit);
     }
 

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestFileLock.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestFileLock.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.spout;
+
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class TestFileLock {
+
+  static MiniDFSCluster.Builder builder;
+  static MiniDFSCluster hdfsCluster;
+  static FileSystem fs;
+  static String hdfsURI;
+  static HdfsConfiguration conf = new  HdfsConfiguration();
+
+  private Path filesDir = new Path("/tmp/lockdir");
+  private Path locksDir = new Path("/tmp/lockdir");
+
+  @BeforeClass
+  public static void setupClass() throws IOException {
+    conf.set(CommonConfigurationKeys.IPC_PING_INTERVAL_KEY,"5000");
+    builder = new MiniDFSCluster.Builder(new Configuration());
+    hdfsCluster = builder.build();
+    fs  = hdfsCluster.getFileSystem();
+    hdfsURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/";
+  }
+
+  @AfterClass
+  public static void teardownClass() throws IOException {
+    fs.close();
+    hdfsCluster.shutdown();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    assert fs.mkdirs(filesDir) ;
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    fs.delete(filesDir, true);
+  }
+
+  @Test
+  public void testBasic() throws Exception {
+  // create empty files in filesDir
+    Path file1 = new Path(filesDir + Path.SEPARATOR + "file1");
+    Path file2 = new Path(filesDir + Path.SEPARATOR + "file2");
+    fs.create(file1).close();
+    fs.create(file2).close(); // create empty file
+
+    // acquire lock on file1 and verify if worked
+    FileLock lock1a = FileLock.tryLock(fs, file1, locksDir, "spout1");
+    Assert.assertNotNull(lock1a);
+    Assert.assertTrue(fs.exists(lock1a.getLockFile()));
+    Assert.assertEquals(lock1a.getLockFile().getParent(), locksDir); // verify lock file location
+    Assert.assertEquals(lock1a.getLockFile().getName(), file1.getName()); // very lock filename
+
+    // acquire another lock on file1 and verify it failed
+    FileLock lock1b = FileLock.tryLock(fs, file1, locksDir, "spout1");
+    Assert.assertNull(lock1b);
+
+    // release lock on file1 and check
+    lock1a.release();
+    Assert.assertFalse(fs.exists(lock1a.getLockFile()));
+
+    // Retry locking and verify
+    FileLock lock1c = FileLock.tryLock(fs, file1, locksDir, "spout1");
+    Assert.assertNotNull(lock1c);
+    Assert.assertTrue(fs.exists(lock1c.getLockFile()));
+    Assert.assertEquals(lock1c.getLockFile().getParent(), locksDir); // verify lock file location
+    Assert.assertEquals(lock1c.getLockFile().getName(), file1.getName()); // very lock filename
+
+    // try locking another file2 at the same time
+    FileLock lock2a = FileLock.tryLock(fs, file2, locksDir, "spout1");
+    Assert.assertNotNull(lock2a);
+    Assert.assertTrue(fs.exists(lock2a.getLockFile()));
+    Assert.assertEquals(lock2a.getLockFile().getParent(), locksDir); // verify lock file location
+    Assert.assertEquals(lock2a.getLockFile().getName(), file1.getName()); // very lock filename
+
+    // release both locks
+    lock2a.release();
+    Assert.assertFalse(fs.exists(lock2a.getLockFile()));
+    lock1c.release();
+    Assert.assertFalse(fs.exists(lock1c.getLockFile()));
+  }
+
+
+}

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestFileLock.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestFileLock.java
@@ -20,10 +20,12 @@ package org.apache.storm.hdfs.spout;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.storm.hdfs.common.HdfsUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -31,7 +33,11 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
 
 public class TestFileLock {
 
@@ -41,8 +47,8 @@ public class TestFileLock {
   static String hdfsURI;
   static HdfsConfiguration conf = new  HdfsConfiguration();
 
-  private Path filesDir = new Path("/tmp/lockdir");
-  private Path locksDir = new Path("/tmp/lockdir");
+  private Path filesDir = new Path("/tmp/filesdir");
+  private Path locksDir = new Path("/tmp/locskdir");
 
   @BeforeClass
   public static void setupClass() throws IOException {
@@ -70,7 +76,7 @@ public class TestFileLock {
   }
 
   @Test
-  public void testBasic() throws Exception {
+  public void testBasicLocking() throws Exception {
   // create empty files in filesDir
     Path file1 = new Path(filesDir + Path.SEPARATOR + "file1");
     Path file2 = new Path(filesDir + Path.SEPARATOR + "file2");
@@ -82,7 +88,7 @@ public class TestFileLock {
     Assert.assertNotNull(lock1a);
     Assert.assertTrue(fs.exists(lock1a.getLockFile()));
     Assert.assertEquals(lock1a.getLockFile().getParent(), locksDir); // verify lock file location
-    Assert.assertEquals(lock1a.getLockFile().getName(), file1.getName()); // very lock filename
+    Assert.assertEquals(lock1a.getLockFile().getName(), file1.getName()); // verify lock filename
 
     // acquire another lock on file1 and verify it failed
     FileLock lock1b = FileLock.tryLock(fs, file1, locksDir, "spout1");
@@ -97,14 +103,14 @@ public class TestFileLock {
     Assert.assertNotNull(lock1c);
     Assert.assertTrue(fs.exists(lock1c.getLockFile()));
     Assert.assertEquals(lock1c.getLockFile().getParent(), locksDir); // verify lock file location
-    Assert.assertEquals(lock1c.getLockFile().getName(), file1.getName()); // very lock filename
+    Assert.assertEquals(lock1c.getLockFile().getName(), file1.getName()); // verify lock filename
 
     // try locking another file2 at the same time
     FileLock lock2a = FileLock.tryLock(fs, file2, locksDir, "spout1");
     Assert.assertNotNull(lock2a);
     Assert.assertTrue(fs.exists(lock2a.getLockFile()));
     Assert.assertEquals(lock2a.getLockFile().getParent(), locksDir); // verify lock file location
-    Assert.assertEquals(lock2a.getLockFile().getName(), file1.getName()); // very lock filename
+    Assert.assertEquals(lock2a.getLockFile().getName(), file2.getName()); // verify lock filename
 
     // release both locks
     lock2a.release();
@@ -113,5 +119,260 @@ public class TestFileLock {
     Assert.assertFalse(fs.exists(lock1c.getLockFile()));
   }
 
+  @Test
+  public void testHeartbeat() throws Exception {
+    Path file1 = new Path(filesDir + Path.SEPARATOR + "file1");
+    fs.create(file1).close();
 
+    // acquire lock on file1
+    FileLock lock1 = FileLock.tryLock(fs, file1, locksDir, "spout1");
+    Assert.assertNotNull(lock1);
+    Assert.assertTrue(fs.exists(lock1.getLockFile()));
+
+    ArrayList<String> lines = readTextFile(lock1.getLockFile());
+    Assert.assertEquals("heartbeats appear to be missing", 1, lines.size());
+
+    // hearbeat upon it
+    lock1.heartbeat("1");
+    lock1.heartbeat("2");
+    lock1.heartbeat("3");
+
+    lines = readTextFile(lock1.getLockFile());
+    Assert.assertEquals("heartbeats appear to be missing", 4, lines.size());
+
+    lock1.heartbeat("4");
+    lock1.heartbeat("5");
+    lock1.heartbeat("6");
+
+    lines = readTextFile(lock1.getLockFile());
+    Assert.assertEquals("heartbeats appear to be missing", 7,  lines.size());
+
+    lock1.release();
+    lines = readTextFile(lock1.getLockFile());
+    Assert.assertNull(lines);
+    Assert.assertFalse(fs.exists(lock1.getLockFile()));
+  }
+
+  @Test
+  public void testConcurrentLocking() throws IOException, InterruptedException {
+    Path file1 = new Path(filesDir + Path.SEPARATOR + "file1");
+    fs.create(file1).close();
+
+    FileLockingThread[] thds = startThreads(100, file1, locksDir);
+    for (FileLockingThread thd : thds) {
+      thd.join();
+      if( !thd.cleanExit)
+        System.err.println(thd.getName() + " did not exit cleanly");
+      Assert.assertTrue(thd.cleanExit);
+    }
+
+    Path lockFile = new Path(locksDir + Path.SEPARATOR + file1.getName());
+    Assert.assertFalse(fs.exists(lockFile));
+  }
+
+  private FileLockingThread[] startThreads(int thdCount, Path fileToLock, Path locksDir)
+          throws IOException {
+    FileLockingThread[] result = new FileLockingThread[thdCount];
+    for (int i = 0; i < thdCount; i++) {
+      result[i] = new FileLockingThread(i, fs, fileToLock, locksDir, "spout" + Integer.toString(i));
+    }
+
+    for (FileLockingThread thd : result) {
+      thd.start();
+    }
+    return result;
+  }
+
+
+  @Test
+  public void testStaleLockDetection_SingleLock() throws Exception {
+    final int LOCK_EXPIRY_SEC = 1;
+    final int WAIT_MSEC = 1500;
+    Path file1 = new Path(filesDir + Path.SEPARATOR + "file1");
+    fs.create(file1).close();
+    FileLock lock1 = FileLock.tryLock(fs, file1, locksDir, "spout1");
+    try {
+      // acquire lock on file1
+      Assert.assertNotNull(lock1);
+      Assert.assertTrue(fs.exists(lock1.getLockFile()));
+      Thread.sleep(WAIT_MSEC);   // wait for lock to expire
+      HdfsUtils.Pair<Path, FileLock.LogEntry> expired = FileLock.locateOldestExpiredLock(fs, locksDir, LOCK_EXPIRY_SEC);
+      Assert.assertNotNull(expired);
+
+      // heartbeat, ensure its no longer stale and read back the heartbeat data
+      lock1.heartbeat("1");
+      expired = FileLock.locateOldestExpiredLock(fs, locksDir, 1);
+      Assert.assertNull(expired);
+
+      FileLock.LogEntry lastEntry = lock1.getLastLogEntry();
+      Assert.assertNotNull(lastEntry);
+      Assert.assertEquals("1", lastEntry.fileOffset);
+
+      // wait and check for expiry again
+      Thread.sleep(WAIT_MSEC);
+      expired = FileLock.locateOldestExpiredLock(fs, locksDir, LOCK_EXPIRY_SEC);
+      Assert.assertNotNull(expired);
+    } finally {
+      lock1.release();
+      fs.delete(file1, false);
+    }
+  }
+
+  @Test
+  public void testStaleLockDetection_MultipleLocks() throws Exception {
+    final int LOCK_EXPIRY_SEC = 1;
+    final int WAIT_MSEC = 1500;
+    Path file1 = new Path(filesDir + Path.SEPARATOR + "file1");
+    Path file2 = new Path(filesDir + Path.SEPARATOR + "file2");
+    Path file3 = new Path(filesDir + Path.SEPARATOR + "file3");
+
+    fs.create(file1).close();
+    fs.create(file2).close();
+    fs.create(file3).close();
+
+    // 1) acquire locks on file1,file2,file3
+    FileLock lock1 = FileLock.tryLock(fs, file1, locksDir, "spout1");
+    FileLock lock2 = FileLock.tryLock(fs, file2, locksDir, "spout2");
+    FileLock lock3 = FileLock.tryLock(fs, file3, locksDir, "spout3");
+    Assert.assertNotNull(lock1);
+    Assert.assertNotNull(lock2);
+    Assert.assertNotNull(lock3);
+
+    try {
+      HdfsUtils.Pair<Path, FileLock.LogEntry> expired = FileLock.locateOldestExpiredLock(fs, locksDir, LOCK_EXPIRY_SEC);
+      Assert.assertNull(expired);
+
+      // 2) wait for all 3 locks to expire then heart beat on 2 locks and verify stale lock
+      Thread.sleep(WAIT_MSEC);
+      lock1.heartbeat("1");
+      lock2.heartbeat("1");
+
+      expired = FileLock.locateOldestExpiredLock(fs, locksDir, LOCK_EXPIRY_SEC);
+      Assert.assertNotNull(expired);
+      Assert.assertEquals("spout3", expired.getValue().componentID);
+    } finally {
+      lock1.release();
+      lock2.release();
+      lock3.release();
+      fs.delete(file1, false);
+      fs.delete(file2, false);
+      fs.delete(file3, false);
+    }
+  }
+
+  @Test
+  public void testStaleLockRecovery() throws Exception {
+    final int LOCK_EXPIRY_SEC = 1;
+    final int WAIT_MSEC = 1500;
+    Path file1 = new Path(filesDir + Path.SEPARATOR + "file1");
+    Path file2 = new Path(filesDir + Path.SEPARATOR + "file2");
+    Path file3 = new Path(filesDir + Path.SEPARATOR + "file3");
+
+    fs.create(file1).close();
+    fs.create(file2).close();
+    fs.create(file3).close();
+
+    // 1) acquire locks on file1,file2,file3
+    FileLock lock1 = FileLock.tryLock(fs, file1, locksDir, "spout1");
+    FileLock lock2 = FileLock.tryLock(fs, file2, locksDir, "spout2");
+    FileLock lock3 = FileLock.tryLock(fs, file3, locksDir, "spout3");
+    Assert.assertNotNull(lock1);
+    Assert.assertNotNull(lock2);
+    Assert.assertNotNull(lock3);
+
+    try {
+      HdfsUtils.Pair<Path, FileLock.LogEntry> expired = FileLock.locateOldestExpiredLock(fs, locksDir, LOCK_EXPIRY_SEC);
+      Assert.assertNull(expired);
+
+      // 2) wait for all 3 locks to expire then heart beat on 2 locks
+      Thread.sleep(WAIT_MSEC);
+      lock1.heartbeat("1");
+      lock2.heartbeat("1");
+
+      //todo: configure the HDFS lease timeout
+
+      // 3) Take ownership of stale lock
+      FileLock lock3b = FileLock.acquireOldestExpiredLock(fs, locksDir, LOCK_EXPIRY_SEC, "spout1");
+//      Assert.assertNotNull(lock3b);
+//      Assert.assertEquals("Expected lock3 file", lock3b.getLockFile(), lock3.getLockFile());
+    }finally {
+      lock1.release();
+      lock2.release();
+      lock3.release();
+      fs.delete(file1, false);
+      fs.delete(file2, false);
+      fs.delete(file3, false);
+    }
+  }
+
+  /** return null if file not found */
+  private ArrayList<String> readTextFile(Path file) throws IOException {
+    FSDataInputStream os = null;
+    try {
+      os = fs.open(file);
+      if (os == null)
+        return null;
+      BufferedReader reader = new BufferedReader(new InputStreamReader(os));
+      ArrayList<String> lines = new ArrayList<>();
+      for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+        lines.add(line);
+      }
+      return lines;
+    } catch( FileNotFoundException e) {
+      return null;
+    } finally {
+      if(os!=null)
+        os.close();
+    }
+  }
+
+  class FileLockingThread extends Thread {
+
+    private int thdNum;
+    private final FileSystem fs;
+    public boolean cleanExit = false;
+    private Path fileToLock;
+    private Path locksDir;
+    private String spoutId;
+
+    public FileLockingThread(int thdNum, FileSystem fs, Path fileToLock, Path locksDir, String spoutId)
+            throws IOException {
+      this.thdNum = thdNum;
+      this.fs = fs;
+      this.fileToLock = fileToLock;
+      this.locksDir = locksDir;
+      this.spoutId = spoutId;
+    }
+
+    @Override
+    public void run() {
+      Thread.currentThread().setName("FileLockingThread-" + thdNum);
+      FileLock lock = null;
+      try {
+        do {
+          System.err.println("Trying lock - " + getName());
+          lock = FileLock.tryLock(fs, this.fileToLock, this.locksDir, spoutId);
+          System.err.println("Acquired lock - " + getName());
+          if(lock==null) {
+            System.out.println("Retrying lock - " + getName());
+          }
+        } while (lock==null);
+        cleanExit= true;
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      finally {
+        try {
+          if(lock!=null) {
+            lock.release();
+            System.err.println("Released lock - " + getName());
+          }
+        } catch (IOException e) {
+          e.printStackTrace(System.err);
+        }
+      }
+      System.err.println("Thread exiting - " + getName());
+    } // run()
+
+  } // class FileLockingThread
 }

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestFileLock.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestFileLock.java
@@ -165,8 +165,9 @@ public class TestFileLock {
     FileLockingThread[] thds = startThreads(100, file1, locksDir);
     for (FileLockingThread thd : thds) {
       thd.join();
-      if( !thd.cleanExit)
+      if( !thd.cleanExit) {
         System.err.println(thd.getName() + " did not exit cleanly");
+      }
       Assert.assertTrue(thd.cleanExit);
     }
 
@@ -325,8 +326,9 @@ public class TestFileLock {
     FSDataInputStream os = null;
     try {
       os = fs.open(file);
-      if (os == null)
+      if (os == null) {
         return null;
+      }
       BufferedReader reader = new BufferedReader(new InputStreamReader(os));
       ArrayList<String> lines = new ArrayList<>();
       for (String line = reader.readLine(); line != null; line = reader.readLine()) {
@@ -336,8 +338,9 @@ public class TestFileLock {
     } catch( FileNotFoundException e) {
       return null;
     } finally {
-      if(os!=null)
+      if(os!=null) {
         os.close();
+      }
     }
   }
 

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestFileLock.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestFileLock.java
@@ -314,7 +314,7 @@ public class TestFileLock {
     }
   }
 
-  private void closeUnderlyingLockFile(FileLock lock) throws ReflectiveOperationException {
+  public static void closeUnderlyingLockFile(FileLock lock) throws ReflectiveOperationException {
     Method m = FileLock.class.getDeclaredMethod("forceCloseLockFile");
     m.setAccessible(true);
     m.invoke(lock);

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSemantics.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSemantics.java
@@ -1,0 +1,204 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hdfs.protocol.AlreadyBeingCreatedException;
+import org.apache.hadoop.ipc.RemoteException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class TestHdfsSemantics {
+
+  static MiniDFSCluster.Builder builder;
+  static MiniDFSCluster hdfsCluster;
+  static FileSystem fs;
+  static String hdfsURI;
+  static HdfsConfiguration conf = new  HdfsConfiguration();
+
+  private Path dir = new Path("/tmp/filesdir");
+
+  @BeforeClass
+  public static void setupClass() throws IOException {
+    conf.set(CommonConfigurationKeys.IPC_PING_INTERVAL_KEY,"5000");
+    builder = new MiniDFSCluster.Builder(new Configuration());
+    hdfsCluster = builder.build();
+    fs  = hdfsCluster.getFileSystem();
+    hdfsURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/";
+  }
+
+  @AfterClass
+  public static void teardownClass() throws IOException {
+    fs.close();
+    hdfsCluster.shutdown();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    assert fs.mkdirs(dir) ;
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    fs.delete(dir, true);
+  }
+
+
+  @Test
+  public void testDeleteSemantics() throws Exception {
+    Path file = new Path(dir.toString() + Path.SEPARATOR_CHAR + "file1");
+//    try {
+    // 1) Delete absent file - should return false
+    Assert.assertFalse(fs.exists(file));
+    try {
+      Assert.assertFalse(fs.delete(file, false));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    // 2) deleting open file - should return true
+    fs.create(file, false);
+    Assert.assertTrue(fs.delete(file, false));
+
+    // 3) deleting closed file  - should return true
+    FSDataOutputStream os = fs.create(file, false);
+    os.close();
+    Assert.assertTrue(fs.exists(file));
+    Assert.assertTrue(fs.delete(file, false));
+    Assert.assertFalse(fs.exists(file));
+  }
+
+  @Test
+  public void testConcurrentDeletion() throws Exception {
+    Path file = new Path(dir.toString() + Path.SEPARATOR_CHAR + "file1");
+    fs.create(file).close();
+    // 1 concurrent deletion - only one thread should succeed
+    FileDeletionThread[] thds = startThreads(10, file);
+    int successCount=0;
+    for (FileDeletionThread thd : thds) {
+      thd.join();
+      if( thd.succeeded)
+        successCount++;
+      if(thd.exception!=null)
+        Assert.assertNotNull(thd.exception);
+    }
+    System.err.println(successCount);
+    Assert.assertEquals(1, successCount);
+
+  }
+
+  @Test
+  public void testAppendSemantics() throws Exception {
+    //1 try to append to an open file
+    Path file1 = new Path(dir.toString() + Path.SEPARATOR_CHAR + "file1");
+    FSDataOutputStream os1 = fs.create(file1, false);
+    try {
+      fs.append(file1); // should fail
+      Assert.assertTrue("Append did not throw an exception", false);
+    } catch (RemoteException e) {
+      // expecting AlreadyBeingCreatedException inside RemoteException
+      Assert.assertEquals(AlreadyBeingCreatedException.class, e.unwrapRemoteException().getClass());
+    }
+
+    //2 try to append to a closed file
+    os1.close();
+    FSDataOutputStream os2 = fs.append(file1); // should pass
+    os2.close();
+  }
+
+  @Test
+  public void testDoubleCreateSemantics() throws Exception {
+    //1 create an already existing open file w/o override flag
+    Path file1 = new Path(dir.toString() + Path.SEPARATOR_CHAR + "file1");
+    FSDataOutputStream os1 = fs.create(file1, false);
+    try {
+      fs.create(file1, false); // should fail
+      Assert.assertTrue("Create did not throw an exception", false);
+    } catch (RemoteException e) {
+      Assert.assertEquals(AlreadyBeingCreatedException.class, e.unwrapRemoteException().getClass());
+    }
+    //2 close file and retry creation
+    os1.close();
+    try {
+      fs.create(file1, false);  // should still fail
+    } catch (FileAlreadyExistsException e) {
+      // expecting this exception
+    }
+
+    //3 delete file and retry creation
+    fs.delete(file1, false);
+    FSDataOutputStream os2 = fs.create(file1, false);  // should pass
+    Assert.assertNotNull(os2);
+    os2.close();
+  }
+
+
+  private FileDeletionThread[] startThreads(int thdCount, Path file)
+          throws IOException {
+    FileDeletionThread[] result = new FileDeletionThread[thdCount];
+    for (int i = 0; i < thdCount; i++) {
+      result[i] = new FileDeletionThread(i, fs, file);
+    }
+
+    for (FileDeletionThread thd : result) {
+      thd.start();
+    }
+    return result;
+  }
+
+  private static class FileDeletionThread extends Thread {
+
+    private final int thdNum;
+    private final FileSystem fs;
+    private final Path file;
+    public boolean succeeded;
+    public Exception exception = null;
+
+    public FileDeletionThread(int thdNum, FileSystem fs, Path file)
+            throws IOException {
+      this.thdNum = thdNum;
+      this.fs = fs;
+      this.file = file;
+    }
+
+    @Override
+    public void run() {
+      Thread.currentThread().setName("FileDeletionThread-" + thdNum);
+      try {
+        succeeded = fs.delete(file, false);
+      } catch (Exception e) {
+        exception = e;
+      }
+    } // run()
+
+  } // class FileLockingThread
+}

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -175,17 +175,17 @@ public class TestHdfsSpout {
     ArrayList<String> result = new ArrayList<>();
 
     for (Path seqFile : seqFiles) {
-      FSDataInputStream istream = fs.open(seqFile);
+      Path file = new Path(fs.getUri().toString() + seqFile.toString());
+      SequenceFile.Reader reader = new SequenceFile.Reader(conf, SequenceFile.Reader.file(file));
       try {
-        SequenceFile.Reader reader = new SequenceFile.Reader(conf, SequenceFile.Reader.file(seqFile));
         Writable key = (Writable) ReflectionUtils.newInstance(reader.getKeyClass(), conf);
         Writable value = (Writable) ReflectionUtils.newInstance(reader.getValueClass(), conf);
-        while (reader.next(key, value) ) {
-          String keyValStr = Arrays.asList(key,value).toString();
+        while (reader.next(key, value)) {
+          String keyValStr = Arrays.asList(key, value).toString();
           result.add(keyValStr);
         }
       } finally {
-        istream.close();
+        reader.close();
       }
     }// for
     return result;
@@ -235,7 +235,7 @@ public class TestHdfsSpout {
       System.err.println(re);
     }
 
-    listDir(source);
+    listDir(archive);
 
 
     Path f1 = new Path(archive + "/file1.seq");

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -1,0 +1,465 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.spout;
+
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.storm.hdfs.common.HdfsUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.storm.hdfs.common.HdfsUtils.Pair;
+
+
+public class TestHdfsSpout {
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+  public File baseFolder;
+  private Path source;
+  private Path archive;
+  private Path badfiles;
+
+
+  public TestHdfsSpout() {
+  }
+
+  static MiniDFSCluster.Builder builder;
+  static MiniDFSCluster hdfsCluster;
+  static FileSystem fs;
+  static String hdfsURI;
+  static Configuration conf = new Configuration();
+
+  @BeforeClass
+  public static void setupClass() throws IOException {
+    builder = new MiniDFSCluster.Builder(new Configuration());
+    hdfsCluster = builder.build();
+    fs  = hdfsCluster.getFileSystem();
+    hdfsURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/";
+  }
+
+  @AfterClass
+  public static void teardownClass() throws IOException {
+    fs.close();
+    hdfsCluster.shutdown();
+  }
+
+
+  @Before
+  public void setup() throws Exception {
+    baseFolder = tempFolder.newFolder("hdfsspout");
+    source = new Path(baseFolder.toString() + "/source");
+    fs.mkdirs(source);
+    archive = new Path(baseFolder.toString() + "/archive");
+    fs.mkdirs(archive);
+    badfiles = new Path(baseFolder.toString() + "/bad");
+    fs.mkdirs(badfiles);
+
+  }
+
+  @After
+  public void shutDown() throws IOException {
+    fs.delete(new Path(baseFolder.toString()),true);
+  }
+
+  @Test
+  public void testSimpleText() throws IOException {
+    Path file1 = new Path(source.toString() + "/file1.txt");
+    createTextFile(file1, 5);
+
+    Path file2 = new Path(source.toString() + "/file2.txt");
+    createTextFile(file2, 5);
+
+    listDir(source);
+
+    Map conf = getDefaultConfig();
+    conf.put(Configs.COMMIT_FREQ_COUNT, "1");
+    conf.put(Configs.COMMIT_FREQ_SEC, "1");
+    HdfsSpout spout = makeSpout(0, conf, Configs.TEXT);
+
+    List<String> res = runSpout(spout,"r11", "a0", "a1", "a2", "a3", "a4");
+    for (String re : res) {
+      System.err.println(re);
+    }
+
+    listCompletedDir();
+    Path arc1 = new Path(archive.toString() + "/file1.txt");
+    Path arc2 = new Path(archive.toString() + "/file2.txt");
+    checkCollectorOutput_txt((MockCollector) spout.getCollector(), arc1, arc2);
+  }
+
+
+  private void checkCollectorOutput_txt(MockCollector collector, Path... txtFiles) throws IOException {
+    ArrayList<String> expected = new ArrayList<>();
+    for (Path txtFile : txtFiles) {
+      List<String> lines= getTextFileContents(fs, txtFile);
+      expected.addAll(lines);
+    }
+
+    List<String> actual = new ArrayList<>();
+    for (Pair<HdfsSpout.MessageId, List<Object>> item : collector.items) {
+      actual.add(item.getValue().get(0).toString());
+    }
+    Assert.assertEquals(expected, actual);
+  }
+
+  private List<String> getTextFileContents(FileSystem fs, Path txtFile) throws IOException {
+    ArrayList<String> result = new ArrayList<>();
+    FSDataInputStream istream = fs.open(txtFile);
+    InputStreamReader isreader = new InputStreamReader(istream,"UTF-8");
+    BufferedReader reader = new BufferedReader(isreader);
+
+    for( String line = reader.readLine(); line!=null; line = reader.readLine() ) {
+      result.add(line);
+    }
+    isreader.close();
+    return result;
+  }
+
+  private void checkCollectorOutput_seq(MockCollector collector, Path... seqFiles) throws IOException {
+    ArrayList<String> expected = new ArrayList<>();
+    for (Path seqFile : seqFiles) {
+      List<String> lines= getSeqFileContents(fs, seqFile);
+      expected.addAll(lines);
+    }
+    Assert.assertTrue(expected.equals(collector.lines));
+  }
+
+  private List<String> getSeqFileContents(FileSystem fs, Path... seqFiles) throws IOException {
+    ArrayList<String> result = new ArrayList<>();
+
+    for (Path seqFile : seqFiles) {
+      FSDataInputStream istream = fs.open(seqFile);
+      try {
+        SequenceFile.Reader reader = new SequenceFile.Reader(conf, SequenceFile.Reader.file(seqFile));
+        Writable key = (Writable) ReflectionUtils.newInstance(reader.getKeyClass(), conf);
+        Writable value = (Writable) ReflectionUtils.newInstance(reader.getValueClass(), conf);
+        while (reader.next(key, value) ) {
+          String keyValStr = Arrays.asList(key,value).toString();
+          result.add(keyValStr);
+        }
+      } finally {
+        istream.close();
+      }
+    }// for
+    return result;
+  }
+
+  private void listCompletedDir() throws IOException {
+    listDir(source);
+    listDir(archive);
+  }
+
+  private List<String> listBadDir() throws IOException {
+    return listDir(badfiles);
+  }
+
+  private List<String> listDir(Path p) throws IOException {
+    ArrayList<String> result = new ArrayList<>();
+    System.err.println("*** Listing " + p);
+    RemoteIterator<LocatedFileStatus> fileNames =  fs.listFiles(p, false);
+    while ( fileNames.hasNext() ) {
+      LocatedFileStatus fileStatus = fileNames.next();
+      System.err.println(fileStatus.getPath());
+      result.add(fileStatus.getPath().toString());
+    }
+    return result;
+  }
+
+
+  @Test
+  public void testSimpleSequenceFile() throws IOException {
+
+    source = new Path("/tmp/hdfsspout/source");
+    fs.mkdirs(source);
+    archive = new Path("/tmp/hdfsspout/archive");
+    fs.mkdirs(archive);
+
+    Path file1 = new Path(source + "/file1.seq");
+    createSeqFile(fs, file1);
+
+    Path file2 = new Path(source + "/file2.seq");
+    createSeqFile(fs, file2);
+
+    Map conf = getDefaultConfig();
+    HdfsSpout spout = makeSpout(0, conf, Configs.SEQ);
+
+    List<String> res = runSpout(spout, "r11", "a0", "a1", "a2", "a3", "a4");
+    for (String re : res) {
+      System.err.println(re);
+    }
+
+    listDir(source);
+
+
+    Path f1 = new Path(archive + "/file1.seq");
+    Path f2 = new Path(archive + "/file2.seq");
+
+    checkCollectorOutput_seq((MockCollector) spout.getCollector(), f1, f2);
+  }
+
+// - TODO: this test needs the spout to fail with an exception
+  @Test
+  public void testFailure() throws Exception {
+
+    Path file1 = new Path(source.toString() + "/file1.txt");
+    createTextFile(file1, 5);
+
+    listDir(source);
+
+    Map conf = getDefaultConfig();
+//    conf.put(HdfsSpout.Configs.BACKOFF_SEC, "2");
+    HdfsSpout spout = makeSpout(0, conf, MockTextFailingReader.class.getName());
+    List<String> res = runSpout(spout, "r3");
+    for (String re : res) {
+      System.err.println(re);
+    }
+
+    listCompletedDir();
+    List<String> badFiles = listBadDir();
+    Assert.assertEquals( badFiles.size(), 1);
+    Assert.assertEquals(((MockCollector) spout.getCollector()).lines.size(), 1);
+  }
+
+  // @Test
+  public void testLocking() throws Exception {
+    Path file1 = new Path(source.toString() + "/file1.txt");
+    createTextFile(file1, 5);
+
+    listDir(source);
+
+    Map conf = getDefaultConfig();
+    conf.put(Configs.COMMIT_FREQ_COUNT, "1");
+    conf.put(Configs.COMMIT_FREQ_SEC, "1");
+    HdfsSpout spout = makeSpout(0, conf, Configs.TEXT);
+    List<String> res = runSpout(spout,"r4");
+    for (String re : res) {
+      System.err.println(re);
+    }
+    List<String> lockFiles = listDir(spout.getLockDirPath());
+    Assert.assertEquals(1, lockFiles.size());
+    runSpout(spout, "r3");
+    List<String> lines = readTextFile(fs, lockFiles.get(0));
+    System.err.println(lines);
+    Assert.assertEquals(6, lines.size());
+  }
+
+  private static List<String> readTextFile(FileSystem fs, String f) throws IOException {
+    Path file = new Path(f);
+    FSDataInputStream x = fs.open(file);
+    BufferedReader reader = new BufferedReader(new InputStreamReader(x));
+    String line = null;
+    ArrayList<String> result = new ArrayList<>();
+    while( (line = reader.readLine()) !=null )
+      result.add( line );
+    return result;
+  }
+
+  private Map getDefaultConfig() {
+    Map conf = new HashMap();
+    conf.put(Configs.SOURCE_DIR, source.toString());
+    conf.put(Configs.ARCHIVE_DIR, archive.toString());
+    conf.put(Configs.BAD_DIR, badfiles.toString());
+    conf.put("filesystem", fs);
+    return conf;
+  }
+
+
+  private static HdfsSpout makeSpout(int spoutId, Map conf, String readerType) {
+    HdfsSpout spout = new HdfsSpout();
+    MockCollector collector = new MockCollector();
+    conf.put(Configs.READER_TYPE, readerType);
+    spout.open(conf, new MockTopologyContext(spoutId), collector);
+    return spout;
+  }
+
+  /**
+   * Execute a sequence of calls to EventHubSpout.
+   *
+   * @param cmds: set of commands to run,
+   * e.g. "r,r,r,r,a1,f2,...". The commands are:
+   * r[N] -  receive() called N times
+   * aN - ack, item number: N
+   * fN - fail, item number: N
+   */
+
+  private List<String> runSpout(HdfsSpout spout,  String...  cmds) {
+    MockCollector collector = (MockCollector) spout.getCollector();
+      for(String cmd : cmds) {
+        if(cmd.startsWith("r")) {
+          int count = 1;
+          if(cmd.length() > 1) {
+            count = Integer.parseInt(cmd.substring(1));
+          }
+          for(int i=0; i<count; ++i) {
+            spout.nextTuple();
+          }
+        }
+        else if(cmd.startsWith("a")) {
+          int n = Integer.parseInt(cmd.substring(1));
+          Pair<HdfsSpout.MessageId, List<Object>> item = collector.items.get(n);
+          spout.ack(item.getKey());
+        }
+        else if(cmd.startsWith("f")) {
+          int n = Integer.parseInt(cmd.substring(1));
+          Pair<HdfsSpout.MessageId, List<Object>> item = collector.items.get(n);
+          spout.fail(item.getKey());
+        }
+      }
+      return collector.lines;
+    }
+
+  private void createTextFile(Path file, int lineCount) throws IOException {
+    FSDataOutputStream os = fs.create(file);
+    for (int i = 0; i < lineCount; i++) {
+      os.writeBytes("line " + i + System.lineSeparator());
+    }
+    os.close();
+  }
+
+
+
+  private static void createSeqFile(FileSystem fs, Path file) throws IOException {
+
+    Configuration conf = new Configuration();
+    try {
+      if(fs.exists(file)) {
+        fs.delete(file, false);
+      }
+
+      SequenceFile.Writer w = SequenceFile.createWriter(fs, conf, file, IntWritable.class, Text.class );
+      for (int i = 0; i < 5; i++) {
+        w.append(new IntWritable(i), new Text("line " + i));
+      }
+      w.close();
+      System.out.println("done");
+    } catch (IOException e) {
+      e.printStackTrace();
+
+    }
+  }
+
+
+
+  static class MockCollector extends SpoutOutputCollector {
+    //comma separated offsets
+    public ArrayList<String> lines;
+    public ArrayList<Pair<HdfsSpout.MessageId, List<Object> > > items;
+
+    public MockCollector() {
+      super(null);
+      lines = new ArrayList<>();
+      items = new ArrayList<>();
+    }
+
+
+
+    @Override
+    public List<Integer> emit(String streamId, List<Object> tuple, Object messageId) {
+//      HdfsSpout.MessageId id = (HdfsSpout.MessageId) messageId;
+//      lines.add(id.toString() + ' ' + tuple.toString());
+      lines.add(tuple.toString());
+      items.add(HdfsUtils.Pair.of(messageId, tuple));
+      return null;
+    }
+
+    @Override
+    public void emitDirect(int arg0, String arg1, List<Object> arg2, Object arg3) {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void reportError(Throwable arg0) {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public long getPendingCount() {
+      return 0;
+    }
+  } // class MockCollector
+
+
+
+  // Throws exceptions for 2nd and 3rd line read attempt
+  static class MockTextFailingReader extends TextFileReader {
+    int readAttempts = 0;
+
+    public MockTextFailingReader(FileSystem fs, Path file, Map conf) throws IOException {
+      super(fs, file, conf);
+    }
+
+    @Override
+    public List<Object> next() throws IOException, ParseException {
+      readAttempts++;
+      if (readAttempts == 2) {
+        throw new IOException("mock test exception");
+      } else if (readAttempts >= 3) {
+        throw new ParseException("mock test exception", null);
+      }
+      return super.next();
+    }
+  }
+
+  static class MockTopologyContext extends TopologyContext {
+    private final int componentId;
+
+    public MockTopologyContext(int componentId) {
+      // StormTopology topology, Map stormConf, Map<Integer, String> taskToComponent, Map<String, List<Integer>> componentToSortedTasks, Map<String, Map<String, Fields>> componentToStreamToFields, String stormId, String codeDir, String pidDir, Integer taskId, Integer workerPort, List<Integer> workerTasks, Map<String, Object> defaultResources, Map<String, Object> userResources, Map<String, Object> executorData, Map<Integer, Map<Integer, Map<String, IMetric>>> registeredMetrics, Atom openOrPrepareWasCalled
+      super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+      this.componentId = componentId;
+    }
+
+    public String getThisComponentId() {
+      return Integer.toString( componentId );
+    }
+
+  }
+
+}

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -565,7 +565,7 @@ public class TestHdfsSpout {
 
 
   private static HdfsSpout makeSpout(int spoutId, Map conf, String readerType) {
-    HdfsSpout spout = new HdfsSpout();
+    HdfsSpout spout = new HdfsSpout().withOutputFields("line");
     MockCollector collector = new MockCollector();
     conf.put(Configs.READER_TYPE, readerType);
     spout.open(conf, new MockTopologyContext(spoutId), collector);

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -190,7 +190,7 @@ public class TestHdfsSpout {
 
     // check lock file contents
     List<String> contents = readTextFile(fs, lock.getLockFile().toString());
-    System.err.println(contents);
+    Assert.assertFalse(contents.isEmpty());
 
     // finish up reading the file
     res2 = runSpout(spout2, "r2");
@@ -237,7 +237,7 @@ public class TestHdfsSpout {
 
     // check lock file contents
     List<String> contents = getTextFileContents(fs, lock.getLockFile());
-    System.err.println(contents);
+    Assert.assertFalse(contents.isEmpty());
 
     // finish up reading the file
     res2 = runSpout(spout2, "r3");
@@ -309,11 +309,9 @@ public class TestHdfsSpout {
 
   private List<String> listDir(Path p) throws IOException {
     ArrayList<String> result = new ArrayList<>();
-    System.err.println("*** Listing " + p);
     RemoteIterator<LocatedFileStatus> fileNames =  fs.listFiles(p, false);
     while ( fileNames.hasNext() ) {
       LocatedFileStatus fileStatus = fileNames.next();
-      System.err.println(fileStatus.getPath());
       result.add(Path.getPathWithoutSchemeAndAuthority(fileStatus.getPath()).toString());
     }
     return result;
@@ -615,7 +613,6 @@ public class TestHdfsSpout {
     for (int i = 0; i < lineCount; i++) {
       os.writeBytes("line " + i + System.lineSeparator());
       String msg = "line " + i + System.lineSeparator();
-      System.err.print(size +  "-" + msg);
       size += msg.getBytes().length;
     }
     os.close();
@@ -660,8 +657,6 @@ public class TestHdfsSpout {
 
     @Override
     public List<Integer> emit(String streamId, List<Object> tuple, Object messageId) {
-//      HdfsSpout.MessageId id = (HdfsSpout.MessageId) messageId;
-//      lines.add(id.toString() + ' ' + tuple.toString());
       lines.add(tuple.toString());
       items.add(HdfsUtils.Pair.of(messageId, tuple));
       return null;

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -103,7 +103,6 @@ public class TestHdfsSpout {
     fs.mkdirs(archive);
     badfiles = new Path(baseFolder.toString() + "/bad");
     fs.mkdirs(badfiles);
-
   }
 
   @After

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -18,9 +18,9 @@
 
 package org.apache.storm.hdfs.spout;
 
-import backtype.storm.Config;
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
+import org.apache.storm.Config;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.Writable;
@@ -44,7 +44,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -58,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.storm.hdfs.common.HdfsUtils.Pair;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 
 public class TestHdfsSpout {
@@ -557,6 +557,7 @@ public class TestHdfsSpout {
     conf.put(Configs.ARCHIVE_DIR, archive.toString());
     conf.put(Configs.BAD_DIR, badfiles.toString());
     conf.put(Configs.HDFS_URI, hdfsCluster.getURI().toString());
+    conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, "0");
     return conf;
   }
 

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestProgressTracker.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestProgressTracker.java
@@ -1,0 +1,108 @@
+package org.apache.storm.hdfs.spout;
+
+
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+public class TestProgressTracker {
+
+  private FileSystem fs;
+  private Configuration conf = new Configuration();
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+  public File baseFolder;
+
+  @Before
+  public void setUp() throws Exception {
+    fs = FileSystem.getLocal(conf);
+  }
+
+  @Test
+  public void testBasic() throws Exception {
+    ProgressTracker tracker = new ProgressTracker();
+    baseFolder = tempFolder.newFolder("trackertest");
+
+    Path file = new Path( baseFolder.toString() + Path.SEPARATOR + "testHeadTrimming.txt" );
+    createTextFile(file, 10);
+
+    // create reader and do some checks
+    TextFileReader reader = new TextFileReader(fs, file, null);
+    FileOffset pos0 = tracker.getCommitPosition();
+    Assert.assertNull(pos0);
+
+    TextFileReader.Offset currOffset = reader.getFileOffset();
+    Assert.assertNotNull(currOffset);
+    Assert.assertEquals(0, currOffset.byteOffset);
+
+    // read 1st line and ack
+    Assert.assertNotNull(reader.next());
+    TextFileReader.Offset pos1 = reader.getFileOffset();
+    tracker.recordAckedOffset(pos1);
+
+    TextFileReader.Offset pos1b = (TextFileReader.Offset) tracker.getCommitPosition();
+    Assert.assertEquals(pos1, pos1b);
+
+    // read 2nd line and ACK
+    Assert.assertNotNull(reader.next());
+    TextFileReader.Offset pos2 = reader.getFileOffset();
+    tracker.recordAckedOffset(pos2);
+
+    tracker.dumpState(System.err);
+    TextFileReader.Offset pos2b = (TextFileReader.Offset) tracker.getCommitPosition();
+    Assert.assertEquals(pos2, pos2b);
+
+
+    // read lines 3..7, don't ACK .. commit pos should remain same
+    Assert.assertNotNull(reader.next());//3
+    TextFileReader.Offset pos3 = reader.getFileOffset();
+    Assert.assertNotNull(reader.next());//4
+    TextFileReader.Offset pos4 = reader.getFileOffset();
+    Assert.assertNotNull(reader.next());//5
+    TextFileReader.Offset pos5 = reader.getFileOffset();
+    Assert.assertNotNull(reader.next());//6
+    TextFileReader.Offset pos6 = reader.getFileOffset();
+    Assert.assertNotNull(reader.next());//7
+    TextFileReader.Offset pos7 = reader.getFileOffset();
+
+    // now ack msg 5 and check
+    tracker.recordAckedOffset(pos5);
+    Assert.assertEquals(pos2, tracker.getCommitPosition()); // should remain unchanged @ 2
+    tracker.recordAckedOffset(pos4);
+    Assert.assertEquals(pos2, tracker.getCommitPosition()); // should remain unchanged @ 2
+    tracker.recordAckedOffset(pos3);
+    Assert.assertEquals(pos5, tracker.getCommitPosition()); // should be at 5
+
+    tracker.recordAckedOffset(pos6);
+    Assert.assertEquals(pos6, tracker.getCommitPosition()); // should be at 6
+    tracker.recordAckedOffset(pos6);                        // double ack on same msg
+    Assert.assertEquals(pos6, tracker.getCommitPosition()); // should still be at 6
+
+    tracker.recordAckedOffset(pos7);
+    Assert.assertEquals(pos7, tracker.getCommitPosition()); // should be at 7
+
+    tracker.dumpState(System.err);
+  }
+
+
+
+  private void createTextFile(Path file, int lineCount) throws IOException {
+    FSDataOutputStream os = fs.create(file);
+    for (int i = 0; i < lineCount; i++) {
+      os.writeBytes("line " + i + System.lineSeparator());
+    }
+    os.close();
+  }
+
+}

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestProgressTracker.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestProgressTracker.java
@@ -1,6 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.storm.hdfs.spout;
-
-
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestProgressTracker.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestProgressTracker.java
@@ -60,7 +60,7 @@ public class TestProgressTracker {
 
     TextFileReader.Offset currOffset = reader.getFileOffset();
     Assert.assertNotNull(currOffset);
-    Assert.assertEquals(0, currOffset.byteOffset);
+    Assert.assertEquals(0, currOffset.charOffset);
 
     // read 1st line and ack
     Assert.assertNotNull(reader.next());

--- a/external/storm-hdfs/src/test/resources/log4j.properties
+++ b/external/storm-hdfs/src/test/resources/log4j.properties
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+log4j.rootLogger = WARN, out
+
+log4j.appender.out = org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout = org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern = %d (%t) [%p - %l] %m%n
+
+log4j.logger.org.apache.storm.hdfs = INFO
+

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <clojure-data-codec.version>0.1.0</clojure-data-codec.version>
         <clojure-contrib.version>1.2.0</clojure-contrib.version>
         <hive.version>0.14.0</hive.version>
-        <hadoop.version>2.7.1</hadoop.version>
+        <hadoop.version>2.6.0</hadoop.version>
         <kryo.version>2.21</kryo.version>
         <servlet.version>2.5</servlet.version>
         <joda-time.version>2.3</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <clojure.tools.cli.version>0.2.4</clojure.tools.cli.version>
         <disruptor.version>3.3.2</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>
-        <guava.version>16.0.1</guava.version>
+        <guava.version>15.0</guava.version>
         <netty.version>3.9.0.Final</netty.version>
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
         <log4j.version>2.1</log4j.version>
@@ -227,7 +227,7 @@
         <clojure-data-codec.version>0.1.0</clojure-data-codec.version>
         <clojure-contrib.version>1.2.0</clojure-contrib.version>
         <hive.version>0.14.0</hive.version>
-        <hadoop.version>2.6.0</hadoop.version>
+        <hadoop.version>2.6.1</hadoop.version>
         <kryo.version>2.21</kryo.version>
         <servlet.version>2.5</servlet.version>
         <joda-time.version>2.3</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
         <clojure.tools.cli.version>0.2.4</clojure.tools.cli.version>
         <disruptor.version>3.3.2</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>
-        <guava.version>15.0</guava.version>
+        <guava.version>16.0.1</guava.version>
         <netty.version>3.9.0.Final</netty.version>
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
         <log4j.version>2.1</log4j.version>


### PR DESCRIPTION
HDFS Spout  for initial review (no Trident support).

**Features:**
 - Monitors directory. Picks up new files as they show up.
 - Built-in  support for consuming Text and Sequence File formats 
 - Extensible to other file formats. 
 - Works with or without ACKers.
 - Concurrent consumption: Each spout instance consumes a different file in parallel. 
 - Zookeeper free synchronization: HDFS based synchronization mechanism enables each spout to concurrently decide which of the available files to consume next. Spout acquires a lock on a file before consuming it. The lock files are stored in a .lock subdirectory. Lock file is deleted once file is consumed.
 - Archiving: Completed files are moved to a (configurable) 'done' folder 
 - Easy progress tracking: Files being consumed are renamed with a '.inprogress' suffix allowing users to easily check which files are being processed by simply listing the dir. More more detailed info users can rely on dashboard metrics.
 - Read model : Buffered reads & lazy tuple parsing. Reads are buffered, but parsing out a tuple is delayed until tuple is needed. Avoids periodic latency spikes involved with 'eager' parsing (e.g Kafka spout) of the entire  batch of records. 
 - Sliding window model used to track outstanding unACKed tuples (instead of Tumbling Window model used in Kafka spout). Tumbling window model prevents new tuple generation even if one tuple in the batch is not acked.
 - Support for clusters where NTP is not used to synchronize machine clocks (for identifying timed out locks - see *spout failure detection* section below). 
 - Kerberos support

**Fault Tolerance :**
 - Un-parseable files - are moved to a  separate (configurable) directory
 - I/O errors - Retry later if currently experiencing I/O errors during read
 - Duplicate Delivery mitigation
     + Spout tracks its progress on HDFS. So if it dies, another spout can resume from where it left off, rather than reprocessing the whole file.
     + Configurable number of outstanding unACKed tuples - helps contain the amount of duplicate emits when a spout takes over the job of a failed spout.
 - Spout Failure and Failover :
  + Spout failure detection - Each spout acquires a lock on the file it is reading and periodically heartbeats (appends) its progress into the lock file with a timestamp. This helps identify stale/abandoned locks easily (based on configurable lock timeout).  Spouts periodically check for stale locks.
  + Failover to another spout - A spout can take ownership of a stale lock and resume reading the file corresponding to the lock. The latest progress noted in the lock file is used to decide the location from which to resume.
 
