### PR TITLE
[STORM-1851] Fix default nimbus impersonation authorizer config

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -76,7 +76,6 @@ nimbus.topology.validator: "org.apache.storm.nimbus.DefaultTopologyValidator"
 topology.min.replication.count: 1
 topology.max.replication.wait.time.sec: 60
 nimbus.credential.renewers.freq.secs: 600
-nimbus.impersonation.authorizer: "org.apache.storm.security.auth.authorizer.ImpersonationAuthorizer"
 nimbus.queue.size: 100000
 scheduler.display.resource: false
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -391,7 +391,7 @@ A storm client may submit requests on behalf of another user. For example, if a 
 it can do so by leveraging the impersonation feature.In order to submit topology as some other user , you can use `StormSubmitter.submitTopologyAs` API. Alternatively you can use `NimbusClient.getConfiguredClientAs` 
 to get a nimbus client as some other user and perform any nimbus action(i.e. kill/rebalance/activate/deactivate) using this client. 
 
-To ensure only authorized users can perform impersonation you should start nimbus with `nimbus.impersonation.authorizer` set to `org.apache.storm.security.auth.authorizer.ImpersonationAuthorizer`. 
+Impersonation authorization is disabled by default which means any user can perform impersonation. To ensure only authorized users can perform impersonation you should start nimbus with `nimbus.impersonation.authorizer` set to `org.apache.storm.security.auth.authorizer.ImpersonationAuthorizer`.
 The `ImpersonationAuthorizer` uses `nimbus.impersonation.acl` as the acl to authorize users. Following is a sample nimbus config for supporting impersonation:
 
 ```yaml


### PR DESCRIPTION
"nimbus.impersonation.authorizer" is set to "ImpersonationAuthorizer" by default and this causes issues when a user tries to submit topology as a different user in secure mode since the "nimbus.impersonation.acl" configuration is not set by default. Users need to set nimbus.impersonation.acl first before they can submit topology as any user other than "storm" in secure mode.

Removing this config allows users to submit topologies in secure mode as any user by default. Users can set up impersonation by providing both authorizer and the acls via storm.yaml.