### PR TITLE
[STORM-1696]-1.x-branch status not sync if zk fails in backpressure

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/worker.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/worker.clj
@@ -138,16 +138,19 @@
             assignment-id (:assignment-id worker)
             port (:port worker)
             storm-cluster-state (:storm-cluster-state worker)
-            prev-backpressure-flag @(:backpressure worker)]
-        (when executors
-          (reset! (:backpressure worker)
-                  (or @(:transfer-backpressure worker)
-                      (reduce #(or %1 %2) (map #(.get-backpressure-flag %1) executors)))))
+            prev-backpressure-flag @(:backpressure worker)
+            ;; the backpressure flag is true if at least one of the disruptor queues has throttle-on
+            curr-backpressure-flag (if executors
+                                     (or (.getThrottleOn (:transfer-queue worker))
+                                       (reduce #(or %1 %2) (map #(.get-backpressure-flag %1) executors)))
+                                     prev-backpressure-flag)]
         ;; update the worker's backpressure flag to zookeeper only when it has changed
-        (log-debug "BP " @(:backpressure worker) " WAS " prev-backpressure-flag)
-        (when (not= prev-backpressure-flag @(:backpressure worker))
+        (when (not= prev-backpressure-flag curr-backpressure-flag)
           (try
-            (.worker-backpressure! storm-cluster-state storm-id assignment-id port @(:backpressure worker))
+            (log-debug "worker backpressure flag changing from " prev-backpressure-flag " to " curr-backpressure-flag)
+            (.worker-backpressure! storm-cluster-state storm-id assignment-id port curr-backpressure-flag)
+            ;; doing the local reset after the zk update succeeds is very important to avoid a bad state upon zk exception
+            (reset! (:backpressure worker) curr-backpressure-flag)
             (catch Exception exc
               (log-error exc "workerBackpressure update failed when connecting to ZK ... will retry"))))
         ))))

--- a/storm-core/src/jvm/org/apache/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/DisruptorQueue.java
@@ -146,8 +146,8 @@ public class DisruptorQueue implements IStatefulObject {
             if (_enableBackpressure && _cb != null && (_metrics.population() + _overflowCount.get()) >= _highWaterMark) {
                 try {
                     if (!_throttleOn) {
-                        _cb.highWaterMark();
                         _throttleOn = true;
+                        _cb.highWaterMark();
                     }
                 } catch (Exception e) {
                     throw new RuntimeException("Exception during calling highWaterMark callback!", e);
@@ -200,8 +200,8 @@ public class DisruptorQueue implements IStatefulObject {
             if (_enableBackpressure && _cb != null && (_metrics.population() + _overflowCount.get()) >= _highWaterMark) {
                 try {
                     if (!_throttleOn) {
-                        _cb.highWaterMark();
                         _throttleOn = true;
+                        _cb.highWaterMark();
                     }
                 } catch (Exception e) {
                     throw new RuntimeException("Exception during calling highWaterMark callback!", e);
@@ -535,6 +535,10 @@ public class DisruptorQueue implements IStatefulObject {
     public DisruptorQueue setEnableBackpressure(boolean enableBackpressure) {
         this._enableBackpressure = enableBackpressure;
         return this;
+    }
+
+    public boolean getThrottleOn() {
+        return _throttleOn;
     }
 
     //This method enables the metrics to be accessed from outside of the DisruptorQueue class


### PR DESCRIPTION
When there is a zk exception happens during worker-backpressure!,
there is a bad state which can block the topology from running normally any more.

The root cause: in worker/mk-backpressure-handler
if the worker-backpressure! fails once due to zk connection exception,
next time when this method gets called by WordBackpressureThread, because (when (not= prev-backpressure-flag curr-backpressure-flag) will never be true, the remote zk node can not be synced with local state.
This problem can cause a topology to be blocked!

This also explains why we will not see any problem when testing in a stable (zk never fail) environment.

Solution is quite straightforward: first change the zk status, if succeeds, change local status.
This change has been manually tested for a topology that causes congestion.