### PR TITLE
STORM-1549: Add support for resetting tuple timeout from bolts via the OutputCollector

### DIFF
--- a/storm-core/src/clj/org/apache/storm/clojure.clj
+++ b/storm-core/src/clj/org/apache/storm/clojure.clj
@@ -173,6 +173,9 @@
 (defn fail! [collector ^Tuple tuple]
   (.fail ^OutputCollector (:output-collector collector) tuple))
 
+(defn reset-timeout! [collector ^Tuple tuple]
+  (.resetTimeout ^OutputCollector (:output-collector collector) tuple))
+
 (defn report-error! [collector ^Tuple tuple]
   (.reportError ^OutputCollector (:output-collector collector) tuple))
 

--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -519,6 +519,11 @@
                                       spout-obj (:object task-data)]
                                   (when (instance? ICredentialsListener spout-obj)
                                     (.setCredentials spout-obj (.getValue tuple 0))))
+                              ACKER-RESET-TIMEOUT-STREAM-ID 
+                                (let [id (.getValue tuple 0)
+                                      pending-for-id (.get pending id)]
+                                   (when pending-for-id
+                                     (.put pending id pending-for-id))) 
                               (let [id (.getValue tuple 0)
                                     [stored-task-id spout-id tuple-finished-info start-time-ms] (.remove pending id)]
                                 (when spout-id
@@ -828,6 +833,11 @@
                                                        (.getSourceComponent tuple)
                                                        (.getSourceStreamId tuple)
                                                        delta))))
+                       (^void resetTimeout [this ^Tuple tuple]
+                         (fast-list-iter [root (.. tuple getMessageId getAnchors)]
+                                         (task/send-unanchored task-data
+                                                               ACKER-RESET-TIMEOUT-STREAM-ID
+                                                               [root])))
                        (reportError [this error]
                          (report-error error)
                          )))))

--- a/storm-core/src/jvm/org/apache/storm/coordination/CoordinatedBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/coordination/CoordinatedBolt.java
@@ -124,6 +124,10 @@ public class CoordinatedBolt implements IRichBolt {
             checkFinishId(tuple, TupleType.REGULAR);
             _delegate.fail(tuple);
         }
+
+        public void resetTimeout(Tuple tuple) {
+            _delegate.resetTimeout(tuple);
+        }
         
         public void reportError(Throwable error) {
             _delegate.reportError(error);

--- a/storm-core/src/jvm/org/apache/storm/task/IOutputCollector.java
+++ b/storm-core/src/jvm/org/apache/storm/task/IOutputCollector.java
@@ -29,4 +29,5 @@ public interface IOutputCollector extends IErrorReporter {
     void emitDirect(int taskId, String streamId, Collection<Tuple> anchors, List<Object> tuple);
     void ack(Tuple input);
     void fail(Tuple input);
+    void resetTimeout(Tuple input);
 }

--- a/storm-core/src/jvm/org/apache/storm/task/OutputCollector.java
+++ b/storm-core/src/jvm/org/apache/storm/task/OutputCollector.java
@@ -221,6 +221,7 @@ public class OutputCollector implements IOutputCollector {
     /**
     * Resets the message timeout for any tuple trees to which the given tuple belongs.
     * The timeout is reset to Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS.
+    * Note that this is an expensive operation, and should be used sparingly.
     * @param input the tuple to reset timeout for
     */
     @Override

--- a/storm-core/src/jvm/org/apache/storm/task/OutputCollector.java
+++ b/storm-core/src/jvm/org/apache/storm/task/OutputCollector.java
@@ -218,6 +218,16 @@ public class OutputCollector implements IOutputCollector {
         _delegate.fail(input);
     }
 
+    /**
+    * Resets the message timeout for any tuple trees to which the given tuple belongs.
+    * The timeout is reset to Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS.
+    * @param input the tuple to reset timeout for
+    */
+    @Override
+    public void resetTimeout(Tuple input) {
+        _delegate.resetTimeout(input);
+    }
+
     @Override
     public void reportError(Throwable error) {
         _delegate.reportError(error);

--- a/storm-core/src/jvm/org/apache/storm/topology/BasicOutputCollector.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/BasicOutputCollector.java
@@ -52,6 +52,12 @@ public class BasicOutputCollector implements IBasicOutputCollector {
         emitDirect(taskId, Utils.DEFAULT_STREAM_ID, tuple);
     }
 
+    /**
+    * Resets the message timeout for any tuple trees to which the given tuple belongs.
+    * The timeout is reset to Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS.
+    * Note that this is an expensive operation, and should be used sparingly.
+    * @param input the tuple to reset timeout for
+    */
     public void resetTimeout(Tuple tuple){
         out.resetTimeout(tuple);
     }

--- a/storm-core/src/jvm/org/apache/storm/topology/BasicOutputCollector.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/BasicOutputCollector.java
@@ -56,7 +56,7 @@ public class BasicOutputCollector implements IBasicOutputCollector {
     * Resets the message timeout for any tuple trees to which the given tuple belongs.
     * The timeout is reset to Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS.
     * Note that this is an expensive operation, and should be used sparingly.
-    * @param input the tuple to reset timeout for
+    * @param tuple the tuple to reset timeout for
     */
     public void resetTimeout(Tuple tuple){
         out.resetTimeout(tuple);

--- a/storm-core/src/jvm/org/apache/storm/topology/BasicOutputCollector.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/BasicOutputCollector.java
@@ -52,6 +52,10 @@ public class BasicOutputCollector implements IBasicOutputCollector {
         emitDirect(taskId, Utils.DEFAULT_STREAM_ID, tuple);
     }
 
+    public void resetTimeout(Tuple tuple){
+        out.resetTimeout(tuple);
+    }
+
     protected IOutputCollector getOutputter() {
         return out;
     }

--- a/storm-core/src/jvm/org/apache/storm/topology/IBasicOutputCollector.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/IBasicOutputCollector.java
@@ -18,10 +18,12 @@
 package org.apache.storm.topology;
 
 import org.apache.storm.task.IErrorReporter;
+import org.apache.storm.tuple.Tuple;
 
 import java.util.List;
 
 public interface IBasicOutputCollector extends IErrorReporter{
     List<Integer> emit(String streamId, List<Object> tuple);
     void emitDirect(int taskId, String streamId, List<Object> tuple);
+    void resetTimeout(Tuple tuple);
 }

--- a/storm-core/src/jvm/org/apache/storm/trident/topology/TridentBoltExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/topology/TridentBoltExecutor.java
@@ -180,6 +180,10 @@ public class TridentBoltExecutor implements IRichBolt {
         public void fail(Tuple tuple) {
             throw new IllegalStateException("Method should never be called");
         }
+
+        public void resetTimeout(Tuple tuple) {
+            throw new IllegalStateException("Method should never be called");
+        }
         
         public void reportError(Throwable error) {
             _delegate.reportError(error);

--- a/storm-core/test/clj/integration/org/apache/storm/integration_test.clj
+++ b/storm-core/test/clj/integration/org/apache/storm/integration_test.clj
@@ -20,6 +20,7 @@
   (:import [org.apache.storm.generated InvalidTopologyException SubmitOptions TopologyInitialStatus RebalanceOptions])
   (:import [org.apache.storm.testing TestWordCounter TestWordSpout TestGlobalCount
             TestAggregatesCounter TestConfBolt AckFailMapTracker AckTracker TestPlannerSpout])
+  (:import [org.apache.storm.utils Time])
   (:import [org.apache.storm.tuple Fields])
   (:use [org.apache.storm testing config clojure util])
   (:use [org.apache.storm.daemon common])
@@ -83,9 +84,18 @@
             (ack! collector tuple)
             ))))))
 
-(defn assert-loop [afn ids]
-  (while (not (every? afn ids))
-    (Thread/sleep 1)))
+(defn assert-loop 
+([afn ids] (assert-loop afn ids 10))
+([afn ids timeout-secs]
+  (loop [remaining-time (* timeout-secs 1000)]
+    (let [start-time (System/currentTimeMillis)
+          assertion-is-true (every? afn ids)]
+      (if (or assertion-is-true (neg? remaining-time))
+        (is assertion-is-true)
+        (do
+          (Thread/sleep 1)
+          (recur (- remaining-time (- (System/currentTimeMillis) start-time)))
+        ))))))
 
 (defn assert-acked [tracker & ids]
   (assert-loop #(.isAcked tracker %) ids))
@@ -115,6 +125,41 @@
       (advance-cluster-time cluster 12)
       (assert-failed tracker 2)
       )))
+
+(defbolt extend-timeout-twice {} {:prepare true}
+  [conf context collector]
+  (let [state (atom -1)]
+    (bolt
+      (execute [tuple]
+        (do
+          (Time/sleep (* 8 1000))
+          (reset-timeout! collector tuple)
+          (Time/sleep (* 8 1000))
+          (reset-timeout! collector tuple)
+          (Time/sleep (* 8 1000))
+          (ack! collector tuple)
+        )))))
+
+(deftest test-reset-timeout
+  (with-simulated-time-local-cluster [cluster :daemon-conf {TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS true}]
+    (let [feeder (feeder-spout ["field1"])
+          tracker (AckFailMapTracker.)
+          _ (.setAckFailDelegate feeder tracker)
+          topology (thrift/mk-topology
+                     {"1" (thrift/mk-spout-spec feeder)}
+                     {"2" (thrift/mk-bolt-spec {"1" :global} extend-timeout-twice)})]
+    (submit-local-topology (:nimbus cluster)
+                           "timeout-tester"
+                           {TOPOLOGY-MESSAGE-TIMEOUT-SECS 10}
+                           topology)
+    (advance-cluster-time cluster 11)
+    (.feed feeder ["a"] 1)
+    (advance-cluster-time cluster 21)
+    (is (not (.isFailed tracker 1)))
+    (is (not (.isAcked tracker 1)))
+    (advance-cluster-time cluster 5)
+    (assert-acked tracker 1)
+    )))
 
 (defn mk-validate-topology-1 []
   (thrift/mk-topology


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/STORM-1549.

Other than implementing tuple timeout reset, I made a minor change to assert-loop in integration_test.clj so it doesn't hang on failing tests. It should now fail the test after 10 seconds. I hope that's okay.