### PR TITLE
[STORM-1250]: port backtype.storm.serialization-test to java

### DIFF
--- a/storm-core/test/clj/org/apache/storm/serialization_test.clj
+++ b/storm-core/test/clj/org/apache/storm/serialization_test.clj
@@ -15,82 +15,15 @@
 ;; limitations under the License.
 (ns org.apache.storm.serialization-test
   (:use [clojure test])
-  (:import [org.apache.storm.serialization KryoTupleSerializer KryoTupleDeserializer
-            KryoValuesSerializer KryoValuesDeserializer])
-  (:import [org.apache.storm.testing TestSerObject TestKryoDecorator])
-  (:import [org.apache.storm.validation ConfigValidation$KryoRegValidator])
-  (:import [org.apache.storm.utils Utils])
-  (:use [org.apache.storm util config]))
+  (:import [org.apache.storm.serialization  SerializationTest]))
 
-(defn mk-conf [extra]
-  (merge (clojurify-structure (Utils/readDefaultConfig)) extra))
 
-(defn serialize [vals conf]
-  (let [serializer (KryoValuesSerializer. (mk-conf conf))]
-    (.serialize serializer vals)
-    ))
-
-(defn deserialize [bytes conf]
-  (let [deserializer (KryoValuesDeserializer. (mk-conf conf))]
-    (.deserialize deserializer bytes)
-    ))
-
-(defn roundtrip
-  ([vals] (roundtrip vals {}))
-  ([vals conf]
-    (deserialize (serialize vals conf) conf)))
-
-(deftest validate-kryo-conf-basic
-  (.validateField (ConfigValidation$KryoRegValidator. ) "test" ["a" "b" "c" {"d" "e"} {"f" "g"}]))
-
-(deftest validate-kryo-conf-fail
-  (try
-    (.validateField (ConfigValidation$KryoRegValidator. ) "test" {"f" "g"})
-    (assert false)
-    (catch IllegalArgumentException e))
-  (try
-    (.validateField (ConfigValidation$KryoRegValidator. ) "test" [1])
-    (assert false)
-    (catch IllegalArgumentException e))
-  (try
-    (.validateField (ConfigValidation$KryoRegValidator. ) "test" [{"a" 1}])
-    (assert false)
-    (catch IllegalArgumentException e))
-)
-
-(deftest test-java-serialization
-  (let [obj (TestSerObject. 1 2)]
-    (is (thrown? Exception
-      (roundtrip [obj] {TOPOLOGY-KRYO-REGISTER {"org.apache.storm.testing.TestSerObject" nil}
-                        TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))
-    (is (= [obj] (roundtrip [obj] {TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION true})))))
-
-(deftest test-kryo-decorator
-  (let [obj (TestSerObject. 1 2)]
-    (is (thrown? Exception
-                 (roundtrip [obj] {TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))
-    (is (= [obj] (roundtrip [obj] {TOPOLOGY-KRYO-DECORATORS ["org.apache.storm.testing.TestKryoDecorator"]
-                                   TOPOLOGY-FALL-BACK-ON-JAVA-SERIALIZATION false})))))
-
-(defn mk-string [size]
-  (let [builder (StringBuilder.)]
-    (doseq [i (range size)]
-      (.append builder "a"))
-    (.toString builder)))
-
-(defn is-roundtrip [vals]
-  (is (= vals (roundtrip vals))))
-
-(deftest test-string-serialization
-  (is-roundtrip ["a" "bb" "cde"])
-  (is-roundtrip [(mk-string (* 64 1024))])
-  (is-roundtrip [(mk-string (* 1024 1024))])
-  (is-roundtrip [(mk-string (* 1024 1024 2))])
-  )
-
+;TODO: We have moved needed tests to SerializationTest.
+;TODO: When we move to java totally, we can remove this test file entirely
 (deftest test-clojure-serialization
-  (is-roundtrip [:a])
-  (is-roundtrip [["a" 1 2 :a] 2 "aaa"])
-  (is-roundtrip [#{:a :b :c}])
-  (is-roundtrip [#{:a :b} 1 2 ["a" 3 5 #{5 6}]])
-  (is-roundtrip [{:a [1 2 #{:a :b 1}] :b 3}]))
+  (let [serializationTest (SerializationTest.)]
+    (.isRoundtrip serializationTest [:a])
+    (.isRoundtrip serializationTest [["a" 1 2 :a] 2 "aaa"])
+    (.isRoundtrip serializationTest [#{:a :b :c}])
+    (.isRoundtrip serializationTest [#{:a :b} 1 2 ["a" 3 5 #{5 6}]])
+    (.isRoundtrip serializationTest [{:a [1 2 #{:a :b 1}] :b 3}])))

--- a/storm-core/test/jvm/org/apache/storm/TestConfigValidate.java
+++ b/storm-core/test/jvm/org/apache/storm/TestConfigValidate.java
@@ -18,6 +18,8 @@
 
 package org.apache.storm;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.validation.ConfigValidation;
 import org.apache.storm.validation.ConfigValidation.*;
@@ -228,6 +230,24 @@ public class TestConfigValidate {
         testList.add(new Long("4"));
         conf.put("eee", testList);
         Utils.isValidConf(conf);
+    }
+
+    @Test
+    public void testKryoRegValidator() {
+        KryoRegValidator validator = new KryoRegValidator();
+
+        // fail cases
+        Object[] failCases = {ImmutableMap.of("f", "g"), ImmutableList.of(1), Arrays.asList(ImmutableMap.of("a", 1))};
+        for (Object value : failCases) {
+            try {
+                validator.validateField("test", value);
+                Assert.fail("Expected Exception not Thrown for value: " + value);
+            } catch (IllegalArgumentException e) {
+            }
+        }
+
+        // pass cases
+        validator.validateField("test", Arrays.asList("a", "b", "c", ImmutableMap.of("d", "e"), ImmutableMap.of("f", "g")));
     }
 
     @Test

--- a/storm-core/test/jvm/org/apache/storm/serialization/SerializationTest.java
+++ b/storm-core/test/jvm/org/apache/storm/serialization/SerializationTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.serialization;
+
+import com.google.common.collect.Lists;
+import org.apache.storm.Config;
+import org.apache.storm.testing.TestSerObject;
+import org.apache.storm.utils.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SerializationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SerializationTest.class);
+
+    @Test
+    public void testJavaSerialization() {
+        Object obj = new TestSerObject(1, 2);
+        List<Object> vals = Lists.newArrayList(obj);
+
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(Config.TOPOLOGY_KRYO_REGISTER, new HashMap<String, String>() {{
+            put("org.apache.storm.testing.TestSerObject", null);
+        }});
+        conf.put(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION, false);
+        try {
+            roundtrip(vals, conf);
+            Assert.fail("Expected Exception not Thrown for config: " + conf);
+        } catch (Exception e) {
+        }
+
+        conf.clear();
+        conf.put(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION, true);
+        Assert.assertEquals(vals, roundtrip(vals, conf));
+    }
+
+    @Test
+    public void testKryoDecorator() {
+        Object obj = new TestSerObject(1, 2);
+        List<Object> vals = Lists.newArrayList(obj);
+
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION, false);
+        try {
+            roundtrip(vals, conf);
+            Assert.fail("Expected Exception not Thrown for config: " + conf);
+        } catch (Exception e) {
+        }
+
+        conf.put(Config.TOPOLOGY_KRYO_DECORATORS, Lists.newArrayList("org.apache.storm.testing.TestKryoDecorator"));
+        Assert.assertEquals(vals, roundtrip(vals, conf));
+    }
+
+    @Test
+    public void testStringSerialization() {
+        isRoundtrip(Lists.newArrayList("a", "bb", "cbe"));
+        isRoundtrip(Lists.newArrayList(mkString(64 * 1024)));
+        isRoundtrip(Lists.newArrayList(mkString(1024 * 1024)));
+        isRoundtrip(Lists.newArrayList(mkString(1024 * 1024 * 2)));
+    }
+
+    private Map mkConf(Map extra) {
+        Map config = Utils.readDefaultConfig();
+        config.putAll(extra);
+        return config;
+    }
+
+    private byte[] serialize(List vals, Map conf) throws IOException {
+        KryoValuesSerializer serializer = new KryoValuesSerializer(mkConf(conf));
+        return serializer.serialize(vals);
+    }
+
+    private List deserialize(byte[] bytes, Map conf) throws IOException {
+        KryoValuesDeserializer deserializer = new KryoValuesDeserializer(mkConf(conf));
+        return deserializer.deserialize(bytes);
+    }
+
+    private List roundtrip(List vals) {
+        return roundtrip(vals, new HashMap());
+    }
+
+    private List roundtrip(List vals, Map conf) {
+        List ret = null;
+        try {
+            ret = deserialize(serialize(vals, conf), conf);
+        } catch (IOException e) {
+            LOG.error("Exception when serialize/deserialize ", e);
+        }
+        return ret;
+    }
+
+    private String mkString(int size) {
+        StringBuilder sb = new StringBuilder();
+        while (size-- > 0) {
+            sb.append("a");
+        }
+        return sb.toString();
+    }
+
+    public void isRoundtrip(List vals) {
+        Assert.assertEquals(vals, roundtrip(vals));
+    }
+}

--- a/storm-core/test/jvm/org/apache/storm/serialization/SerializationTest.java
+++ b/storm-core/test/jvm/org/apache/storm/serialization/SerializationTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,8 +23,6 @@ import org.apache.storm.testing.TestSerObject;
 import org.apache.storm.utils.Utils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -33,10 +31,8 @@ import java.util.Map;
 
 public class SerializationTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SerializationTest.class);
-
     @Test
-    public void testJavaSerialization() {
+    public void testJavaSerialization() throws IOException {
         Object obj = new TestSerObject(1, 2);
         List<Object> vals = Lists.newArrayList(obj);
 
@@ -57,7 +53,7 @@ public class SerializationTest {
     }
 
     @Test
-    public void testKryoDecorator() {
+    public void testKryoDecorator() throws IOException {
         Object obj = new TestSerObject(1, 2);
         List<Object> vals = Lists.newArrayList(obj);
 
@@ -74,7 +70,7 @@ public class SerializationTest {
     }
 
     @Test
-    public void testStringSerialization() {
+    public void testStringSerialization() throws IOException {
         isRoundtrip(Lists.newArrayList("a", "bb", "cbe"));
         isRoundtrip(Lists.newArrayList(mkString(64 * 1024)));
         isRoundtrip(Lists.newArrayList(mkString(1024 * 1024)));
@@ -97,18 +93,12 @@ public class SerializationTest {
         return deserializer.deserialize(bytes);
     }
 
-    private List roundtrip(List vals) {
+    private List roundtrip(List vals) throws IOException {
         return roundtrip(vals, new HashMap());
     }
 
-    private List roundtrip(List vals, Map conf) {
-        List ret = null;
-        try {
-            ret = deserialize(serialize(vals, conf), conf);
-        } catch (IOException e) {
-            LOG.error("Exception when serialize/deserialize ", e);
-        }
-        return ret;
+    private List roundtrip(List vals, Map conf) throws IOException {
+        return deserialize(serialize(vals, conf), conf);
     }
 
     private String mkString(int size) {
@@ -119,7 +109,7 @@ public class SerializationTest {
         return sb.toString();
     }
 
-    public void isRoundtrip(List vals) {
+    public void isRoundtrip(List vals) throws IOException {
         Assert.assertEquals(vals, roundtrip(vals));
     }
 }


### PR DESCRIPTION
1. Move `validate-kryo-conf-basic` and `validate-kryo-conf-fail` to `TestConfigValidate.java`, and merge this two tests into one
2. I'm not sure wether to translate `test-clojure-serialization`. So I translate it and commet it.