### PR TITLE
Fixed incorrect storm-kafka documentation.

### DIFF
--- a/external/storm-kafka/README.md
+++ b/external/storm-kafka/README.md
@@ -56,7 +56,6 @@ behavior specific to KafkaSpout. The Zkroot will be used as root to store your c
 identify your spout.
 ```java
 public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id);
-public SpoutConfig(BrokerHosts hosts, String topic, String id);
 ```
 In addition to these parameters, SpoutConfig contains the following fields that control how KafkaSpout behaves:
 ```java


### PR DESCRIPTION
Removed an incorrect (outdated?) constructor of `SpoutConfig` from the README.

Just threw me for a quick loop until I [looked at the source](https://github.com/apache/storm/blob/master/external/storm-kafka/src/jvm/org/apache/storm/kafka/SpoutConfig.java#L41) and confirmed that, sure enough, `zkRoot` isn't optional (the constructor isn't ***actually*** overloaded like the README claims).