### PR TITLE
[STORM-1687] divide by zero in StatsUtil

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/stats/StatsUtil.java
+++ b/storm-core/src/jvm/org/apache/storm/stats/StatsUtil.java
@@ -2136,7 +2136,7 @@ public class StatsUtil {
      * </pre>
      */
     private static double computeAggCapacity(Map m, Integer uptime) {
-        if (uptime != null) {
+        if (uptime != null && uptime != 0) {
             Map execAvg = (Map) ((Map) getByKey(m, EXEC_LATENCIES)).get(TEN_MIN_IN_SECONDS_STR);
             Map exec = (Map) ((Map) getByKey(m, EXECUTED)).get(TEN_MIN_IN_SECONDS_STR);
 


### PR DESCRIPTION
uptime sometimes equals to zero which causes divide exception.