### PR TITLE
[STORM-1457] Avoid collecting pending tuples if topology.debug is off

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -497,6 +497,7 @@
         spouts (ArrayList. (map :object (vals task-datas)))
         rand (Random. (Utils/secureRandomLong))
         ^DisruptorQueue transfer-queue (executor-data :batch-transfer-queue)
+        debug? (= true (storm-conf TOPOLOGY-DEBUG))
 
         pending (RotatingMap.
                  2 ;; microoptimize for performance of .size method
@@ -573,7 +574,7 @@
                                              (.put pending root-id [task-id
                                                                     message-id
                                                                     {:stream out-stream-id 
-                                                                     :values (if (= true (storm-conf TOPOLOGY-DEBUG)) values nil)}
+                                                                     :values (if debug? values nil)}
                                                                     (if (sampler) (System/currentTimeMillis))])
                                              (task/send-unanchored task-data
                                                                    ACKER-INIT-STREAM-ID

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -572,7 +572,8 @@
                                            (do
                                              (.put pending root-id [task-id
                                                                     message-id
-                                                                    {:stream out-stream-id :values values}
+                                                                    {:stream out-stream-id 
+                                                                     :values (if (= true (storm-conf TOPOLOGY-DEBUG)) values nil)}
                                                                     (if (sampler) (System/currentTimeMillis))])
                                              (task/send-unanchored task-data
                                                                    ACKER-INIT-STREAM-ID


### PR DESCRIPTION
This would help lower heap memory usage when ```topology.debug``` is off.