### PR TITLE
[STORM-1387] workers-artifacts directory configurable, and default to be under storm.log.dir.

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -52,6 +52,7 @@ storm.auth.simple-acl.admins: []
 storm.cluster.state.store: "backtype.storm.cluster_state.zookeeper_state_factory"
 storm.meta.serialization.delegate: "backtype.storm.serialization.GzipThriftSerializationDelegate"
 storm.codedistributor.class: "backtype.storm.codedistributor.LocalFileSystemCodeDistributor"
+storm.workers.artifacts.dir: "workers-artifacts"
 storm.health.check.dir: "healthchecks"
 storm.health.check.timeout.ms: 5000
 

--- a/storm-core/src/clj/backtype/storm/config.clj
+++ b/storm-core/src/clj/backtype/storm/config.clj
@@ -254,11 +254,12 @@
 
 (defn worker-artifacts-root
   ([conf]
-    (let [workers-artifacts-dir (conf STORM-WORKERS-ARTIFACTS-DIR)]
-      (if workers-artifacts-dir
-        (if (is-absolute-path? workers-artifacts-dir)
-          workers-artifacts-dir
-          (str backtype.storm.util/LOG-DIR file-path-separator workers-artifacts-dir)))))
+   (let [workers-artifacts-dir (conf STORM-WORKERS-ARTIFACTS-DIR)]
+     (if workers-artifacts-dir
+       (if (is-absolute-path? workers-artifacts-dir)
+         workers-artifacts-dir
+         (str backtype.storm.util/LOG-DIR file-path-separator workers-artifacts-dir))
+       (str backtype.storm.util/LOG-DIR file-path-separator "workers-artifacts"))))
   ([conf id]
    (str (worker-artifacts-root conf) file-path-separator id))
   ([conf id port]

--- a/storm-core/src/clj/backtype/storm/config.clj
+++ b/storm-core/src/clj/backtype/storm/config.clj
@@ -254,7 +254,11 @@
 
 (defn worker-artifacts-root
   ([conf]
-   (str (absolute-storm-local-dir conf) file-path-separator "workers-artifacts"))
+    (let [workers-artifacts-dir (conf STORM-WORKERS-ARTIFACTS-DIR)]
+      (if workers-artifacts-dir
+        (if (is-absolute-path? workers-artifacts-dir)
+          workers-artifacts-dir
+          (str backtype.storm.util/LOG-DIR file-path-separator workers-artifacts-dir)))))
   ([conf id]
    (str (worker-artifacts-root conf) file-path-separator id))
   ([conf id port]

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -1044,7 +1044,6 @@
   (.getCanonicalPath
     (clojure.java.io/file (or (System/getProperty "storm.log.dir") (str (System/getProperty "storm.home") "logs")))))
 
-
 (defn logs-filename
   [storm-id port]
   (str storm-id file-path-separator port file-path-separator "worker.log"))

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -345,6 +345,14 @@ public class Config extends HashMap<String, Object> {
     public static final String STORM_ID = "storm.id";
 
     /**
+     * The workers-artifacts directory (where we place all workers' logs), can be either absolute or relative.
+     * By default, ${storm.log.dir}/workers-artifacts is where worker logs go.
+     * If the setting is a relative directory, it is relative to storm.log.dir.
+     */
+    @isString
+    public static final String STORM_WORKERS_ARTIFACTS_DIR = "storm.workers.artifacts.dir";
+
+    /**
      * The directory where storm's health scripts go.
      */
     @isString

--- a/storm-core/test/clj/backtype/storm/supervisor_test.clj
+++ b/storm-core/test/clj/backtype/storm/supervisor_test.clj
@@ -461,6 +461,7 @@
                 _ (.mkdirs (io/file storm-local "workers" mock-worker-id))
                 mock-supervisor {:conf {STORM-CLUSTER-MODE :distributed
                                         STORM-LOCAL-DIR storm-local
+                                        STORM-WORKERS-ARTIFACTS-DIR (str storm-local "/workers-artifacts")
                                         SUPERVISOR-RUN-WORKER-AS-USER true
                                         WORKER-CHILDOPTS string-opts}}]
             (stubbing [read-supervisor-storm-conf {TOPOLOGY-WORKER-CHILDOPTS
@@ -491,6 +492,7 @@
                 exp-script (exp-script-fn list-opts topo-list-opts)
                 mock-supervisor {:conf {STORM-CLUSTER-MODE :distributed
                                         STORM-LOCAL-DIR storm-local
+                                        STORM-WORKERS-ARTIFACTS-DIR (str storm-local "/workers-artifacts")
                                         SUPERVISOR-RUN-WORKER-AS-USER true
                                         WORKER-CHILDOPTS list-opts}}]
             (stubbing [read-supervisor-storm-conf {TOPOLOGY-WORKER-CHILDOPTS


### PR DESCRIPTION
Now, by default, log structure looks like this:

storm-home/logs/
------supervisor.log
------nimbus.log
------logviewer.log
------workers-artifacts/
-----------topo1/
-----------topo2/
------------------port1/
------------------port2/
------------------------worker.log
------------------------worker.log.err
------------------------worker.log.out
------------------------gc.log