### PR TITLE
STORM-1629 (For 1.x) Files/move doesn't work properly with non-empty directory in Windows

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
@@ -959,9 +959,13 @@
     (if (download-blobs-for-topology-succeed? (supervisor-stormconf-path tmproot) tmproot)
       (do
         (log-message "Successfully downloaded blob resources for storm-id " storm-id)
-        (FileUtils/forceMkdir (File. stormroot))
-        (Files/move (.toPath (File. tmproot)) (.toPath (File. stormroot))
-          (doto (make-array StandardCopyOption 1) (aset 0 StandardCopyOption/ATOMIC_MOVE)))
+        (if on-windows?
+          ; Files/move with non-empty directory doesn't work well on Windows
+          (FileUtils/moveDirectory (File. tmproot) (File. stormroot))
+          (do
+            (FileUtils/forceMkdir (File. stormroot))
+            (Files/move (.toPath (File. tmproot)) (.toPath (File. stormroot))
+                        (doto (make-array StandardCopyOption 1) (aset 0 StandardCopyOption/ATOMIC_MOVE)))))
         (setup-storm-code-dir conf (read-supervisor-storm-conf conf storm-id) stormroot))
       (do
         (log-message "Failed to download blob resources for storm-id " storm-id)


### PR DESCRIPTION
PR based on master is here: https://github.com/apache/storm/pull/1214

* Use FileUtils/moveDirectory on Windows
  * It copies whole contents inside directory, and delete directory
* Keep using Files/move on non-Windows
  * it's still better option since doesn't require copying contents inside directory