### PR TITLE
This closes #STORM-1730 #1730 LocalCluster#shutdown() does not terminate all storm threads/thread pools.

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/DisruptorQueue.java
@@ -69,12 +69,15 @@ public class DisruptorQueue implements IStatefulObject {
         private ThreadPoolExecutor _exec;
         private HashMap<Long, ArrayList<Flusher>> _pendingFlush = new HashMap<>();
         private HashMap<Long, TimerTask> _tt = new HashMap<>();
-        
+
         public FlusherPool() {
-        	_exec = new ThreadPoolExecutor(1, 100, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1024), new ThreadPoolExecutor.DiscardPolicy());
-			ThreadFactory threadFactory = new ThreadFactoryBuilder().setDaemon(true).setNameFormat(THREAD_PREFIX + "-task-pool").build();
-			_exec.setThreadFactory(threadFactory);
-		}
+            _exec = new ThreadPoolExecutor(1, 100, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1024), new ThreadPoolExecutor.DiscardPolicy());
+            ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                    .setDaemon(true)
+                    .setNameFormat(THREAD_PREFIX + "-task-pool")
+                    .build();
+            _exec.setThreadFactory(threadFactory);
+        }
 
         public synchronized void start(Flusher flusher, final long flushInterval) {
             ArrayList<Flusher> pending = _pendingFlush.get(flushInterval);

--- a/storm-core/src/jvm/org/apache/storm/utils/DisruptorQueue.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/DisruptorQueue.java
@@ -72,10 +72,7 @@ public class DisruptorQueue implements IStatefulObject {
         
         public FlusherPool() {
         	_exec = new ThreadPoolExecutor(1, 100, 10, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(1024), new ThreadPoolExecutor.DiscardPolicy());
-			ThreadFactory threadFactory = new ThreadFactoryBuilder()
-					.setDaemon(true)
-					.setNameFormat(THREAD_PREFIX + "-task-pool")
-					.build();
+			ThreadFactory threadFactory = new ThreadFactoryBuilder().setDaemon(true).setNameFormat(THREAD_PREFIX + "-task-pool").build();
 			_exec.setThreadFactory(threadFactory);
 		}
 


### PR DESCRIPTION
The thread pool executor used by the `DisruptorQueue.FlusherPool` is in a static context of the
DisruptorQueue.  To avoid major changes to how this queues lifecycle is
managed I added a simple fix is to create a thread pool factory which creates daemon
threads.  The threads are now also named with the 'disruptor-flush'
prefix to be consistent with the TimerTask.