### PR TITLE
[Storm-1585]  Add DDL support for UDFs in storm-sql

### DIFF
--- a/external/sql/storm-sql-core/src/codegen/data/Parser.tdd
+++ b/external/sql/storm-sql-core/src/codegen/data/Parser.tdd
@@ -38,7 +38,8 @@
 
   # List of methods for parsing custom SQL statements.
   statementParserMethods: [
-    "SqlCreateTable()"
+    "SqlCreateTable()",
+    "SqlCreateFunction()"
   ]
 
   # List of methods for parsing custom literals.

--- a/external/sql/storm-sql-core/src/codegen/data/Parser.tdd
+++ b/external/sql/storm-sql-core/src/codegen/data/Parser.tdd
@@ -34,6 +34,7 @@
     "OUTPUTFORMAT",
     "STORED",
     "TBLPROPERTIES",
+    "JAR"
   ]
 
   # List of methods for parsing custom SQL statements.

--- a/external/sql/storm-sql-core/src/codegen/includes/parserImpls.ftl
+++ b/external/sql/storm-sql-core/src/codegen/includes/parserImpls.ftl
@@ -93,13 +93,19 @@ SqlNode SqlCreateFunction() :
     SqlParserPos pos;
     SqlIdentifier functionName;
     SqlNode className;
+    SqlNode jarName = null;
 }
 {
     <CREATE> { pos = getPos(); }
     <FUNCTION>
-    functionName = CompoundIdentifier()
+        functionName = CompoundIdentifier()
     <AS>
-    className = StringLiteral() {
-        return new SqlCreateFunction(pos, functionName, className);
+        className = StringLiteral()
+    [
+      <USING> <JAR>
+      jarName = StringLiteral()
+    ]
+    {
+      return new SqlCreateFunction(pos, functionName, className, jarName);
     }
 }

--- a/external/sql/storm-sql-core/src/codegen/includes/parserImpls.ftl
+++ b/external/sql/storm-sql-core/src/codegen/includes/parserImpls.ftl
@@ -84,3 +84,22 @@ SqlNode SqlCreateTable() :
         tbl_properties, select);
     }
 }
+
+/**
+ * CREATE FUNCTION functionname AS 'classname'
+ */
+SqlNode SqlCreateFunction() :
+{
+    SqlParserPos pos;
+    SqlIdentifier functionName;
+    SqlNode className;
+}
+{
+    <CREATE> { pos = getPos(); }
+    <FUNCTION>
+    functionName = CompoundIdentifier()
+    <AS>
+    className = StringLiteral() {
+        return new SqlCreateFunction(pos, functionName, className);
+    }
+}

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSqlImpl.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSqlImpl.java
@@ -165,6 +165,9 @@ class StormSqlImpl extends StormSql {
   }
 
   private void handleCreateFunction(SqlCreateFunction sqlCreateFunction) throws ClassNotFoundException {
+    if(sqlCreateFunction.jarName() != null) {
+      throw new UnsupportedOperationException("UDF 'USING JAR' not implemented");
+    }
     schema.add(sqlCreateFunction.functionName().toUpperCase(),
                ScalarFunctionImpl.create(Class.forName(sqlCreateFunction.className()), "evaluate"));
     hasUdf = true;

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSqlImpl.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSqlImpl.java
@@ -17,6 +17,12 @@
  */
 package org.apache.storm.sql;
 
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.schema.impl.ScalarFunctionImpl;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
 import org.apache.storm.StormSubmitter;
 import org.apache.storm.generated.SubmitOptions;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
@@ -34,6 +40,7 @@ import org.apache.storm.sql.compiler.backends.standalone.PlanCompiler;
 import org.apache.storm.sql.javac.CompilingClassLoader;
 import org.apache.storm.sql.parser.ColumnConstraint;
 import org.apache.storm.sql.parser.ColumnDefinition;
+import org.apache.storm.sql.parser.SqlCreateFunction;
 import org.apache.storm.sql.parser.SqlCreateTable;
 import org.apache.storm.sql.parser.StormParser;
 import org.apache.storm.sql.runtime.*;
@@ -47,6 +54,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +69,7 @@ class StormSqlImpl extends StormSql {
   private final JavaTypeFactory typeFactory = new JavaTypeFactoryImpl(
       RelDataTypeSystem.DEFAULT);
   private final SchemaPlus schema = Frameworks.createRootSchema(true);
+  private boolean hasUdf = false;
 
   @Override
   public void execute(
@@ -72,9 +81,10 @@ class StormSqlImpl extends StormSql {
       SqlNode node = parser.impl().parseSqlStmtEof();
       if (node instanceof SqlCreateTable) {
         handleCreateTable((SqlCreateTable) node, dataSources);
+      } else if (node instanceof SqlCreateFunction) {
+        handleCreateFunction((SqlCreateFunction) node);
       } else {
-        FrameworkConfig config = Frameworks.newConfigBuilder().defaultSchema(
-            schema).build();
+        FrameworkConfig config = buildFrameWorkConfig();
         Planner planner = Frameworks.getPlanner(config);
         SqlNode parse = planner.parse(sql);
         SqlNode validate = planner.validate(parse);
@@ -97,9 +107,10 @@ class StormSqlImpl extends StormSql {
       SqlNode node = parser.impl().parseSqlStmtEof();
       if (node instanceof SqlCreateTable) {
         handleCreateTableForTrident((SqlCreateTable) node, dataSources);
-      } else {
-        FrameworkConfig config = Frameworks.newConfigBuilder().defaultSchema(
-            schema).build();
+      } else if (node instanceof SqlCreateFunction) {
+        handleCreateFunction((SqlCreateFunction) node);
+      }  else {
+        FrameworkConfig config = buildFrameWorkConfig();
         Planner planner = Frameworks.getPlanner(config);
         SqlNode parse = planner.parse(sql);
         SqlNode validate = planner.validate(parse);
@@ -153,6 +164,12 @@ class StormSqlImpl extends StormSql {
     dataSources.put(n.tableName(), ds);
   }
 
+  private void handleCreateFunction(SqlCreateFunction sqlCreateFunction) throws ClassNotFoundException {
+    schema.add(sqlCreateFunction.functionName().toUpperCase(),
+               ScalarFunctionImpl.create(Class.forName(sqlCreateFunction.className()), "evaluate"));
+    hasUdf = true;
+  }
+
   private void handleCreateTableForTrident(
       SqlCreateTable n, Map<String, ISqlTridentDataSource> dataSources) {
     List<FieldInfo> fields = updateSchema(n);
@@ -183,5 +200,19 @@ class StormSqlImpl extends StormSql {
     Table table = builder.build();
     schema.add(n.tableName(), table);
     return fields;
+  }
+
+  private FrameworkConfig buildFrameWorkConfig() {
+    if (hasUdf) {
+      List<SqlOperatorTable> sqlOperatorTables = new ArrayList<>();
+      sqlOperatorTables.add(SqlStdOperatorTable.instance());
+      sqlOperatorTables.add(new CalciteCatalogReader(CalciteSchema.from(schema),
+                                                     false,
+                                                     Collections.<String>emptyList(), typeFactory));
+      return Frameworks.newConfigBuilder().defaultSchema(schema)
+              .operatorTable(new ChainedSqlOperatorTable(sqlOperatorTables)).build();
+    } else {
+      return Frameworks.newConfigBuilder().defaultSchema(schema).build();
+    }
   }
 }

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/parser/SqlCreateFunction.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/parser/SqlCreateFunction.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.storm.sql.parser;
 
 import org.apache.calcite.sql.SqlCall;
@@ -21,7 +38,7 @@ public class SqlCreateFunction extends SqlCall {
         public SqlCall createCall(
                 SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... o) {
             assert functionQualifier == null;
-            return new SqlCreateFunction(pos, (SqlIdentifier) o[0], o[1]);
+            return new SqlCreateFunction(pos, (SqlIdentifier) o[0], o[1], o[2]);
         }
 
         @Override
@@ -30,16 +47,21 @@ public class SqlCreateFunction extends SqlCall {
             SqlCreateFunction t = (SqlCreateFunction) call;
             UnparseUtil u = new UnparseUtil(writer, leftPrec, rightPrec);
             u.keyword("CREATE", "FUNCTION").node(t.functionName).keyword("AS").node(t.className);
+            if (t.jarName != null) {
+                u.keyword("USING", "JAR").node(t.jarName);
+            }
         }
     };
 
     private final SqlIdentifier functionName;
     private final SqlNode className;
+    private final SqlNode jarName;
 
-    public SqlCreateFunction(SqlParserPos pos, SqlIdentifier functionName, SqlNode className) {
+    public SqlCreateFunction(SqlParserPos pos, SqlIdentifier functionName, SqlNode className, SqlNode jarName) {
         super(pos);
         this.functionName = functionName;
         this.className = className;
+        this.jarName = jarName;
     }
 
     @Override
@@ -64,5 +86,9 @@ public class SqlCreateFunction extends SqlCall {
 
     public String className() {
         return ((NlsString)SqlLiteral.value(className)).getValue();
+    }
+
+    public String jarName() {
+        return jarName == null ? null : ((NlsString)SqlLiteral.value(jarName)).getValue();
     }
 }

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/parser/SqlCreateFunction.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/parser/SqlCreateFunction.java
@@ -1,0 +1,68 @@
+package org.apache.storm.sql.parser;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.NlsString;
+
+import java.util.List;
+
+public class SqlCreateFunction extends SqlCall {
+    public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator(
+            "CREATE_FUNCTION", SqlKind.OTHER) {
+        @Override
+        public SqlCall createCall(
+                SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... o) {
+            assert functionQualifier == null;
+            return new SqlCreateFunction(pos, (SqlIdentifier) o[0], o[1]);
+        }
+
+        @Override
+        public void unparse(
+                SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+            SqlCreateFunction t = (SqlCreateFunction) call;
+            UnparseUtil u = new UnparseUtil(writer, leftPrec, rightPrec);
+            u.keyword("CREATE", "FUNCTION").node(t.functionName).keyword("AS").node(t.className);
+        }
+    };
+
+    private final SqlIdentifier functionName;
+    private final SqlNode className;
+
+    public SqlCreateFunction(SqlParserPos pos, SqlIdentifier functionName, SqlNode className) {
+        super(pos);
+        this.functionName = functionName;
+        this.className = className;
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of(functionName, className);
+    }
+
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        getOperator().unparse(writer, this, leftPrec, rightPrec);
+    }
+
+    public String functionName() {
+        return functionName.toString();
+    }
+
+    public String className() {
+        return ((NlsString)SqlLiteral.value(className)).getValue();
+    }
+}

--- a/external/sql/storm-sql-core/src/test/org/apache/storm/sql/TestStormSql.java
+++ b/external/sql/storm-sql-core/src/test/org/apache/storm/sql/TestStormSql.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,8 @@
 package org.apache.storm.sql;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.calcite.sql.validate.SqlValidatorException;
+import org.apache.calcite.tools.ValidationException;
 import org.apache.storm.sql.runtime.ChannelHandler;
 import org.apache.storm.sql.runtime.DataSource;
 import org.apache.storm.sql.runtime.DataSourcesProvider;
@@ -135,6 +137,33 @@ public class TestStormSql {
     Assert.assertEquals(0, values.size());
   }
 
+  @Test(expected = ValidationException.class)
+  public void testExternalUdfType() throws Exception {
+    List<String> stmt = new ArrayList<>();
+    stmt.add("CREATE EXTERNAL TABLE FOO (ID INT, NAME VARCHAR) LOCATION 'mock:///foo'");
+    stmt.add("CREATE FUNCTION MYPLUS AS 'org.apache.storm.sql.TestUtils$MyPlus'");
+    stmt.add("SELECT STREAM MYPLUS(NAME, 1) FROM FOO WHERE ID = 0");
+    StormSql sql = StormSql.construct();
+    List<Values> values = new ArrayList<>();
+    ChannelHandler h = new TestUtils.CollectDataChannelHandler(values);
+    sql.execute(stmt, h);
+    System.out.println(values);
+
+  }
+
+  @Test
+  public void testExternalUdfType2() throws Exception {
+    List<String> stmt = new ArrayList<>();
+    stmt.add("CREATE EXTERNAL TABLE FOO (ID INT, NAME VARCHAR) LOCATION 'mock:///foo'");
+    stmt.add("CREATE FUNCTION MYPLUS AS 'org.apache.storm.sql.TestUtils$MyPlus'");
+    stmt.add("SELECT STREAM ID FROM FOO WHERE MYPLUS(ID, 1) = 'x'");
+    StormSql sql = StormSql.construct();
+    List<Values> values = new ArrayList<>();
+    ChannelHandler h = new TestUtils.CollectDataChannelHandler(values);
+    sql.execute(stmt, h);
+    Assert.assertEquals(0, values.size());
+  }
+
   @Test
   public void testExternalUdf() throws Exception {
     List<String> stmt = new ArrayList<>();
@@ -150,4 +179,15 @@ public class TestStormSql {
     Assert.assertEquals(5, values.get(1).get(0));
   }
 
+  @Test(expected = UnsupportedOperationException.class)
+  public void testExternalUdfUsingJar() throws Exception {
+    List<String> stmt = new ArrayList<>();
+    stmt.add("CREATE EXTERNAL TABLE FOO (ID INT) LOCATION 'mock:///foo'");
+    stmt.add("CREATE FUNCTION MYPLUS AS 'org.apache.storm.sql.TestUtils$MyPlus' USING JAR 'foo'");
+    stmt.add("SELECT STREAM MYPLUS(ID, 1) FROM FOO WHERE ID > 2");
+    StormSql sql = StormSql.construct();
+    List<Values> values = new ArrayList<>();
+    ChannelHandler h = new TestUtils.CollectDataChannelHandler(values);
+    sql.execute(stmt, h);
+  }
 }

--- a/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/backends/standalone/TestPlanCompiler.java
+++ b/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/backends/standalone/TestPlanCompiler.java
@@ -86,4 +86,20 @@ public class TestPlanCompiler {
     Map<String, Map<String, Integer>> nestedMap = ImmutableMap.of("a", map);
     Assert.assertEquals(new Values(2, map, nestedMap, Arrays.asList(100, 200, 300)), values.get(0));
   }
+
+  @Test
+  public void testUdf() throws Exception {
+    String sql = "SELECT MYPLUS(ID, 3)" +
+            "FROM FOO " +
+            "WHERE ID = 2";
+    TestCompilerUtils.CalciteState state = TestCompilerUtils.sqlOverNestedTable(sql);
+    PlanCompiler compiler = new PlanCompiler(typeFactory);
+    AbstractValuesProcessor proc = compiler.compile(state.tree());
+    Map<String, DataSource> data = new HashMap<>();
+    data.put("FOO", new TestUtils.MockDataSource());
+    List<Values> values = new ArrayList<>();
+    ChannelHandler h = new TestUtils.CollectDataChannelHandler(values);
+    proc.initialize(data, h);
+    Assert.assertEquals(new Values(5), values.get(0));
+  }
 }

--- a/external/sql/storm-sql-core/src/test/org/apache/storm/sql/parser/TestSqlParser.java
+++ b/external/sql/storm-sql-core/src/test/org/apache/storm/sql/parser/TestSqlParser.java
@@ -41,6 +41,12 @@ public class TestSqlParser {
     parse(sql);
   }
 
+  @Test
+  public void testCreateFunction() throws Exception {
+    String sql = "CREATE FUNCTION foo AS 'org.apache.storm.sql.MyUDF'";
+    parse(sql);
+  }
+
   private static SqlNode parse(String sql) throws Exception {
     StormParser parser = new StormParser(sql);
     return parser.impl().parseSqlStmtEof();

--- a/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
+++ b/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
@@ -41,6 +41,12 @@ import java.util.List;
 import java.util.Map;
 
 public class TestUtils {
+  public static class MyPlus {
+    public static Integer evaluate(Integer x, Integer y) {
+      return x + y;
+    }
+  }
+
   public static class MockDataSource implements DataSource {
     private final ArrayList<Values> RECORDS = new ArrayList<>();
 


### PR DESCRIPTION
This patch proposes to expose the user defined function support added
in STORM-1586 via DDL statements. 

Note: This includes changes from https://github.com/apache/storm/pull/1162