### PR TITLE
[STORM-1501] launch worker process exception will cause supervisor process exited

### DIFF
--- a/storm-core/src/clj/org/apache/storm/util.clj
+++ b/storm-core/src/clj/org/apache/storm/util.clj
@@ -554,7 +554,7 @@
                  (log-message log-prefix " interrupted.")))
              (exit-code-callback (.exitValue process)))
            nil)
-          :kill-fn (fn [error] (log-error (RuntimeException. ("launch process failed...")))))
+          :kill-fn (fn [error] (log-error (RuntimeException. ("launch process failed..."))))))
       process)))
    
 (defn exists-file?

--- a/storm-core/src/clj/org/apache/storm/util.clj
+++ b/storm-core/src/clj/org/apache/storm/util.clj
@@ -553,7 +553,8 @@
                (catch InterruptedException e
                  (log-message log-prefix " interrupted.")))
              (exit-code-callback (.exitValue process)))
-           nil)))                    
+           nil)
+          :kill-fn (fn [error] (log-error (RuntimeException. ("launch process failed...")))))
       process)))
    
 (defn exists-file?


### PR DESCRIPTION
[util.clj/async-loop](https://github.com/apache/storm/blob/master/storm-core/src/clj/org/apache/storm/util.clj#L474) default kill-fn will kill current process  

when supervisor use [util.clj/launch-process](https://github.com/apache/storm/blob/master/storm-core/src/clj/org/apache/storm/util.clj#L546) to launch worker process , if exeception occurs , supervisor process will exit.
