### PR TITLE
[STORM-1576] fix ConcurrentModificationException in addCheckpointInputs

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/topology/TopologyBuilder.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/TopologyBuilder.java
@@ -35,8 +35,11 @@ import java.io.NotSerializableException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import org.apache.storm.windowing.TupleWindow;
 import org.json.simple.JSONValue;
 import static org.apache.storm.spout.CheckpointSpout.CHECKPOINT_COMPONENT_ID;
@@ -357,15 +360,17 @@ public class TopologyBuilder {
      * add checkpoint stream from the previous bolt to its input.
      */
     private void addCheckPointInputs(ComponentCommon component) {
+        Set<GlobalStreamId> checkPointInputs = new HashSet<>();
         for (GlobalStreamId inputStream : component.get_inputs().keySet()) {
             String sourceId = inputStream.get_componentId();
             if (_spouts.containsKey(sourceId)) {
-                GlobalStreamId checkPointStream = new GlobalStreamId(CHECKPOINT_COMPONENT_ID, CHECKPOINT_STREAM_ID);
-                component.put_to_inputs(checkPointStream, Grouping.all(new NullStruct()));
+                checkPointInputs.add(new GlobalStreamId(CHECKPOINT_COMPONENT_ID, CHECKPOINT_STREAM_ID));
             } else {
-                GlobalStreamId checkPointStream = new GlobalStreamId(sourceId, CHECKPOINT_STREAM_ID);
-                component.put_to_inputs(checkPointStream, Grouping.all(new NullStruct()));
+                checkPointInputs.add(new GlobalStreamId(sourceId, CHECKPOINT_STREAM_ID));
             }
+        }
+        for (GlobalStreamId streamId : checkPointInputs) {
+            component.put_to_inputs(streamId, Grouping.all(new NullStruct()));
         }
     }
 

--- a/storm-core/test/jvm/org/apache/storm/topology/TopologyBuilderTest.java
+++ b/storm-core/test/jvm/org/apache/storm/topology/TopologyBuilderTest.java
@@ -17,7 +17,20 @@
  */
 package org.apache.storm.topology;
 
+import com.google.common.collect.ImmutableSet;
+import org.apache.storm.generated.GlobalStreamId;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.state.State;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.base.BaseRichSpout;
+import org.apache.storm.topology.base.BaseStatefulBolt;
+import org.apache.storm.tuple.Tuple;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.Mockito.mock;
 
@@ -50,4 +63,56 @@ public class TopologyBuilderTest {
 //        builder.setStateSpout("stateSpout", mock(IRichStateSpout.class), 0);
 //    }
 
+    @Test
+    public void testStatefulTopology() {
+        builder.setSpout("spout1", makeDummySpout());
+        builder.setSpout("spout2", makeDummySpout());
+        builder.setBolt("bolt1", makeDummyStatefulBolt(), 1)
+                .shuffleGrouping("spout1").shuffleGrouping("spout2");
+        builder.setBolt("bolt2", makeDummyStatefulBolt(), 1).shuffleGrouping("spout1");
+        builder.setBolt("bolt3", makeDummyStatefulBolt(), 1)
+                .shuffleGrouping("bolt1").shuffleGrouping("bolt2");
+        StormTopology topology = builder.createTopology();
+
+        Assert.assertNotNull(topology);
+        Set<String> spouts = topology.get_spouts().keySet();
+        // checkpoint spout should 've been added
+        Assert.assertEquals(ImmutableSet.of("spout1", "spout2", "$checkpointspout"), spouts);
+        // bolt1, bolt2 should also receive from checkpoint spout
+        Assert.assertEquals(ImmutableSet.of(new GlobalStreamId("spout1", "default"),
+                                            new GlobalStreamId("spout2", "default"),
+                                            new GlobalStreamId("$checkpointspout", "$checkpoint")),
+                            topology.get_bolts().get("bolt1").get_common().get_inputs().keySet());
+        Assert.assertEquals(ImmutableSet.of(new GlobalStreamId("spout1", "default"),
+                                            new GlobalStreamId("$checkpointspout", "$checkpoint")),
+                            topology.get_bolts().get("bolt2").get_common().get_inputs().keySet());
+        // bolt3 should also receive from checkpoint streams of bolt1, bolt2
+        Assert.assertEquals(ImmutableSet.of(new GlobalStreamId("bolt1", "default"),
+                                            new GlobalStreamId("bolt1", "$checkpoint"),
+                                            new GlobalStreamId("bolt2", "default"),
+                                            new GlobalStreamId("bolt2", "$checkpoint")),
+                            topology.get_bolts().get("bolt3").get_common().get_inputs().keySet());
+    }
+
+    private IRichSpout makeDummySpout() {
+        return new BaseRichSpout() {
+            @Override
+            public void declareOutputFields(OutputFieldsDeclarer declarer) {}
+            @Override
+            public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {}
+            @Override
+            public void nextTuple() {}
+            private void writeObject(java.io.ObjectOutputStream stream) {}
+        };
+    }
+
+    private IStatefulBolt makeDummyStatefulBolt() {
+        return new BaseStatefulBolt() {
+            @Override
+            public void execute(Tuple input) {}
+            @Override
+            public void initState(State state) {}
+            private void writeObject(java.io.ObjectOutputStream stream) {}
+        };
+    }
 }


### PR DESCRIPTION
Proposed patch addresses the ConcurrentModificationException while
creating a topology with an IStatefulBolt having more than one
input.

Note: Submitting the changes merged in https://github.com/apache/storm/pull/1151 against 1.x-branch