### PR TITLE
STORM-1492 With nimbus.seeds set to default, a nimbus for localhost may appear "Offline"

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -63,6 +63,7 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.ClassLoaderObjectInputStream;
 import org.apache.storm.Config;
@@ -106,6 +107,7 @@ public class Utils {
     public static final String DEFAULT_STREAM_ID = "default";
     private static final Set<Class> defaultAllowedExceptions = new HashSet<>();
     public static final String FILE_PATH_SEPARATOR = System.getProperty("file.separator");
+    private static final List<String> LOCALHOST_ADDRESSES = Lists.newArrayList("localhost", "127.0.0.1", "0:0:0:0:0:0:0:1");
 
     private static ThreadLocal<TSerializer> threadSer = new ThreadLocal<TSerializer>();
     private static ThreadLocal<TDeserializer> threadDes = new ThreadLocal<TDeserializer>();
@@ -1504,5 +1506,9 @@ public class Utils {
             defaultsConf.putAll(stormConf);
         }
         return defaultsConf;
+    }
+
+    public static boolean isLocalhostAddress(String address) {
+        return LOCALHOST_ADDRESSES.contains(address);
     }
 }

--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -434,7 +434,7 @@
       (nimbus-summary
         (.get_nimbuses (.getClusterInfo ^Nimbus$Client nimbus)))))
   ([nimbuses]
-    (let [nimbus-seeds (set (map #(str %1 ":" (*STORM-CONF* NIMBUS-THRIFT-PORT)) (set (*STORM-CONF* NIMBUS-SEEDS))))
+    (let [nimbus-seeds (set (map #(str %1 ":" (*STORM-CONF* NIMBUS-THRIFT-PORT)) (remove #(Utils/isLocalhostAddress %) (set (*STORM-CONF* NIMBUS-SEEDS)))))
           alive-nimbuses (set (map #(str (.get_host %1) ":" (.get_port %1)) nimbuses))
           offline-nimbuses (clojure.set/difference nimbus-seeds alive-nimbuses)
           offline-nimbuses-summary (map #(convert-to-nimbus-summary %1) offline-nimbuses)]


### PR DESCRIPTION
First of all, AFAIK, it's just an issue of API output, and it doesn't hurt functionality although we don't fix it.
- when determining nimbus addresses from nimbus.seeds, filter out localhost addresses
  - localhost address: 127.0.0.1, localhost, 0:0:0:0:0:0:0:1
- there may be a chance that nimbus (localhost) is not reachable so we can't get info from alive-nimbuses
  - but it means ui process itself can't reach nimbus so we can ignore this case
- there may be another change that user specifies nimbus.seeds to both unreachable localhost address and other reachable nimbuses fqdn
  - ui process can reach other nimbus and localhost itself is lost
  - but I think we can treat it as configuration error
