### PR TITLE
[STORM-1499] Fix Kafka spout to maintain backward compatibility

### DIFF
--- a/storm-core/src/jvm/backtype/storm/spout/RawMultiScheme.java
+++ b/storm-core/src/jvm/backtype/storm/spout/RawMultiScheme.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import backtype.storm.tuple.Fields;
+import backtype.storm.utils.Utils;
 
 
 import static backtype.storm.utils.Utils.tuple;
@@ -29,7 +30,7 @@ import static java.util.Arrays.asList;
 public class RawMultiScheme implements MultiScheme {
   @Override
   public Iterable<List<Object>> deserialize(ByteBuffer ser) {
-    return asList(tuple(ser));
+    return asList(tuple(Utils.toByteArray(ser)));
   }
 
   @Override


### PR DESCRIPTION
STORM-1220 introduced some changes where in one place it passes ByteBuffer as is instead of byte[].
Existing bolts (0.10.0) expects a byte[] and fails with
"java.lang.RuntimeException: java.lang.ClassCastException: java.nio.HeapByteBuffer cannot be cast to [B "
This patch addresses the issue by emiting byte[] instead of ByteBuffer.