### PR TITLE
[STORM-1532]: Fix readCommandLineOpts to parse JSON correctly in windows

### DIFF
--- a/bin/storm-config.cmd
+++ b/bin/storm-config.cmd
@@ -86,6 +86,10 @@ if not defined STORM_LOG_DIR (
 @rem retrieve storm.log4j2.conf.dir from conf file
 @rem
 
+if not defined CMD_TEMP_FILE (
+  set CMD_TEMP_FILE=tmpfile
+)
+
 "%JAVA%" -client -Dstorm.options= -Dstorm.conf.file= -cp "%CLASSPATH%" org.apache.storm.command.config_value storm.log4j2.conf.dir > %CMD_TEMP_FILE%
 
 FOR /F "delims=" %%i in (%CMD_TEMP_FILE%) do (

--- a/bin/storm.cmd
+++ b/bin/storm.cmd
@@ -90,7 +90,7 @@
     )
 
     if "%c-opt%"=="second" (
-      set config-options=%config-options%=%1
+      set config-options=%config-options%=%~1
       set c-opt=
       goto start
     )

--- a/storm-core/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/Utils.java
@@ -330,7 +330,17 @@ public class Utils {
         Map ret = new HashMap();
         String commandOptions = System.getProperty("storm.options");
         if (commandOptions != null) {
-            String[] configs = commandOptions.split(",");
+            /*
+             Below regex uses negative lookahead to not split in the middle of json objects '{}'
+             or json arrays '[]'. This is needed to parse valid json object/arrays passed as options
+             via 'storm.cmd' in windows. This is not an issue while using 'storm.py' since it url-encodes
+             the options and the below regex just does a split on the commas that separates each option.
+
+             Note:- This regex handles only valid json strings and could produce invalid results
+             if the options contain un-encoded invalid json or strings with unmatched '[, ], { or }'. We can
+             replace below code with split(",") once 'storm.cmd' is fixed to send url-encoded options.
+              */
+            String[] configs = commandOptions.split(",(?![^\\[\\]{}]*(]|}))");
             for (String config : configs) {
                 config = URLDecoder.decode(config);
                 String[] options = config.split("=", 2);


### PR DESCRIPTION
In Windows env, the storm.options are not url-encoded. The parsing logic needs to be fixed to not split in the middle of raw JSON objects.