### PR TITLE
Throw exception if messages fetched by storm-kafka is emtpy

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaUtils.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaUtils.java
@@ -19,6 +19,7 @@ package org.apache.storm.kafka;
 
 import com.google.common.base.Preconditions;
 
+import kafka.common.MessageSizeTooLargeException;
 import org.apache.storm.kafka.trident.GlobalPartitionInformation;
 import org.apache.storm.kafka.trident.IBrokerReader;
 import org.apache.storm.kafka.trident.StaticBrokerReader;
@@ -218,6 +219,11 @@ public class KafkaUtils {
             }
         } else {
             msgs = fetchResponse.messageSet(topic, partitionId);
+            if (msgs.validBytes() == 0) {
+                throw new MessageSizeTooLargeException("Found a message larger than the maximum fetch size of this consumer on topic " +
+                        "%s partition %d at fetch offset %d. Increase the fetch size, or decrease the maximum message size the broker will allow."
+                                .format(partition.topic, partition.partition, offset));
+            }
         }
         return msgs;
     }


### PR DESCRIPTION
In kafka [ConsumerIterator](https://github.com/apache/kafka/blob/a81ad2582ee0e533d335fe0dc5c5cc885dbf645d/core/src/main/scala/kafka/consumer/ConsumerIterator.scala), there is some codes like this:

`// if we just updated the current chunk and it is empty that means the fetch size is too small!
      if(currentDataChunk.messages.validBytes == 0)
        throw new MessageSizeTooLargeException("Found a message larger than the maximum fetch size of this consumer on topic " +
                                               "%s partition %d at fetch offset %d. Increase the fetch size, or decrease the maximum message size the broker will allow."
                                               .format(currentDataChunk.topicInfo.topic, currentDataChunk.topicInfo.partitionId, currentDataChunk.fetchOffset))`

When "fetch.message.max.bytes" config is smaller than the actual message size in topic, ConsumerIterator will throw an exception to notify user.
But in storm-kafka, there is no such logic. And as a result, if KafkaConfig.fetchSizeBytes is smaller than actual message size, the topology will fetch no data but still be running.
To prevent this situation, we need throw MessageSizeTooLargeException as well.
