### PR TITLE
[STORM-1383] Avoid supervisor crashing if nimbus is unavailable

### DIFF
--- a/storm-core/src/jvm/backtype/storm/utils/NimbusClient.java
+++ b/storm-core/src/jvm/backtype/storm/utils/NimbusClient.java
@@ -82,12 +82,15 @@ public class NimbusClient extends ThriftClient {
                         }
                     }
                 }
-                throw new RuntimeException("Found nimbuses " + nimbuses + " none of which is elected as leader, please try " +
+                throw new NimbusLeaderNotFoundException(
+                        "Found nimbuses " + nimbuses + " none of which is elected as leader, please try " +
                         "again after some time.");
             }
         }
-        throw new RuntimeException("Could not find leader nimbus from seed hosts " + seeds + ". " +
-                "Did you specify a valid list of nimbus hosts for config " + Config.NIMBUS_SEEDS);
+        throw new NimbusLeaderNotFoundException(
+                "Could not find leader nimbus from seed hosts " + seeds + ". " +
+                "Did you specify a valid list of nimbus hosts for config " +
+                        Config.NIMBUS_SEEDS + "?");
     }
 
     public NimbusClient(Map conf, String host, int port) throws TTransportException {

--- a/storm-core/src/jvm/backtype/storm/utils/NimbusLeaderNotFoundException.java
+++ b/storm-core/src/jvm/backtype/storm/utils/NimbusLeaderNotFoundException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.utils;
+
+/**
+ * This exception class is used to signify a problem with nimbus leader
+ * identification.  It should not be used when connection failures happen, but
+ * only when successful operations result in the absence of an identified
+ * leader.
+ */
+public class NimbusLeaderNotFoundException extends RuntimeException {
+    public NimbusLeaderNotFoundException() {
+        super();
+    }
+    public NimbusLeaderNotFoundException(String msg) {
+        super(msg);
+    }
+
+    public NimbusLeaderNotFoundException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public NimbusLeaderNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
* Adds a new exception to differentiate the failure to find a nimbus leader from a network failure.
* Since blobs are scanned for updates periodically, do not crash the supervisor if nimbus is not available.
* Do not crash the supervisor if nimbus is unavailable when downloading topology resources for launch.
