### PR TITLE
[STORM-1667] Log the IO exception when deleting worker pid dir

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
@@ -297,9 +297,7 @@
           (rmr-as-user conf id (worker-pid-path conf id pid))
           (rmpath (worker-pid-path conf id pid))
           (rmpath (worker-tmp-root conf id pid))
-          (catch IOException e
-            (log-warn-error e "Failed to cleanup pid dir: " pid " for worker " id". Will retry later"))
-          (catch RuntimeException e
+          (catch Exception e
             (log-warn-error e "Failed to cleanup pid dir: " pid " for worker " id". Will retry later")))))
           ;; on windows, the supervisor may still holds the lock on the worker directory
     (try-cleanup-worker conf id))

--- a/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
@@ -269,10 +269,7 @@
   (catch IOException e
     (log-warn-error e "Failed to cleanup worker " id ". Will retry later"))
   (catch RuntimeException e
-    (log-warn-error e "Failed to cleanup worker " id ". Will retry later")
-    )
-  (catch java.io.FileNotFoundException e (log-message (.getMessage e)))
-    ))
+    (log-warn-error e "Failed to cleanup worker " id ". Will retry later"))))
 
 (defn shutdown-worker [supervisor id]
   (log-message "Shutting down " (:supervisor-id supervisor) ":" id)
@@ -296,11 +293,15 @@
         (worker-launcher-and-wait conf user ["signal" pid "9"] :log-prefix (str "kill -9 " pid))
         (force-kill-process pid))
       (if as-user
-        (rmr-as-user conf id (worker-pid-path conf id pid))
         (try
+          (rmr-as-user conf id (worker-pid-path conf id pid))
           (rmpath (worker-pid-path conf id pid))
           (rmpath (worker-tmp-root conf id pid))
-          (catch Exception e)))) ;; on windows, the supervisor may still holds the lock on the worker directory
+          (catch IOException e
+            (log-warn-error e "Failed to cleanup pid dir: " pid " for worker " id". Will retry later"))
+          (catch RuntimeException e
+            (log-warn-error e "Failed to cleanup pid dir: " pid " for worker " id". Will retry later")))))
+          ;; on windows, the supervisor may still holds the lock on the worker directory
     (try-cleanup-worker conf id))
   (log-message "Shut down " (:supervisor-id supervisor) ":" id))
 


### PR DESCRIPTION
We find a race condition in supervisor which can sometimes crash supervisor.
This race condition exists because: shutdown-worker is called by both sync-processes and synchronize-supervisor. One pid directory might have already been deleted when rmr-as-user tries to delete it. 
To avoid crashing the supervisor, we should log the exception rather than throw it.