### PR TITLE
STORM-1693: Do not cancel the task after stats are rendered

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -415,7 +415,7 @@
         (doseq [t threads]
           (.interrupt t)
           (.join t))
-        
+        (stats/cleanup-stats! (:stats executor-data))
         (doseq [user-context (map :user-context (vals task-datas))]
           (doseq [hook (.getHooks user-context)]
             (.cleanup hook)))

--- a/storm-core/src/jvm/org/apache/storm/metric/internal/RateTracker.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/internal/RateTracker.java
@@ -17,7 +17,6 @@
  */
 package org.apache.storm.metric.internal;
 
-import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -136,30 +135,5 @@ public class RateTracker{
         public void run () {
             rotateBuckets(System.currentTimeMillis());
         }
-    }
-
-    public static void main (String args[]) throws Exception {
-        final int number = (args.length >= 1) ? Integer.parseInt(args[0]) : 100000000;
-        for (int i = 0; i < 10; i++) {
-            testRate(number);
-        }
-    }
-
-    private static void testRate(int number) {
-        RateTracker rt = new RateTracker(10000, 10);
-        long start = System.currentTimeMillis();
-        for (int i = 0; i < number; i++) {
-            rt.notify(1);
-            if ((i % 1000000) == 0) {
-                //There is an issue with some JVM versions where an integer for loop that takes a long time
-                // can starve other threads resulting in  the timer thread not getting called.
-                // This is a work around for that, and we still get the same results.
-                Thread.yield();
-            }
-        }
-        long end = System.currentTimeMillis();
-        double rate = rt.reportRate();
-        rt.close();
-        System.out.printf("time %,8d count %,8d rate %,15.2f reported rate %,15.2f\n", end-start,number, ((number * 1000.0)/(end-start)), rate);
     }
 }

--- a/storm-core/src/jvm/org/apache/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/DisruptorQueue.java
@@ -30,6 +30,11 @@ import com.lmax.disruptor.TimeoutException;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.dsl.ProducerType;
 
+import org.apache.storm.metric.api.IStatefulObject;
+import org.apache.storm.metric.internal.RateTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,12 +50,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.apache.storm.metric.api.IStatefulObject;
-import org.apache.storm.metric.internal.RateTracker;
 
 /**
  * A single consumer queue that uses the LMAX Disruptor. They key to the performance is
@@ -341,6 +340,10 @@ public class DisruptorQueue implements IStatefulObject {
         public void notifyArrivals(long counts) {
             _rateTracker.notify(counts);
         }
+
+        public void close() {
+            _rateTracker.close();
+        }
     }
 
     private final RingBuffer<AtomicReference<Object>> _buffer;
@@ -393,6 +396,7 @@ public class DisruptorQueue implements IStatefulObject {
         try {
             publishDirect(new ArrayList<Object>(Arrays.asList(INTERRUPT)), true);
             _flusher.close();
+            _metrics.close();
         } catch (InsufficientCapacityException e) {
             //This should be impossible
             throw new RuntimeException(e);


### PR DESCRIPTION
Fresher task is cancelled right after 3 seconds when executor heartbeat is sent. getValueAndReset can rotate the buckets but it is not time bound. Metric tick is in same queue as the input tuples from spout. If processing input tuples is slow, it may take much more to generate metrics and call getValueAndReset and thus `System.currentTimeMillis() - _bucketStart` is more than 10 minutes. 