### PR TITLE
STORM-1515: Reset LocalState if corrupted after a hard reboot on Windows

### DIFF
--- a/storm-core/test/clj/backtype/storm/local_state_test.clj
+++ b/storm-core/test/clj/backtype/storm/local_state_test.clj
@@ -53,3 +53,13 @@
       (.put ls "a" 1)
       (is (= 1 (.get ls "a")))
   )))
+
+(deftest all-nul-state
+  (with-local-tmp [dir]
+    (let [ls (LocalState. dir)
+          data (FileUtils/openOutputStream (File. dir "12345"))
+          version (FileUtils/openOutputStream (File. dir "12345.version"))]
+      (.write data (byte-array (repeat 100 (byte 0))))
+      (is (= nil (.get ls "c")))
+      (.put ls "a" 1)
+      (is (= 1 (.get ls "a"))))))


### PR DESCRIPTION
On Windows LocalState IO requests interrupted by a hard reboot can
result in a file full of NULs, similar to the empty-file corruption seen in STORM-307.

I've fixed this for 0.9.x first since I haven't upgraded to 0.10 yet. The fix for 0.10 will be slightly different due to the move to Thrift for LocalState serialization.

It might be desirable to catch EOFException instead of checking serialized.length, since it could cover more cases of corruption, like a partially-written serialization stream.