### PR TITLE
[STORM-1564] fix wrong package-info in org.apache.storm.utils.staticmocking

### DIFF
--- a/storm-core/test/jvm/org/apache/storm/utils/staticmocking/package-info.java
+++ b/storm-core/test/jvm/org/apache/storm/utils/staticmocking/package-info.java
@@ -92,4 +92,4 @@
  * This class should be removed when troublesome static methods have been
  * replaced in the code.
  */
-package org.apache.storm.testing.staticmocking;
+package org.apache.storm.utils.staticmocking;


### PR DESCRIPTION
Minor fix. Or it will cause a compilation error:
>The declared package "org.apache.storm.testing.staticmocking" does not match the expected 
 package "org.apache.storm.utils.staticmocking"