### PR TITLE
STORM-1733 (0.10.x) Flush stdout and stderr before calling "os.execvp" to prevent log loss

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -201,6 +201,7 @@ def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]
         "-cp", get_classpath(extrajars, daemon),
     ] + jvmopts + [klass] + list(args)
     print("Running: " + " ".join(all_args))
+    sys.stdout.flush()
     if fork:
         os.spawnvp(os.P_WAIT, JAVA_CMD, all_args)
     elif is_windows():


### PR DESCRIPTION
Related to #1360