### PR TITLE
fallbacks to startoffset time if offset is out of range

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
@@ -106,9 +106,11 @@ public class TridentKafkaEmitter {
             if (_config.forceFromStart && !_topologyInstanceId.equals(lastInstanceId)) {
                 offset = KafkaUtils.getOffset(consumer, _config.topic, partition.partition, _config.startOffsetTime);
                 if(_config.useStartOffsetTimeIfOffsetOutOfRange){
+                    long nextOffset = (Long) lastMeta.get("nextOffset");
                     long earliestAvailableOffset = KafkaUtils.getOffset(consumer, _config.topic, partition.partition, OffsetRequest.EarliestTime());
-                    if(offset < earliestAvailableOffset) {
-                        offset = earliestAvailableOffset;
+                    long latestAvailableOffset = KafkaUtils.getOffset(consumer, _config.topic, partition.partition, OffsetRequest.LatestTime());
+                    if(earliestAvailableOffset <= nextOffset && nextOffset <= latestAvailableOffset) { // in the offset range.
+                        offset = nextOffset;
                     }
                 }
             } else {

--- a/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
@@ -23,6 +23,7 @@ import backtype.storm.metric.api.MeanReducer;
 import backtype.storm.metric.api.ReducedMetric;
 import backtype.storm.task.TopologyContext;
 import com.google.common.collect.ImmutableMap;
+import kafka.api.OffsetRequest;
 import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.Message;
@@ -104,6 +105,12 @@ public class TridentKafkaEmitter {
             }
             if (_config.forceFromStart && !_topologyInstanceId.equals(lastInstanceId)) {
                 offset = KafkaUtils.getOffset(consumer, _config.topic, partition.partition, _config.startOffsetTime);
+                if(_config.useStartOffsetTimeIfOffsetOutOfRange){
+                    long earliestAvailableOffset = KafkaUtils.getOffset(consumer, _config.topic, partition.partition, OffsetRequest.EarliestTime());
+                    if(offset < earliestAvailableOffset) {
+                        offset = earliestAvailableOffset;
+                    }
+                }
             } else {
                 offset = (Long) lastMeta.get("nextOffset");
             }


### PR DESCRIPTION
If the offset of kafka is purged / removed due to retention policy etc. The user starts getting UpdateOffsetException, The current issue is, that there is no way in 0.9.3 release to have a way in which we can enable storm to read from starting of stream in case offset is missing. 
There is a param "useStartOffsetTimeIfOffsetOutOfRange" which speak of it is not used to effect. 
