### PR TITLE
[STORM-1517] add peek api in trident stream

### DIFF
--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentMapExample.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentMapExample.java
@@ -25,6 +25,7 @@ import org.apache.storm.generated.StormTopology;
 import org.apache.storm.trident.TridentState;
 import org.apache.storm.trident.TridentTopology;
 import org.apache.storm.trident.operation.BaseFilter;
+import org.apache.storm.trident.operation.Consumer;
 import org.apache.storm.trident.operation.Filter;
 import org.apache.storm.trident.operation.FlatMapFunction;
 import org.apache.storm.trident.operation.MapFunction;
@@ -84,6 +85,12 @@ public class TridentMapExample {
                 .flatMap(split)
                 .map(toUpper)
                 .filter(theFilter)
+                .peek(new Consumer() {
+                    @Override
+                    public void accept(TridentTuple input) {
+                        System.out.println(input.getString(0));
+                    }
+                })
                 .groupBy(new Fields("word"))
                 .persistentAggregate(new MemoryMapState.Factory(), new Count(), new Fields("count"))
                 .parallelismHint(16);

--- a/storm-core/src/jvm/org/apache/storm/trident/Stream.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/Stream.java
@@ -21,8 +21,10 @@ import org.apache.storm.generated.Grouping;
 import org.apache.storm.generated.NullStruct;
 import org.apache.storm.trident.fluent.ChainedAggregatorDeclarer;
 import org.apache.storm.grouping.CustomStreamGrouping;
+import org.apache.storm.trident.operation.Consumer;
 import org.apache.storm.trident.operation.FlatMapFunction;
 import org.apache.storm.trident.operation.MapFunction;
+import org.apache.storm.trident.operation.impl.ConsumerExecutor;
 import org.apache.storm.trident.operation.impl.FlatMapFunctionExecutor;
 import org.apache.storm.trident.operation.impl.MapFunctionExecutor;
 import org.apache.storm.trident.planner.processor.MapProcessor;
@@ -385,6 +387,25 @@ public class Stream implements IAggregatableStream {
                                                 getOutputFields(),
                                                 getOutputFields(),
                                                 new MapProcessor(getOutputFields(), new FlatMapFunctionExecutor(function))));
+    }
+
+    /**
+     * Returns a stream consisting of the trident tuples of this stream, additionally performing the provided action on
+     * each trident tuple as they are consumed from the resulting stream. This is mostly useful for debugging
+     * to see the tuples as they flow past a certain point in a pipeline.
+     *
+     * @param action the action to perform on the trident tuple as they are consumed from the stream
+     * @return the new stream
+     */
+    public Stream peek(Consumer action) {
+        projectionValidation(getOutputFields());
+        return _topology.addSourcedNode(this,
+                                        new ProcessorNode(
+                                                _topology.getUniqueStreamId(),
+                                                _name,
+                                                getOutputFields(),
+                                                getOutputFields(),
+                                                new MapProcessor(getOutputFields(), new ConsumerExecutor(action))));
     }
 
     public ChainedAggregatorDeclarer chainedAgg() {

--- a/storm-core/src/jvm/org/apache/storm/trident/operation/Consumer.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/operation/Consumer.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.trident.operation;
+
+import org.apache.storm.trident.tuple.TridentTuple;
+
+import java.io.Serializable;
+
+/**
+ * Represents an operation that accepts a single input argument and returns no result.
+ * This is similar to the Consumer interface in Java 8.
+ */
+public interface Consumer extends Serializable {
+    /**
+     * Performs the operation on the input trident tuple.
+     *
+     * @param input the input trident tuple
+     */
+    void accept(TridentTuple input);
+}

--- a/storm-core/src/jvm/org/apache/storm/trident/operation/impl/ConsumerExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/operation/impl/ConsumerExecutor.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.trident.operation.impl;
+
+import org.apache.storm.trident.operation.BaseOperation;
+import org.apache.storm.trident.operation.Consumer;
+import org.apache.storm.trident.operation.Function;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.tuple.TridentTuple;
+
+public class ConsumerExecutor extends BaseOperation implements Function {
+    private final Consumer consumer;
+
+    public ConsumerExecutor(Consumer consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public void execute(TridentTuple tuple, TridentCollector collector) {
+        consumer.accept(tuple);
+        collector.emit(tuple);
+    }
+}


### PR DESCRIPTION
Similar to the Java 8 peek, the peek api can be used to examine trident tuples at
some point in the stream pipeline or execute some custom actions.

Note: this includes changes from https://github.com/apache/storm/pull/1050 and should go away once that gets merged.