### PR TITLE
STORM-1849: HDFSFileTopology should use the third argument as topologyName.

### DIFF
--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/HdfsFileTopology.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/HdfsFileTopology.java
@@ -106,9 +106,9 @@ public class HdfsFileTopology {
             cluster.shutdown();
             System.exit(0);
         } else if (args.length == 3) {
-            StormSubmitter.submitTopology(args[0], config, builder.createTopology());
+            StormSubmitter.submitTopology(args[2], config, builder.createTopology());
         } else{
-            System.out.println("Usage: HdfsFileTopology [topology name] <yaml config file>");
+            System.out.println("Usage: HdfsFileTopology [hdfs url] [hdfs yaml config file] <topology name>");
         }
     }
 


### PR DESCRIPTION
The change with the fix needs to be cherry picked into master.