### PR TITLE
[STORM-1612] Remove hardcoded port, and unreferenced global from netty_unit_test

### DIFF
--- a/storm-core/test/clj/org/apache/storm/messaging/netty_unit_test.clj
+++ b/storm-core/test/clj/org/apache/storm/messaging/netty_unit_test.clj
@@ -21,7 +21,6 @@
   (:use [org.apache.storm.daemon.worker :only [is-connection-ready]])
   (:import [java.util ArrayList]))
 
-(def port (available-port))
 (def task 1)
 
 ;; In a "real" cluster (or an integration test), Storm itself would ensure that a topology's workers would only be
@@ -66,7 +65,7 @@
   (log-message "1. Should send and receive a basic message")
   (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
         context (TransportFactory/makeContext storm-conf)
-        port (available-port 6700)
+        port (available-port)
         resp (atom nil)
         server (.bind context nil port)
         _ (register-callback (fn [message] (reset! resp message)) server)
@@ -104,7 +103,7 @@
   (log-message "2 test load")
   (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
         context (TransportFactory/makeContext storm-conf)
-        port (available-port 6700)
+        port (available-port)
         resp (atom nil)
         server (.bind context nil port)
         _ (register-callback (fn [message] (reset! resp message)) server)
@@ -147,7 +146,7 @@
   (log-message "3 Should send and receive a large message")
   (let [req_msg (apply str (repeat 2048000 'c'))
         context (TransportFactory/makeContext storm-conf)
-        port (available-port 6700)
+        port (available-port)
         resp (atom nil)
         server (.bind context nil port)
         _ (register-callback (fn [message] (reset! resp message)) server)
@@ -186,7 +185,7 @@
   (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
         context (TransportFactory/makeContext storm-conf)
         resp (atom nil)
-        port (available-port 6700)
+        port (available-port)
         client (.connect context nil "localhost" port)
 
         server (Thread.
@@ -234,7 +233,7 @@
         resp (ArrayList.)
         received (atom 0)
         context (TransportFactory/makeContext storm-conf)
-        port (available-port 6700)
+        port (available-port)
         server (.bind context nil port)
         _ (register-callback (fn [message] (.add resp message) (swap! received inc)) server)
         client (.connect context nil "localhost" port)
@@ -292,7 +291,7 @@
                       TOPOLOGY-SKIP-MISSING-KRYO-REGISTRATIONS false}
           resp (atom nil)
           context (TransportFactory/makeContext storm-conf)
-          port (available-port 6700)
+          port (available-port)
           client (.connect context nil "localhost" port)
           _ (.send client task (.getBytes req_msg))
           server (.bind context nil port)


### PR DESCRIPTION
Just remove the unnecessary hardcoded port, so that the call will return an ephemeral port, and remove unused global "port".