### PR TITLE
STORM-1733 (0.9.x) Flush stdout and stderr before calling "os.execvp" to prevent log loss.

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -177,6 +177,7 @@ def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]
         "-cp", get_classpath(extrajars),
     ] + jvmopts + [klass] + list(args)
     print("Running: " + " ".join(all_args))
+    sys.stdout.flush()
     if fork:
         os.spawnvp(os.P_WAIT, JAVA_CMD, all_args)
     else:


### PR DESCRIPTION
Related to https://github.com/apache/storm/pull/1360/#issuecomment-215073019