### PR TITLE
STORM-1742 (1.x) More accurate 'complete latency'

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/common.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/common.clj
@@ -221,9 +221,9 @@
   (let [num-executors (if (nil? (storm-conf TOPOLOGY-ACKER-EXECUTORS)) (storm-conf TOPOLOGY-WORKERS) (storm-conf TOPOLOGY-ACKER-EXECUTORS))
         acker-bolt (thrift/mk-bolt-spec* (acker-inputs ret)
                                          (new org.apache.storm.daemon.acker)
-                                         {ACKER-ACK-STREAM-ID (thrift/direct-output-fields ["id"])
-                                          ACKER-FAIL-STREAM-ID (thrift/direct-output-fields ["id"])
-                                          ACKER-RESET-TIMEOUT-STREAM-ID (thrift/direct-output-fields ["id"])
+                                         {ACKER-ACK-STREAM-ID (thrift/direct-output-fields ["id" "time-delta-ms"])
+                                          ACKER-FAIL-STREAM-ID (thrift/direct-output-fields ["id" "time-delta-ms"])
+                                          ACKER-RESET-TIMEOUT-STREAM-ID (thrift/direct-output-fields ["id" "time-delta-ms"])
                                           }
                                          :p num-executors
                                          :conf {TOPOLOGY-TASKS num-executors

--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -524,11 +524,12 @@
                                    (when pending-for-id
                                      (.put pending id pending-for-id))) 
                               (let [id (.getValue tuple 0)
+                                    time-delta-ms (.getValue tuple 1)
                                     [stored-task-id spout-id tuple-finished-info start-time-ms] (.remove pending id)]
                                 (when spout-id
                                   (when-not (= stored-task-id task-id)
                                     (throw-runtime "Fatal error, mismatched task ids: " task-id " " stored-task-id))
-                                  (let [time-delta (if start-time-ms (time-delta-ms start-time-ms))]
+                                  (let [time-delta (if start-time-ms time-delta-ms)]
                                     (condp = stream-id
                                       ACKER-ACK-STREAM-ID (ack-spout-msg executor-data (get task-datas task-id)
                                                                          spout-id tuple-finished-info time-delta id debug?)


### PR DESCRIPTION
PR for master: #1523 

* Acker computes 'complete latency' and sends back to Spout
  * start time: Acker receiving ACK_INIT from Spout
  * end time: Acker receiving ACK message which make the tuple tree completed
* When Acker provides complete latency, Spout just uses this value to record that latency
  * exception case: tuple timed out - Spout doesn't receive failed information from Acker

Btw, in fact Spout measures latency only acked tuple, not failed tuple. If performance matters, we can get rid of using time delta with fail / reset timeout cases.