### PR TITLE
[STORM-1687]-1.x divide by zero in stats

### DIFF
--- a/storm-core/src/clj/org/apache/storm/stats.clj
+++ b/storm-core/src/clj/org/apache/storm/stats.clj
@@ -411,7 +411,7 @@
       ((fn [[weighted-avg cnt]]
          (if (> uptime 0)
            (div weighted-avg (* 1000 (min uptime 600)))
-           0))))))
+           0.))))))
 
 (defn agg-pre-merge-comp-page-bolt
   [{exec-id :exec-id

--- a/storm-core/src/clj/org/apache/storm/stats.clj
+++ b/storm-core/src/clj/org/apache/storm/stats.clj
@@ -409,7 +409,9 @@
       (reduce add-pairs
               [0. 0]) ;; Combine weighted averages and counts.
       ((fn [[weighted-avg cnt]]
-        (div weighted-avg (* 1000 (min uptime TEN-MIN-IN-SECONDS))))))))
+         (if (> uptime 0)
+           (div weighted-avg (* 1000 (min uptime 600)))
+           0))))))
 
 (defn agg-pre-merge-comp-page-bolt
   [{exec-id :exec-id

--- a/storm-core/src/clj/org/apache/storm/stats.clj
+++ b/storm-core/src/clj/org/apache/storm/stats.clj
@@ -410,7 +410,7 @@
               [0. 0]) ;; Combine weighted averages and counts.
       ((fn [[weighted-avg cnt]]
          (if (> uptime 0)
-           (div weighted-avg (* 1000 (min uptime 600)))
+           (div weighted-avg (* 1000 (min uptime TEN-MIN-IN-SECONDS)))
            0.))))))
 
 (defn agg-pre-merge-comp-page-bolt


### PR DESCRIPTION
This fixes the "divide by zero" error in stats/compute-agg-capacity.