### PR TITLE
[STORM-1707]  Remove two minute timeout after worker launch

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/local_supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/local_supervisor.clj
@@ -15,7 +15,7 @@
 ;; limitations under the License.
 (ns org.apache.storm.daemon.local-supervisor
   (:import [org.apache.storm.daemon.supervisor SyncProcessEvent SupervisorData Supervisor SupervisorUtils]
-           [org.apache.storm.utils Utils ConfigUtils]
+           [org.apache.storm.utils Time Utils ConfigUtils]
            [org.apache.storm ProcessSimulator])
   (:use [org.apache.storm.daemon common]
         [org.apache.storm log])
@@ -34,7 +34,9 @@
                  workerId)]
     (ConfigUtils/setWorkerUserWSE conf workerId "")
     (ProcessSimulator/registerProcess pid worker)
-    (.put (.getWorkerThreadPids supervisorData) workerId pid)))
+    (.put (.getWorkerThreadPids supervisorData) workerId pid)
+    (.put (.getWorkerIdsToLaunchTimes supervisorData) workerId (Time/currentTimeSecs))
+    (.put (.getWorkerIdsToPorts supervisorData) workerId port)))
 
 (defn shutdown-local-worker [supervisorData worker-manager workerId]
   (log-message "shutdown-local-worker")

--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/SupervisorData.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/SupervisorData.java
@@ -58,6 +58,8 @@ public class SupervisorData {
     private final Utils.UptimeComputer upTime;
     private final String stormVersion;
     private final ConcurrentHashMap<String, String> workerThreadPids; // for local mode
+    private final ConcurrentHashMap<String, Long> workerIdsToLaunchTimes;
+    private final ConcurrentHashMap<String, Integer> workerIdsToPorts;
     private final IStormClusterState stormClusterState;
     private final LocalState localState;
     private final String supervisorId;
@@ -84,6 +86,8 @@ public class SupervisorData {
         this.upTime = Utils.makeUptimeComputer();
         this.stormVersion = VersionInfo.getVersion();
         this.workerThreadPids = new ConcurrentHashMap<String, String>();
+        this.workerIdsToLaunchTimes = new ConcurrentHashMap<String, Long>();
+        this.workerIdsToPorts = new ConcurrentHashMap<String, Integer>();
         this.deadWorkers = new ConcurrentHashSet();
 
         List<ACL> acls = null;
@@ -166,6 +170,14 @@ public class SupervisorData {
 
     public ConcurrentHashMap<String, String> getWorkerThreadPids() {
         return workerThreadPids;
+    }
+
+    public ConcurrentHashMap<String, Long> getWorkerIdsToLaunchTimes() {
+        return workerIdsToLaunchTimes;
+    }
+
+    public ConcurrentHashMap<String, Integer> getWorkerIdsToPorts() {
+        return workerIdsToPorts;
     }
 
     public IStormClusterState getStormClusterState() {


### PR DESCRIPTION
This is a logic change the removes the two minute wait after worker launch in sync processes.  Instead of sitting in a wait loop for all of the workers to come up, SyncProcessEvent now checks to see if a worker is in the NOT-STARTED state, and has elapsed the Config.SUPERVISOR_WORKER_START_TIMEOUT_SECS time.  If it has, it kills and cleans up the worker. 
