### PR TITLE
[STORM-1609] Netty Client is not best effort delivery on failed Connection

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/messaging/netty/Client.java
+++ b/storm-core/src/jvm/org/apache/storm/messaging/netty/Client.java
@@ -75,7 +75,7 @@ public class Client extends ConnectionWithStatus implements IStatefulObject, ISa
     private static final Logger LOG = LoggerFactory.getLogger(Client.class);
     private static final String PREFIX = "Netty-Client-";
     private static final long NO_DELAY_MS = 0L;
-    private static Timer timer;
+    private static final Timer timer = new Timer("Netty-ChannelAlive-Timer", true);
 
     private final Map stormConf;
     private final StormBoundedExponentialBackoffRetry retryPolicy;
@@ -173,13 +173,6 @@ public class Client extends ConnectionWithStatus implements IStatefulObject, ISa
     private void launchChannelAliveThread() {
         // netty TimerTask is already defined and hence a fully
         // qualified name
-        if (timer == null) {
-            synchronized (Client.class) {
-                if (timer == null) {
-                    timer = new Timer("Netty-ChannelAlive-Timer", true);
-                }
-            }
-        }
         timer.schedule(new java.util.TimerTask() {
             public void run() {
                 try {


### PR DESCRIPTION
If Worker-A has connection to Worker-B that is unused ( and if Worker-B restarted), we drop messages because Channel is not in good state. Can we avoid message drop until we succeed in making new connection or a timeout?