### PR TITLE
[STORM-1571]Improvment Kafka Spout Time Metric

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
@@ -170,7 +170,7 @@ public class PartitionManager {
 
 
     private void fill() {
-        long start = System.nanoTime();
+        long start = System.currentTimeMillis();
         Long offset;
 
         // Are there failed tuples? If so, fetch those first.
@@ -205,8 +205,7 @@ public class PartitionManager {
             
             return;
         }
-        long end = System.nanoTime();
-        long millis = (end - start) / 1000000;
+        long millis = System.currentTimeMillis() - start;
         _fetchAPILatencyMax.update(millis);
         _fetchAPILatencyMean.update(millis);
         _fetchAPICallCount.incr();

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/trident/TridentKafkaEmitter.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/trident/TridentKafkaEmitter.java
@@ -136,11 +136,10 @@ public class TridentKafkaEmitter {
     }
 
     private ByteBufferMessageSet fetchMessages(SimpleConsumer consumer, Partition partition, long offset) {
-        long start = System.nanoTime();
+        long start = System.currentTimeMillis();
         ByteBufferMessageSet msgs = null;
         msgs = KafkaUtils.fetchMessages(_config, consumer, partition, offset);
-        long end = System.nanoTime();
-        long millis = (end - start) / 1000000;
+        long millis = System.currentTimeMillis() - start;
         _kafkaMeanFetchLatencyMetric.update(millis);
         _kafkaMaxFetchLatencyMetric.update(millis);
         return msgs;


### PR DESCRIPTION
[STORM-1571](https://issues.apache.org/jira/browse/STORM-1571) System.currentTimeMillis to calculation time interval is better than System.nanoTime :)