### PR TITLE
When using keytab insure login is done at most once per process

### DIFF
--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/security/HBaseSecurityUtil.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/security/HBaseSecurityUtil.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.hbase.security;
 
+import backtype.storm.Config;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -39,26 +40,34 @@ public class HBaseSecurityUtil {
 
     public static final String STORM_KEYTAB_FILE_KEY = "storm.keytab.file";
     public static final String STORM_USER_NAME_KEY = "storm.kerberos.principal";
+    private static  UserProvider legacyProvider = null;
 
     public static UserProvider login(Map conf, Configuration hbaseConfig) throws IOException {
         //Allowing keytab based login for backward compatibility.
-        UserProvider provider = UserProvider.instantiate(hbaseConfig);
-        if (conf.get(TOPOLOGY_AUTO_CREDENTIALS) == null ||
-                !(((List) conf.get(TOPOLOGY_AUTO_CREDENTIALS)).contains(AutoHBase.class.getName()))) {
-            LOG.info("Logging in using keytab as AutoHBase is not specified for " + TOPOLOGY_AUTO_CREDENTIALS);
-            if (UserGroupInformation.isSecurityEnabled()) {
-                String keytab = (String) conf.get(STORM_KEYTAB_FILE_KEY);
-                if (keytab != null) {
-                    hbaseConfig.set(STORM_KEYTAB_FILE_KEY, keytab);
+        if (UserGroupInformation.isSecurityEnabled() && (conf.get(Config.TOPOLOGY_AUTO_CREDENTIALS) == null ||
+                !(((List) conf.get(Config.TOPOLOGY_AUTO_CREDENTIALS)).contains(AutoHBase.class.getName())))) {
+            LOG.info("Logging in using keytab as AutoHBase is not specified for " + Config.TOPOLOGY_AUTO_CREDENTIALS);
+            //insure that if keytab is used only one login per process executed
+            if(legacyProvider == null) {
+                synchronized (HBaseSecurityUtil.class) {
+                    if(legacyProvider == null) {
+                        legacyProvider = UserProvider.instantiate(hbaseConfig);
+                        String keytab = (String) conf.get(STORM_KEYTAB_FILE_KEY);
+                        if (keytab != null) {
+                            hbaseConfig.set(STORM_KEYTAB_FILE_KEY, keytab);
+                        }
+                        String userName = (String) conf.get(STORM_USER_NAME_KEY);
+                        if (userName != null) {
+                            hbaseConfig.set(STORM_USER_NAME_KEY, userName);
+                        }
+                        legacyProvider.login(STORM_KEYTAB_FILE_KEY, STORM_USER_NAME_KEY,
+                                InetAddress.getLocalHost().getCanonicalHostName());
+                    }
                 }
-                String userName = (String) conf.get(STORM_USER_NAME_KEY);
-                if (userName != null) {
-                    hbaseConfig.set(STORM_USER_NAME_KEY, userName);
-                }
-                provider.login(STORM_KEYTAB_FILE_KEY, STORM_USER_NAME_KEY,
-                        InetAddress.getLocalHost().getCanonicalHostName());
             }
+            return legacyProvider;
+        } else {
+            return UserProvider.instantiate(hbaseConfig);
         }
-        return provider;
     }
 }


### PR DESCRIPTION
When using a topology that has multiple executors in same process or multiple HBase bolts the tickets do not get renewed. After the ticket expiration the bolts are no longer able to write/read from HBase. That is caused by a login from keytab for every thread, this fixe ensures that there will only be one login per process.