### PR TITLE
STORM-1602 Blobstore UTs are failed on Windows

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
@@ -1168,8 +1168,10 @@
         blob-store (Utils/getNimbusBlobStore conf master-code-dir nil)]
     (try
       (FileUtils/forceMkdir (File. tmproot))
-      (.readBlobTo blob-store (master-stormcode-key storm-id) (FileOutputStream. (supervisor-stormcode-path tmproot)) nil)
-      (.readBlobTo blob-store (master-stormconf-key storm-id) (FileOutputStream. (supervisor-stormconf-path tmproot)) nil)
+      (with-open [fos-storm-code (FileOutputStream. (supervisor-stormcode-path tmproot))
+                  fos-storm-conf (FileOutputStream. (supervisor-stormconf-path tmproot))]
+        (.readBlobTo blob-store (master-stormcode-key storm-id) fos-storm-code nil)
+        (.readBlobTo blob-store (master-stormconf-key storm-id) fos-storm-conf nil))
       (finally
         (.shutdown blob-store)))
     (FileUtils/moveDirectory (File. tmproot) (File. stormroot))

--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobStore.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobStore.java
@@ -396,6 +396,11 @@ public abstract class BlobStore implements Shutdownable {
         public long getFileLength() throws IOException {
             return part.getFileLength();
         }
+
+        @Override
+        public void close() throws IOException {
+            in.close();
+        }
     }
 
     /**

--- a/storm-core/test/jvm/org/apache/storm/localizer/LocalizerTest.java
+++ b/storm-core/test/jvm/org/apache/storm/localizer/LocalizerTest.java
@@ -110,7 +110,7 @@ public class LocalizerTest {
 
   @Before
   public void setUp() throws Exception {
-    baseDir = new File("/tmp/blob-store-localizer-test-"+ UUID.randomUUID());
+    baseDir = new File(System.getProperty("java.io.tmpdir") + "/blob-store-localizer-test-"+ UUID.randomUUID());
     if (!baseDir.mkdir()) {
       throw new IOException("failed to create base directory");
     }
@@ -259,6 +259,11 @@ public class LocalizerTest {
 
   // archive passed in must contain symlink named tmptestsymlink if not a zip file
   public void testArchives(String archivePath, boolean supportSymlinks, int size) throws Exception {
+    if (isOnWindows()) {
+      // Windows should set this to false cause symlink in compressed file doesn't work properly.
+      supportSymlinks = false;
+    }
+
     Map conf = new HashMap();
     // set clean time really high so doesn't kick in
     conf.put(Config.SUPERVISOR_LOCALIZER_CACHE_CLEANUP_INTERVAL_MS, 60*60*1000);
@@ -663,5 +668,12 @@ public class LocalizerTest {
     assertTrue("blob version file not created", versionFile.exists());
     assertEquals("blob version not correct", 3, Utils.localVersionOfBlob(keyFile.toString()));
     assertTrue("blob file with version 3 not created", new File(keyFile + ".3").exists());
+  }
+
+  private boolean isOnWindows() {
+    if (System.getenv("OS") != null) {
+      return System.getenv("OS").equals("Windows_NT");
+    }
+    return false;
   }
 }


### PR DESCRIPTION
* ensures objects of InputStream / OutputStream are closed after used
  * clojure: with-open
  * java: try-with-resource
* skip checking symbolic link in LocalizerTest when on Windows
  * Windows seems not handle symbolic link in compressed file properly

Some integration tests are still failing on Windows, but it should be handled with another issues.

I'll also address this based on master immediately.

Please have a look. Thanks!