### PR TITLE
[STORM-1503] Worker should not crash on failure to send heartbeats to Pacemaker/ZK

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/worker.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/worker.clj
@@ -72,8 +72,10 @@
                :time-secs (current-time-secs)
                }]
     ;; do the zookeeper heartbeat
-    (.worker-heartbeat! (:storm-cluster-state worker) (:storm-id worker) (:assignment-id worker) (:port worker) zk-hb)
-    ))
+    (try
+      (.worker-heartbeat! (:storm-cluster-state worker) (:storm-id worker) (:assignment-id worker) (:port worker) zk-hb)
+      (catch Exception exc
+        (log-error exc "Worker failed to write heatbeats to ZK or Pacemaker...will retry")))))
 
 (defn do-heartbeat [worker]
   (let [conf (:conf worker)

--- a/storm-core/src/jvm/org/apache/storm/pacemaker/PacemakerClient.java
+++ b/storm-core/src/jvm/org/apache/storm/pacemaker/PacemakerClient.java
@@ -127,6 +127,12 @@ public class PacemakerClient implements ISaslClient {
     }
 
     public synchronized void channelConnected(Channel channel) {
+        Channel oldChannel = channelRef.get();
+        if (oldChannel != null) {
+            LOG.debug("Closing oldChannel is connected: {}", oldChannel.toString());
+            close_channel();
+        }
+
         LOG.debug("Channel is connected: {}", channel.toString());
         channelRef.set(channel);
 
@@ -153,23 +159,7 @@ public class PacemakerClient implements ISaslClient {
     }
 
     public HBMessage send(HBMessage m) {
-        // Wait for 'ready' (channel connected and maybe authentication)
-        if(!ready) {
-            synchronized(this) {
-                if(!ready) {
-                    LOG.debug("Waiting for netty channel to be ready.");
-                    try {
-                        this.wait(1000);
-                        if(!ready) {
-                            throw new RuntimeException("Timed out waiting for channel ready.");
-                        }
-                    } catch (java.lang.InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            }
-        }
-
+        waitUntilReady();
         LOG.debug("Sending message: {}", m.toString());
         try {
 
@@ -179,6 +169,12 @@ public class PacemakerClient implements ISaslClient {
                 messages[next] = m;
                 LOG.debug("Put message in slot: {}", Integer.toString(next));
                 do {
+                    Channel channel = channelRef.get();
+                    if(channel == null )
+                    {
+                        reconnect();
+                        waitUntilReady();
+                    }
                     channelRef.get().write(m);
                     m.wait(1000);
                 } while (messages[next] == m);
@@ -196,6 +192,25 @@ public class PacemakerClient implements ISaslClient {
         catch (InterruptedException e) {
             LOG.error("PacemakerClient send interrupted: ", e);
             throw new RuntimeException(e);
+        }
+    }
+
+    private void waitUntilReady() {
+        // Wait for 'ready' (channel connected and maybe authentication)
+        if(!ready || channelRef.get() == null) {
+            synchronized(this) {
+                if(!ready) {
+                    LOG.debug("Waiting for netty channel to be ready.");
+                    try {
+                        this.wait(1000);
+                        if(!ready || channelRef.get() == null) {
+                            throw new RuntimeException("Timed out waiting for channel ready.");
+                        }
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- Worker should catch and log Exception related to sending worker heartbeats to ZK/pacemaker.
- `PacemakerClient` should not leave open previous channels.. If successfully reconnected - made new `Channel`. This avoids worker having unused Channel open to Pacemaker around.