### PR TITLE
Fix Log4j2.xml config to output the the timestamp in HH:mm:ss.SSS

### DIFF
--- a/conf/log4j2.xml
+++ b/conf/log4j2.xml
@@ -19,7 +19,7 @@
 <configuration monitorInterval="60">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-     <PatternLayout pattern="%-4r [%t] %-5p %c{1.} - %msg%n"/>
+     <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5p %c{1.} - %msg%n"/>
     </Console>
   </Appenders>
   <Loggers>


### PR DESCRIPTION
Currently the -r option outputs the number of milliseconds elapsed from the construction of the layout until the creation of the logging event.