### PR TITLE
[STORM-1368] change heapdump file permissions so that UI download wil…

### DIFF
--- a/bin/flight.bash
+++ b/bin/flight.bash
@@ -65,6 +65,7 @@ function jstack_record {
 function jmap_record {
     FILENAME=recording-$1-${NOW}.bin
     $BINPATH/jmap -dump:format=b,file="$2/${FILENAME}" $1
+    /bin/chmod g+r "$2/${FILENAME}"
 }
 
 function stop_record {

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -165,6 +165,20 @@ supervisor.cpu.capacity: 400.0
 ### worker.* configs are for task workers
 worker.heap.memory.mb: 768
 worker.childopts: "-Xmx%HEAP-MEM%m -XX:+PrintGCDetails -Xloggc:artifacts/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"
+
+worker.childopts:
+- -Xmx%HEAP-MEM%m
+- -XX:+PrintGCDetails
+- -Xloggc:artifacts/gc.%p.log
+- -XX:+PrintGCDateStamps
+- -XX:+PrintGCTimeStamps
+- -XX:+UseGCLogFileRotation
+- -XX:NumberOfGCLogFiles=10
+- -XX:GCLogFileSize=1M
+- -XX:+HeapDumpOnOutOfMemoryError
+- -XX:HeapDumpPath=artifacts/heapdump
+- -XX:OnOutOfMemoryError="chmod g+r artifacts/*.hprof artifacts/heapdump"
+
 worker.gc.childopts: ""
 
 # Unlocking commercial features requires a special license from Oracle.

--- a/storm-core/src/clj/org/apache/storm/cluster.clj
+++ b/storm-core/src/clj/org/apache/storm/cluster.clj
@@ -494,7 +494,7 @@
     
       (topology-backpressure
         [this storm-id callback]
-        "if the backpresure/storm-id dir is empty, this topology has throttle-on, otherwise not."
+        "if the backpresure/storm-id dir is not empty, this topology has throttle-on, otherwise throttle-off."
         (when callback
           (swap! backpressure-callback assoc storm-id callback))
         (let [path (backpressure-storm-root storm-id)

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -231,7 +231,7 @@ public class Config extends HashMap<String, Object> {
 
     /**
      * Whether we want to display all the resource capacity and scheduled usage on the UI page.
-     * We suggest to have this variable set if you are using any kind of resource-related scheduler.
+     * You msut have this variable set if you are using any kind of resource-related scheduler.
      *
      * If this is not set, we will not display resource capacity and usage on the UI.
      */

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -231,7 +231,7 @@ public class Config extends HashMap<String, Object> {
 
     /**
      * Whether we want to display all the resource capacity and scheduled usage on the UI page.
-     * You msut have this variable set if you are using any kind of resource-related scheduler.
+     * You must have this variable set if you are using any kind of resource-related scheduler.
      *
      * If this is not set, we will not display resource capacity and usage on the UI.
      */


### PR DESCRIPTION
Change heapdump file permissions so that UI download wil work in secure clusters for them.
a. For automatically generated heapdump files by system
b. For heapdump generated by user from UI
