### PR TITLE
STORM-1754: Correct java version in 0.10.x storm-starter

### DIFF
--- a/examples/storm-starter/README.markdown
+++ b/examples/storm-starter/README.markdown
@@ -150,7 +150,7 @@ The following instructions will import storm-starter as a new project in Intelli
   defaults.  Click _Next_.
 * Click _Next_ on the following screen about selecting Maven projects to import.
 * Select the JDK to be used by IDEA for storm-starter, then click _Next_.
-    * At the time of this writing you should use JDK 6.
-    * It is strongly recommended to use Sun/Oracle JDK 6 rather than OpenJDK 6.
+    * At the time of this writing you should use JDK 7.
+    * It is strongly recommended to use Sun/Oracle JDK 7 rather than OpenJDK 7.
 * You may now optionally change the name of the project in IDEA.  The default name suggested by IDEA is "storm-starter".
   Click _Finish_ once you are done.


### PR DESCRIPTION
Correct java version in storm-starter, because we drop supporting JDK 1.6 since Storm 0.10.0.