### PR TITLE
[STORM-1605] use '/usr/bin/env python' to check python version

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -30,16 +30,8 @@ while [ -h "${PRG}" ]; do
   fi
 done
 
-# find python >= 2.6
-if [ -a /usr/bin/python2.6 ]; then
-  PYTHON=/usr/bin/python2.6
-fi
-
-if [ -z "$PYTHON" ]; then
-  PYTHON=/usr/bin/python
-fi
-
 # check for version
+PYTHON="/usr/bin/env python"
 majversion=`$PYTHON -V 2>&1 | awk '{print $2}' | cut -d'.' -f1`
 minversion=`$PYTHON -V 2>&1 | awk '{print $2}' | cut -d'.' -f2`
 numversion=$(( 10 * $majversion + $minversion))
@@ -71,4 +63,4 @@ if [ -f "${STORM_CONF_DIR}/storm-env.sh" ]; then
   . "${STORM_CONF_DIR}/storm-env.sh"
 fi
 
-exec "$PYTHON" "${STORM_BIN_DIR}/storm.py" "$@"
+exec "${STORM_BIN_DIR}/storm.py" "$@"

--- a/bin/storm.py
+++ b/bin/storm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
Current python version check is hard-coded and it cannot detect python 2.7.x versions. Changed to /usr/bin/env to keep consistent with storm.py