### PR TITLE
STORM-1756: Explicitly null KafkaServer reference in KafkaTestBroker …

### DIFF
--- a/external/storm-kafka/src/test/org/apache/storm/kafka/KafkaTestBroker.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/KafkaTestBroker.java
@@ -78,7 +78,12 @@ public class KafkaTestBroker {
         return port;
     }
     public void shutdown() {
-        kafka.shutdown();
+        if (kafka != null) {
+            kafka.shutdown();
+            kafka.awaitShutdown();
+        }
+        //Ensure kafka server is eligible for garbage collection immediately
+        kafka = null;
         if (zookeeper.getState().equals(CuratorFrameworkState.STARTED)) {
             zookeeper.close();
         }


### PR DESCRIPTION
…to prevent out of memory on large test classes.

I'm not clear on whether JUnit keeps the reference for the lifetime of the module test, or whether they're released after all tests in a class have run. Either way, a test class with a KafkaTestBroker field and many tests would likely still run out of memory.