### PR TITLE
STORM-1725: Kafka Spout New Consumer API - KafkaSpoutRetryExponentialBackoff method should use HashMap instead of TreeMap not to throw Exception

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryExponentialBackoff.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryExponentialBackoff.java
@@ -162,7 +162,7 @@ public class KafkaSpoutRetryExponentialBackoff implements KafkaSpoutRetryService
 
     @Override
     public Set<TopicPartition> retriableTopicPartitions() {
-        final Set<TopicPartition> tps = new TreeSet<>();
+        final Set<TopicPartition> tps = new HashSet<>();
         final long currentTimeNanos = System.nanoTime();
         for (RetrySchedule retrySchedule : retrySchedules) {
             if (retrySchedule.retry(currentTimeNanos)) {


### PR DESCRIPTION
- Replace TreeMap with HashMap