### PR TITLE
STORM-1700 Introduce 'whitelist' / 'blacklist' option to MetricsConsumer (1.x)

### DIFF
--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -41,8 +41,10 @@
 ## Metrics Consumers
 # topology.metrics.consumer.register:
 #   - class: "org.apache.storm.metric.LoggingMetricsConsumer"
+#     max.retain.metric.tuples: 100
 #     parallelism.hint: 1
 #   - class: "org.mycompany.MyMetricsConsumer"
+#     max.retain.metric.tuples: 100
 #     parallelism.hint: 1
 #     argument:
 #       - endpoint: "metrics-collector.mycompany.org"

--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -39,12 +39,21 @@
 #     - "server2"
 
 ## Metrics Consumers
+## max.retain.metric.tuples
+## - task queue will be unbounded when max.retain.metric.tuples is equal or less than 0.
+## whitelist / blacklist
+## - when none of configuration for metric filter are specified, it'll be treated as 'pass all'.
+## - you need to specify either whitelist or blacklist, or none of them. You can't specify both of them.
+## - you can specify multiple whitelist / blacklist with regular expression
 # topology.metrics.consumer.register:
 #   - class: "org.apache.storm.metric.LoggingMetricsConsumer"
 #     max.retain.metric.tuples: 100
 #     parallelism.hint: 1
 #   - class: "org.mycompany.MyMetricsConsumer"
 #     max.retain.metric.tuples: 100
+#     whitelist:
+#       - "execute.*"
+#       - "^__complete-latency$"
 #     parallelism.hint: 1
 #     argument:
 #       - endpoint: "metrics-collector.mycompany.org"

--- a/storm-core/src/clj/org/apache/storm/daemon/common.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/common.clj
@@ -298,17 +298,18 @@
                       {[comp-id METRICS-STREAM-ID] :shuffle})
                     (into {}))
         
-        mk-bolt-spec (fn [class arg p]
+        mk-bolt-spec (fn [class arg p max-retain-metric-tuples]
                        (thrift/mk-bolt-spec*
                         inputs
-                        (org.apache.storm.metric.MetricsConsumerBolt. class arg)
+                        (org.apache.storm.metric.MetricsConsumerBolt. class arg max-retain-metric-tuples)
                         {} :p p :conf {TOPOLOGY-TASKS p}))]
     
     (map
      (fn [component-id register]           
        [component-id (mk-bolt-spec (get register "class")
                                    (get register "argument")
-                                   (or (get register "parallelism.hint") 1))])
+                                   (or (get register "parallelism.hint") 1)
+                                   (or (get register "max.retain.metric.tuples") 100))])
      
      (metrics-consumer-register-ids storm-conf)
      (get storm-conf TOPOLOGY-METRICS-CONSUMER-REGISTER))))

--- a/storm-core/src/jvm/org/apache/storm/metric/filter/FilterByMetricName.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/filter/FilterByMetricName.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.metric.filter;
+
+import com.google.common.base.Function;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import org.apache.storm.metric.api.IMetricsConsumer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class FilterByMetricName implements MetricsFilter {
+    private final Cache<String, Boolean> filterCache;
+    private final List<Pattern> whitelistPattern;
+    private final List<Pattern> blacklistPattern;
+    private boolean noneSpecified = false;
+
+    public FilterByMetricName(List<String> whitelistPattern, List<String> blacklistPattern) {
+        // guard NPE
+        if (whitelistPattern == null) {
+            this.whitelistPattern = Collections.emptyList();
+        } else {
+            this.whitelistPattern = convertPatternStringsToPatternInstances(whitelistPattern);
+        }
+
+        // guard NPE
+        if (blacklistPattern == null) {
+            this.blacklistPattern = Collections.emptyList();
+        } else {
+            this.blacklistPattern = convertPatternStringsToPatternInstances(blacklistPattern);
+        }
+
+        if (this.whitelistPattern.isEmpty() && this.blacklistPattern.isEmpty()) {
+            noneSpecified = true;
+        } else if (!this.whitelistPattern.isEmpty() && !this.blacklistPattern.isEmpty()) {
+            throw new IllegalArgumentException("You have to specify either includes or excludes, or none.");
+        }
+
+        filterCache = CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .build();
+    }
+
+    @Override
+    public boolean apply(IMetricsConsumer.DataPoint dataPoint) {
+        if (noneSpecified) {
+            return true;
+        }
+
+        String metricName = dataPoint.name;
+
+        Boolean cachedFilteredIn = filterCache.getIfPresent(metricName);
+        if (cachedFilteredIn != null) {
+            return cachedFilteredIn;
+        } else {
+            boolean filteredIn = isFilteredIn(metricName);
+            filterCache.put(metricName, filteredIn);
+            return filteredIn;
+        }
+    }
+
+    private ArrayList<Pattern> convertPatternStringsToPatternInstances(List<String> patterns) {
+        return Lists.newArrayList(Iterators.transform(patterns.iterator(), new Function<String, Pattern>() {
+            @Override
+            public Pattern apply(String s) {
+                return Pattern.compile(s);
+            }
+        }));
+    }
+
+    private boolean isFilteredIn(String metricName) {
+
+        if (!whitelistPattern.isEmpty()) {
+            return checkMatching(metricName, whitelistPattern, true);
+        } else if (!blacklistPattern.isEmpty()) {
+            return checkMatching(metricName, blacklistPattern, false);
+        }
+
+        throw new IllegalStateException("Shouldn't reach here");
+    }
+
+    private boolean checkMatching(String metricName, List<Pattern> patterns, boolean valueWhenMatched) {
+        for (Pattern pattern : patterns) {
+            if (pattern.matcher(metricName).find()) {
+                return valueWhenMatched;
+            }
+        }
+
+        return !valueWhenMatched;
+    }
+}

--- a/storm-core/src/jvm/org/apache/storm/metric/filter/MetricsFilter.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/filter/MetricsFilter.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.metric.filter;
+
+import com.google.common.base.Predicate;
+import org.apache.storm.metric.api.IMetricsConsumer;
+
+import java.io.Serializable;
+
+public interface MetricsFilter extends Predicate<IMetricsConsumer.DataPoint>, Serializable {
+}

--- a/storm-core/test/jvm/org/apache/storm/metric/filter/FilterByMetricNameTest.java
+++ b/storm-core/test/jvm/org/apache/storm/metric/filter/FilterByMetricNameTest.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.metric.filter;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.storm.metric.api.IMetricsConsumer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+public class FilterByMetricNameTest {
+    @Before
+    public void setUp() throws Exception {
+
+    }
+
+    @Test
+    public void testWhitelist() {
+        List<String> whitelistPattern = Lists.newArrayList("^metric\\.", "test\\.hello\\.[0-9]+");
+        FilterByMetricName sut = new FilterByMetricName(whitelistPattern, null);
+
+        Map<String, Boolean> testMetricNamesAndExpected = Maps.newHashMap();
+        testMetricNamesAndExpected.put("storm.metric.hello", false);
+        testMetricNamesAndExpected.put("test.hello.world", false);
+        testMetricNamesAndExpected.put("test.hello.123", true);
+        testMetricNamesAndExpected.put("test.metric.world", false);
+        testMetricNamesAndExpected.put("metric.world", true);
+
+        assertTests(sut, testMetricNamesAndExpected);
+    }
+
+    @Test
+    public void testBlacklist() {
+        List<String> blacklistPattern = Lists.newArrayList("^__", "test\\.");
+        FilterByMetricName sut = new FilterByMetricName(null, blacklistPattern);
+
+        Map<String, Boolean> testMetricNamesAndExpected = Maps.newHashMap();
+        testMetricNamesAndExpected.put("__storm.metric.hello", false);
+        testMetricNamesAndExpected.put("storm.metric.__hello", true);
+        testMetricNamesAndExpected.put("test.hello.world", false);
+        testMetricNamesAndExpected.put("storm.test.123", false);
+        testMetricNamesAndExpected.put("metric.world", true);
+
+        assertTests(sut, testMetricNamesAndExpected);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBothWhitelistAndBlacklistAreSpecified() {
+        List<String> whitelistPattern = Lists.newArrayList("^metric\\.", "test\\.hello\\.[0-9]+");
+        List<String> blacklistPattern = Lists.newArrayList("^__", "test\\.");
+        new FilterByMetricName(whitelistPattern, blacklistPattern);
+    }
+
+    @Test
+    public void testNoneIsSpecified() {
+        FilterByMetricName sut = new FilterByMetricName(null, null);
+
+        Map<String, Boolean> testMetricNamesAndExpected = Maps.newHashMap();
+        testMetricNamesAndExpected.put("__storm.metric.hello", true);
+        testMetricNamesAndExpected.put("storm.metric.__hello", true);
+        testMetricNamesAndExpected.put("test.hello.world", true);
+        testMetricNamesAndExpected.put("storm.test.123", true);
+        testMetricNamesAndExpected.put("metric.world", true);
+
+        assertTests(sut, testMetricNamesAndExpected);
+    }
+
+    private void assertTests(FilterByMetricName sut, Map<String, Boolean> testMetricNamesAndExpected) {
+        for (Map.Entry<String, Boolean> testEntry : testMetricNamesAndExpected.entrySet()) {
+            assertEquals("actual filter result is not same: " + testEntry.getKey(),
+                    testEntry.getValue(), sut.apply(new IMetricsConsumer.DataPoint(testEntry.getKey(), 1)));
+        }
+    }
+}


### PR DESCRIPTION
> NOTE: This is based on STORM-1698, PR #1323  

* Users can set whitelist or blacklist to filter out metrics by name
  * if none of them specified (by default), no metrics are filtered out
* how to match: substring match with regular expression
  * use both ^ and $ when you want to match strictly (full string match)
* added unit test