### PR TITLE
[STORM-1606] print the  information of testcase which is on failure

### DIFF
--- a/dev-tools/travis/print-errors-from-test-reports.py
+++ b/dev-tools/travis/print-errors-from-test-reports.py
@@ -55,6 +55,10 @@ def print_error_reports_from_report_file(file_path):
         if fail is not None:
             print_detail_information(testcase, fail)
 
+        failure = testcase.find("failure")
+        if failure is not None:
+            print_detail_information(testcase, failure)
+
 
 def main(report_dir_path):
     for test_report in glob.iglob(report_dir_path + '/*.xml'):


### PR DESCRIPTION
the api "find(match)" of Python ElementTree finds the first sub element matching match. So the match is sub element, but not sub string