### PR TITLE
[STORM-1715] using Jedis Protocol.DEFAULT_HOST to replace DEFAULT_HOST

### DIFF
--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisPoolConfig.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisPoolConfig.java
@@ -25,7 +25,6 @@ import java.io.Serializable;
  * Configuration for JedisPool.
  */
 public class JedisPoolConfig implements Serializable {
-    public static final String DEFAULT_HOST = "127.0.0.1";
 
     private String host;
     private int port;
@@ -99,7 +98,7 @@ public class JedisPoolConfig implements Serializable {
      * Builder for initializing JedisPoolConfig.
      */
     public static class Builder {
-        private String host = DEFAULT_HOST;
+        private String host = Protocol.DEFAULT_HOST;
         private int port = Protocol.DEFAULT_PORT;
         private int timeout = Protocol.DEFAULT_TIMEOUT;
         private int database = Protocol.DEFAULT_DATABASE;


### PR DESCRIPTION
Using Jedis Protocol.DEFAULT_HOST to replace DEFAULT_HOST  see : [STORM-1715](https://issues.apache.org/jira/browse/STORM-1715)