### PR TITLE
[STORM-1540] Fix Debug/Sampling for Trident

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/serialization/SerializationFactory.java
+++ b/storm-core/src/jvm/org/apache/storm/serialization/SerializationFactory.java
@@ -24,6 +24,7 @@ import org.apache.storm.serialization.types.ArrayListSerializer;
 import org.apache.storm.serialization.types.HashMapSerializer;
 import org.apache.storm.serialization.types.HashSetSerializer;
 import org.apache.storm.transactional.TransactionAttempt;
+import org.apache.storm.trident.tuple.ConsList;
 import org.apache.storm.tuple.Values;
 import org.apache.storm.utils.ListDelegate;
 import org.apache.storm.utils.Utils;
@@ -68,6 +69,7 @@ public class SerializationFactory {
         k.register(Values.class);
         k.register(org.apache.storm.metric.api.IMetricsConsumer.DataPoint.class);
         k.register(org.apache.storm.metric.api.IMetricsConsumer.TaskInfo.class);
+        k.register(ConsList.class);
         try {
             JavaBridge.registerPrimitives(k);
             JavaBridge.registerCollections(k);

--- a/storm-core/src/jvm/org/apache/storm/trident/tuple/ConsList.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/tuple/ConsList.java
@@ -18,12 +18,18 @@
 package org.apache.storm.trident.tuple;
 
 import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ConsList extends AbstractList<Object> {
     List<Object> _elems;
     Object _first;
-    
+
+    // for kryo
+    private ConsList() {
+        _elems = new ArrayList<>();
+    }
+
     public ConsList(Object o, List<Object> elems) {
         _elems = elems;
         _first = o;
@@ -39,6 +45,16 @@ public class ConsList extends AbstractList<Object> {
 
     @Override
     public int size() {
-        return _elems.size() + 1;
+        return _first == null ? _elems.size() : _elems.size() + 1;
+    }
+
+    // for kryo
+    @Override
+    public void add(int index, Object element) {
+        if (index == 0) {
+            _first = element;
+        } else {
+            _elems.add(index - 1, element);
+        }
     }
 }


### PR DESCRIPTION
When ConsList emitted by a trident spout has to be transferred over
the network, it fails during Serialization. The proposed fix is to make ConsList
kyro serializable.