### PR TITLE
STORM-1522 should create error worker log location only when error-host and error-port are available

### DIFF
--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -146,8 +146,10 @@
   (logviewer-link host (event-logs-filename topology-id port) secure?))
 
 (defn worker-log-link [host port topology-id secure?]
-  (let [fname (logs-filename topology-id port)]
-    (logviewer-link host fname secure?)))
+  (if (or (empty? host) (let [port_str (str port "")] (or (empty? port_str) (= "0" port_str))))
+    ""
+    (let [fname (logs-filename topology-id port)]
+      (logviewer-link host fname secure?))))
 
 (defn nimbus-log-link [host]
   (url-format "http://%s:%s/daemonlog?file=nimbus.log" host (*STORM-CONF* LOGVIEWER-PORT)))


### PR DESCRIPTION
STORM-1522 should create error worker log location only when error-hOst and error-port are available