### PR TITLE
modify delegateIndex to protected

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/trident/tuple/ValuePointer.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/tuple/ValuePointer.java
@@ -43,7 +43,7 @@ public class ValuePointer {
         return ret;
     }    
     
-    public int delegateIndex;
+    protected int delegateIndex;
     protected int index;
     protected String field;
     


### PR DESCRIPTION
The delegateIndex field in ValuePointer is only used in TridentTupleView, which is in the same package.
