### PR TITLE
STORM-1516 Fixed issue in writing pids with distributed cluster mode.

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/worker.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/worker.clj
@@ -603,11 +603,11 @@
 (defserverfn mk-worker [conf shared-mq-context storm-id assignment-id port worker-id]
   (log-message "Launching worker for " storm-id " on " assignment-id ":" port " with id " worker-id
                " and conf " conf)
-  (if-not (ConfigUtils/isLocalMode conf)
-    (SysOutOverSLF4J/sendSystemOutAndErrToSLF4J))
   ;; because in local mode, its not a separate
   ;; process. supervisor will register it in this case
-  (when (= :distributed (ConfigUtils/clusterMode conf))
+  ;; if (ConfigUtils/isLocalMode conf) returns false then it is in distributed mode.
+  (when-not (ConfigUtils/isLocalMode conf)
+    (SysOutOverSLF4J/sendSystemOutAndErrToSLF4J)
     (let [pid (Utils/processPid)]
       (FileUtils/touch (ConfigUtils/workerPidPath conf worker-id pid))
       (spit (ConfigUtils/workerArtifactsPidPath conf storm-id port) pid)))


### PR DESCRIPTION
Whenever a topology is submitted, it creates respective workers on supervisor/s. These worker pids are stored as files in ${storm-localdir}/workers/{worker-id}/pids/ on supervisor. But there is an issue in storing worker pids. So, supervisor could not find respective worker pids when a topology is killed. Subsequent topology deployment workers are failed because of earlier workers are still alive and bound to the respective ports. 

Fixed worker.clj to have right checks while writing pids to respective locations.