### PR TITLE
STORM-1750 (0.10.x): Ensure worker dies when report-error-and-die is …

### DIFF
--- a/storm-core/src/clj/backtype/storm/cluster.clj
+++ b/storm-core/src/clj/backtype/storm/cluster.clj
@@ -103,12 +103,10 @@
          (zk/set-data zk path data)
          (do
            (zk/mkdirs zk (parent-path path) acls)
-           (try
+           (try-cause
              (zk/create-node zk path data :persistent acls)
-             (catch RuntimeException e
-               (if (instance? KeeperException$NodeExistsException (.getCause e))
-                 (zk/set-data zk path data)
-                 (throw e)))))))
+             (catch KeeperException$NodeExistsException e
+               (zk/set-data zk path data))))))
 
      (delete-node
        [this path]

--- a/storm-core/src/clj/backtype/storm/cluster.clj
+++ b/storm-core/src/clj/backtype/storm/cluster.clj
@@ -18,7 +18,7 @@
   (:import [org.apache.zookeeper.data Stat ACL Id]
            [backtype.storm.generated SupervisorInfo Assignment StormBase ClusterWorkerHeartbeat ErrorInfo Credentials]
            [java.io Serializable])
-  (:import [org.apache.zookeeper KeeperException KeeperException$NoNodeException ZooDefs ZooDefs$Ids ZooDefs$Perms])
+  (:import [org.apache.zookeeper KeeperException KeeperException$NoNodeException KeeperException$NodeExistsException ZooDefs ZooDefs$Ids ZooDefs$Perms])
   (:import [backtype.storm.utils Utils])
   (:import [java.security MessageDigest])
   (:import [org.apache.zookeeper.server.auth DigestAuthenticationProvider])
@@ -103,7 +103,12 @@
          (zk/set-data zk path data)
          (do
            (zk/mkdirs zk (parent-path path) acls)
-           (zk/create-node zk path data :persistent acls))))
+           (try
+             (zk/create-node zk path data :persistent acls)
+             (catch RuntimeException e
+               (if (instance? KeeperException$NodeExistsException (.getCause e))
+                 (zk/set-data zk path data)
+                 (throw e)))))))
 
      (delete-node
        [this path]

--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -253,7 +253,10 @@
      :stream->component->grouper (outbound-components worker-context component-id)
      :report-error (throttled-report-error-fn <>)
      :report-error-and-die (fn [error]
-                             ((:report-error <>) error)
+                             (try
+                               ((:report-error <>) error)
+                               (catch Exception e
+                                 (log-message "Error while reporting error to cluster, proceeding with shutdown")))
                              (if (or
                                     (exception-cause? InterruptedException error)
                                     (exception-cause? java.io.InterruptedIOException error))


### PR DESCRIPTION
…called. Make cluster set-data try setting data if node creation fails because the node exists.

Backport of STORM-1750