### PR TITLE
[STORM-1206] Reduce logviewer memory usage through directory stream

### DIFF
--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -1056,8 +1056,8 @@
 
 (defn clojure-from-yaml-file [yamlFile]
   (try
-    (let [obj (.load (Yaml. (SafeConstructor.)) (java.io.FileReader. yamlFile))]
-      (clojurify-structure obj))
+    (with-open [reader (java.io.FileReader. yamlFile)]
+      (clojurify-structure (.load (Yaml. (SafeConstructor.)) reader)))
     (catch Exception ex
       (log-error ex))))
 

--- a/storm-core/src/jvm/backtype/storm/daemon/DirectoryCleaner.java
+++ b/storm-core/src/jvm/backtype/storm/daemon/DirectoryCleaner.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package backtype.storm.daemon;
+
+import java.io.IOException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.nio.file.DirectoryStream;
+import java.util.Stack;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provide methods to help Logviewer to clean up
+ * files in directories and to get a list of files without
+ * worrying about excessive memory usage.
+ *
+ */
+public class DirectoryCleaner {
+    private static final Logger LOG = LoggerFactory.getLogger(DirectoryCleaner.class);
+    // used to recognize the pattern of active log files, we may remove the "current" from this list
+    private static final Pattern ACTIVE_LOG_PATTERN = Pattern.compile(".*\\.(log|err|out|current|yaml|pid)$");
+    // used to recognize the pattern of some meta files in a worker log directory
+    private static final Pattern META_LOG_PATTERN= Pattern.compile(".*\\.(yaml|pid)$");
+
+    // not defining this as static is to allow for mocking in tests
+    public DirectoryStream<Path> getStreamForDirectory(File dir) throws IOException {
+        DirectoryStream<Path> stream = Files.newDirectoryStream(dir.toPath());
+        return stream;
+    }
+
+    /**
+     * If totalSize of files exceeds the either the per-worker quota or global quota,
+     * Logviewer deletes oldest inactive log files in a worker directory or in all worker dirs.
+     * We use the parameter for_per_dir to switch between the two deletion modes.
+     * @param dirs the list of directories to be scanned for deletion
+     * @param quota the per-dir quota or the total quota for the all directories
+     * @param for_per_dir if true, deletion happens for a single dir; otherwise, for all directories globally
+     * @param active_dirs only for global deletion, we want to skip the active logs in active_dirs
+     * @return number of files deleted
+     */
+    public int deleteOldestWhileTooLarge(List<File> dirs,
+                        long quota, boolean for_per_dir, Set<String> active_dirs) throws IOException {
+        final int PQ_SIZE = 1024; // max number of files to delete for every round
+        final int MAX_ROUNDS  = 512; // max rounds of scanning the dirs
+        long totalSize = 0;
+        int deletedFiles = 0;
+
+        for (File dir : dirs) {
+            try (DirectoryStream<Path> stream = getStreamForDirectory(dir)) {
+                for (Path path : stream) {
+                    File file = path.toFile();
+                    totalSize += file.length();
+                }
+            }
+        }
+        long toDeleteSize = totalSize - quota;
+        if (toDeleteSize <= 0) {
+            return deletedFiles;
+        }
+
+        Comparator<File> comparator = new Comparator<File>() {
+            public int compare(File f1, File f2) {
+                if (f1.lastModified() > f2.lastModified()) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            }
+        };
+        // the oldest pq_size files in this directory will be placed in PQ, with the newest at the root
+        PriorityQueue<File> pq = new PriorityQueue<File>(PQ_SIZE, comparator);
+        int round = 0;
+        while (toDeleteSize > 0) {
+            LOG.debug("To delete size is {}, start a new round of deletion, round: {}", toDeleteSize, round);
+            for (File dir : dirs) {
+                try (DirectoryStream<Path> stream = getStreamForDirectory(dir)) {
+                    for (Path path : stream) {
+                        File file = path.toFile();
+                        if (for_per_dir) {
+                            if (ACTIVE_LOG_PATTERN.matcher(file.getName()).matches()) {
+                                continue; // skip active log files
+                            }
+                        } else { // for global cleanup
+                            if (active_dirs.contains(dir.getCanonicalPath())) { // for an active worker's dir, make sure for the last "/"
+                                if (ACTIVE_LOG_PATTERN.matcher(file.getName()).matches()) {
+                                    continue; // skip active log files
+                                }
+                            } else {
+                                if (META_LOG_PATTERN.matcher(file.getName()).matches()) {
+                                    continue; // skip yaml and pid files
+                                }
+                            }
+                        }
+                        if (pq.size() < PQ_SIZE) {
+                            pq.offer(file);
+                        } else {
+                            if (file.lastModified() < pq.peek().lastModified()) {
+                                pq.poll();
+                                pq.offer(file);
+                            }
+                        }
+                    }
+                }
+            }
+            // need to reverse the order of elements in PQ to delete files from oldest to newest
+            Stack<File> stack = new Stack<File>();
+            while (!pq.isEmpty()) {
+                File file = pq.poll();
+                stack.push(file);
+            }
+            while (!stack.isEmpty() && toDeleteSize > 0) {
+                File file = stack.pop();
+                toDeleteSize -= file.length();
+                LOG.info("Delete file: {}, size: {}, lastModified: {}", file.getName(), file.length(), file.lastModified());
+                file.delete();
+                deletedFiles++;
+            }
+            pq.clear();
+            round++;
+            if (round >= MAX_ROUNDS) {
+                if (for_per_dir) {
+                    LOG.warn("Reach the MAX_ROUNDS: {} during per-dir deletion, you may have too many files in " +
+                            "a single directory : {}, will delete the rest files in next interval.",
+                            MAX_ROUNDS, dirs.get(0).getCanonicalPath());
+                } else {
+                    LOG.warn("Reach the MAX_ROUNDS: {} during global deletion, you may have too many files, " +
+                            "will delete the rest files in next interval.", MAX_ROUNDS);
+                }
+                break;
+            }
+        }
+        return deletedFiles;
+    }
+
+    // Note that to avoid memory problem, we only return the first 1024 files in a directory
+    public static List<File> getFilesForDir(File dir) throws IOException {
+        List<File> files = new ArrayList<File>();
+        final int MAX_NUM = 1024;
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir.toPath())) {
+            for (Path path : stream) {
+                files.add(path.toFile());
+                if (files.size() >= MAX_NUM) {
+                    break;
+                }
+            }
+        }
+        return files;
+    }
+}

--- a/storm-core/test/clj/backtype/storm/logviewer_test.clj
+++ b/storm-core/test/clj/backtype/storm/logviewer_test.clj
@@ -21,10 +21,24 @@
   (:use [clojure test])
   (:use [conjure core])
   (:use [backtype.storm.ui helpers])
+  (:import [backtype.storm.daemon DirectoryCleaner])
+  (:import [java.nio.file Files Path DirectoryStream])
   (:import [java.nio.file Files])
   (:import [java.nio.file.attribute FileAttribute])
   (:import [java.io File])
+  (:import [java.util ArrayList])
   (:import [org.mockito Mockito]))
+
+(defn mk-mock-Path [file]
+  (let [mockPath (Mockito/mock java.nio.file.Path)]
+    (. (Mockito/when (.toFile mockPath)) thenReturn file)
+    mockPath))
+
+(defn mk-DirectoryStream [^ArrayList list-of-paths]
+  (reify DirectoryStream
+    (close [this])
+    (iterator [this]
+      (.iterator list-of-paths))))
 
 (defmulti mk-mock-File #(:type %))
 
@@ -48,10 +62,26 @@
     (. (Mockito/when (.lastModified mockDir)) thenReturn mtime)
     (. (Mockito/when (.isFile mockDir)) thenReturn false)
     (. (Mockito/when (.listFiles mockDir)) thenReturn (into-array File files))
+    (. (Mockito/when (.getCanonicalPath mockDir)) thenReturn dir-name)
     mockDir))
+
+(deftest test-get-size-for-logdir
+  (testing "get the file sizes of a worker log directory"
+  (stubbing [logviewer/get-stream-for-dir (fn [x] (map #(mk-mock-Path %) (.listFiles x)))]
+            (let [now-millis (current-time-millis)
+                  files1 (into-array File (map #(mk-mock-File {:name (str %)
+                                                               :type :file
+                                                               :mtime (- now-millis (* 100 %))
+                                                               :length 200})
+                                               (range 1 6))) ;; 5 files
+                  port1-dir (mk-mock-File {:name "/workers-artifacts/topo1/port1"
+                                           :type :directory
+                                           :files files1})]
+              (is (= (logviewer/get-size-for-logdir port1-dir) 1000))))))
 
 (deftest test-mk-FileFilter-for-log-cleanup
   (testing "log file filter selects the correct worker-log dirs for purge"
+    (stubbing [logviewer/get-stream-for-dir (fn [x] (map #(mk-mock-Path %) (.listFiles x)))]
     (let [now-millis (current-time-millis)
           conf {LOGVIEWER-CLEANUP-AGE-MINS 60
                 LOGVIEWER-CLEANUP-INTERVAL-SECS 300}
@@ -89,111 +119,110 @@
                              :mtime new-mtime-millis}
                             ])
           file-filter (logviewer/mk-FileFilter-for-log-cleanup conf now-millis)]
-      (is   (every? #(.accept file-filter %) matching-files))
+      (is (every? #(.accept file-filter %) matching-files))
       (is (not-any? #(.accept file-filter %) excluded-files))
-      )))
+      ))))
 
-(deftest test-sort-worker-logs
-  (testing "cleaner sorts the log files in ascending ages for deletion"
-    (stubbing [logviewer/filter-candidate-files (fn [x _] x)]
-      (let [now-millis (current-time-millis)
-            files1 (into-array File (map #(mk-mock-File {:name (str %)
-                                                         :type :file
-                                                         :mtime (- now-millis (* 100 %))})
-                                      (range 1 6)))
-            files2 (into-array File (map #(mk-mock-File {:name (str %)
-                                                         :type :file
-                                                         :mtime (- now-millis (* 100 %))})
-                                      (range 6 11)))
-            files3 (into-array File (map #(mk-mock-File {:name (str %)
-                                                         :type :file
-                                                         :mtime (- now-millis (* 100 %))})
-                                      (range 11 16)))
-            port1-dir (mk-mock-File {:name "/workers-artifacts/topo1/port1"
-                                     :type :directory
-                                     :files files1})
-            port2-dir (mk-mock-File {:name "/workers-artifacts/topo1/port2"
-                                     :type :directory
-                                     :files files2})
-            port3-dir (mk-mock-File {:name "/workers-artifacts/topo2/port3"
-                                     :type :directory
-                                     :files files3})
-            topo1-files (into-array File [port1-dir port2-dir])
-            topo2-files (into-array File [port3-dir])
-            topo1-dir (mk-mock-File {:name "/workers-artifacts/topo1"
-                                     :type :directory
-                                     :files topo1-files})
-            topo2-dir (mk-mock-File {:name "/workers-artifacts/topo2"
-                                     :type :directory
-                                     :files topo2-files})
-            root-files (into-array File [topo1-dir topo2-dir])
-            root-dir (mk-mock-File {:name "/workers-artifacts"
-                                    :type :directory
-                                    :files root-files})
-            sorted-logs (logviewer/sorted-worker-logs root-dir)
-            sorted-ints (map #(Integer. (.getName %)) sorted-logs)]
-        (is (= (count sorted-logs) 15))
-        (is (= (count sorted-ints) 15))
-        (is (apply #'> sorted-ints))))))
-
-(deftest test-per-workerdir-cleanup
+(deftest test-per-workerdir-cleanup!
   (testing "cleaner deletes oldest files in each worker dir if files are larger than per-dir quota."
     (stubbing [rmr nil]
-      (let [now-millis (current-time-millis)
-            files1 (into-array File (map #(mk-mock-File {:name (str "A" %)
-                                                         :type :file
-                                                         :mtime (+ now-millis (* 100 %))
-                                                         :length 200 })
-                                      (range 0 10)))
-            files2 (into-array File (map #(mk-mock-File {:name (str "B" %)
-                                                         :type :file
-                                                         :mtime (+ now-millis (* 100 %))
-                                                         :length 200 })
-                                      (range 0 10)))
-            files3 (into-array File (map #(mk-mock-File {:name (str "C" %)
-                                                         :type :file
-                                                         :mtime (+ now-millis (* 100 %))
-                                                         :length 200 })
-                                      (range 0 10)))
-            port1-dir (mk-mock-File {:name "/workers-artifacts/topo1/port1"
-                                     :type :directory
-                                     :files files1})
-            port2-dir (mk-mock-File {:name "/workers-artifacts/topo1/port2"
-                                     :type :directory
-                                     :files files2})
-            port3-dir (mk-mock-File {:name "/workers-artifacts/topo2/port3"
-                                     :type :directory
-                                     :files files3})
-            topo1-files (into-array File [port1-dir port2-dir])
-            topo2-files (into-array File [port3-dir])
-            topo1-dir (mk-mock-File {:name "/workers-artifacts/topo1"
-                                     :type :directory
-                                     :files topo1-files})
-            topo2-dir (mk-mock-File {:name "/workers-artifacts/topo2"
-                                     :type :directory
-                                     :files topo2-files})
-            root-files (into-array File [topo1-dir topo2-dir])
-            root-dir (mk-mock-File {:name "/workers-artifacts"
-                                    :type :directory
-                                    :files root-files})
-            remaining-logs (logviewer/per-workerdir-cleanup root-dir 1200)]
-        (is (= (count (first remaining-logs)) 6))
-        (is (= (count (second remaining-logs)) 6))
-        (is (= (count (last remaining-logs)) 6))))))
+              (let [cleaner (proxy [backtype.storm.daemon.DirectoryCleaner] []
+                              (getStreamForDirectory
+                                ([^File dir]
+                                  (mk-DirectoryStream
+                                    (ArrayList.
+                                      (map #(mk-mock-Path %) (.listFiles dir)))))))
+                    now-millis (current-time-millis)
+                    files1 (into-array File (map #(mk-mock-File {:name (str "A" %)
+                                                                 :type :file
+                                                                 :mtime (+ now-millis (* 100 %))
+                                                                 :length 200 })
+                                                 (range 0 10)))
+                    files2 (into-array File (map #(mk-mock-File {:name (str "B" %)
+                                                                 :type :file
+                                                                 :mtime (+ now-millis (* 100 %))
+                                                                 :length 200 })
+                                                 (range 0 10)))
+                    files3 (into-array File (map #(mk-mock-File {:name (str "C" %)
+                                                                 :type :file
+                                                                 :mtime (+ now-millis (* 100 %))
+                                                                 :length 200 })
+                                                 (range 0 10)))
+                    port1-dir (mk-mock-File {:name "/workers-artifacts/topo1/port1"
+                                             :type :directory
+                                             :files files1})
+                    port2-dir (mk-mock-File {:name "/workers-artifacts/topo1/port2"
+                                             :type :directory
+                                             :files files2})
+                    port3-dir (mk-mock-File {:name "/workers-artifacts/topo2/port3"
+                                             :type :directory
+                                             :files files3})
+                    topo1-files (into-array File [port1-dir port2-dir])
+                    topo2-files (into-array File [port3-dir])
+                    topo1-dir (mk-mock-File {:name "/workers-artifacts/topo1"
+                                             :type :directory
+                                             :files topo1-files})
+                    topo2-dir (mk-mock-File {:name "/workers-artifacts/topo2"
+                                             :type :directory
+                                             :files topo2-files})
+                    root-files (into-array File [topo1-dir topo2-dir])
+                    root-dir (mk-mock-File {:name "/workers-artifacts"
+                                            :type :directory
+                                            :files root-files})
+                    deletedFiles (logviewer/per-workerdir-cleanup! root-dir 1200 cleaner)]
+                (is (= (first deletedFiles) 4))
+                (is (= (second deletedFiles) 4))
+                (is (= (last deletedFiles) 4))))))
 
-(deftest test-delete-oldest-log-cleanup
-  (testing "delete oldest logs deletes the oldest set of logs when the total size gets too large."
-    (stubbing [rmr nil]
-      (let [now-millis (current-time-millis)
-            files (into-array File (map #(mk-mock-File {:name (str %)
-                                                        :type :file
-                                                        :mtime (+ now-millis (* 100 %))
-                                                        :length 100 })
-                                     (range 0 20)))
-            remaining-logs (logviewer/delete-oldest-while-logs-too-large files 501)]
-        (is (= (logviewer/sum-file-size files) 2000))
-        (is (= (count remaining-logs) 5))
-        (is (= (.getName (first remaining-logs)) "15"))))))
+(deftest test-global-log-cleanup!
+  (testing "cleaner deletes oldest when files' sizes are larger than the global quota."
+    (stubbing [rmr nil
+               logviewer/get-alive-worker-dirs ["/workers-artifacts/topo1/port1"]]
+              (let [cleaner (proxy [backtype.storm.daemon.DirectoryCleaner] []
+                              (getStreamForDirectory
+                                ([^File dir]
+                                  (mk-DirectoryStream
+                                    (ArrayList.
+                                      (map #(mk-mock-Path %) (.listFiles dir)))))))
+                    now-millis (current-time-millis)
+                    files1 (into-array File (map #(mk-mock-File {:name (str "A" % ".log")
+                                                                 :type :file
+                                                                 :mtime (+ now-millis (* 100 %))
+                                                                 :length 200 })
+                                                 (range 0 10)))
+                    files2 (into-array File (map #(mk-mock-File {:name (str "B" %)
+                                                                 :type :file
+                                                                 :mtime (+ now-millis (* 100 %))
+                                                                 :length 200 })
+                                                 (range 0 10)))
+                    files3 (into-array File (map #(mk-mock-File {:name (str "C" %)
+                                                                 :type :file
+                                                                 :mtime (+ now-millis (* 100 %))
+                                                                 :length 200 })
+                                                 (range 0 10)))
+                    port1-dir (mk-mock-File {:name "/workers-artifacts/topo1/port1"
+                                             :type :directory
+                                             :files files1}) ;; note that port1-dir is active worker containing active logs
+                    port2-dir (mk-mock-File {:name "/workers-artifacts/topo1/port2"
+                                             :type :directory
+                                             :files files2})
+                    port3-dir (mk-mock-File {:name "/workers-artifacts/topo2/port3"
+                                             :type :directory
+                                             :files files3})
+                    topo1-files (into-array File [port1-dir port2-dir])
+                    topo2-files (into-array File [port3-dir])
+                    topo1-dir (mk-mock-File {:name "/workers-artifacts/topo1"
+                                             :type :directory
+                                             :files topo1-files})
+                    topo2-dir (mk-mock-File {:name "/workers-artifacts/topo2"
+                                             :type :directory
+                                             :files topo2-files})
+                    root-files (into-array File [topo1-dir topo2-dir])
+                    root-dir (mk-mock-File {:name "/workers-artifacts"
+                                            :type :directory
+                                            :files root-files})
+                    deletedFiles (logviewer/global-log-cleanup! root-dir 2400 cleaner)]
+                (is (= deletedFiles 18))))))
 
 (deftest test-identify-worker-log-dirs
   (testing "Build up workerid-workerlogdir map for the old workers' dirs"
@@ -228,7 +257,7 @@
           mockfile2 (mk-mock-File {:name "delete-me2" :type :file})]
       (stubbing [logviewer/select-dirs-for-cleanup nil
                  logviewer/get-dead-worker-dirs (sorted-set mockfile1 mockfile2)
-                 logviewer/cleanup-empty-topodir nil
+                 logviewer/cleanup-empty-topodir! nil
                  rmr nil]
         (logviewer/cleanup-fn! "/bogus/path")
         (verify-call-times-for rmr 2)


### PR DESCRIPTION
Using DirectoryStream to replace File.listFiles will save logviewer memory usage since it does not require loading all files' metadata into memory. This avoids potential memory usage problem in extreme case (e.g., you have millions of small files in your log directory).
Also, a multi-phase PQ-based sorting and cleaning scheme is introduced in DirectoryCleaner for replacing the global in-memory sorting.