### PR TITLE
STORM-1764: Pacemaker is throwing some stack traces

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/pacemaker/PacemakerServer.java
+++ b/storm-core/src/jvm/org/apache/storm/pacemaker/PacemakerServer.java
@@ -138,8 +138,13 @@ class PacemakerServer implements ISaslServer {
         LOG.debug("received message. Passing to handler. {} : {} : {}",
                   handler.toString(), m.toString(), channel.toString());
         HBMessage response = handler.handleMessage(m, authenticated);
-        LOG.debug("Got Response from handler: {}", response.toString());
-        channel.write(response);
+        if(response != null) {
+            LOG.debug("Got Response from handler: {}", response);
+            channel.write(response);
+        }
+        else {
+            LOG.info("Got null response from handler handling message: {}", m);
+        }
     }
 
     public void closeChannel(Channel c) {

--- a/storm-core/src/jvm/org/apache/storm/pacemaker/codec/ThriftDecoder.java
+++ b/storm-core/src/jvm/org/apache/storm/pacemaker/codec/ThriftDecoder.java
@@ -50,11 +50,9 @@ public class ThriftDecoder extends FrameDecoder {
             return null;
         }
 
-        
         byte serialized[] = new byte[thriftLen];
         buf.readBytes(serialized, 0, thriftLen);
         HBMessage m = (HBMessage)Utils.thriftDeserialize(HBMessage.class, serialized);
-
 
         if(m.get_type() == HBServerMessageType.CONTROL_MESSAGE) {
             ControlMessage cm = ControlMessage.read(m.get_data().get_message_blob());


### PR DESCRIPTION
Pacemaker throws a handful of stack traces when the occasional weird thing happens. This fixes an IndexOutOfBounds exception, a very strange IllegalStateException, and a NullPointerException.