### PR TITLE
[STORM-1608] Fix stateful topology acking behavior

### DIFF
--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/spout/RandomIntegerSpout.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/spout/RandomIntegerSpout.java
@@ -24,6 +24,8 @@ import org.apache.storm.topology.base.BaseRichSpout;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Values;
 import org.apache.storm.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Random;
@@ -33,6 +35,7 @@ import java.util.Random;
  * every 100 ms. The ts field can be used in tuple time based windowing.
  */
 public class RandomIntegerSpout extends BaseRichSpout {
+    private static final Logger LOG = LoggerFactory.getLogger(RandomIntegerSpout.class);
     private SpoutOutputCollector collector;
     private Random rand;
     private long msgId = 0;
@@ -51,6 +54,16 @@ public class RandomIntegerSpout extends BaseRichSpout {
     @Override
     public void nextTuple() {
         Utils.sleep(100);
-        collector.emit(new Values(rand.nextInt(1000), System.currentTimeMillis() - (24 * 60 * 60 * 1000), ++msgId));
+        collector.emit(new Values(rand.nextInt(1000), System.currentTimeMillis() - (24 * 60 * 60 * 1000), ++msgId), msgId);
+    }
+
+    @Override
+    public void ack(Object msgId) {
+        LOG.debug("Got ACK for msgId : " + msgId);
+    }
+
+    @Override
+    public void fail(Object msgId) {
+        LOG.debug("Got FAIL for msgId : " + msgId);
     }
 }

--- a/examples/storm-starter/src/jvm/storm/starter/StatefulTopology.java
+++ b/examples/storm-starter/src/jvm/storm/starter/StatefulTopology.java
@@ -90,6 +90,7 @@ public class StatefulTopology {
             LOG.debug("{} sum = {}", name, sum);
             kvState.put("sum", sum);
             collector.emit(input, new Values(sum));
+            collector.ack(input);
         }
 
         @Override

--- a/storm-core/src/jvm/org/apache/storm/topology/CheckpointTupleForwarder.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/CheckpointTupleForwarder.java
@@ -51,7 +51,7 @@ public class CheckpointTupleForwarder implements IRichBolt {
     private final Map<TransactionRequest, Integer> transactionRequestCount;
     private int checkPointInputTaskCount;
     private long lastTxid = Long.MIN_VALUE;
-    protected AnchoringOutputCollector collector;
+    private AnchoringOutputCollector collector;
 
     public CheckpointTupleForwarder(IRichBolt bolt) {
         this.bolt = bolt;
@@ -60,9 +60,13 @@ public class CheckpointTupleForwarder implements IRichBolt {
 
     @Override
     public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
-        this.collector = new AnchoringOutputCollector(collector);
+        init(context, collector);
         bolt.prepare(stormConf, context, this.collector);
-        checkPointInputTaskCount = getCheckpointInputTaskCount(context);
+    }
+
+    protected void init(TopologyContext context, OutputCollector collector) {
+        this.collector = new AnchoringOutputCollector(collector);
+        this.checkPointInputTaskCount = getCheckpointInputTaskCount(context);
     }
 
     @Override
@@ -114,7 +118,6 @@ public class CheckpointTupleForwarder implements IRichBolt {
      * @param input the input tuple
      */
     protected void handleTuple(Tuple input) {
-        collector.setContext(input);
         bolt.execute(input);
     }
 
@@ -224,24 +227,18 @@ public class CheckpointTupleForwarder implements IRichBolt {
 
 
     protected static class AnchoringOutputCollector extends OutputCollector {
-        private Tuple inputTuple;
-
         AnchoringOutputCollector(IOutputCollector delegate) {
             super(delegate);
         }
 
-        void setContext(Tuple inputTuple) {
-            this.inputTuple = inputTuple;
-        }
-
         @Override
         public List<Integer> emit(String streamId, List<Object> tuple) {
-            return emit(streamId, inputTuple, tuple);
+            throw new UnsupportedOperationException("Bolts in a stateful topology must emit anchored tuples.");
         }
 
         @Override
         public void emitDirect(int taskId, String streamId, List<Object> tuple) {
-            emitDirect(taskId, streamId, inputTuple, tuple);
+            throw new UnsupportedOperationException("Bolts in a stateful topology must emit anchored tuples.");
         }
 
     }

--- a/storm-core/src/jvm/org/apache/storm/topology/CheckpointTupleForwarder.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/CheckpointTupleForwarder.java
@@ -116,7 +116,6 @@ public class CheckpointTupleForwarder implements IRichBolt {
     protected void handleTuple(Tuple input) {
         collector.setContext(input);
         bolt.execute(input);
-        collector.ack(input);
     }
 
     /**

--- a/storm-core/src/jvm/org/apache/storm/topology/IStatefulBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/IStatefulBolt.java
@@ -20,7 +20,12 @@ package org.apache.storm.topology;
 import org.apache.storm.state.State;
 
 /**
- * A bolt abstraction for supporting stateful computation.
+ * A bolt abstraction for supporting stateful computation. The state of the bolt is
+ * periodically checkpointed.
+ *
+ * <p>The framework provides at-least once guarantee for the
+ * state updates. The stateful bolts are expected to anchor the tuples while emitting
+ * and ack the input tuples once its processed.</p>
  */
 public interface IStatefulBolt<T extends State> extends IStatefulComponent<T>, IRichBolt {
 }

--- a/storm-core/src/jvm/org/apache/storm/topology/TopologyBuilder.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/TopologyBuilder.java
@@ -234,7 +234,10 @@ public class TopologyBuilder {
      * state (of computation) to be saved. When this bolt is initialized, the {@link IStatefulBolt#initState(State)} method
      * is invoked after {@link IStatefulBolt#prepare(Map, TopologyContext, OutputCollector)} but before {@link IStatefulBolt#execute(Tuple)}
      * with its previously saved state.
-     *
+     * <p>
+     * The framework provides at-least once guarantee for the state updates. Bolts (both stateful and non-stateful) in a stateful topology
+     * are expected to anchor the tuples while emitting and ack the input tuples once its processed.
+     * </p>
      * @param id the id of this component. This id is referenced by other components that want to consume this bolt's outputs.
      * @param bolt the stateful bolt
      * @param parallelism_hint the number of tasks that should be assigned to execute this bolt. Each task will run on a thread in a process somwehere around the cluster.

--- a/storm-core/test/jvm/org/apache/storm/topology/StatefulBoltExecutorTest.java
+++ b/storm-core/test/jvm/org/apache/storm/topology/StatefulBoltExecutorTest.java
@@ -170,6 +170,7 @@ public class StatefulBoltExecutorTest {
         Mockito.when(mockCheckpointTuple.getValueByField(CHECKPOINT_FIELD_ACTION)).thenReturn(COMMIT);
         Mockito.when(mockCheckpointTuple.getLongByField(CHECKPOINT_FIELD_TXID)).thenReturn(new Long(100));
         executor.execute(mockCheckpointTuple);
+        mockOutputCollector.ack(mockTuple);
         Mockito.verify(mockState, Mockito.times(1)).commit(new Long(100));
         Mockito.verify(mockBolt, Mockito.times(2)).execute(mockTuple);
         Mockito.verify(mockOutputCollector, Mockito.times(1)).ack(mockTuple);


### PR DESCRIPTION
Right now the acking is automatically taken care of for the non-stateful bolts in a stateful topology. This leads to double acking if BaseRichBolts are part of the topology and the acking does not complete and tuples are re-emitted.

For the non-stateful bolts, its better to let the bolt do the acking rather than automatically acking.