### PR TITLE
STORM-1654 (1.x) HBaseBolt creates tick tuples with no interval when we don't set flushIntervalSecs

### DIFF
--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/AbstractHBaseBolt.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/AbstractHBaseBolt.java
@@ -43,7 +43,6 @@ public abstract class AbstractHBaseBolt extends BaseRichBolt {
     protected HBaseMapper mapper;
     protected String configKey;
     protected int batchSize = 15000;
-    protected int flushIntervalSecs = 0;
 
     public AbstractHBaseBolt(String tableName, HBaseMapper mapper) {
         Validate.notEmpty(tableName, "Table name can not be blank or null");


### PR DESCRIPTION
Same patch to #1251, based on 1.x-branch.