### PR TITLE
fix typo in worker.clj

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/worker.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/worker.clj
@@ -77,7 +77,7 @@
       (.workerHeartbeat (:storm-cluster-state worker) (:storm-id worker) (:assignment-id worker) (long (:port worker))
         (StatsUtil/thriftifyZkWorkerHb zk-hb))
       (catch Exception exc
-        (log-error exc "Worker failed to write heatbeats to ZK or Pacemaker...will retry")))))
+        (log-error exc "Worker failed to write heartbeats to ZK or Pacemaker...will retry")))))
 
 (defn do-heartbeat [worker]
   (let [conf (:conf worker)


### PR DESCRIPTION
"heatbeat" -> "heartbeat"