### PR TITLE
STORM-1464: Support multiple file outputs

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -17,14 +17,12 @@
  */
 package org.apache.storm.hdfs.bolt;
 
-import org.apache.storm.Config;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.TupleUtils;
-import org.apache.storm.utils.Utils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -32,6 +30,9 @@ import org.apache.storm.hdfs.bolt.format.FileNameFormat;
 import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
 import org.apache.storm.hdfs.bolt.rotation.TimedRotationPolicy;
 import org.apache.storm.hdfs.bolt.sync.SyncPolicy;
+import org.apache.storm.hdfs.common.AbstractHDFSWriter;
+import org.apache.storm.hdfs.common.NullPartitioner;
+import org.apache.storm.hdfs.common.Partitioner;
 import org.apache.storm.hdfs.common.rotation.RotationAction;
 import org.apache.storm.hdfs.common.security.HdfsSecurityUtil;
 import org.slf4j.Logger;
@@ -39,6 +40,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.List;
@@ -52,15 +55,16 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
      * Half of the default Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS
      */
     private static final int DEFAULT_TICK_TUPLE_INTERVAL_SECS = 15;
+    private static final Integer DEFAULT_MAX_OPEN_FILES = 50;
 
-    protected ArrayList<RotationAction> rotationActions = new ArrayList<RotationAction>();
-    private Path currentFile;
+    protected Map<String, AbstractHDFSWriter> writers;
+    protected Map<String, Integer> rotationCounterMap = new HashMap<>();
+    protected List<RotationAction> rotationActions = new ArrayList<>();
     protected OutputCollector collector;
     protected transient FileSystem fs;
     protected SyncPolicy syncPolicy;
     protected FileRotationPolicy rotationPolicy;
     protected FileNameFormat fileNameFormat;
-    protected int rotation = 0;
     protected String fsUrl;
     protected String configKey;
     protected transient Object writeLock;
@@ -69,22 +73,21 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
     protected long offset = 0;
     protected Integer fileRetryCount = DEFAULT_RETRY_COUNT;
     protected Integer tickTupleInterval = DEFAULT_TICK_TUPLE_INTERVAL_SECS;
+    protected Integer maxOpenFiles = DEFAULT_MAX_OPEN_FILES;
+    protected Partitioner partitioner = new NullPartitioner();
 
     protected transient Configuration hdfsConfig;
 
-    protected void rotateOutputFile() throws IOException {
+    protected void rotateOutputFile(AbstractHDFSWriter writer) throws IOException {
         LOG.info("Rotating output file...");
         long start = System.currentTimeMillis();
         synchronized (this.writeLock) {
-            closeOutputFile();
-            this.rotation++;
+            writer.close();
 
-            Path newFile = createOutputFile();
             LOG.info("Performing {} file rotation actions.", this.rotationActions.size());
             for (RotationAction action : this.rotationActions) {
-                action.execute(this.fs, this.currentFile);
+                action.execute(this.fs, writer.getFilePath());
             }
-            this.currentFile = newFile;
         }
         long time = System.currentTimeMillis() - start;
         LOG.info("File rotation took {} ms.", time);
@@ -104,6 +107,8 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
             throw new IllegalStateException("File system URL must be specified.");
         }
 
+        writers = new WritersMap(this.maxOpenFiles);
+
         this.collector = collector;
         this.fileNameFormat.prepare(conf, topologyContext);
         this.hdfsConfig = new Configuration();
@@ -117,26 +122,12 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
         try{
             HdfsSecurityUtil.login(conf, hdfsConfig);
             doPrepare(conf, topologyContext, collector);
-            this.currentFile = createOutputFile();
-
         } catch (Exception e){
             throw new RuntimeException("Error preparing HdfsBolt: " + e.getMessage(), e);
         }
 
         if(this.rotationPolicy instanceof TimedRotationPolicy){
-            long interval = ((TimedRotationPolicy)this.rotationPolicy).getInterval();
-            this.rotationTimer = new Timer(true);
-            TimerTask task = new TimerTask() {
-                @Override
-                public void run() {
-                    try {
-                        rotateOutputFile();
-                    } catch(IOException e){
-                        LOG.warn("IOException during scheduled file rotation.", e);
-                    }
-                }
-            };
-            this.rotationTimer.scheduleAtFixedRate(task, interval, interval);
+            startTimedRotationPolicy();
         }
     }
 
@@ -145,13 +136,20 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
 
         synchronized (this.writeLock) {
             boolean forceSync = false;
+            AbstractHDFSWriter writer = null;
+            String writerKey = null;
+
             if (TupleUtils.isTick(tuple)) {
                 LOG.debug("TICK! forcing a file system flush");
                 this.collector.ack(tuple);
                 forceSync = true;
             } else {
+
+                writerKey = getHashKeyForTuple(tuple);
+
                 try {
-                    writeTuple(tuple);
+                    writer = getOrCreateWriter(writerKey, tuple);
+                    this.offset = writer.write(tuple);
                     tupleBatch.add(tuple);
                 } catch (IOException e) {
                     //If the write failed, try to sync anything already written
@@ -171,7 +169,7 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
                 while (success == false && attempts < fileRetryCount) {
                     attempts += 1;
                     try {
-                        syncTuples();
+                        syncAllWriters();
                         LOG.debug("Data synced to filesystem. Ack'ing [{}] tuples", tupleBatch.size());
                         for (Tuple t : tupleBatch) {
                             this.collector.ack(t);
@@ -198,19 +196,50 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
                 }
             }
 
-            if(this.rotationPolicy.mark(tuple, this.offset)) {
-                try {
-                    rotateOutputFile();
-                    this.rotationPolicy.reset();
-                    this.offset = 0;
-                } catch (IOException e) {
-                    this.collector.reportError(e);
-                    LOG.warn("File could not be rotated");
-                    //At this point there is nothing to do.  In all likelihood any filesystem operations will fail.
-                    //The next tuple will almost certainly fail to write and/or sync, which force a rotation.  That
-                    //will give rotateAndReset() a chance to work which includes creating a fresh file handle.
-                }
+            if (writer != null && writer.needsRotation()) {
+                    doRotationAndRemoveWriter(writerKey, writer);
             }
+        }
+    }
+
+    private AbstractHDFSWriter getOrCreateWriter(String writerKey, Tuple tuple) throws IOException {
+        AbstractHDFSWriter writer;
+
+        writer = writers.get(writerKey);
+        if (writer == null) {
+            Path pathForNextFile = getBasePathForNextFile(tuple);
+            writer = makeNewWriter(pathForNextFile, tuple);
+            writers.put(writerKey, writer);
+        }
+        return writer;
+    }
+
+    /**
+     * A tuple must be mapped to a writer based on two factors:
+     *  - bolt specific logic that must separate tuples into different files in the same directory (see the avro bolt
+     *    for an example of this)
+     *  - the directory the tuple will be partioned into
+     *
+     * @param tuple
+     * @return
+     */
+    private String getHashKeyForTuple(Tuple tuple) {
+        final String boltKey = getWriterKey(tuple);
+        final String partitionDir = this.partitioner.getPartitionPath(tuple);
+        return boltKey + "****" + partitionDir;
+    }
+
+    void doRotationAndRemoveWriter(String writerKey, AbstractHDFSWriter writer) {
+        try {
+            rotateOutputFile(writer);
+        } catch (IOException e) {
+            this.collector.reportError(e);
+            LOG.error("File could not be rotated");
+            //At this point there is nothing to do.  In all likelihood any filesystem operations will fail.
+            //The next tuple will almost certainly fail to write and/or sync, which force a rotation.  That
+            //will give rotateAndReset() a chance to work which includes creating a fresh file handle.
+        } finally {
+            writers.remove(writerKey);
         }
     }
 
@@ -223,29 +252,64 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
     public void declareOutputFields(OutputFieldsDeclarer outputFieldsDeclarer) {
     }
 
-    /**
-     * writes a tuple to the underlying filesystem but makes no guarantees about syncing data.
-     *
-     * this.offset is also updated to reflect additional data written
-     *
-     * @param tuple
-     * @throws IOException
-     */
-    abstract protected void writeTuple(Tuple tuple) throws IOException;
+    private void syncAllWriters() throws IOException {
+        for (AbstractHDFSWriter writer : writers.values()) {
+            writer.sync();
+        }
+    }
 
-    /**
-     * Make the best effort to sync written data to the underlying file system.  Concrete classes should very clearly
-     * state the file state that sync guarantees.  For example, HdfsBolt can make a much stronger guarantee than
-     * SequenceFileBolt.
-     *
-     * @throws IOException
-     */
-    abstract protected void syncTuples() throws IOException;
+    private void startTimedRotationPolicy() {
+        long interval = ((TimedRotationPolicy)this.rotationPolicy).getInterval();
+        this.rotationTimer = new Timer(true);
+        TimerTask task = new TimerTask() {
+            @Override
+            public void run() {
+                for (final AbstractHDFSWriter writer : writers.values()) {
+                    try {
+                        rotateOutputFile(writer);
+                    } catch (IOException e) {
+                        LOG.warn("IOException during scheduled file rotation.", e);
+                    }
+                }
+                writers.clear();
+            }
+        };
+        this.rotationTimer.scheduleAtFixedRate(task, interval, interval);
+    }
 
-    abstract protected void closeOutputFile() throws IOException;
+    protected Path getBasePathForNextFile(Tuple tuple) {
 
-    abstract protected Path createOutputFile() throws IOException;
+        final String partitionPath = this.partitioner.getPartitionPath(tuple);
+        final int rotation;
+        if (rotationCounterMap.containsKey(partitionPath))
+        {
+            rotation = rotationCounterMap.get(partitionPath) + 1;
+        } else {
+            rotation = 0;
+        }
+        rotationCounterMap.put(partitionPath, rotation);
+
+        return new Path(this.fsUrl + this.fileNameFormat.getPath() + partitionPath,
+                this.fileNameFormat.getName(rotation, System.currentTimeMillis()));
+    }
 
     abstract protected void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException;
 
+    abstract protected String getWriterKey(Tuple tuple);
+
+    abstract protected AbstractHDFSWriter makeNewWriter(Path path, Tuple tuple) throws IOException;
+
+    static class WritersMap extends LinkedHashMap<String, AbstractHDFSWriter> {
+        final long maxWriters;
+
+        public WritersMap(long maxWriters) {
+            super((int)maxWriters, 0.75f, true);
+            this.maxWriters = maxWriters;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, AbstractHDFSWriter> eldest) {
+            return this.size() > this.maxWriters;
+        }
+    }
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBolt.java
@@ -17,18 +17,16 @@
  */
 package org.apache.storm.hdfs.bolt;
 
+import org.apache.storm.hdfs.common.AbstractHDFSWriter;
+import org.apache.storm.hdfs.common.AvroGenericRecordHDFSWriter;
+import org.apache.storm.hdfs.common.Partitioner;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.apache.avro.Schema;
-import org.apache.avro.file.DataFileWriter;
-import org.apache.avro.io.DatumWriter;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
 
 import org.apache.storm.hdfs.bolt.format.FileNameFormat;
 import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
@@ -38,23 +36,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
-import java.util.EnumSet;
 import java.util.Map;
 
 public class AvroGenericRecordBolt extends AbstractHdfsBolt{
 
     private static final Logger LOG = LoggerFactory.getLogger(AvroGenericRecordBolt.class);
-
-    private transient FSDataOutputStream out;
-    private Schema schema;
-    private String schemaAsString;
-    private DataFileWriter<GenericRecord> avroWriter;
-
-    public AvroGenericRecordBolt withSchemaAsString(String schemaAsString)
-    {
-        this.schemaAsString = schemaAsString;
-        return this;
-    }
 
     public AvroGenericRecordBolt withFsUrl(String fsUrl){
         this.fsUrl = fsUrl;
@@ -91,51 +77,36 @@ public class AvroGenericRecordBolt extends AbstractHdfsBolt{
         return this;
     }
 
+    public AvroGenericRecordBolt withMaxOpenFiles(int maxOpenFiles) {
+        this.maxOpenFiles = maxOpenFiles;
+        return this;
+    }
+
+    public AvroGenericRecordBolt withPartitioner(Partitioner partitioner) {
+        this.partitioner = partitioner;
+        return this;
+    }
+
     @Override
     protected void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException {
         LOG.info("Preparing AvroGenericRecord Bolt...");
         this.fs = FileSystem.get(URI.create(this.fsUrl), hdfsConfig);
-        Schema.Parser parser = new Schema.Parser();
-        this.schema = parser.parse(this.schemaAsString);
+    }
+
+    /**
+     * AvroGenericRecordBolt must override this method because messages with different schemas cannot be written to the
+     * same file.  By treating the complete schema as the "key" AbstractHdfsBolt will associate a different writer for
+     * every distinct schema.
+     */
+    @Override
+    protected String getWriterKey(Tuple tuple) {
+        Schema recordSchema = ((GenericRecord) tuple.getValue(0)).getSchema();
+        return recordSchema.toString();
     }
 
     @Override
-    protected void writeTuple(Tuple tuple) throws IOException {
-        GenericRecord avroRecord = (GenericRecord) tuple.getValue(0);
-        avroWriter.append(avroRecord);
-        offset = this.out.getPos();
-    }
-
-    @Override
-    protected void syncTuples() throws IOException {
-        avroWriter.flush();
-
-        LOG.debug("Attempting to sync all data to filesystem");
-        if (this.out instanceof HdfsDataOutputStream) {
-            ((HdfsDataOutputStream) this.out).hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.UPDATE_LENGTH));
-        } else {
-            this.out.hsync();
-        }
-        this.syncPolicy.reset();
-    }
-
-    @Override
-    protected void closeOutputFile() throws IOException
-    {
-        avroWriter.close();
-        this.out.close();
-    }
-
-    @Override
-    protected Path createOutputFile() throws IOException {
-        Path path = new Path(this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
-        this.out = this.fs.create(path);
-
-        //Initialize writer
-        DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
-        avroWriter = new DataFileWriter<>(datumWriter);
-        avroWriter.create(this.schema, this.out);
-
-        return path;
+    protected AbstractHDFSWriter makeNewWriter(Path path, Tuple tuple) throws IOException {
+        Schema recordSchema = ((GenericRecord) tuple.getValue(0)).getSchema();
+        return new AvroGenericRecordHDFSWriter(this.rotationPolicy, path, this.fs.create(path), recordSchema);
     }
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileBolt.java
@@ -28,6 +28,9 @@ import org.apache.storm.hdfs.bolt.format.FileNameFormat;
 import org.apache.storm.hdfs.bolt.format.SequenceFormat;
 import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
 import org.apache.storm.hdfs.bolt.sync.SyncPolicy;
+import org.apache.storm.hdfs.common.AbstractHDFSWriter;
+import org.apache.storm.hdfs.common.Partitioner;
+import org.apache.storm.hdfs.common.SequenceFileWriter;
 import org.apache.storm.hdfs.common.rotation.RotationAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,6 +107,16 @@ public class SequenceFileBolt extends AbstractHdfsBolt {
         return this;
     }
 
+    public SequenceFileBolt withPartitioner(Partitioner partitioner) {
+        this.partitioner = partitioner;
+        return this;
+    }
+
+    public SequenceFileBolt withMaxOpenFiles(int maxOpenFiles) {
+        this.maxOpenFiles = maxOpenFiles;
+        return this;
+    }
+
     @Override
     public void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException {
         LOG.info("Preparing Sequence File Bolt...");
@@ -114,30 +127,20 @@ public class SequenceFileBolt extends AbstractHdfsBolt {
     }
 
     @Override
-    protected void syncTuples() throws IOException {
-        LOG.debug("Attempting to sync all data to filesystem");
-        this.writer.hsync();
+    protected String getWriterKey(Tuple tuple) {
+        return "CONSTANT";
     }
 
     @Override
-    protected void writeTuple(Tuple tuple) throws IOException {
-        this.writer.append(this.format.key(tuple), this.format.value(tuple));
-        this.offset = this.writer.getLength();
-    }
-
-    protected Path createOutputFile() throws IOException {
-        Path p = new Path(this.fsUrl + this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
-        this.writer = SequenceFile.createWriter(
+    protected AbstractHDFSWriter makeNewWriter(Path path, Tuple tuple) throws IOException {
+        SequenceFile.Writer writer = SequenceFile.createWriter(
                 this.hdfsConfig,
-                SequenceFile.Writer.file(p),
+                SequenceFile.Writer.file(path),
                 SequenceFile.Writer.keyClass(this.format.keyClass()),
                 SequenceFile.Writer.valueClass(this.format.valueClass()),
                 SequenceFile.Writer.compression(this.compressionType, this.codecFactory.getCodecByName(this.compressionCodec))
         );
-        return p;
-    }
 
-    protected void closeOutputFile() throws IOException {
-        this.writer.close();
+        return new SequenceFileWriter(this.rotationPolicy, path, writer, this.format);
     }
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/rotation/FileRotationPolicy.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/rotation/FileRotationPolicy.java
@@ -48,4 +48,9 @@ public interface FileRotationPolicy extends Serializable {
      *
      */
     void reset();
+
+    /**
+     * Must be able to copy the rotation policy
+     */
+    FileRotationPolicy copy();
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/rotation/FileSizeRotationPolicy.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/rotation/FileSizeRotationPolicy.java
@@ -64,6 +64,10 @@ public class FileSizeRotationPolicy implements FileRotationPolicy {
         this.maxBytes = (long)(count * units.getByteCount());
     }
 
+    protected FileSizeRotationPolicy(long maxBytes) {
+        this.maxBytes = maxBytes;
+    }
+
     @Override
     public boolean mark(Tuple tuple, long offset) {
         long diff = offset - this.lastOffset;
@@ -78,4 +82,8 @@ public class FileSizeRotationPolicy implements FileRotationPolicy {
         this.lastOffset = 0;
     }
 
+    @Override
+    public FileRotationPolicy copy() {
+        return new FileSizeRotationPolicy(this.maxBytes);
+    }
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/rotation/TimedRotationPolicy.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/rotation/TimedRotationPolicy.java
@@ -45,6 +45,9 @@ public class TimedRotationPolicy implements FileRotationPolicy {
         this.interval = (long)(count * units.getMilliSeconds());
     }
 
+    protected TimedRotationPolicy(long interval) {
+        this.interval = interval;
+    }
 
     /**
      * Called for every tuple the HdfsBolt executes.
@@ -64,6 +67,11 @@ public class TimedRotationPolicy implements FileRotationPolicy {
     @Override
     public void reset() {
 
+    }
+
+    @Override
+    public FileRotationPolicy copy() {
+        return new TimedRotationPolicy(this.interval);
     }
 
     public long getInterval(){

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/AbstractHDFSWriter.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/AbstractHDFSWriter.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.common;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
+import org.apache.storm.tuple.Tuple;
+
+import java.io.IOException;
+
+abstract public class AbstractHDFSWriter {
+    long lastUsedTime;
+    long offset;
+    boolean needsRotation;
+    Path filePath;
+    FileRotationPolicy rotationPolicy;
+
+    AbstractHDFSWriter(FileRotationPolicy policy, Path path) {
+        //This must be defensively copied, because a bolt probably has only one rotation policy object
+        this.rotationPolicy = policy.copy();
+        this.filePath = path;
+    }
+
+    final public long write(Tuple tuple) throws IOException{
+        doWrite(tuple);
+        this.needsRotation = rotationPolicy.mark(tuple, offset);
+
+        return this.offset;
+    }
+
+    final public void sync() throws IOException {
+        doSync();
+    }
+
+    final public void close() throws IOException {
+        doClose();
+    }
+
+    public boolean needsRotation() {
+        return needsRotation;
+    }
+
+    public Path getFilePath() {
+        return this.filePath;
+    }
+
+    abstract protected void doWrite(Tuple tuple) throws IOException;
+
+    abstract protected void doSync() throws IOException;
+
+    abstract protected void doClose() throws IOException;
+
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/AvroGenericRecordHDFSWriter.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/AvroGenericRecordHDFSWriter.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.common;
+
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumWriter;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+public class AvroGenericRecordHDFSWriter extends AbstractHDFSWriter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AvroGenericRecordHDFSWriter.class);
+
+    private FSDataOutputStream out;
+    private Schema schema;
+    private DataFileWriter<GenericRecord> avroWriter;
+
+    public AvroGenericRecordHDFSWriter(FileRotationPolicy policy, Path path, FSDataOutputStream stream, Schema schema) throws IOException {
+        super(policy, path);
+        this.out = stream;
+        this.schema = schema;
+        DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
+        avroWriter = new DataFileWriter<>(datumWriter);
+        avroWriter.create(this.schema, this.out);
+    }
+
+    @Override
+    protected void doWrite(Tuple tuple) throws IOException {
+        GenericRecord avroRecord = (GenericRecord) tuple.getValue(0);
+        avroWriter.append(avroRecord);
+        offset = this.out.getPos();
+
+        this.needsRotation = this.rotationPolicy.mark(tuple, offset);
+    }
+
+    @Override
+    protected void doSync() throws IOException {
+        avroWriter.flush();
+
+        LOG.debug("Attempting to sync all data to filesystem");
+        if (this.out instanceof HdfsDataOutputStream) {
+            ((HdfsDataOutputStream) this.out).hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.UPDATE_LENGTH));
+        } else {
+            this.out.hsync();
+        }
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        this.avroWriter.close();
+        this.out.close();
+    }
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HDFSWriter.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/HDFSWriter.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.common;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+import org.apache.storm.hdfs.bolt.format.RecordFormat;
+import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+public class HDFSWriter extends AbstractHDFSWriter{
+
+    private static final Logger LOG = LoggerFactory.getLogger(HDFSWriter.class);
+
+    private FSDataOutputStream out;
+    private RecordFormat format;
+
+    public HDFSWriter(FileRotationPolicy policy, Path path, FSDataOutputStream out, RecordFormat format) {
+        super(policy, path);
+        this.out = out;
+        this.format = format;
+    }
+
+    @Override
+    protected void doWrite(Tuple tuple) throws IOException {
+        byte[] bytes = this.format.format(tuple);
+        out.write(bytes);
+        this.offset += bytes.length;
+    }
+
+    @Override
+    protected void doSync() throws IOException {
+        LOG.info("Attempting to sync all data to filesystem");
+        if (this.out instanceof HdfsDataOutputStream) {
+            ((HdfsDataOutputStream) this.out).hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.UPDATE_LENGTH));
+        } else {
+            this.out.hsync();
+        }
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        this.out.close();
+    }
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/NullPartitioner.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/NullPartitioner.java
@@ -15,26 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.hdfs.bolt.rotation;
+package org.apache.storm.hdfs.common;
 
 import org.apache.storm.tuple.Tuple;
 
 /**
- * File rotation policy that will never rotate...
- * Just one big file. Intended for testing purposes.
+ * The NullPartitioner partitions every tuple to the empty string. In otherwords, no partition sub directories will
+ * be added to the path.
  */
-public class NoRotationPolicy implements FileRotationPolicy {
+public class NullPartitioner implements Partitioner {
     @Override
-    public boolean mark(Tuple tuple, long offset) {
-        return false;
-    }
-
-    @Override
-    public void reset() {
-    }
-
-    @Override
-    public FileRotationPolicy copy() {
-        return this;
+    public String getPartitionPath(final Tuple tuple) {
+        return "";
     }
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/Partitioner.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/Partitioner.java
@@ -15,26 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.hdfs.bolt.rotation;
+package org.apache.storm.hdfs.common;
 
 import org.apache.storm.tuple.Tuple;
 
-/**
- * File rotation policy that will never rotate...
- * Just one big file. Intended for testing purposes.
- */
-public class NoRotationPolicy implements FileRotationPolicy {
-    @Override
-    public boolean mark(Tuple tuple, long offset) {
-        return false;
-    }
+import java.io.Serializable;
 
-    @Override
-    public void reset() {
-    }
+public interface Partitioner extends Serializable{
 
-    @Override
-    public FileRotationPolicy copy() {
-        return this;
-    }
+    /**
+     * Return a relative path that the tuple should be written to. For example, if an HdfsBolt were configured to write
+     * to /common/output and a partitioner returned "/foo" then the bolt should open a file in "/common/output/foo"
+     *
+     * A best practice is to use Path.SEPARATOR instead of a literal "/"
+     *
+     * @param tuple The tuple for which the relative path is being calculated.
+     * @return
+     */
+    public String getPartitionPath(final Tuple tuple);
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/SequenceFileWriter.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/SequenceFileWriter.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.common;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.storm.hdfs.bolt.format.SequenceFormat;
+import org.apache.storm.hdfs.bolt.rotation.FileRotationPolicy;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class SequenceFileWriter extends AbstractHDFSWriter{
+
+    private static final Logger LOG = LoggerFactory.getLogger(SequenceFileWriter.class);
+
+    private SequenceFile.Writer writer;
+    private SequenceFormat format;
+
+    public SequenceFileWriter(FileRotationPolicy policy, Path path, SequenceFile.Writer writer, SequenceFormat format) {
+        super(policy, path);
+        this.writer = writer;
+        this.format = format;
+    }
+
+    @Override
+    protected void doWrite(Tuple tuple) throws IOException {
+        this.writer.append(this.format.key(tuple), this.format.value(tuple));
+        this.offset = this.writer.getLength();
+    }
+
+    @Override
+    protected void doSync() throws IOException {
+        LOG.debug("Attempting to sync all data to filesystem");
+        this.writer.hsync();
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        this.writer.close();
+    }
+}

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestSequenceFileBolt.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestSequenceFileBolt.java
@@ -127,14 +127,14 @@ public class TestSequenceFileBolt {
     @Test
     public void testFailedSync() throws IOException
     {
-        SequenceFileBolt bolt = makeSeqBolt(hdfsURI, 1, .00001f);
+        SequenceFileBolt bolt = makeSeqBolt(hdfsURI, 2, 10000f);
         bolt.prepare(new Config(), topologyContext, collector);
+        bolt.execute(tuple1);
 
         fs.setSafeMode(SafeModeAction.SAFEMODE_ENTER);
         // All writes/syncs will fail so this should cause a RuntimeException
         thrown.expect(RuntimeException.class);
         bolt.execute(tuple1);
-
     }
 
     private SequenceFileBolt makeSeqBolt(String nameNodeAddr, int countSync, float rotationSizeMB) {

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestWritersMap.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestWritersMap.java
@@ -15,26 +15,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.hdfs.bolt.rotation;
+package org.apache.storm.hdfs.bolt;
 
-import org.apache.storm.tuple.Tuple;
+import org.apache.storm.hdfs.common.AbstractHDFSWriter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mock;
 
-/**
- * File rotation policy that will never rotate...
- * Just one big file. Intended for testing purposes.
- */
-public class NoRotationPolicy implements FileRotationPolicy {
-    @Override
-    public boolean mark(Tuple tuple, long offset) {
-        return false;
-    }
+public class TestWritersMap {
 
-    @Override
-    public void reset() {
-    }
+    AbstractHdfsBolt.WritersMap map = new AbstractHdfsBolt.WritersMap(2);
+    @Mock AbstractHDFSWriter foo;
+    @Mock AbstractHDFSWriter bar;
+    @Mock AbstractHDFSWriter baz;
 
-    @Override
-    public FileRotationPolicy copy() {
-        return this;
+    @Test public void testLRUBehavior()
+    {
+        map.put("FOO", foo);
+        map.put("BAR", bar);
+
+        //Access foo to make it most recently used
+        map.get("FOO");
+
+        //Add an element and bar should drop out
+        map.put("BAZ", baz);
+
+        Assert.assertTrue(map.keySet().contains("FOO"));
+        Assert.assertTrue(map.keySet().contains("BAZ"));
+
+        Assert.assertFalse(map.keySet().contains("BAR"));
     }
 }


### PR DESCRIPTION
This PR will enable storm-hdfs to write to multiple files in a couple of different circumstances:

- If a bolt requires multiple output files.  For example, the avro bolt needs to write different Avro records with different schemas to different files.  Schema evolution is a common use of Avro so I expect this to be common use.

- Partitioning output of the HDFS bolt.  Based on mailing discussion, there is demand for this feature.

It does introduce a couple of incompatible changes.  The most obvious is adding a method to the FileRotationPolicy interface.  I tried to minimize other API changes at the expense of some less than elegant code in a couple of places.