### PR TITLE
STORM-1655 (1.x) Flux doesn't set return code to non-zero when there's any exception while deploying topology to remote cluster

### DIFF
--- a/external/flux/flux-core/src/main/java/org/apache/storm/flux/Flux.java
+++ b/external/flux/flux-core/src/main/java/org/apache/storm/flux/Flux.java
@@ -159,20 +159,16 @@ public class Flux {
         if(!cmd.hasOption(OPTION_DRY_RUN)) {
             if (cmd.hasOption(OPTION_REMOTE)) {
                 LOG.info("Running remotely...");
-                try {
-                    // should the topology be active or inactive
-                    SubmitOptions submitOptions = null;
-                    if(cmd.hasOption(OPTION_INACTIVE)){
-                        LOG.info("Deploying topology in an INACTIVE state...");
-                        submitOptions = new SubmitOptions(TopologyInitialStatus.INACTIVE);
-                    } else {
-                        LOG.info("Deploying topology in an ACTIVE state...");
-                        submitOptions = new SubmitOptions(TopologyInitialStatus.ACTIVE);
-                    }
-                    StormSubmitter.submitTopology(topologyName, conf, topology, submitOptions, null);
-                } catch (Exception e) {
-                    LOG.warn("Unable to deploy topology to remote cluster.", e);
+                // should the topology be active or inactive
+                SubmitOptions submitOptions = null;
+                if(cmd.hasOption(OPTION_INACTIVE)){
+                    LOG.info("Deploying topology in an INACTIVE state...");
+                    submitOptions = new SubmitOptions(TopologyInitialStatus.INACTIVE);
+                } else {
+                    LOG.info("Deploying topology in an ACTIVE state...");
+                    submitOptions = new SubmitOptions(TopologyInitialStatus.ACTIVE);
                 }
+                StormSubmitter.submitTopology(topologyName, conf, topology, submitOptions, null);
             } else {
                 LOG.info("Running in local mode...");
 


### PR DESCRIPTION
* Modify Flux.runCli() to not catching exceptions so that exception can be propagated to main()