### PR TITLE
[STORM-1385] stats.clj divide by zero exception

### DIFF
--- a/storm-core/src/clj/backtype/storm/stats.clj
+++ b/storm-core/src/clj/backtype/storm/stats.clj
@@ -1333,7 +1333,7 @@
 
 (defn- val-avg
   [[t c]]
-  (if (= t 0) 0
+  (if (= c 0) 0
     (double (/ t c))))
 
 (defn aggregate-averages


### PR DESCRIPTION
Might cause divide by zero exception