### PR TITLE
[STORM-1661] Introduce ACL Validation config for insecure mode

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -133,6 +133,8 @@ nimbus.blobstore.expiration.secs: 600
 storm.blobstore.inputstream.buffer.size.bytes: 65536
 client.blobstore.class: "org.apache.storm.blobstore.NimbusBlobStore"
 storm.blobstore.replication.factor: 3
+# For secure mode we would want to change this config to true
+storm.blobstore.acl.validation.enabled: false
 
 ### supervisor.* configs are for node supervisors
 # Define the amount of workers that can be run on this machine. Each worker is assigned a port to use for communication

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -940,7 +940,7 @@ public class Config extends HashMap<String, Object> {
 
     /**
      * The maximum number of threads that should be used by the Pacemaker.
-     * When Pacemaker gets loaded it will spawn new threads, up to 
+     * When Pacemaker gets loaded it will spawn new threads, up to
      * this many total, to handle the load.
      */
     @isNumber
@@ -964,7 +964,7 @@ public class Config extends HashMap<String, Object> {
      */
     @CustomValidator(validatorClass=PacemakerAuthTypeValidator.class)
     public static final String PACEMAKER_AUTH_METHOD = "pacemaker.auth.method";
-    
+
     /**
      * List of DRPC servers so that the DRPCSpout knows who to talk to.
      */
@@ -1256,6 +1256,13 @@ public class Config extends HashMap<String, Object> {
     @isPositiveNumber
     @isInteger
     public static final String STORM_BLOBSTORE_REPLICATION_FACTOR = "storm.blobstore.replication.factor";
+
+    /**
+     *  For secure mode we would want to turn on this config
+     *  By default this is turned off assuming the default is insecure
+     */
+    @isBoolean
+    public static final String STORM_BLOBSTORE_ACL_VALIDATION_ENABLED = "storm.blobstore.acl.validation.enabled";
 
     /**
      * What blobstore implementation nimbus should use.

--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobStoreAclHandler.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobStoreAclHandler.java
@@ -54,6 +54,7 @@ public class BlobStoreAclHandler {
     public static final List<AccessControl> DEFAULT = new ArrayList<AccessControl>();
     private Set<String> _supervisors;
     private Set<String> _admins;
+    private boolean doAclValidation;
 
     public BlobStoreAclHandler(Map conf) {
         _ptol = AuthUtils.GetPrincipalToLocalPlugin(conf);
@@ -64,6 +65,9 @@ public class BlobStoreAclHandler {
         }
         if (conf.containsKey(Config.NIMBUS_ADMINS)) {
             _admins.addAll((List<String>)conf.get(Config.NIMBUS_ADMINS));
+        }
+        if (conf.containsKey(Config.STORM_BLOBSTORE_ACL_VALIDATION_ENABLED)) {
+           doAclValidation = (boolean)conf.get(Config.STORM_BLOBSTORE_ACL_VALIDATION_ENABLED);
         }
     }
 
@@ -245,6 +249,9 @@ public class BlobStoreAclHandler {
      * @throws AuthorizationException
      */
     public void hasAnyPermissions(List<AccessControl> acl, int mask, Subject who, String key) throws AuthorizationException {
+        if (!doAclValidation) {
+            return;
+        }
         Set<String> user = constructUserFromPrincipals(who);
         LOG.debug("user {}", user);
         if (checkForValidUsers(who, mask)) {
@@ -275,6 +282,9 @@ public class BlobStoreAclHandler {
      * @throws AuthorizationException
      */
     public void hasPermissions(List<AccessControl> acl, int mask, Subject who, String key) throws AuthorizationException {
+        if (!doAclValidation) {
+            return;
+        }
         Set<String> user = constructUserFromPrincipals(who);
         LOG.debug("user {}", user);
         if (checkForValidUsers(who, mask)) {


### PR DESCRIPTION
With PlainSaslTransport, in scenarios where insecure environments pick a cluster user to launch the daemons and the topology is launched as an other user it might be a problem for acl validation. It is nice to have a config to switch off acl validation if used in insecure environments.