### PR TITLE
STORM-1859: Ack late tuples in windowed mode

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
@@ -268,6 +268,7 @@ public class WindowedBoltExecutor implements IRichBolt {
             if (waterMarkEventGenerator.track(input.getSourceGlobalStreamId(), ts)) {
                 windowManager.add(input, ts);
             } else {
+                windowedOutputCollector.ack(input);
                 LOG.info("Received a late tuple {} with ts {}. This will not processed.", input, ts);
             }
         } else {


### PR DESCRIPTION
The current implementation simply ignores late tuples without acking
them, which causes timeouts and replays after
TOPOLOGY_MESSAGE_TIMEOUT_SECS. A tuple which was late at a some time
is going to be late at any moment in the future, so there is no point
of replaying it, because the lingering late tuples will just block the
topology (especially if TOPOLOGY_MAX_SPOUT_PENDING is set).