### PR TITLE
[STORM-1478] make bolt's getComponentConfiguration method cleaner/simpler

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -216,7 +216,7 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
 
     @Override
     public Map<String, Object> getComponentConfiguration() {
-        return TupleUtils.putTickFreqencyIntoComponentConfig(super.getComponentConfiguration(), tickTupleInterval);
+        return TupleUtils.putTickFrequencyIntoComponentConfig(super.getComponentConfiguration(), tickTupleInterval);
     }
 
     @Override

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -216,16 +216,7 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
 
     @Override
     public Map<String, Object> getComponentConfiguration() {
-        Map<String, Object> conf = super.getComponentConfiguration();
-        if (conf == null)
-            conf = new Config();
-
-        if (tickTupleInterval > 0) {
-            LOG.info("Enabling tick tuple with interval [{}]", tickTupleInterval);
-            conf.put(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS, tickTupleInterval);
-        }
-
-        return conf;
+        return TupleUtils.putTickFreqencyIntoComponentConfig(super.getComponentConfiguration(), tickTupleInterval);
     }
 
     @Override

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
@@ -188,7 +188,7 @@ public class HiveBolt extends  BaseRichBolt {
 
     @Override
     public Map<String, Object> getComponentConfiguration() {
-        return TupleUtils.putTickFreqencyIntoComponentConfig(super.getComponentConfiguration(),
+        return TupleUtils.putTickFrequencyIntoComponentConfig(super.getComponentConfiguration(),
                 options.getTickTupleInterval());
     }
 

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
@@ -188,14 +188,8 @@ public class HiveBolt extends  BaseRichBolt {
 
     @Override
     public Map<String, Object> getComponentConfiguration() {
-        Map<String, Object> conf = super.getComponentConfiguration();
-        if (conf == null)
-            conf = new Config();
-
-        if (options.getTickTupleInterval() > 0)
-            conf.put(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS, options.getTickTupleInterval());
-
-        return conf;
+        return TupleUtils.putTickFreqencyIntoComponentConfig(super.getComponentConfiguration(),
+                options.getTickTupleInterval());
     }
 
     private void setupHeartBeatTimer() {

--- a/external/storm-solr/src/main/java/org/apache/storm/solr/bolt/SolrUpdateBolt.java
+++ b/external/storm-solr/src/main/java/org/apache/storm/solr/bolt/SolrUpdateBolt.java
@@ -153,7 +153,7 @@ public class SolrUpdateBolt extends BaseRichBolt {
 
     @Override
     public Map<String, Object> getComponentConfiguration() {
-        return TupleUtils.putTickFreqencyIntoComponentConfig(super.getComponentConfiguration(), tickTupleInterval);
+        return TupleUtils.putTickFrequencyIntoComponentConfig(super.getComponentConfiguration(), tickTupleInterval);
     }
 
     @Override

--- a/storm-core/src/jvm/org/apache/storm/utils/TupleUtils.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/TupleUtils.java
@@ -48,7 +48,7 @@ public final class TupleUtils {
       }
     }
 
-    public static Map<String, Object> putTickFreqencyIntoComponentConfig(Map<String, Object> conf, int tickFreqSecs) {
+    public static Map<String, Object> putTickFrequencyIntoComponentConfig(Map<String, Object> conf, int tickFreqSecs) {
       if (conf == null) {
           conf = new Config();
       }


### PR DESCRIPTION
This PR follow https://github.com/apache/storm/pull/977#discussion_r49160913 @hmcl 's comment:
>I noticed that the body of this method is exactly the same for AbstractHdfsBolt. Furthermore, it's very likely that many Storm connector bolts will use the same code. Can you please write a helper method in TupleUtils and call that method here and AbstractHdfsBolt.