### PR TITLE
storm-hdfs : change visibility of create and closeOutputFile methods to protected

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -231,7 +231,7 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
      * @param tuple
      * @throws IOException
      */
-    abstract void writeTuple(Tuple tuple) throws IOException;
+    abstract protected void writeTuple(Tuple tuple) throws IOException;
 
     /**
      * Make the best effort to sync written data to the underlying file system.  Concrete classes should very clearly
@@ -240,12 +240,12 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
      *
      * @throws IOException
      */
-    abstract void syncTuples() throws IOException;
+    abstract protected void syncTuples() throws IOException;
 
     abstract protected void closeOutputFile() throws IOException;
 
     abstract protected Path createOutputFile() throws IOException;
 
-    abstract void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException;
+    abstract protected void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException;
 
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -242,9 +242,9 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
      */
     abstract void syncTuples() throws IOException;
 
-    abstract void closeOutputFile() throws IOException;
+    abstract protected void closeOutputFile() throws IOException;
 
-    abstract Path createOutputFile() throws IOException;
+    abstract protected Path createOutputFile() throws IOException;
 
     abstract void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException;
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBolt.java
@@ -127,7 +127,7 @@ public class AvroGenericRecordBolt extends AbstractHdfsBolt{
     }
 
     @Override
-    Path createOutputFile() throws IOException {
+    protected Path createOutputFile() throws IOException {
         Path path = new Path(this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
         this.out = this.fs.create(path);
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBolt.java
@@ -92,7 +92,7 @@ public class AvroGenericRecordBolt extends AbstractHdfsBolt{
     }
 
     @Override
-    void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException {
+    protected void doPrepare(Map conf, TopologyContext topologyContext, OutputCollector collector) throws IOException {
         LOG.info("Preparing AvroGenericRecord Bolt...");
         this.fs = FileSystem.get(URI.create(this.fsUrl), hdfsConfig);
         Schema.Parser parser = new Schema.Parser();
@@ -100,14 +100,14 @@ public class AvroGenericRecordBolt extends AbstractHdfsBolt{
     }
 
     @Override
-    void writeTuple(Tuple tuple) throws IOException {
+    protected void writeTuple(Tuple tuple) throws IOException {
         GenericRecord avroRecord = (GenericRecord) tuple.getValue(0);
         avroWriter.append(avroRecord);
         offset = this.out.getPos();
     }
 
     @Override
-    void syncTuples() throws IOException {
+    protected void syncTuples() throws IOException {
         avroWriter.flush();
 
         LOG.debug("Attempting to sync all data to filesystem");

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/HdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/HdfsBolt.java
@@ -96,7 +96,7 @@ public class HdfsBolt extends AbstractHdfsBolt{
     }
 
     @Override
-    void syncTuples() throws IOException {
+    protected void syncTuples() throws IOException {
         LOG.debug("Attempting to sync all data to filesystem");
         if (this.out instanceof HdfsDataOutputStream) {
             ((HdfsDataOutputStream) this.out).hsync(EnumSet.of(SyncFlag.UPDATE_LENGTH));
@@ -106,7 +106,7 @@ public class HdfsBolt extends AbstractHdfsBolt{
     }
 
     @Override
-    void writeTuple(Tuple tuple) throws IOException {
+    protected void writeTuple(Tuple tuple) throws IOException {
         byte[] bytes = this.format.format(tuple);
         out.write(bytes);
         this.offset += bytes.length;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/HdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/HdfsBolt.java
@@ -113,12 +113,12 @@ public class HdfsBolt extends AbstractHdfsBolt{
     }
 
     @Override
-    void closeOutputFile() throws IOException {
+    protected void closeOutputFile() throws IOException {
         this.out.close();
     }
 
     @Override
-    Path createOutputFile() throws IOException {
+    protected Path createOutputFile() throws IOException {
         Path path = new Path(this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
         this.out = this.fs.create(path);
         return path;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileBolt.java
@@ -114,13 +114,13 @@ public class SequenceFileBolt extends AbstractHdfsBolt {
     }
 
     @Override
-    void syncTuples() throws IOException {
+    protected void syncTuples() throws IOException {
         LOG.debug("Attempting to sync all data to filesystem");
         this.writer.hsync();
     }
 
     @Override
-    void writeTuple(Tuple tuple) throws IOException {
+    protected void writeTuple(Tuple tuple) throws IOException {
         this.writer.append(this.format.key(tuple), this.format.value(tuple));
         this.offset = this.writer.getLength();
     }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileBolt.java
@@ -125,7 +125,7 @@ public class SequenceFileBolt extends AbstractHdfsBolt {
         this.offset = this.writer.getLength();
     }
 
-    Path createOutputFile() throws IOException {
+    protected Path createOutputFile() throws IOException {
         Path p = new Path(this.fsUrl + this.fileNameFormat.getPath(), this.fileNameFormat.getName(this.rotation, System.currentTimeMillis()));
         this.writer = SequenceFile.createWriter(
                 this.hdfsConfig,
@@ -137,7 +137,7 @@ public class SequenceFileBolt extends AbstractHdfsBolt {
         return p;
     }
 
-    void closeOutputFile() throws IOException {
+    protected void closeOutputFile() throws IOException {
         this.writer.close();
     }
 }


### PR DESCRIPTION
When extending HdfsBolt it can be useful to be able to override the methods createOutputFile() or closeOutputFile(), for instance to add a header or footer to the files created. This is currently not possible when the class is outside the `org.apache.storm.hdfs.bolt` package. This patch makes it possible.