### PR TITLE
STORM-1675 - Allow submitting multiple jars from the client

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/ConfigUtils.java
@@ -216,7 +216,7 @@ public class ConfigUtils {
     }
 
     public static String masterStormJarKey(String topologyId) {
-        return (topologyId + "-stormjar.jar");
+        return (topologyId + "-stormjar.zip");
     }
 
     public static String masterStormCodeKey(String topologyId) {
@@ -253,7 +253,7 @@ public class ConfigUtils {
     }
 
     public static String masterStormJarPath(String stormRoot) {
-        return (stormRoot + FILE_SEPARATOR + "stormjar.jar");
+        return (stormRoot + FILE_SEPARATOR + "stormjar.zip");
     }
 
     public static String masterInbox(Map conf) throws IOException {
@@ -308,8 +308,8 @@ public class ConfigUtils {
         return ret;
     }
 
-    public static String supervisorStormJarPath(String stormRoot) {
-        return (concatIfNotNull(stormRoot) + FILE_SEPARATOR + "stormjar.jar");
+    public static String supervisorStormJarZipPath(String stormRoot) {
+        return (concatIfNotNull(stormRoot) + FILE_SEPARATOR + "stormjar.zip");
     }
 
     public static String supervisorStormCodePath(String stormRoot) {
@@ -396,7 +396,7 @@ public class ConfigUtils {
 
     public static String getIdFromBlobKey(String key) {
         if (key == null) return null;
-        final String STORM_JAR_SUFFIX = "-stormjar.jar";
+        final String STORM_JAR_SUFFIX = "-stormjar.zip";
         final String STORM_CODE_SUFFIX = "-stormcode.ser";
         final String STORM_CONF_SUFFIX = "-stormconf.ser";
 

--- a/storm-core/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/Utils.java
@@ -2032,7 +2032,7 @@ public class Utils {
      * @param dir the directory to search
      * @return the jar file names
      */
-    private static List<String> getFullJars(String dir) {
+    public static List<String> getFullJars(String dir) {
         File[] files = new File(dir).listFiles(jarFilter);
 
         if(files == null) {

--- a/storm-core/src/jvm/org/apache/storm/utils/Zipper.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/Zipper.java
@@ -1,0 +1,82 @@
+package org.apache.storm.utils;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+public class Zipper {
+
+    public static void zip(List<String> paths, String zipFilePath) throws IOException {
+        File zipFile = new File(zipFilePath);
+        if (!zipFile.exists()) {
+            zipFile.delete();
+        }
+        zipFile.createNewFile();
+
+        ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(zipFile));
+        Map<String, File> zipEntryFiles = new HashMap<>();
+        for (String path : paths) {
+            File file = new File(path);
+            String parentPath = file.getParent();
+            if (file.isDirectory()) {
+                Collection<File> nestedFiles = FileUtils.listFiles(file, null, true);
+                for (File nestedFile : nestedFiles) {
+                    String relativePath = Paths.get(parentPath).relativize(Paths.get(nestedFile.getPath())).toString();
+                    zipEntryFiles.put(relativePath, nestedFile);
+                }
+            } else {
+                zipEntryFiles.put(file.getName(), file);
+            }
+        }
+        for (Map.Entry<String, File> zipEntryFile : zipEntryFiles.entrySet()) {
+            File fileToBeZipped = zipEntryFile.getValue();
+            zipOutputStream.putNextEntry(new ZipEntry(zipEntryFile.getKey()));
+            copyContents(zipOutputStream, new FileInputStream(fileToBeZipped));
+            zipOutputStream.closeEntry();
+        }
+        zipOutputStream.close();
+    }
+
+    public static void unzip(String zipFile, String localDir) throws IOException {
+        File file = new File(localDir);
+        if (!file.exists()) {
+            file.mkdir();
+        }
+
+        ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(zipFile));
+        ZipEntry entry = zipInputStream.getNextEntry();
+        while (null != entry) {
+            File outputFile = new File(localDir, entry.getName());
+            outputFile.getParentFile().mkdirs();
+            FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
+            copyContents(fileOutputStream, zipInputStream);
+            zipInputStream.closeEntry();
+            entry = zipInputStream.getNextEntry();
+        }
+        zipInputStream.close();
+    }
+
+    private static void copyContents(OutputStream out, InputStream inputStream) throws IOException {
+        BufferedInputStream in = new BufferedInputStream(inputStream);
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = in.read(buffer)) >= 0) {
+            out.write(buffer, 0, len);
+        }
+    }
+
+}


### PR DESCRIPTION
The PR is not complete yet and needs some refinements. I wanted to get some feedback first. I tried out multiple approaches -
1. Submitting individual jar one by one - Right now the stormjar has a hardcoded key so that both supervisor and nimbus can download/upload the jar. This becomes complicated if there is more than one jar. The keys for all the jars have to be passed from nimbus to supervisor. Then these keys have to be updated, removed, waited--upon-for-code-replication etc. 
2. Build an app-assembly jar programmatically - It is not desired as it changes the internal structure of jar. which can result in unknown issues e.g. manifests have to be handled correctly. 
3. Packing jars into a zip, upload it and unzip it and supervisor - This is the current approach. It seemed to me the cleanest approach. 

I tested out word-count-topology with two jars and they were added to classpath correctly - 
`/usr/local/storm/apache-storm-2.0.0-SNAPSHOT/bin/storm jar /usr/local/storm/apache-storm-2.0.0-SNAPSHOT/lib/kryo-3.0.3.jar:../../examples/storm-starter/target/storm-starter-2.0.0-SNAPSHOT.jar:../../examples/storm-starter/multilang/resources:../../storm-multilang/python/src/main/resources/resources org.apache.storm.starter.WordCountTopology remote`

I can also add an option to turn zip/unzip off for single jar topologies. 
