### PR TITLE
[STORM-1636] - Supervisor shutdown with worker id pass in being nil

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
@@ -592,7 +592,7 @@
         port->worker-id (clojure.set/map-invert (map-val #((nth % 1) :port) valid-allocated))]
     (doseq [p (set/intersection (set (keys existing-assignment))
                                 (set (keys new-assignment)))]
-      (if (not= (:executors (existing-assignment p)) (:executors (new-assignment p)))
+      (if (not= (set (:executors (existing-assignment p))) (set (:executors (new-assignment p))))
         (shutdown-worker supervisor (port->worker-id p))))))
 
 (defn ->LocalAssignment


### PR DESCRIPTION
In function kill-existing-workers-with-change-in-components in supervisor.clj:
The function tries to detect whether there is a change in assignment. The bug in this function is that the ordering of the assignment matters but it shouldn't. For example, if a worker assignment is [[1 1] [2 2]] and it changed to [[2 2] [1 1]] it will cause the supervisor to restart the worker