### PR TITLE
STORM-1629 Files/move doesn't work properly with non-empty directory in Windows

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
@@ -1060,9 +1060,13 @@
     (if (download-blobs-for-topology-succeed? (ConfigUtils/supervisorStormConfPath tmproot) tmproot)
       (do
         (log-message "Successfully downloaded blob resources for storm-id " storm-id)
-        (FileUtils/forceMkdir (File. stormroot))
-        (Files/move (.toPath (File. tmproot)) (.toPath (File. stormroot))
-          (doto (make-array StandardCopyOption 1) (aset 0 StandardCopyOption/ATOMIC_MOVE)))
+        (if (Utils/isOnWindows)
+          ; Files/move with non-empty directory doesn't work well on Windows
+          (FileUtils/moveDirectory (File. tmproot) (File. stormroot))
+          (do
+            (FileUtils/forceMkdir (File. stormroot))
+            (Files/move (.toPath (File. tmproot)) (.toPath (File. stormroot))
+                        (doto (make-array StandardCopyOption 1) (aset 0 StandardCopyOption/ATOMIC_MOVE)))))
         (setup-storm-code-dir conf (clojurify-structure (ConfigUtils/readSupervisorStormConf conf storm-id)) stormroot))
       (do
         (log-message "Failed to download blob resources for storm-id " storm-id)


### PR DESCRIPTION
Please refer https://issues.apache.org/jira/browse/STORM-1629 to see why Files/move with non-empty directory fails on Windows.

* Use FileUtils/moveDirectory on Windows
  * It copies whole contents inside directory, and delete directory
* Keep using Files/move on non-Windows
  * it's still better option since doesn't require copying contents inside directory

Since `on-windows?` is ported to Java, I'll create separate pull request for 1.x-branch.