### PR TITLE
STORM-1750 (1.x): Ensure worker dies when report-error-and-die is called. M…

### DIFF
--- a/storm-core/src/clj/org/apache/storm/cluster_state/zookeeper_state_factory.clj
+++ b/storm-core/src/clj/org/apache/storm/cluster_state/zookeeper_state_factory.clj
@@ -92,12 +92,10 @@
          (zk/set-data zk-writer path data)
          (do
            (zk/mkdirs zk-writer (parent-path path) acls)
-           (try
+           (try-cause
              (zk/create-node zk-writer path data :persistent acls)
-             (catch RuntimeException e
-               (if (instance? KeeperException$NodeExistsException (.getCause e))
-                 (zk/set-data zk-writer path data)
-                 (throw e)))))))
+             (catch KeeperException$NodeExistsException e
+               (zk/set-data zk-writer path data))))))
 
      (set-worker-hb
        [this path data acls]

--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -263,7 +263,10 @@
      :stream->component->grouper (outbound-components worker-context component-id storm-conf)
      :report-error (throttled-report-error-fn <>)
      :report-error-and-die (fn [error]
-                             ((:report-error <>) error)
+                             (try
+                               ((:report-error <>) error)
+                               (catch Exception e
+                                 (log-message "Error while reporting error to cluster, proceeding with shutdown")))
                              (if (or
                                     (exception-cause? InterruptedException error)
                                     (exception-cause? java.io.InterruptedIOException error))


### PR DESCRIPTION
…ake zookeeper_state_factory set-data try setting data if node creation fails because the node exists.

Backport of STORM-1750