### PR TITLE
STORM-1432: Spurious failure in storm-kafka test

### DIFF
--- a/external/storm-kafka/src/test/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
@@ -50,14 +50,14 @@ public class ExponentialBackoffMsgRetryManagerTest {
 
     @Test
     public void testSingleDelay() throws Exception {
-        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(10, 1d, 100);
+        ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(100, 1d, 1000);
         manager.failed(TEST_OFFSET);
         Thread.sleep(5);
         Long next = manager.nextFailedMessageToRetry();
         assertNull("expect no message ready for retry yet", next);
         assertFalse("message should not be ready for retry yet", manager.shouldRetryMsg(TEST_OFFSET));
 
-        Thread.sleep(10);
+        Thread.sleep(100);
         next = manager.nextFailedMessageToRetry();
         assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
         assertTrue("message should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));

--- a/external/storm-kafka/src/test/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
+++ b/external/storm-kafka/src/test/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
@@ -163,9 +163,9 @@ public class ExponentialBackoffMsgRetryManagerTest {
 
     @Test
     public void testMaxBackoff() throws Exception {
-        final long initial = 10;
+        final long initial = 100;
         final double mult = 2d;
-        final long max = 20;
+        final long max = 2000;
         ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(initial, mult, max);
 
         long expectedWaitTime = initial;


### PR DESCRIPTION
ExponentialBackoffMsgRetryManagerTest.testMaxBackoff() fails sometimes, I think due to too small times. It can miss the mark on slow machines.