### PR TITLE
STORM-1733 Flush stdout and stderr before calling "os.execvp" to prevent log loss.

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -208,6 +208,7 @@ def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]
         "-cp", get_classpath(extrajars, daemon),
     ] + jvmopts + [klass] + list(args)
     print("Running: " + " ".join(all_args))
+    sys.stdout.flush()
     if fork:
         os.spawnvp(os.P_WAIT, JAVA_CMD, all_args)
     elif is_windows():


### PR DESCRIPTION
bin/storm.py emits the following crucial information that is lost because we don't flush the stdout before exec. 
```
2016-04-25T08:23:43.17141 Running: java -server -Dstorm.options= -Dstorm.home= -Xmx1024m -Dlogfile.name=nimbus.log -Dlogback.configurationFile=logback/cluster.xml  backtype.storm.ui.core.nimbus
```

Observed Environment:
```
OS: CentOS release 6.5
Kernel: 2.6.32-431.el6.x86_64
Python version: Python 2.7.2
```