### PR TITLE
STORM-1641: make subtree node creation consistent

### DIFF
--- a/storm-core/src/clj/org/apache/storm/cluster.clj
+++ b/storm-core/src/clj/org/apache/storm/cluster.clj
@@ -278,7 +278,7 @@
                          ;; this should never happen
                          (exit-process! 30 "Unknown callback for subtree " subtree args)))))]
     (doseq [p [ASSIGNMENTS-SUBTREE STORMS-SUBTREE SUPERVISORS-SUBTREE WORKERBEATS-SUBTREE ERRORS-SUBTREE BLOBSTORE-SUBTREE NIMBUSES-SUBTREE
-               LOGCONFIG-SUBTREE BACKPRESSURE-ROOT]]
+               LOGCONFIG-SUBTREE BACKPRESSURE-SUBTREE]]
       (.mkdirs cluster-state p acls))
     (reify
       StormClusterState


### PR DESCRIPTION
This doesn't appear to make a difference. When starting nimbus, I get 9 znodes inside of /storm either way. However, it was inconsistent.