### PR TITLE
Make StormTimer join task thread on close

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/StormTimer.java
+++ b/storm-core/src/jvm/org/apache/storm/StormTimer.java
@@ -230,6 +230,7 @@ public class StormTimer implements AutoCloseable {
         checkActive();
         this.task.setActive(false);
         this.task.interrupt();
+        this.task.join();
     }
 
     /**


### PR DESCRIPTION
Most tests creating a cluster can be flaky because the supervisor threads can terminate out of order. The StormTimer's close should block until the thread is dead.