### PR TITLE
[STORM-1377] Correct timeouts for milliseconds

### DIFF
--- a/storm-core/test/clj/backtype/storm/security/auth/ThriftClient_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/ThriftClient_test.clj
@@ -20,26 +20,26 @@
   (:import [org.apache.thrift.transport TTransportException])
 )
 
+(def TIMEOUT (Integer. (* 3 1000)))
+
 (deftest test-ctor-throws-if-port-invalid
   (let [conf (merge
               (read-default-config)
-              {STORM-NIMBUS-RETRY-TIMES 0})
-        timeout (Integer. 30)]
+              {STORM-NIMBUS-RETRY-TIMES 0})]
     (is (thrown-cause? java.lang.IllegalArgumentException
-      (ThriftClient. conf ThriftConnectionType/DRPC "bogushost" (int -1) timeout)))
+      (ThriftClient. conf ThriftConnectionType/DRPC "bogushost" (int -1) TIMEOUT)))
     (is (thrown-cause? java.lang.IllegalArgumentException
-        (ThriftClient. conf ThriftConnectionType/DRPC "bogushost" (int 0) timeout)))
+        (ThriftClient. conf ThriftConnectionType/DRPC "bogushost" (int 0) TIMEOUT)))
   )
 )
 
 (deftest test-ctor-throws-if-host-not-set
   (let [conf (merge
               (read-default-config)
-              {STORM-NIMBUS-RETRY-TIMES 0})
-        timeout (Integer. 60)]
+              {STORM-NIMBUS-RETRY-TIMES 0})]
     (is (thrown-cause? TTransportException
-         (ThriftClient. conf ThriftConnectionType/DRPC "" (int 4242) timeout)))
+         (ThriftClient. conf ThriftConnectionType/DRPC "" (int 4242) TIMEOUT)))
     (is (thrown-cause? IllegalArgumentException
-        (ThriftClient. conf ThriftConnectionType/DRPC nil (int 4242) timeout)))
+        (ThriftClient. conf ThriftConnectionType/DRPC nil (int 4242) TIMEOUT)))
   )
 )

--- a/storm-core/test/clj/backtype/storm/security/auth/ThriftClient_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/ThriftClient_test.clj
@@ -16,20 +16,27 @@
 (ns backtype.storm.security.auth.ThriftClient-test
   (:use [backtype.storm config util])
   (:use [clojure test])
+  (:require [backtype.storm.security.auth [auth-test :refer [nimbus-timeout]]])
   (:import [backtype.storm.security.auth ThriftClient ThriftConnectionType])
   (:import [org.apache.thrift.transport TTransportException])
 )
-
-(def TIMEOUT (Integer. (* 3 1000)))
 
 (deftest test-ctor-throws-if-port-invalid
   (let [conf (merge
               (read-default-config)
               {STORM-NIMBUS-RETRY-TIMES 0})]
     (is (thrown-cause? java.lang.IllegalArgumentException
-      (ThriftClient. conf ThriftConnectionType/DRPC "bogushost" (int -1) TIMEOUT)))
+      (ThriftClient. conf
+                     ThriftConnectionType/DRPC
+                     "bogushost"
+                     (int -1)
+                     nimbus-timeout)))
     (is (thrown-cause? java.lang.IllegalArgumentException
-        (ThriftClient. conf ThriftConnectionType/DRPC "bogushost" (int 0) TIMEOUT)))
+        (ThriftClient. conf
+                       ThriftConnectionType/DRPC
+                       "bogushost"
+                       (int 0)
+                       nimbus-timeout)))
   )
 )
 
@@ -38,8 +45,16 @@
               (read-default-config)
               {STORM-NIMBUS-RETRY-TIMES 0})]
     (is (thrown-cause? TTransportException
-         (ThriftClient. conf ThriftConnectionType/DRPC "" (int 4242) TIMEOUT)))
+         (ThriftClient. conf
+                        ThriftConnectionType/DRPC
+                        ""
+                        (int 4242)
+                        nimbus-timeout)))
     (is (thrown-cause? IllegalArgumentException
-        (ThriftClient. conf ThriftConnectionType/DRPC nil (int 4242) TIMEOUT)))
+        (ThriftClient. conf
+                       ThriftConnectionType/DRPC
+                       nil
+                       (int 4242)
+                       nimbus-timeout)))
   )
 )

--- a/storm-core/test/clj/backtype/storm/security/auth/auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/auth_test.clj
@@ -47,6 +47,8 @@
 (defn mk-subject [name]
   (Subject. true #{(mk-principal name)} #{} #{}))
 
+;; 3 seconds in milliseconds
+;; This is plenty of time for a thrift client to respond.
 (def nimbus-timeout (Integer. (* 3 1000)))
 
 (defn nimbus-data [storm-conf inimbus]

--- a/storm-core/test/clj/backtype/storm/security/auth/auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/auth_test.clj
@@ -47,7 +47,7 @@
 (defn mk-subject [name]
   (Subject. true #{(mk-principal name)} #{} #{}))
 
-(def nimbus-timeout (Integer. 120))
+(def nimbus-timeout (Integer. (* 3 1000)))
 
 (defn nimbus-data [storm-conf inimbus]
   (let [forced-scheduler (.getForcedScheduler inimbus)]

--- a/storm-core/test/clj/backtype/storm/security/auth/drpc_auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/drpc_auth_test.clj
@@ -29,8 +29,6 @@
   (:use [backtype.storm.daemon common])
   (:use [backtype.storm testing]))
 
-(def drpc-timeout (Integer. 30))
-
 (def DRPC-TIMEOUT-SEC (* (/ TEST-TIMEOUT-MS 1000) 2))
 
 (defn launch-server [conf drpcAznClass transportPluginClass login-cfg client-port invocations-port]

--- a/storm-core/test/clj/backtype/storm/security/auth/nimbus_auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/nimbus_auth_test.clj
@@ -31,7 +31,7 @@
   (:require [conjure.core])
   (:use [conjure core]))
 
-(def nimbus-timeout (Integer. 30))
+(def nimbus-timeout (Integer. (* 3 1000)))
 
 (defn launch-test-cluster [nimbus-port login-cfg aznClass transportPluginClass] 
   (let [conf {NIMBUS-AUTHORIZER aznClass 

--- a/storm-core/test/clj/backtype/storm/security/auth/nimbus_auth_test.clj
+++ b/storm-core/test/clj/backtype/storm/security/auth/nimbus_auth_test.clj
@@ -18,6 +18,7 @@
   (:require [backtype.storm [testing :as testing]])
   (:require [backtype.storm.daemon [nimbus :as nimbus]])
   (:require [backtype.storm [zookeeper :as zk]])
+  (:require [backtype.storm.security.auth [auth-test :refer [nimbus-timeout]]])
   (:import [java.nio ByteBuffer])
   (:import [backtype.storm Config])
   (:import [backtype.storm.utils NimbusClient])
@@ -30,8 +31,6 @@
             AuthorizationException SubmitOptions TopologyInitialStatus KillOptions])
   (:require [conjure.core])
   (:use [conjure core]))
-
-(def nimbus-timeout (Integer. (* 3 1000)))
 
 (defn launch-test-cluster [nimbus-port login-cfg aznClass transportPluginClass] 
   (let [conf {NIMBUS-AUTHORIZER aznClass 


### PR DESCRIPTION
Thrift client timeouts had been given in seconds, when java.net.Socket expects them in milliseconds.