### PR TITLE
STORM-1750: Ensure worker dies when report-error-and-die is called. M…

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -204,7 +204,11 @@
      :report-error-and-die (reify
                              Thread$UncaughtExceptionHandler
                              (uncaughtException [this _ error]
-                               ((:report-error <>) error)
+                               (try
+                                 ((:report-error <>) error)
+                               (catch Exception e
+                                 (log-error e "Error while reporting error to cluster, proceeding with shutdown")
+                               ))
                                (if (or
                                     (Utils/exceptionCauseIsInstanceOf InterruptedException error)
                                     (Utils/exceptionCauseIsInstanceOf java.io.InterruptedIOException error))

--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -206,9 +206,8 @@
                              (uncaughtException [this _ error]
                                (try
                                  ((:report-error <>) error)
-                               (catch Exception e
-                                 (log-error e "Error while reporting error to cluster, proceeding with shutdown")
-                               ))
+                                 (catch Exception e
+                                   (log-error e "Error while reporting error to cluster, proceeding with shutdown")))
                                (if (or
                                     (Utils/exceptionCauseIsInstanceOf InterruptedException error)
                                     (Utils/exceptionCauseIsInstanceOf java.io.InterruptedIOException error))

--- a/storm-core/src/jvm/org/apache/storm/cluster/ZKStateStorage.java
+++ b/storm-core/src/jvm/org/apache/storm/cluster/ZKStateStorage.java
@@ -28,7 +28,6 @@ import org.apache.storm.utils.Utils;
 import org.apache.storm.zookeeper.Zookeeper;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.KeeperException.NodeExistsException;
 import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
@@ -193,7 +192,7 @@ public class ZKStateStorage implements IStateStorage {
             try {
                 Zookeeper.createNode(zkWriter, path, data, CreateMode.PERSISTENT, acls);
             } catch (RuntimeException e) {
-                if (e.getCause() instanceof NodeExistsException) {
+                if (Utils.exceptionCauseIsInstanceOf(KeeperException.NodeExistsException.class, e)) {
                     Zookeeper.setData(zkWriter, path, data);
                 } else {
                     throw e;


### PR DESCRIPTION
…ake ZkStateStorage set_data try setting data if node creation fails because the node exists

Similar changes probably need to be made to 0.10.x and 1.x to prevent executors from disappearing until the worker is manually rebooted. The change to ZkStateStorage may not be strictly necessary to fix this issue, but it should reduce the number of exceptions thrown out of set_data due to some component creating a node after another has passed the exists check.