### PR TITLE
Fix logging for LoggingMetricsConsumer STORM-584

### DIFF
--- a/log4j2/cluster.xml
+++ b/log4j2/cluster.xml
@@ -19,7 +19,6 @@
 <configuration monitorInterval="60">
 <properties>
     <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} [%p] %msg%n</property>
-    <property name="patternMetrics">%d %-8r %m%n</property>
 </properties>
 <appenders>
     <RollingFile name="A1" immediateFlush="false"
@@ -55,17 +54,6 @@
         </Policies>
         <DefaultRolloverStrategy max="9"/>
     </RollingFile>
-    <RollingFile name="METRICS" immediateFlush="false"
-                 fileName="${sys:storm.log.dir}/metrics.log"
-                 filePattern="${sys:storm.log.dir}/metrics.log.%i.gz">
-        <PatternLayout>
-            <pattern>${patternMetrics}</pattern>
-        </PatternLayout>
-        <Policies>
-            <SizeBasedTriggeringPolicy size="2 MB"/> <!-- Or every 100 MB -->
-        </Policies>
-        <DefaultRolloverStrategy max="9"/>
-    </RollingFile>
     <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"
             protocol="UDP" appName="[${sys:daemon.name}]" mdcId="mdc" includeMDC="true"
             facility="LOCAL5" enterpriseNumber="18060" newLine="true" exceptionPattern="%rEx{full}"
@@ -80,9 +68,6 @@
     <Logger name="org.apache.storm.logging.ThriftAccessLogger" level="info" additivity="false">
         <AppenderRef ref="THRIFT-ACCESS"/>
         <AppenderRef ref="syslog"/>
-    </Logger>
-    <Logger name="org.apache.storm.metric.LoggingMetricsConsumer" level="info">
-        <AppenderRef ref="METRICS"/>
     </Logger>
     <root level="info"> <!-- We log everything -->
         <appender-ref ref="A1"/>

--- a/log4j2/worker.xml
+++ b/log4j2/worker.xml
@@ -20,6 +20,7 @@
 <properties>
     <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} [%p] %msg%n</property>
     <property name="patternNoTime">%msg%n</property>
+    <property name="patternMetrics">%d %-8r %m%n</property>
 </properties>
 <appenders>
     <RollingFile name="A1"
@@ -55,6 +56,17 @@
         </Policies>
         <DefaultRolloverStrategy max="4"/>
     </RollingFile>
+    <RollingFile name="METRICS"
+		fileName="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.metrics"
+		filePattern="${sys:workers.artifacts}/${sys:storm.id}/${sys:worker.port}/${sys:logfile.name}.metrics.%i.gz">
+        <PatternLayout>
+            <pattern>${patternMetrics}</pattern>
+        </PatternLayout>
+        <Policies>
+            <SizeBasedTriggeringPolicy size="2 MB"/>
+        </Policies>
+        <DefaultRolloverStrategy max="9"/>
+    </RollingFile>
     <Syslog name="syslog" format="RFC5424" charset="UTF-8" host="localhost" port="514"
         protocol="UDP" appName="[${sys:storm.id}:${sys:worker.port}]" mdcId="mdc" includeMDC="true"
         facility="LOCAL5" enterpriseNumber="18060" newLine="true" exceptionPattern="%rEx{full}"
@@ -65,6 +77,9 @@
         <appender-ref ref="A1"/>
         <appender-ref ref="syslog"/>
     </root>
+    <Logger name="backtype.storm.metric.LoggingMetricsConsumer" level="info" additivity="false">
+        <appender-ref ref="METRICS"/>
+    </Logger>
     <Logger name="STDERR" level="INFO">
         <appender-ref ref="STDERR"/>
         <appender-ref ref="syslog"/>


### PR DESCRIPTION
Currently the metrics.log file is always empty and it declared in the cluster.xml file whereas it should be in the worker one. The metrics end up in the log file which is not a huge issue but it would be cleaner to have them in a separate file, as originally intended. 

This patch addresses this and makes so that there is one metrics file per worker, as per the other log files, which should address the issues mentioned in [https://issues.apache.org/jira/browse/STORM-584].