### PR TITLE
[STORM-1488] fix broken component error times

### DIFF
--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -157,11 +157,6 @@
 (defn supervisor-log-link [host]
   (url-format "http://%s:%s/daemonlog?file=supervisor.log" host (*STORM-CONF* LOGVIEWER-PORT)))
 
-(defn get-error-time
-  [error]
-  (if error
-    (time-delta (.get_error_time_secs ^ErrorInfo error))))
-
 (defn get-error-data
   [error]
   (if error
@@ -184,7 +179,7 @@
   [error]
   (if error
     (.get_error_time_secs ^ErrorInfo error)
-    ""))
+    0))
 
 (defn worker-dump-link [host port topology-id]
   (url-format "http://%s:%s/dumps/%s/%s"
@@ -518,7 +513,7 @@
      "errorTime" (get-error-time error-info)
      "errorHost" host
      "errorPort" port
-     "errorLapsedSecs" (get-error-time error-info)
+     "errorLapsedSecs" (time-delta (get-error-time error-info))
      "errorWorkerLogLink" (worker-log-link host port topo-id secure?)}))
 
 (defn- common-agg-stats-json
@@ -644,14 +639,14 @@
                     reverse)]
     {"componentErrors"
      (for [^ErrorInfo e errors]
-       {"errorTime" (* 1000 (long (.get_error_time_secs e)))
+       {"errorTime" (get-error-time e)
         "errorHost" (.get_host e)
         "errorPort"  (.get_port e)
         "errorWorkerLogLink"  (worker-log-link (.get_host e)
                                                (.get_port e)
                                                topology-id
                                                secure?)
-        "errorLapsedSecs" (get-error-time e)
+        "errorLapsedSecs" (time-delta (get-error-time e))
         "error" (.get_error e)})}))
 
 (defmulti unpack-comp-agg-stat

--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -178,8 +178,7 @@
 (defn get-error-time
   [error]
   (if error
-    (.get_error_time_secs ^ErrorInfo error)
-    0))
+    (.get_error_time_secs ^ErrorInfo error)))
 
 (defn worker-dump-link [host port topology-id]
   (url-format "http://%s:%s/dumps/%s/%s"
@@ -513,7 +512,7 @@
      "errorTime" (get-error-time error-info)
      "errorHost" host
      "errorPort" port
-     "errorLapsedSecs" (time-delta (get-error-time error-info))
+     "errorLapsedSecs" (if-let [t (get-error-time error-info)] (time-delta t))
      "errorWorkerLogLink" (worker-log-link host port topo-id secure?)}))
 
 (defn- common-agg-stats-json
@@ -646,7 +645,7 @@
                                                (.get_port e)
                                                topology-id
                                                secure?)
-        "errorLapsedSecs" (time-delta (get-error-time e))
+        "errorLapsedSecs" (if-let [t (get-error-time e)] (time-delta t))
         "error" (.get_error e)})}))
 
 (defmulti unpack-comp-agg-stat

--- a/storm-core/src/ui/public/component.html
+++ b/storm-core/src/ui/public/component.html
@@ -301,7 +301,7 @@ $(document).ready(function() {
             var errorTimeCells = document.getElementsByClassName("errorTimeSpan");
             for (i = 0; i < errorTimeCells.length; i++)
             {
-              var timeInMilliseconds = errorTimeCells[i].id;
+              var timeInMilliseconds = errorTimeCells[i].id * 1000;
               var time = parseInt(timeInMilliseconds);
               var date = new Date(time);
               errorTimeCells[i].innerHTML = date.toJSON();

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -323,7 +323,9 @@
           <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
         </td>
         <td>
+          {{#errorTime}}
           <span id="{{errorTime}}" class="errorTime" data-toggle="tooltip" title="{{errorLapsedSecs}}">{{errorTime}}</span>
+          {{/errorTime}}
         </td>
         {{/spouts}}
     </tbody>
@@ -417,7 +419,9 @@
           <span id="{{errorLapsedSecs}}" class="errorSpan">{{lastError}}</span>
         </td>
         <td>
+          {{#errorTime}}
           <span id="{{errorTime}}" class="errorTime" data-toggle="tooltip" title="{{errorLapsedSecs}}">{{errorTime}}</span>
+          {{/errorTime}}
         </td>
         {{/bolts}}
     </tbody>

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -350,7 +350,7 @@ $(document).ready(function() {
             {
               if((errorTime[i].id))
               {
-                var a = new Date(parseInt(errorTime[i].id));
+                var a = new Date(parseInt(errorTime[i].id) * 1000);
                 var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
                 var days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'];
                 var year = a.getFullYear();


### PR DESCRIPTION
Note that the errorTime reported for the component/ path was previously in milliseconds, but the errorTime reported for the topology/ path was in seconds.  This inconsistency fixed, but we should also update the REST API example. The REST API doc currently does not specify the units.


This should also go to master branch.