### PR TITLE
STORM-1654 HBaseBolt creates tick tuples with no interval when we don't set flushIntervalSecs

### DIFF
--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/AbstractHBaseBolt.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/AbstractHBaseBolt.java
@@ -43,7 +43,6 @@ public abstract class AbstractHBaseBolt extends BaseRichBolt {
     protected HBaseMapper mapper;
     protected String configKey;
     protected int batchSize = 15000;
-    protected int flushIntervalSecs = 0;
 
     public AbstractHBaseBolt(String tableName, HBaseMapper mapper) {
         Validate.notEmpty(tableName, "Table name can not be blank or null");


### PR DESCRIPTION
Please also refer #893 to see why this change is necessary.

Set 'default' flush interval seconds to HBaseBolt, since taking half of message timeout secs doesn't work, as #893 showed.
Since we should hardcode default flush interval seconds for now, I think we can change default flush interval to 1s since I guess it's enough for HBase, and anyone never set up tuple timeout seconds to 1. (When if this is happening, all bolts with batching manner using tick tuple should also fail.) 

I'll craft separate PR to be applied to 1.x-branch.