### PR TITLE
STORM-1678: abstract batch processing to common api `BatchHelper`

### DIFF
--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/AbstractHBaseBolt.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/AbstractHBaseBolt.java
@@ -42,7 +42,6 @@ public abstract class AbstractHBaseBolt extends BaseRichBolt {
     protected String tableName;
     protected HBaseMapper mapper;
     protected String configKey;
-    protected int batchSize = 15000;
 
     public AbstractHBaseBolt(String tableName, HBaseMapper mapper) {
         Validate.notEmpty(tableName, "Table name can not be blank or null");

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/HiveBolt.java
@@ -23,10 +23,13 @@ import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.utils.BatchHelper;
 import org.apache.storm.utils.TupleUtils;
 import org.apache.storm.Config;
 import org.apache.storm.hive.common.HiveWriter;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import org.apache.hive.hcatalog.streaming.*;
 import org.apache.storm.hive.common.HiveOptions;
 import org.apache.storm.hive.common.HiveUtils;
@@ -34,7 +37,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,7 +51,7 @@ import java.util.List;
 import java.util.LinkedList;
 import java.io.IOException;
 
-public class HiveBolt extends  BaseRichBolt {
+public class HiveBolt extends BaseRichBolt {
     private static final Logger LOG = LoggerFactory.getLogger(HiveBolt.class);
     private OutputCollector collector;
     private HiveOptions options;
@@ -59,11 +61,10 @@ public class HiveBolt extends  BaseRichBolt {
     private AtomicBoolean sendHeartBeat = new AtomicBoolean(false);
     private UserGroupInformation ugi = null;
     private Map<HiveEndPoint, HiveWriter> allWriters;
-    private List<Tuple> tupleBatch;
+    private BatchHelper batchHelper;
 
     public HiveBolt(HiveOptions options) {
         this.options = options;
-        tupleBatch = new LinkedList<Tuple>();
     }
 
     @Override
@@ -87,6 +88,7 @@ public class HiveBolt extends  BaseRichBolt {
                 }
             }
             this.collector = collector;
+            this.batchHelper = new BatchHelper(options.getBatchSize(), collector);
             allWriters = new ConcurrentHashMap<HiveEndPoint,HiveWriter>();
             String timeoutName = "hive-bolt-%d";
             this.callTimeoutPool = Executors.newFixedThreadPool(1,
@@ -104,39 +106,25 @@ public class HiveBolt extends  BaseRichBolt {
     @Override
     public void execute(Tuple tuple) {
         try {
-            boolean forceFlush = false;
-            if (TupleUtils.isTick(tuple)) {
-                LOG.debug("TICK received! current batch status [{}/{}]", tupleBatch.size(), options.getBatchSize());
-                forceFlush = true;
-            } else {
+            if (batchHelper.shouldHandle(tuple)) {
                 List<String> partitionVals = options.getMapper().mapPartitions(tuple);
                 HiveEndPoint endPoint = HiveUtils.makeEndPoint(partitionVals, options);
                 HiveWriter writer = getOrCreateWriter(endPoint);
                 writer.write(options.getMapper().mapRecord(tuple));
-                tupleBatch.add(tuple);
-                if (tupleBatch.size() >= options.getBatchSize())
-                    forceFlush = true;
+                batchHelper.addBatch(tuple);
             }
 
-            if(forceFlush && !tupleBatch.isEmpty()) {
+            if(batchHelper.shouldFlush()) {
                 flushAllWriters(true);
                 LOG.info("acknowledging tuples after writers flushed ");
-                for(Tuple t : tupleBatch) {
-                    collector.ack(t);
-                }
-                tupleBatch.clear();
+                batchHelper.ack();
             }
         } catch(SerializationError se) {
             LOG.info("Serialization exception occurred, tuple is acknowledged but not written to Hive.", tuple);
             this.collector.reportError(se);
             collector.ack(tuple);
         } catch(Exception e) {
-            this.collector.reportError(e);
-            collector.fail(tuple);
-            for (Tuple t : tupleBatch) {
-                collector.fail(t);
-            }
-            tupleBatch.clear();
+            batchHelper.fail(e);
             abortAndCloseWriters();
         }
     }

--- a/storm-core/src/jvm/org/apache/storm/utils/BatchHelper.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/BatchHelper.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.utils;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.TupleUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BatchHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BatchHelper.class);
+
+    private int batchSize = 15000;  //default batch size 15000
+    private List<Tuple> tupleBatch;
+    private boolean forceFlush = false;
+    private OutputCollector collector;
+
+    public BatchHelper(int batchSize, OutputCollector collector) {
+        if (batchSize > 0) {
+            this.batchSize = batchSize;
+        }
+        this.collector = collector;
+        this.tupleBatch = new LinkedList<>();
+    }
+
+    public void fail(Exception e) {
+        collector.reportError(e);
+        for (Tuple t : tupleBatch) {
+            collector.fail(t);
+        }
+        tupleBatch.clear();
+        forceFlush = false;
+    }
+
+    public void ack() {
+        for (Tuple t : tupleBatch) {
+            collector.ack(t);
+        }
+        tupleBatch.clear();
+        forceFlush = false;
+    }
+
+    public boolean shouldHandle(Tuple tuple) {
+        if (TupleUtils.isTick(tuple)) {
+            LOG.debug("TICK received! current batch status [{}/{}]", tupleBatch.size(), batchSize);
+            forceFlush = true;
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public void addBatch(Tuple tuple) {
+        tupleBatch.add(tuple);
+        if (tupleBatch.size() >= batchSize) {
+            forceFlush = true;
+        }
+    }
+
+    public List<Tuple> getBatchTuples() {
+        return this.tupleBatch;
+    }
+
+    public int getBatchSize() {
+        return this.batchSize;
+    }
+
+    public boolean shouldFlush() {
+        return forceFlush && !tupleBatch.isEmpty();
+    }
+
+}


### PR DESCRIPTION
Some external projects(eg: `storm-hbase`, `storm-hive`, `storm-mongodb`) have the same batch processing logic.
Abstracting for that could make code simpler and cleaner.