### PR TITLE
STORM-1746: Downgrade NOT_LEADER_FOR_PARTITION log to warn from error

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaUtils.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaUtils.java
@@ -213,11 +213,6 @@ public class KafkaUtils {
                 throw new TopicOffsetOutOfRangeException(msg);
             } else {
                 String message = "Error fetching data from [" + partition + "] for topic [" + topic + "]: [" + error + "]";
-                if (error.equals(KafkaError.NOT_LEADER_FOR_PARTITION)) {
-                    LOG.warn(message);
-                } else {
-                    LOG.error(message);
-                }
                 throw new FailedFetchException(message);
             }
         } else {

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaUtils.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaUtils.java
@@ -183,7 +183,7 @@ public class KafkaUtils {
     }
 
     public static ByteBufferMessageSet fetchMessages(KafkaConfig config, SimpleConsumer consumer, Partition partition, long offset)
-            throws TopicOffsetOutOfRangeException, FailedFetchException,RuntimeException {
+            throws TopicOffsetOutOfRangeException, FailedFetchException, RuntimeException {
         ByteBufferMessageSet msgs = null;
         String topic = partition.topic;
         int partitionId = partition.partition;
@@ -213,7 +213,11 @@ public class KafkaUtils {
                 throw new TopicOffsetOutOfRangeException(msg);
             } else {
                 String message = "Error fetching data from [" + partition + "] for topic [" + topic + "]: [" + error + "]";
-                LOG.error(message);
+                if (error.equals(KafkaError.NOT_LEADER_FOR_PARTITION)) {
+                    LOG.warn(message);
+                } else {
+                    LOG.error(message);
+                }
                 throw new FailedFetchException(message);
             }
         } else {

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/trident/TridentKafkaEmitter.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/trident/TridentKafkaEmitter.java
@@ -76,7 +76,7 @@ public class TridentKafkaEmitter {
         try {
             return failFastEmitNewPartitionBatch(attempt, collector, partition, lastMeta);
         } catch (FailedFetchException e) {
-            LOG.warn("Failed to fetch from partition " + partition);
+            LOG.warn("Failed to fetch from partition " + partition, e);
             if (lastMeta == null) {
                 return null;
             } else {


### PR DESCRIPTION
This error is transient most of the time and will occur during normal operation. Downgrading it to warning makes the error log much less noisy.
