### PR TITLE
STORM-515: Clojure documentation and examples

### DIFF
--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -222,6 +222,9 @@
           <sourceDirectories>
             <sourceDirectory>src/clj</sourceDirectory>
           </sourceDirectories>
+          <testSourceDirectories>
+            <testSourceDirectory>test/clj</testSourceDirectory>
+          </testSourceDirectories>
         </configuration>
         <executions>
           <execution>
@@ -229,6 +232,13 @@
             <phase>compile</phase>
             <goals>
               <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-clojure</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
             </goals>
           </execution>
         </executions>

--- a/examples/storm-starter/src/clj/org/apache/storm/starter/clj/bolts.clj
+++ b/examples/storm-starter/src/clj/org/apache/storm/starter/clj/bolts.clj
@@ -1,0 +1,75 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns org.apache.storm.starter.clj.bolts
+  (:require [org.apache.storm
+             [clojure :refer :all]
+             [config :refer :all]
+             [log :refer :all]])
+  (:import [org.apache.storm.starter.tools
+            NthLastModifiedTimeTracker SlidingWindowCounter
+            Rankings RankableObjectWithFields]
+           [org.apache.storm.utils TupleUtils]))
+
+(defbolt rolling-count-bolt ["obj" "count" "actualWindowLengthInSeconds"]
+  {:prepare true
+   :params [window-length emit-frequency]
+   :conf {TOPOLOGY-TICK-TUPLE-FREQ-SECS emit-frequency}}
+  [conf context collector]
+  (let [num-windows (/ window-length emit-frequency)
+        counter (SlidingWindowCounter. num-windows)
+        tracker (NthLastModifiedTimeTracker. num-windows)]
+    (bolt
+     (execute [{word "word" :as tuple}]
+       (if (TupleUtils/isTick tuple)
+         (let [counts (.getCountsThenAdvanceWindow counter)
+               actual-window-length (.secondsSinceOldestModification tracker)]
+           (log-debug "Received tick tuple, triggering emit of current window counts")
+           (.markAsModified tracker)
+           (doseq [[obj count] counts]
+             (emit-bolt! collector [obj count actual-window-length])))
+         (do
+           (.incrementCount counter word)
+           (ack! collector tuple)))))))
+
+(defmacro update-rankings [& body]
+  `(if (TupleUtils/isTick ~'tuple)
+     (do
+       (log-debug "Received tick tuple, triggering emit of current rankings")
+       (emit-bolt! ~'collector [(.copy ~'rankings)])
+       (log-debug "Rankings: " ~'rankings))
+     ~@body))
+
+(defbolt intermediate-rankings-bolt ["rankings"]
+  {:prepare true
+   :params [top-n emit-frequency]
+   :conf {TOPOLOGY-TICK-TUPLE-FREQ-SECS emit-frequency}}
+  [conf context collector]
+  (let [rankings (Rankings. top-n)]
+    (bolt
+     (execute [tuple]
+       (update-rankings (.updateWith rankings (RankableObjectWithFields/from tuple)))))))
+
+(defbolt total-rankings-bolt ["rankings"]
+  {:prepare true
+   :params [top-n emit-frequency]
+   :conf {TOPOLOGY-TICK-TUPLE-FREQ-SECS emit-frequency}}
+  [conf context collector]
+  (let [rankings (Rankings. top-n)]
+    (bolt
+     (execute [{rankings-to-merge "rankings" :as tuple}]
+       (update-rankings (doto rankings
+                          (.updateWith rankings-to-merge)
+                          (.pruneZeroCounts)))))))

--- a/examples/storm-starter/src/clj/org/apache/storm/starter/clj/exclamation.clj
+++ b/examples/storm-starter/src/clj/org/apache/storm/starter/clj/exclamation.clj
@@ -1,0 +1,52 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns org.apache.storm.starter.clj.exclamation
+  (:import [org.apache.storm StormSubmitter LocalCluster]
+           [org.apache.storm.utils Utils]
+           [org.apache.storm.testing TestWordSpout])
+  (:use [org.apache.storm clojure config])
+  (:gen-class))
+
+(defbolt exclamation-bolt ["word"]
+  [{word "word" :as tuple} collector]
+  (emit-bolt! collector [(str word "!!!")] :anchor tuple)
+  (ack! collector tuple))
+
+(defn mk-topology []
+  (topology
+   {"word"     (spout-spec (TestWordSpout.) :p 10)}
+   {"exclaim1" (bolt-spec {"word" :shuffle} exclamation-bolt :p 3)
+    "exclaim2" (bolt-spec {"exclaim1" :shuffle} exclamation-bolt :p 2)}))
+
+(defn run-local! []
+  (let [cluster (LocalCluster.)]
+    (.submitTopology cluster "exclamation" {TOPOLOGY-DEBUG true} (mk-topology))
+    (Utils/sleep 10000)
+    (.killTopology cluster "exclamation")
+    (.shutdown cluster)))
+
+(defn submit-topology! [name]
+  (StormSubmitter/submitTopologyWithProgressBar
+   name
+   {TOPOLOGY-DEBUG true
+    TOPOLOGY-WORKERS 3}
+   (mk-topology)))
+
+(defn -main
+  ([]
+   (run-local!))
+  ([name]
+   (submit-topology! name)))

--- a/examples/storm-starter/src/clj/org/apache/storm/starter/clj/rolling_top_words.clj
+++ b/examples/storm-starter/src/clj/org/apache/storm/starter/clj/rolling_top_words.clj
@@ -1,0 +1,58 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns org.apache.storm.starter.clj.rolling-top-words
+  (:require [org.apache.storm [clojure :refer :all] [config :refer :all]]
+            [org.apache.storm.starter.clj.bolts :refer
+             [rolling-count-bolt intermediate-rankings-bolt total-rankings-bolt]])
+  (:import [org.apache.storm StormSubmitter LocalCluster]
+           [org.apache.storm.utils Utils]
+           [org.apache.storm.testing TestWordSpout])
+  (:gen-class))
+
+(defn mk-topology []
+  (let [spout-id "wordGenerator"
+        counter-id "counter"
+        ranker-id "intermediateRanker"
+        total-ranker-id "finalRanker"]
+    (topology
+     {spout-id   (spout-spec (TestWordSpout.) :p 5)}
+     {counter-id (bolt-spec {spout-id ["word"]}
+                            (rolling-count-bolt 9 3)
+                            :p 4)
+      ranker-id (bolt-spec {counter-id ["obj"]}
+                           (intermediate-rankings-bolt 5 2)
+                           :p 4)
+      total-ranker-id (bolt-spec {ranker-id :global}
+                                 (total-rankings-bolt 5 2))})))
+
+(defn run-local! []
+  (let [cluster (LocalCluster.)]
+    (.submitTopology cluster "slidingWindowCounts" {TOPOLOGY-DEBUG true} (mk-topology))
+    (Utils/sleep 60000)
+    (.shutdown cluster)))
+
+(defn submit-topology! [name]
+  (StormSubmitter/submitTopology
+   name
+   {TOPOLOGY-DEBUG true
+    TOPOLOGY-WORKERS 3}
+   (mk-topology)))
+
+(defn -main
+  ([]
+   (run-local!))
+  ([name]
+   (submit-topology! name)))

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/FastWordCountTopology.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/FastWordCountTopology.java
@@ -40,7 +40,7 @@ import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * WordCount but teh spout does not stop, and the bolts are implemented in
+ * WordCount but the spout does not stop, and the bolts are implemented in
  * java.  This can show how fast the word count can run.
  */
 public class FastWordCountTopology {

--- a/examples/storm-starter/test/clj/org/apache/storm/starter/clj/bolts_test.clj
+++ b/examples/storm-starter/test/clj/org/apache/storm/starter/clj/bolts_test.clj
@@ -1,0 +1,115 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+(ns org.apache.storm.starter.clj.bolts-test
+  (:require [clojure.test :refer :all]
+            [org.apache.storm.starter.clj.word-count :refer [word-count split-sentence]]
+            [org.apache.storm.starter.clj.exclamation :refer [exclamation-bolt]]
+            [org.apache.storm.starter.clj.bolts :refer
+             [rolling-count-bolt intermediate-rankings-bolt total-rankings-bolt]]
+            [org.apache.storm [testing :refer :all]])
+  (:import [org.apache.storm Constants]
+           [org.apache.storm.task OutputCollector IOutputCollector]
+           [org.apache.storm.starter.tools Rankable]
+           [org.apache.storm.tuple Tuple]))
+
+(defmacro test-with-tuple [[bolt tuples] & body]
+  `(let [bolt# ~bolt
+         tuples# (atom [])]
+     (.prepare bolt# {} nil (OutputCollector.
+                       (reify IOutputCollector
+                         (emit [_ _ _ tuple#]
+                           (swap! tuples# conj tuple#))
+                         (ack [_ input]))))
+     (if (vector? ~tuples)
+       (doseq [t# ~tuples]
+         (.execute bolt# t#))
+       (.execute bolt# ~tuples))
+     (let [~'tuples @tuples#]
+       ~@body)))
+
+(defn- mock-tuple [m & {component :component stream-id :stream-id
+                        :or {component "1" stream-id "1"}}]
+  (reify
+    Tuple
+    (getSourceComponent [_]
+      component)
+    (getSourceStreamId [_]
+      stream-id)
+    (getString [this i]
+      (nth (vals m) 0))
+    (getValues [_]
+      (vals m))
+    clojure.lang.IPersistentMap
+    (valAt [_ key]
+      (get m key))
+    (seq [_]
+      (seq m))))
+
+(def ^{:private true} tick-tuple
+  (mock-tuple {}
+              :component Constants/SYSTEM_COMPONENT_ID
+              :stream-id Constants/SYSTEM_TICK_STREAM_ID))
+
+(deftest test-split-sentence
+  (testing "Bolt emits word per sentence"
+    (test-with-tuple [split-sentence (mock-tuple
+                                        {"sentence" "the cat jumped over the door"})]
+      (is (= [["the"] ["cat"] ["jumped"] ["over"] ["the"] ["door"]] tuples)))))
+
+(deftest test-word-count
+  (testing "Bolt emits new count"
+    (test-with-tuple [word-count [(mock-tuple {"word" "the"})
+                                  (mock-tuple {"word" "the"})
+                                  (mock-tuple {"word" "cat"})]]
+      (is (ms= [["the" 1] ["the" 2] ["cat" 1]] tuples)))))
+
+(deftest test-exclamation-bolt
+  (testing "Bolt emits word with exclamation marks"
+    (test-with-tuple [exclamation-bolt (mock-tuple {"word" "nathan"})]
+      (is (= [["nathan!!!"]] tuples)))))
+
+(deftest test-rolling-bolt
+  (testing "Emits nothing if no object has been counted"
+    (test-with-tuple [(rolling-count-bolt 9 3) tick-tuple]
+      (is (empty? tuples))))
+  (testing "Emits something if object was counted"
+    (test-with-tuple [(rolling-count-bolt 9 3)
+                      [(mock-tuple {"word" "nathan"}) tick-tuple]]
+      (is (= [["nathan" 1 0]] tuples)))))
+
+(deftest test-intermediate-rankings-bolt
+  (testing "Emits rankings for tick tuple"
+    (test-with-tuple [(intermediate-rankings-bolt 5 2) tick-tuple]
+      (is (seq tuples))))
+  (testing "Emits nothing for normal tuple"
+    (test-with-tuple [(intermediate-rankings-bolt 5 2)
+                      (mock-tuple {"obj" "nathan" "count" 1})]
+      (is (empty? tuples)))))
+
+(defn- mock-rankable [object count]
+  "Creates rankable with object and count"
+  (reify Rankable
+    (getCount [_] count)
+    (getObject [_] object)))
+
+(deftest test-total-rankings-bolt
+  (testing "Emits rankings for tick tuple"
+    (test-with-tuple [(total-rankings-bolt 5 2) tick-tuple]
+      (is (seq tuples))))
+  (testing "Emits nothing for normal tuple"
+    (test-with-tuple [(total-rankings-bolt 5 2)
+                      (mock-tuple {"rankings" (mock-rankable "nathan" 2)})]
+     (is (empty? tuples)))))

--- a/storm-core/src/clj/org/apache/storm/testing.clj
+++ b/storm-core/src/clj/org/apache/storm/testing.clj
@@ -90,13 +90,13 @@
   []
   (Time/stopSimulating))
 
- (defmacro with-simulated-time
-   [& body]
-   `(try
-     (start-simulating-time!)
-     ~@body
-     (finally
-       (stop-simulating-time!))))
+(defmacro with-simulated-time
+  [& body]
+  `(try
+    (start-simulating-time!)
+    ~@body
+    (finally
+      (stop-simulating-time!))))
 
 (defn advance-time-ms! [ms]
   (Time/advanceTime ms))


### PR DESCRIPTION
Add some more examples with Clojure, which show using parameters with config and global grouping.
Also add tests for all clojure bolts.