### PR TITLE
[STORM-1711] Kerberos principals gets mixed up while using storm-hive

### DIFF
--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/HiveMapper.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/HiveMapper.java
@@ -25,6 +25,7 @@ import org.apache.hive.hcatalog.streaming.HiveEndPoint;
 import org.apache.hive.hcatalog.streaming.RecordWriter;
 import org.apache.hive.hcatalog.streaming.TransactionBatch;
 import org.apache.hive.hcatalog.streaming.StreamingException;
+import org.apache.hadoop.security.UserGroupInformation;
 import java.io.Serializable;
 
 import java.io.IOException;
@@ -42,8 +43,8 @@ public interface HiveMapper extends Serializable {
      * @return
      */
 
-    RecordWriter createRecordWriter(HiveEndPoint endPoint)
-        throws StreamingException, IOException, ClassNotFoundException;
+    RecordWriter createRecordWriter(final HiveEndPoint endPoint, final UserGroupInformation ugi)
+        throws StreamingException, IOException, ClassNotFoundException, InterruptedException;
 
     void write(TransactionBatch txnBatch, Tuple tuple)
         throws StreamingException, IOException, InterruptedException;

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveUtils.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveUtils.java
@@ -64,8 +64,7 @@ public class HiveUtils {
             throw new AuthenticationFailed("Host lookup error when resolving principal " + principal, e);
         }
         try {
-            UserGroupInformation.loginUserFromKeytab(principal, keytab);
-            return UserGroupInformation.getLoginUser();
+            return UserGroupInformation.loginUserFromKeytabAndReturnUGI(principal, keytab);
         } catch (IOException e) {
             throw new AuthenticationFailed("Login failed for principal " + principal, e);
         }

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveWriter.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/common/HiveWriter.java
@@ -68,7 +68,7 @@ public class HiveWriter {
             this.ugi = ugi;
             this.connection = newConnection(ugi);
             this.txnsPerBatch = txnsPerBatch;
-            this.recordWriter = mapper.createRecordWriter(endPoint);
+            this.recordWriter = mapper.createRecordWriter(endPoint, ugi);
             this.txnBatch = nextTxnBatch(recordWriter);
             this.closed = false;
             this.lastUsed = System.currentTimeMillis();


### PR DESCRIPTION
Storm-hive uses UserGroupInformation.loginUserFromKeytab which updates the static variable that stores current UGI. Modified HiveUtils.authenticate to use UserGroupInformation.loginUserFromKeytabAndReturnUGI() which returns the new UGI instead of modifying the current UGI.
