### PR TITLE
[STORM-1572] throw NPE when parsing the command line arguments by CLI

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/command/CLI.java
+++ b/storm-core/src/jvm/org/apache/storm/command/CLI.java
@@ -238,10 +238,13 @@ public class CLI {
             DefaultParser parser = new DefaultParser();
             CommandLine cl = parser.parse(options, rawArgs);
             HashMap<String, Object> ret = new HashMap<>();
-            for (Opt opt: opts) {
+            for (Opt opt : opts) {
                 Object current = null;
-                for (String val: cl.getOptionValues(opt.shortName)) {
-                    current = opt.process(current, val);
+                String[] strings = cl.getOptionValues(opt.shortName);
+                if (strings != null) {
+                    for (String val : cl.getOptionValues(opt.shortName)) {
+                        current = opt.process(current, val);
+                    }
                 }
                 if (current == null) {
                     current = opt.defaultValue;

--- a/storm-core/test/jvm/org/apache/storm/command/TestCLI.java
+++ b/storm-core/test/jvm/org/apache/storm/command/TestCLI.java
@@ -32,13 +32,15 @@ public class TestCLI {
            .opt("b", "bb", 1, CLI.AS_INT)
            .opt("c", "cc", 1, CLI.AS_INT, CLI.FIRST_WINS)
            .opt("d", "dd", null, CLI.AS_STRING, CLI.INTO_LIST)
+           .opt("e", "ee", null, CLI.AS_INT)
            .arg("A")
            .arg("B", CLI.AS_INT)
            .parse("-a100", "--aa", "200", "-c2", "-b", "50", "--cc", "100", "A-VALUE", "1", "2", "3", "-b40", "-d1", "-d2", "-d3");
-        assertEquals(6, values.size());
+        assertEquals(7, values.size());
         assertEquals("200", (String)values.get("a"));
         assertEquals((Integer)40, (Integer)values.get("b"));
         assertEquals((Integer)2, (Integer)values.get("c"));
+        assertEquals(null, values.get("e"));
 
         List<String> d = (List<String>)values.get("d");
         assertEquals(3, d.size());


### PR DESCRIPTION
$ storm kill test
Running: /data/nfs_share/soft/jdk1.7.0_79/bin/java -client -Ddaemon.name= -Dstorm.options= -Dstorm.home=/data/nfs_share/soft/storm -Dstorm.log.dir=/home/admin/storm_logs -Djava.library.path=/usr/local/lib -Dstorm.conf.file= -cp /data/nfs_share/soft/storm/lib/servlet-api-2.5.jar:/data/nfs_share/soft/storm/lib/slf4j-api-1.7.7.jar:/data/nfs_share/soft/storm/lib/log4j-over-slf4j-1.6.6.jar:/data/nfs_share/soft/storm/lib/reflectasm-1.07-shaded.jar:/data/nfs_share/soft/storm/lib/log4j-api-2.1.jar:/data/nfs_share/soft/storm/lib/storm-core-2.0.0-SNAPSHOT.jar:/data/nfs_share/soft/storm/lib/log4j-core-2.1.jar:/data/nfs_share/soft/storm/lib/kryo-2.21.jar:/data/nfs_share/soft/storm/lib/clojure-1.7.0.jar:/data/nfs_share/soft/storm/lib/log4j-slf4j-impl-2.1.jar:/data/nfs_share/soft/storm/lib/minlog-1.2.jar:/data/nfs_share/soft/storm/lib/disruptor-3.3.2.jar:/data/nfs_share/soft/storm/lib/asm-4.0.jar:/home/admin/.storm:/data/nfs_share/soft/storm/bin org.apache.storm.command.KillTopology test
Exception in thread "main" java.lang.NullPointerException
at org.apache.storm.command.CLI$CLIBuilder.parse(CLI.java:243)
at org.apache.storm.command.KillTopology.main(KillTopology.java:33)