### PR TITLE
[STORM-1472] Fix the errorTime bug and show the time to be readable

### DIFF
--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -646,7 +646,7 @@
                     reverse)]
     {"componentErrors"
      (for [^ErrorInfo e errors]
-       {"time" (* 1000 (long (.get_error_time_secs e)))
+       {"errorTime" (* 1000 (long (.get_error_time_secs e)))
         "errorHost" (.get_host e)
         "errorPort"  (.get_port e)
         "errorWorkerLogLink"  (worker-log-link (.get_host e)

--- a/storm-core/src/jvm/org/apache/storm/scheduler/Cluster.java
+++ b/storm-core/src/jvm/org/apache/storm/scheduler/Cluster.java
@@ -32,11 +32,13 @@ import org.apache.storm.utils.Utils;
 public class Cluster {
 
     /**
-     * key: supervisor id, value: supervisor details
+     * key: supervisor id,
+     * value: supervisor's total and used resources, i.e. {totalMem, totalCpu, usedMem, usedCpu}
      */
     private Map<String, SupervisorDetails> supervisors;
     /**
      * key: supervisor id, value: supervisor's total and used resources
+     * value: {requestedMemOnHeap, requestedMemOffHeap, requestedCpu, assignedMemOnHeap, assignedMemOffHeap, assignedCpu}
      */
     private Map<String, Double[]> supervisorsResources;
 

--- a/storm-core/src/jvm/org/apache/storm/scheduler/Cluster.java
+++ b/storm-core/src/jvm/org/apache/storm/scheduler/Cluster.java
@@ -32,13 +32,11 @@ import org.apache.storm.utils.Utils;
 public class Cluster {
 
     /**
-     * key: supervisor id,
-     * value: supervisor's total and used resources, i.e. {totalMem, totalCpu, usedMem, usedCpu}
+     * key: supervisor id, value: supervisor details
      */
     private Map<String, SupervisorDetails> supervisors;
     /**
      * key: supervisor id, value: supervisor's total and used resources
-     * value: {requestedMemOnHeap, requestedMemOffHeap, requestedCpu, assignedMemOnHeap, assignedMemOffHeap, assignedCpu}
      */
     private Map<String, Double[]> supervisorsResources;
 

--- a/storm-core/src/ui/public/component.html
+++ b/storm-core/src/ui/public/component.html
@@ -298,6 +298,15 @@ $(document).ready(function() {
             //time, error
             dtAutoPage("#component-errors-table", {});
 
+            var errorTimeCells = document.getElementsByClassName("errorTimeSpan");
+            for (i = 0; i < errorTimeCells.length; i++)
+            {
+              var timeInMilliseconds = errorTimeCells[i].id;
+              var time = parseInt(timeInMilliseconds);
+              var date = new Date(time);
+              errorTimeCells[i].innerHTML = date.toJSON();
+            }
+
             var errorCells = document.getElementsByClassName("errorSpan");
             for (i =0; i < errorCells.length; i++)
             {

--- a/storm-core/src/ui/public/templates/component-page-template.html
+++ b/storm-core/src/ui/public/templates/component-page-template.html
@@ -539,7 +539,9 @@
     <tbody>
       {{#componentErrors}}
       <tr>
-        <td>{{errorTime}}</td>
+        <td>
+          <span id="{{errorTime}}" class="errorTimeSpan">{{errorTime}}</span>
+        </td>
         <td>{{errorHost}}</td>
         <td><a href="{{errorWorkerLogLink}}">{{errorPort}}</a></td>
         <td>


### PR DESCRIPTION
1. Checking the code, find a bug in storm-core/src/clj/backtype/storm/ui/core.clj
"time" changed to "errorTime", however the REST info is still "time".
Error log link can not show any info for time.

2. In the error log link of UI, long of millisecond dates makes little sense to user. It would be nice to change it to be readable date.
