### PR TITLE
[storm-core] Added exception for emit to undeclared stream

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -142,7 +142,7 @@
                   (.getComponentOutputFields worker-context component-id stream-id)
                   component->grouping
                   topo-conf)]))
-         (into {})
+         (into (apply merge (map #(hash-map % nil) (.keySet (.get_streams (.getComponentCommon worker-context component-id))))))
          (HashMap.)))
 
 (defn executor-type [^WorkerTopologyContext context component-id]

--- a/storm-core/src/clj/org/apache/storm/daemon/task.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/task.clj
@@ -150,6 +150,8 @@
            (when debug?
              (log-message "Emitting: " component-id " " stream " " values))
            (let [out-tasks (ArrayList.)]
+             (if (not (.containsKey stream->component->grouper stream))
+               (throw (IllegalArgumentException. (str "Unknown stream ID: " stream))))
              (fast-map-iter [[out-component grouper] (get stream->component->grouper stream)]
                (when (= :direct grouper)
                   ;;  TODO: this is wrong, need to check how the stream was declared


### PR DESCRIPTION
`stream->component->grouper` does only contain streams that are not consumed. Thus, I add entries for all streams (with key is `streamID` and `null` as value) to the computed `HashMap` in `outbound-components`.