### PR TITLE
[STORM-1587] Avoid NPE while prining Metrics

### DIFF
--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/ThroughputVsLatency.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/ThroughputVsLatency.java
@@ -273,7 +273,7 @@ public class ThroughputVsLatency {
     long acked = 0;
     long failed = 0;
     for (ExecutorSummary exec: info.get_executors()) {
-      if ("spout".equals(exec.get_component_id())) {
+      if ("spout".equals(exec.get_component_id()) && exec.get_stats() != null && exec.get_stats().get_specific() != null) {
         SpoutStats stats = exec.get_stats().get_specific().get_spout();
         Map<String, Long> failedMap = stats.get_failed().get(":all-time");
         Map<String, Long> ackedMap = stats.get_acked().get(":all-time");


### PR DESCRIPTION
Avoiding..
```
1701 [main] INFO  o.a.s.StormSubmitter - Submitting topology wc-test in distributed mode with conf {"topology.worker.metrics":{"CPU":"org.apache.storm.metrics.sigar.CPUMetric"},"storm.zookeeper.topology.auth.scheme":"digest","topology.worker.gc.childopts":"-XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:NewSize=128m -XX:CMSInitiatingOccupancyFraction=70 -XX:-CMSConcurrentMTEnabled","topology.workers":4,"topology.builtin.metrics.bucket.size.secs":10,"topology.worker.childopts":"-Xmx2g","storm.zookeeper.topology.auth.payload":"-5601074936064852696:-8332153375154710952","topology.metrics.consumer.register":[{"argument":null,"class":"org.apache.storm.metric.LoggingMetricsConsumer","parallelism.hint":1},{"argument":"http:\/\/survivedlived.corp.ir2.yahoo.com:45976\/","class":"org.apache.storm.metric.HttpForwardingMetricsConsumer","parallelism.hint":1}]}
2137 [main] INFO  o.a.s.StormSubmitter - Finished submitting topology: wc-test
Exception in thread "main" java.lang.NullPointerException
	at org.apache.storm.starter.ThroughputVsLatency.printMetrics(ThroughputVsLatency.java:277)
	at org.apache.storm.starter.ThroughputVsLatency.main(ThroughputVsLatency.java:425)
```