### PR TITLE
[STORM-1452] Fixes profiling/debugging out of the box

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -167,7 +167,7 @@ worker.heap.memory.mb: 768
 worker.childopts: "-Xmx%HEAP-MEM%m -XX:+PrintGCDetails -Xloggc:artifacts/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"
 worker.gc.childopts: ""
 worker.profiler.childopts: "-XX:+UnlockCommercialFeatures -XX:+FlightRecorder"
-worker.profiler.enabled: true
+worker.profiler.enabled: false
 worker.profiler.command: "flight.bash"
 worker.heartbeat.frequency.secs: 1
 

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -166,8 +166,12 @@ supervisor.cpu.capacity: 400.0
 worker.heap.memory.mb: 768
 worker.childopts: "-Xmx%HEAP-MEM%m -XX:+PrintGCDetails -Xloggc:artifacts/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"
 worker.gc.childopts: ""
-worker.profiler.childopts: "-XX:+UnlockCommercialFeatures -XX:+FlightRecorder"
+
+# Unlocking commercial features requires a special license from Oracle.
+# See http://www.oracle.com/technetwork/java/javase/terms/products/index.html
+# For this reason, profiler features are disabled by default.
 worker.profiler.enabled: false
+worker.profiler.childopts: "-XX:+UnlockCommercialFeatures -XX:+FlightRecorder"
 worker.profiler.command: "flight.bash"
 worker.heartbeat.frequency.secs: 1
 

--- a/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
@@ -709,7 +709,10 @@
             stormid->profiler-actions @(:stormid->profiler-actions supervisor)
             storm-cluster-state (:storm-cluster-state supervisor)
             hostname (:my-hostname supervisor)
-            profile-cmd (conf WORKER-PROFILER-COMMAND)
+            storm-home (System/getProperty "storm.home")
+            profile-cmd (str (clojure.java.io/file storm-home
+                                                   "bin"
+                                                   (conf WORKER-PROFILER-COMMAND)))
             new-assignment @(:curr-assignment supervisor)
             assigned-storm-ids (assigned-storm-ids-from-port-assignments new-assignment)]
         (doseq [[storm-id profiler-actions] stormid->profiler-actions]

--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -105,14 +105,6 @@
            (throw (AuthorizationException.
                    (str "UI request '" op "' for '" user "' user is not authorized")))))))))
 
-
-(defn assert-authorized-profiler-action
-  [op]
-  (if-not (*STORM-CONF* WORKER-PROFILER-ENABLED)
-    (throw (AuthorizationException.
-             (str "UI request for profiler action '" op "' is disabled.")))))
-
-
 (defn executor-summary-type
   [topology ^ExecutorSummary s]
   (component-type topology (.get_component_id s)))
@@ -863,6 +855,7 @@
                                       (.get_eventlog_host comp-page-info)
                                       (.get_eventlog_port comp-page-info)
                                       secure?)
+       "profilingAndDebuggingCapable" (not on-windows?)
        "profileActionEnabled" (*STORM-CONF* WORKER-PROFILER-ENABLED)
        "profilerActive" (if (*STORM-CONF* WORKER-PROFILER-ENABLED)
                           (get-active-profile-actions nimbus topology-id component)
@@ -920,6 +913,15 @@
 (defn get-user-name
   [servlet-request]
   (.getUserName http-creds-handler servlet-request))
+
+(defn json-profiling-disabled
+  "Return a JSON response communicating that profiling is disabled and
+  therefore unavailable."
+  [callback]
+  (json-response {"status" "disabled",
+                  "message" "Profiling is not enabled on this server"}
+                 callback
+                 :status 501))
 
 (defroutes main-routes
   (GET "/api/v1/cluster/configuration" [& m]
@@ -1107,62 +1109,71 @@
 
   (GET "/api/v1/topology/:id/profiling/start/:host-port/:timeout"
        [:as {:keys [servlet-request]} id host-port timeout & m]
-       (thrift/with-configured-nimbus-connection nimbus
-         (assert-authorized-user "setWorkerProfiler" (topology-config id))
-         (assert-authorized-profiler-action "start")
-         (let [[host, port] (split host-port #":")
-               nodeinfo (NodeInfo. host (set [(Long. port)]))
-               timestamp (+ (System/currentTimeMillis) (* 60000 (Long. timeout)))
-               request (ProfileRequest. nodeinfo
-                                        ProfileAction/JPROFILE_STOP)]
-           (.set_time_stamp request timestamp)
-           (.setWorkerProfiler nimbus id request)
-           (json-response {"status" "ok"
-                           "id" host-port
-                           "timeout" timeout
-                           "dumplink" (worker-dump-link
-                                       host
-                                       port
-                                       id)}
-                          (m "callback")))))
+       (if (get *STORM-CONF* WORKER-PROFILER-ENABLED)
+         (do
+           (populate-context! servlet-request)
+           (thrift/with-configured-nimbus-connection nimbus
+             (assert-authorized-user "setWorkerProfiler" (topology-config id))
+             (let [[host, port] (split host-port #":")
+                   nodeinfo (NodeInfo. host (set [(Long. port)]))
+                   timestamp (+ (System/currentTimeMillis) (* 60000 (Long. timeout)))
+                   request (ProfileRequest. nodeinfo
+                                            ProfileAction/JPROFILE_STOP)]
+               (.set_time_stamp request timestamp)
+               (.setWorkerProfiler nimbus id request)
+               (json-response {"status" "ok"
+                               "id" host-port
+                               "timeout" timeout
+                               "dumplink" (worker-dump-link
+                                           host
+                                           port
+                                           id)}
+                              (m "callback")))))
+         (json-profiling-disabled (m "callback"))))
 
   (GET "/api/v1/topology/:id/profiling/stop/:host-port"
        [:as {:keys [servlet-request]} id host-port & m]
-       (thrift/with-configured-nimbus-connection nimbus
-         (assert-authorized-user "setWorkerProfiler" (topology-config id))
-         (assert-authorized-profiler-action "stop")
-         (let [[host, port] (split host-port #":")
-               nodeinfo (NodeInfo. host (set [(Long. port)]))
-               timestamp 0
-               request (ProfileRequest. nodeinfo
-                                        ProfileAction/JPROFILE_STOP)]
-           (.set_time_stamp request timestamp)
-           (.setWorkerProfiler nimbus id request)
-           (json-response {"status" "ok"
-                           "id" host-port}
-                          (m "callback")))))
-  
+       (if (get *STORM-CONF* WORKER-PROFILER-ENABLED)
+         (do
+           (populate-context! servlet-request)
+           (thrift/with-configured-nimbus-connection nimbus
+             (assert-authorized-user "setWorkerProfiler" (topology-config id))
+             (let [[host, port] (split host-port #":")
+                   nodeinfo (NodeInfo. host (set [(Long. port)]))
+                   timestamp 0
+                   request (ProfileRequest. nodeinfo
+                                            ProfileAction/JPROFILE_STOP)]
+               (.set_time_stamp request timestamp)
+               (.setWorkerProfiler nimbus id request)
+               (json-response {"status" "ok"
+                               "id" host-port}
+                              (m "callback")))))
+         (json-profiling-disabled (m "callback"))))
+
   (GET "/api/v1/topology/:id/profiling/dumpprofile/:host-port"
        [:as {:keys [servlet-request]} id host-port & m]
-       (thrift/with-configured-nimbus-connection nimbus
-         (assert-authorized-user "setWorkerProfiler" (topology-config id))
-         (assert-authorized-profiler-action "dumpprofile")
-         (let [[host, port] (split host-port #":")
-               nodeinfo (NodeInfo. host (set [(Long. port)]))
-               timestamp (System/currentTimeMillis)
-               request (ProfileRequest. nodeinfo
-                                        ProfileAction/JPROFILE_DUMP)]
-           (.set_time_stamp request timestamp)
-           (.setWorkerProfiler nimbus id request)
-           (json-response {"status" "ok"
-                           "id" host-port}
-                          (m "callback")))))
+       (if (get *STORM-CONF* WORKER-PROFILER-ENABLED)
+         (do
+           (populate-context! servlet-request)
+           (thrift/with-configured-nimbus-connection nimbus
+             (assert-authorized-user "setWorkerProfiler" (topology-config id))
+             (let [[host, port] (split host-port #":")
+                   nodeinfo (NodeInfo. host (set [(Long. port)]))
+                   timestamp (System/currentTimeMillis)
+                   request (ProfileRequest. nodeinfo
+                                            ProfileAction/JPROFILE_DUMP)]
+               (.set_time_stamp request timestamp)
+               (.setWorkerProfiler nimbus id request)
+               (json-response {"status" "ok"
+                               "id" host-port}
+                              (m "callback")))))
+         (json-profiling-disabled (m "callback"))))
 
   (GET "/api/v1/topology/:id/profiling/dumpjstack/:host-port"
        [:as {:keys [servlet-request]} id host-port & m]
+       (populate-context! servlet-request)
        (thrift/with-configured-nimbus-connection nimbus
          (assert-authorized-user "setWorkerProfiler" (topology-config id))
-         (assert-authorized-profiler-action "dumpjstack")
          (let [[host, port] (split host-port #":")
                nodeinfo (NodeInfo. host (set [(Long. port)]))
                timestamp (System/currentTimeMillis)
@@ -1176,9 +1187,9 @@
 
   (GET "/api/v1/topology/:id/profiling/restartworker/:host-port"
        [:as {:keys [servlet-request]} id host-port & m]
+       (populate-context! servlet-request)
        (thrift/with-configured-nimbus-connection nimbus
          (assert-authorized-user "setWorkerProfiler" (topology-config id))
-         (assert-authorized-profiler-action "restartworker")
          (let [[host, port] (split host-port #":")
                nodeinfo (NodeInfo. host (set [(Long. port)]))
                timestamp (System/currentTimeMillis)
@@ -1192,9 +1203,9 @@
        
   (GET "/api/v1/topology/:id/profiling/dumpheap/:host-port"
        [:as {:keys [servlet-request]} id host-port & m]
+       (populate-context! servlet-request)
        (thrift/with-configured-nimbus-connection nimbus
          (assert-authorized-user "setWorkerProfiler" (topology-config id))
-         (assert-authorized-profiler-action "dumpheap")
          (let [[host, port] (split host-port #":")
                nodeinfo (NodeInfo. host (set [(Long. port)]))
                timestamp (System/currentTimeMillis)

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -1374,7 +1374,9 @@ public class Config extends HashMap<String, Object> {
     public static final String WORKER_PROFILER_CHILDOPTS = "worker.profiler.childopts";
 
     /**
-     * This configuration would enable or disable component page profiing and debugging for workers.
+     * Enable profiling of worker JVMs using Oracle's Java Flight Recorder.
+     * Unlocking commercial features requires a special license from Oracle.
+     * See http://www.oracle.com/technetwork/java/javase/terms/products/index.html
      */
     @isBoolean
     public static final String WORKER_PROFILER_ENABLED = "worker.profiler.enabled";

--- a/storm-core/src/ui/public/component.html
+++ b/storm-core/src/ui/public/component.html
@@ -219,7 +219,7 @@ $(document).ready(function() {
               componentActions.append(Mustache.render($(template).filter("#component-actions-template").html(),buttonJsonData));
             });
 
-            if(response["profileActionEnabled"] == true) {
+            if (response["profilingAndDebuggingCapable"] == true) {
                 jsError(function () {
                     var part = $(template).filter('#profiler-active-partial').html();
                     var partials = {"profilerActive": part};

--- a/storm-core/src/ui/public/templates/component-page-template.html
+++ b/storm-core/src/ui/public/templates/component-page-template.html
@@ -254,7 +254,9 @@
         </td>
         <td>
           <span id="workerActionButtons">
+            {{#profileActionEnabled}}
             <input type="button" value="Start" name="start" onClick="start_profiling()" class="btn btn-secondary" disabled/>
+            {{/profileActionEnabled}}
             <input type="button" value="JStack" name="jstack" onClick="dump_jstacks()" class="btn btn-secondary" disabled/>
             <input type="button" value="Restart Worker" name="jvmrestart" onClick="restart_worker_jvms()" class="btn btn-secondary" disabled/>
             <input type="button" value="Heap" name="heap" onClick="dump_heaps()" class="btn btn-secondary" disabled/>

--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -42,6 +42,7 @@
             <outputDirectory>bin</outputDirectory>
             <includes>
                 <include>storm*</include>
+                <include>flight.bash</include>
             </includes>
             <fileMode>0755</fileMode>
         </fileSet>


### PR DESCRIPTION
Ships the flight.bash script
Disables UI display of Profiling and Debugging if on windows
Changes worker.profiler.enabled to control only profiling, not other debugging actions
Changes default of worker.profiler.enabled to false
Adds missing UI REST API data.
Populates user context on profiler UI routes

I would also like to see this applied to the master branch.