### PR TITLE
STORM-1536: Remove Java use of TimeCacheMap

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/coordination/CoordinatedBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/coordination/CoordinatedBolt.java
@@ -31,7 +31,7 @@ import org.apache.storm.topology.IRichBolt;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
-import org.apache.storm.utils.TimeCacheMap;
+import org.apache.storm.utils.RotatingMap;
 import org.apache.storm.utils.Utils;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -150,7 +150,7 @@ public class CoordinatedBolt implements IRichBolt {
     private Integer _numSourceReports;
     private List<Integer> _countOutTasks = new ArrayList<>();
     private OutputCollector _collector;
-    private TimeCacheMap<Object, TrackingInfo> _tracked;
+    private RotatingMap<Object, TrackingInfo> _tracked;
 
     public static class TrackingInfo {
         int reportCount = 0;
@@ -205,11 +205,11 @@ public class CoordinatedBolt implements IRichBolt {
     }
     
     public void prepare(Map config, TopologyContext context, OutputCollector collector) {
-        TimeCacheMap.ExpiredCallback<Object, TrackingInfo> callback = null;
+        RotatingMap.ExpiredCallback<Object, TrackingInfo> callback = null;
         if(_delegate instanceof TimeoutCallback) {
             callback = new TimeoutItems();
         }
-        _tracked = new TimeCacheMap<>(context.maxTopologyMessageTimeout(), callback);
+        _tracked = new RotatingMap<>(context.maxTopologyMessageTimeout(), callback);
         _collector = collector;
         _delegate.prepare(config, context, new OutputCollector(new CoordinatedOutputCollector(collector)));
         for(String component: Utils.get(context.getThisTargets(),
@@ -329,7 +329,6 @@ public class CoordinatedBolt implements IRichBolt {
 
     public void cleanup() {
         _delegate.cleanup();
-        _tracked.cleanup();
     }
 
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
@@ -348,7 +347,7 @@ public class CoordinatedBolt implements IRichBolt {
         return ret;
     }
     
-    private class TimeoutItems implements TimeCacheMap.ExpiredCallback<Object, TrackingInfo> {
+    private class TimeoutItems implements RotatingMap.ExpiredCallback<Object, TrackingInfo> {
         @Override
         public void expire(Object id, TrackingInfo val) {
             synchronized(_tracked) {

--- a/storm-core/src/jvm/org/apache/storm/security/auth/ShellBasedGroupsMapping.java
+++ b/storm-core/src/jvm/org/apache/storm/security/auth/ShellBasedGroupsMapping.java
@@ -24,9 +24,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.StringTokenizer;
 import org.apache.storm.Config;
+import org.apache.storm.utils.RotatingMap;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.utils.ShellUtils;
-import org.apache.storm.utils.TimeCacheMap;
 import org.apache.storm.utils.ShellUtils.ExitCodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +36,7 @@ public class ShellBasedGroupsMapping implements
                                              IGroupMappingServiceProvider {
 
     public static final Logger LOG = LoggerFactory.getLogger(ShellBasedGroupsMapping.class);
-    public TimeCacheMap<String, Set<String>> cachedGroups;
+    public RotatingMap<String, Set<String>> cachedGroups;
 
     /**
      * Invoked once immediately after construction
@@ -45,7 +45,7 @@ public class ShellBasedGroupsMapping implements
     @Override
     public void prepare(Map storm_conf) {
         int timeout = Utils.getInt(storm_conf.get(Config.STORM_GROUP_MAPPING_SERVICE_CACHE_DURATION_SECS));
-        cachedGroups = new TimeCacheMap<>(timeout);
+        cachedGroups = new RotatingMap<>(timeout);
     }
 
     /**


### PR DESCRIPTION
This removes java use of TimeCacheMap.  I attempted to replace TimeCacheMap with RotationMap in nimbus.clj but consistently get error messages such as:

```
111654 [heartbeat-timer] ERROR o.a.s.d.worker - Error when processing event
java.lang.RuntimeException: java.io.FileNotFoundException: /var/folders/g6/x6w1f66n16z_pf7qyqq58d_swvmvh5/T/0d68bae5-27b5-46ae-b0ba-40b2f252b98d/workers/2bedd279-f18c-4d5f-9712-dc689f98d8dd/heartbeats/1455040724667 (Too many open files in system)
	at org.apache.storm.utils.LocalState.persistInternal(LocalState.java:178) ~[classes/:?]
	at org.apache.storm.utils.LocalState.put(LocalState.java:143) ~[classes/:?]
	at org.apache.storm.local_state$ls_worker_heartbeat_BANG_.invoke(local_state.clj:122) ~[classes/:?]
	at org.apache.storm.daemon.worker$do_heartbeat.invoke(worker.clj:84) ~[classes/:?]
	at org.apache.storm.daemon.worker$fn__9722$exec_fn__2613__auto__$reify__9724$heartbeat_fn__9725.invoke(worker.clj:606) ~[classes/:?]
	at org.apache.storm.timer$schedule_recurring$this__1305.invoke(timer.clj:105) ~[classes/:?]
	at org.apache.storm.timer$mk_timer$fn__1288$fn__1289.invoke(timer.clj:50) [classes/:?]
	at org.apache.storm.timer$mk_timer$fn__1288.invoke(timer.clj:42) [classes/:?]
	at clojure.lang.AFn.run(AFn.java:22) [clojure-1.7.0.jar:?]
	at java.lang.Thread.run(Thread.java:745) [?:1.7.0_75]
```