### PR TITLE
add private constructor to KafkaUtils

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaUtils.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaUtils.java
@@ -50,6 +50,10 @@ public class KafkaUtils {
     public static final Logger LOG = LoggerFactory.getLogger(KafkaUtils.class);
     private static final int NO_OFFSET = -5;
 
+    //suppress default constructor for noninstantiablility
+    private KafkaUtils(){
+        throw new AssertionError();
+    }
 
     public static IBrokerReader makeBrokerReader(Map stormConf, KafkaConfig conf) {
         if (conf.hosts instanceof StaticHosts) {


### PR DESCRIPTION
Since all of the methods and fields are static, I think it is a good idea to add a private constructor to KafkaUtils to  avoid been constructed.