### PR TITLE
[STORM-1646] Fix Kafka unit tests

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/ExponentialBackoffMsgRetryManager.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/ExponentialBackoffMsgRetryManager.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.kafka;
 
+import org.apache.storm.utils.Time;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
@@ -72,7 +73,7 @@ public class ExponentialBackoffMsgRetryManager implements FailedMsgRetryManager 
     public Long nextFailedMessageToRetry() {
         if (this.waiting.size() > 0) {
             MessageRetryRecord first = this.waiting.peek();
-            if (System.currentTimeMillis() >= first.retryTimeUTC) {
+            if (Time.currentTimeMillis() >= first.retryTimeUTC) {
                 if (this.records.containsKey(first.offset)) {
                     return first.offset;
                 } else {
@@ -90,7 +91,7 @@ public class ExponentialBackoffMsgRetryManager implements FailedMsgRetryManager 
         MessageRetryRecord record = this.records.get(offset);
         return record != null &&
                 this.waiting.contains(record) &&
-                System.currentTimeMillis() >= record.retryTimeUTC;
+                Time.currentTimeMillis() >= record.retryTimeUTC;
     }
 
     @Override
@@ -133,7 +134,7 @@ public class ExponentialBackoffMsgRetryManager implements FailedMsgRetryManager 
         private MessageRetryRecord(long offset, int retryNum) {
             this.offset = offset;
             this.retryNum = retryNum;
-            this.retryTimeUTC = System.currentTimeMillis() + calculateRetryDelay();
+            this.retryTimeUTC = Time.currentTimeMillis() + calculateRetryDelay();
         }
 
         /**

--- a/external/storm-kafka/src/test/org/apache/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
@@ -17,6 +17,9 @@
  */
 package org.apache.storm.kafka;
 
+import org.apache.storm.utils.Time;
+import org.junit.After;
+import org.junit.Before;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -31,6 +34,16 @@ public class ExponentialBackoffMsgRetryManagerTest {
     private static final Long TEST_OFFSET2 = 102L;
     private static final Long TEST_OFFSET3 = 105L;
     private static final Long TEST_NEW_OFFSET = 103L;
+
+    @Before
+    public void setup() throws Exception {
+        Time.startSimulating();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        Time.stopSimulating();
+    }
 
     @Test
     public void testImmediateRetry() throws Exception {
@@ -52,12 +65,12 @@ public class ExponentialBackoffMsgRetryManagerTest {
     public void testSingleDelay() throws Exception {
         ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(100, 1d, 1000);
         manager.failed(TEST_OFFSET);
-        Thread.sleep(5);
+        Time.advanceTime(5);
         Long next = manager.nextFailedMessageToRetry();
         assertNull("expect no message ready for retry yet", next);
         assertFalse("message should not be ready for retry yet", manager.shouldRetryMsg(TEST_OFFSET));
 
-        Thread.sleep(100);
+        Time.advanceTime(100);
         next = manager.nextFailedMessageToRetry();
         assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
         assertTrue("message should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
@@ -73,10 +86,10 @@ public class ExponentialBackoffMsgRetryManagerTest {
         for (long i = 0L; i < 3L; ++i) {
             manager.failed(TEST_OFFSET);
 
-            Thread.sleep((expectedWaitTime + 1L) / 2L);
+            Time.advanceTime((expectedWaitTime + 1L) / 2L);
             assertFalse("message should not be ready for retry yet", manager.shouldRetryMsg(TEST_OFFSET));
 
-            Thread.sleep((expectedWaitTime + 1L) / 2L);
+            Time.advanceTime((expectedWaitTime + 1L) / 2L);
             Long next = manager.nextFailedMessageToRetry();
             assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
             assertTrue("message should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
@@ -94,7 +107,7 @@ public class ExponentialBackoffMsgRetryManagerTest {
         ExponentialBackoffMsgRetryManager manager = new ExponentialBackoffMsgRetryManager(initial, mult, max);
 
         manager.failed(TEST_OFFSET);
-        Thread.sleep(initial);
+        Time.advanceTime(initial);
 
         manager.retryStarted(TEST_OFFSET);
         manager.failed(TEST_OFFSET);
@@ -103,14 +116,14 @@ public class ExponentialBackoffMsgRetryManagerTest {
         // although TEST_OFFSET failed first, it's retry delay time is longer b/c this is the second retry
         // so TEST_OFFSET2 should come first
 
-        Thread.sleep(initial * 2);
+        Time.advanceTime(initial * 2);
         assertTrue("message "+TEST_OFFSET+"should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));
         assertTrue("message "+TEST_OFFSET2+"should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET2));
 
         Long next = manager.nextFailedMessageToRetry();
         assertEquals("expect first message to retry is "+TEST_OFFSET2, TEST_OFFSET2, next);
 
-        Thread.sleep(initial);
+        Time.advanceTime(initial);
 
         // haven't retried yet, so first should still be TEST_OFFSET2
         next = manager.nextFailedMessageToRetry();
@@ -172,10 +185,10 @@ public class ExponentialBackoffMsgRetryManagerTest {
         for (long i = 0L; i < 4L; ++i) {
             manager.failed(TEST_OFFSET);
 
-            Thread.sleep((expectedWaitTime + 1L) / 2L);
+            Time.advanceTime((expectedWaitTime + 1L) / 2L);
             assertFalse("message should not be ready for retry yet", manager.shouldRetryMsg(TEST_OFFSET));
 
-            Thread.sleep((expectedWaitTime + 1L) / 2L);
+            Time.advanceTime((expectedWaitTime + 1L) / 2L);
             Long next = manager.nextFailedMessageToRetry();
             assertEquals("expect test offset next available for retry", TEST_OFFSET, next);
             assertTrue("message should be ready for retry", manager.shouldRetryMsg(TEST_OFFSET));

--- a/external/storm-kafka/src/test/org/apache/storm/kafka/KafkaUtilsTest.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/KafkaUtilsTest.java
@@ -238,13 +238,13 @@ public class KafkaUtilsTest {
         p.put("bootstrap.servers", broker.getBrokerConnectionString());
         p.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
         p.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        p.put("metadata.fetch.timeout.ms", 1000);
+        p.put("max.block.ms", 5000);
         KafkaProducer<String, String> producer = new KafkaProducer<String, String>(p);
         try {
             producer.send(new ProducerRecord<String, String>(config.topic, key, value)).get();
         } catch (Exception e) {
-            Assert.fail(e.getMessage());
             LOG.error("Failed to do synchronous sending due to " + e, e);
+            Assert.fail(e.getMessage());
         } finally {
             producer.close();
         }

--- a/external/storm-kafka/src/test/org/apache/storm/kafka/bolt/KafkaBoltTest.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/bolt/KafkaBoltTest.java
@@ -208,7 +208,7 @@ public class KafkaBoltTest {
         props.put("bootstrap.servers", broker.getBrokerConnectionString());
         props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
         props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        props.put("metadata.fetch.timeout.ms", 1000);
+        props.put("max.block.ms", 5000);
         KafkaBolt bolt = new KafkaBolt().withProducerProperties(props);
         bolt.prepare(config, null, new OutputCollector(collector));
         bolt.setAsync(false);
@@ -222,7 +222,7 @@ public class KafkaBoltTest {
         props.put("bootstrap.servers", broker.getBrokerConnectionString());
         props.put("key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
         props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-        props.put("metadata.fetch.timeout.ms", 1000);
+        props.put("max.block.ms", 5000);
         props.put("linger.ms", 0);
         KafkaBolt bolt = new KafkaBolt().withProducerProperties(props);
         bolt.prepare(config, null, new OutputCollector(collector));
@@ -240,7 +240,7 @@ public class KafkaBoltTest {
         props.put("bootstrap.servers", broker.getBrokerConnectionString());
         props.put("key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
         props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-        props.put("metadata.fetch.timeout.ms", 1000);
+        props.put("max.block.ms", 5000);
         props.put("linger.ms", 0);
         KafkaBolt bolt = new KafkaBolt().withProducerProperties(props);
         bolt.prepare(config, null, new OutputCollector(collector));

--- a/external/storm-kafka/src/test/resources/log4j2-test.xml
+++ b/external/storm-kafka/src/test/resources/log4j2-test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<configuration monitorInterval="60">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT" follow="true">
+            <PatternLayout pattern="%-4r [%t] %-5p %c{1.} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.apache.zookeeper" level="WARN"/>
+        <Root level="${env:LOG_LEVEL:-INFO}">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</configuration>


### PR DESCRIPTION
This fixes two unit test failures in external/kafka I saw when running tests repeatedly, especially on low resource VMs.

There was a race in the Exponential Backoff Manager that was fixed by switching the test to use simulated time.

The Kafka Utils Test was seeing failures on underpowered systems due to a timeout value that was too small. Added log4j2 properties xml to be able to change the log level printed in the output. Also changed metadata.fetch.timeout.ms to max.block.ms, as kafka 0.9 had deprecated the config. The test output had warnings like

39890 [main] WARN o.a.k.c.p.KafkaProducer - metadata.fetch.timeout.ms config is deprecated and will be removed soon. Please use max.block.ms
