### PR TITLE
STORM-1773 Utils.javaDeserialize() doesn't work with primitive types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <compojure.version>1.1.3</compojure.version>
         <hiccup.version>0.3.6</hiccup.version>
         <commons-compress.version>1.4.1</commons-compress.version>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.5</commons-io.version>
         <commons-lang.version>2.5</commons-lang.version>
         <commons-exec.version>1.1</commons-exec.version>
         <commons-fileupload.version>1.2.1</commons-fileupload.version>


### PR DESCRIPTION
* upgrade commons-io from 2.4 to 2.5 to resolve IO-378

Fix for 1.x : #1412 

Please refer http://issues.apache.org/jira/browse/STORM-1773 for more details.