### PR TITLE
[STORM-1872]Release Jedis connection when topology shutdown

### DIFF
--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
@@ -106,4 +106,9 @@ public abstract class AbstractRedisBolt extends BaseRichBolt {
     protected void returnInstance(JedisCommands instance) {
         this.container.returnInstance(instance);
     }
+
+    @Override
+    public void cleanup() {
+        container.close();
+    }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisClusterContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisClusterContainer.java
@@ -20,7 +20,6 @@ package org.apache.storm.redis.common.container;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisCommands;
 
-import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -28,7 +27,7 @@ import java.io.IOException;
  * <p/>
  * Note that JedisCluster doesn't need to be pooled since it's thread-safe and it stores pools internally.
  */
-public class JedisClusterContainer implements JedisCommandsInstanceContainer, Closeable {
+public class JedisClusterContainer implements JedisCommandsInstanceContainer {
 
     private JedisCluster jedisCluster;
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsInstanceContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsInstanceContainer.java
@@ -19,10 +19,12 @@ package org.apache.storm.redis.common.container;
 
 import redis.clients.jedis.JedisCommands;
 
+import java.io.Closeable;
+
 /**
  * Interfaces for containers which stores instances implementing JedisCommands.
  */
-public interface JedisCommandsInstanceContainer {
+public interface JedisCommandsInstanceContainer extends Closeable {
     /**
      * Borrows instance from container.
      * @return instance which implements JedisCommands
@@ -34,4 +36,10 @@ public interface JedisCommandsInstanceContainer {
      * @param jedisCommands borrowed instance
      */
     void returnInstance(JedisCommands jedisCommands);
+
+    /**
+     * Release Container
+     */
+    @Override
+    public void close();
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisContainer.java
@@ -19,7 +19,6 @@ package org.apache.storm.redis.common.container;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCommands;
 import redis.clients.jedis.JedisPool;
 
@@ -29,7 +28,7 @@ import java.io.IOException;
 /**
  * Container for managing Jedis instances.
  */
-public class JedisContainer implements JedisCommandsInstanceContainer, Closeable {
+public class JedisContainer implements JedisCommandsInstanceContainer {
     private static final Logger LOG = LoggerFactory.getLogger(JedisContainer.class);
 
     private JedisPool jedisPool;


### PR DESCRIPTION
[STORM-1872](https://issues.apache.org/jira/browse/STORM-1872)  

Strom Redis connect should be release when topology shutdown .