### PR TITLE
STORM-1630 Add guide page for Windows users

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -46,6 +46,7 @@ title: Documentation
                                 <li><a href="documentation/Troubleshooting.html">Troubleshooting</a></li>
                                 <li><a href="documentation/Running-topologies-on-a-production-cluster.html">Running topologies on a production cluster</a></li>
                                 <li><a href="documentation/Maven.html">Building Storm</a> with Maven</li>
+                                <li><a href="documentation/windows-users-guide.html">Windows users guide</li>
                             </ul>
                         </div>
                         <div role="tabpanel" class="tab-pane" id="integration">

--- a/documentation/windows-users-guide.md
+++ b/documentation/windows-users-guide.md
@@ -1,0 +1,21 @@
+---
+title: Windows Users Guide
+layout: documentation
+documentation: true
+---
+
+This page guides how to set up environment on Windows for Apache Storm.
+
+## Symbolic Link
+
+Starting at 1.0.0, Apache Storm utilizes `symbolic link` to aggregate log directory and resource directory into worker directory.
+Unfortunately, `creating symbolic link` on Windows needs non-default privilege, so users should configure it manually to make sure Storm processes can create symbolic link on runtime.
+
+Below pages (MS technet) guide how to configure that policy to the account which Storm runs on.
+
+* [How to Configure Security Policy Settings](https://technet.microsoft.com/en-us/library/dn452420.aspx)
+* [Create symbolic links](https://technet.microsoft.com/en-us/library/dn221947.aspx)
+
+One tricky point is, `administrator` group already has this privilege, but it's activated only process is run as `administrator` account.
+So if your account belongs to `administrator` group (and you don't want to change it), you may want to open `command prompt` with `run as administrator` and execute processes within that console.
+If you don't want to execute Storm processes directly (not on command prompt), please execute processes with `runas /user:administrator` to run as administrator account.


### PR DESCRIPTION
* starting at 1.0.0, Windows users should take care of privilege on account
  * "create symbolic link"

@hustfxj 
I made this page before seeing your comment. 
While technet pages cover how to set up privilege, we could be more kind to providing tl;dr. by pasting your comment on JIRA issue.

```
1) Launch secpol.msc via Start or Start → Run.
2) Open Security Settings → Local Policies → User Rights Assignment.
3) In the list, find the "Create symbolic links" item, which represents SeCreateSymbolicLinkPrivilege.
4) Double-click on the item and add yourself (or the whole Users group) to the list.
```

If you think it would be better to add it, I'll take care of it.