### PR TITLE
AvroGenericRecordBolt instead of SequenceFileBolt

### DIFF
--- a/external/storm-hdfs/README.md
+++ b/external/storm-hdfs/README.md
@@ -295,7 +295,7 @@ The `org.apache.storm.hdfs.bolt.AvroGenericRecordBolt` class allows you to write
         // create sequence format instance.
         DefaultSequenceFormat format = new DefaultSequenceFormat("timestamp", "sentence");
 
-        SequenceFileBolt bolt = new SequenceFileBolt()
+        AvroGenericRecordBolt bolt = new AvroGenericRecordBolt()
                 .withFsUrl("hdfs://localhost:54310")
                 .withFileNameFormat(fileNameFormat)
                 .withSchemaAsString(schema)


### PR DESCRIPTION
Changing the **example code** and use **AvroGenericRecordBolt**  instead of
**SequenceFileBolt**…

Section “Support for Avro Files” starts by explained the use of org.apache.storm.hdfs.bolt.AvroGenericRecordBolt for Avro files.
However, the example code uses SequenceFileBolt instead, and that
doesn’t work, obviously because the method withSchemaAsString isn’t
part of SequenceFileBolt, but part of
org.apache.storm.hdfs.bolt.AvroGenericRecordBolt instead. So, the
change is nothing but changing the name of class SequenceFileBolt and
replace it with the correct AvroGenericRecordBolt.