### PR TITLE
remove unnecessary registerSerialization about TransactionAttempt because we will register the class in the SerializationFactory

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/trident/topology/MasterBatchCoordinator.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/topology/MasterBatchCoordinator.java
@@ -219,7 +219,6 @@ public class MasterBatchCoordinator extends BaseRichSpout {
     public Map<String, Object> getComponentConfiguration() {
         Config ret = new Config();
         ret.setMaxTaskParallelism(1);
-        ret.registerSerialization(TransactionAttempt.class);
         return ret;
     }
     


### PR DESCRIPTION
very minor. 
