### PR TITLE
STORM-1887: Fixed help message for set_log_level command

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -256,7 +256,7 @@ def jar(jarfile, klass, *args):
             jvmopts=JAR_JVM_OPTS + ["-Dstorm.jar=" + jarfile])
 
 def sql(sql_file, topology_name):
-    """Syntax: [storm sql sql-file topology]
+    """Syntax: [storm sql sql-file topology-name]
 
     Compiles the SQL statements into a Trident topology and submits it to Storm.
     """
@@ -360,26 +360,26 @@ def set_log_level(*args):
     """
     Dynamically change topology log levels
 
-    Syntax: [storm set_log_level -l [logger name]=[log level][:optional timeout] -r [logger name]
+    Syntax: [storm set_log_level -l [logger name]=[log level][:optional timeout] -r [logger name] topology-name]
     where log level is one of:
         ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF
     and timeout is integer seconds.
 
     e.g.
-        ./bin/storm set_log_level -l ROOT=DEBUG:30
+        ./bin/storm set_log_level -l ROOT=DEBUG:30 topology-name
 
         Set the root logger's level to DEBUG for 30 seconds
 
-        ./bin/storm set_log_level -l com.myapp=WARN
+        ./bin/storm set_log_level -l com.myapp=WARN topology-name
 
         Set the com.myapp logger's level to WARN for 30 seconds
 
-        ./bin/storm set_log_level -l com.myapp=WARN -l com.myOtherLogger=ERROR:123
+        ./bin/storm set_log_level -l com.myapp=WARN -l com.myOtherLogger=ERROR:123 topology-name
 
         Set the com.myapp logger's level to WARN indifinitely, and com.myOtherLogger
         to ERROR for 123 seconds
 
-        ./bin/storm set_log_level -r com.myOtherLogger
+        ./bin/storm set_log_level -r com.myOtherLogger topology-name
 
         Clears settings, resetting back to the original level
     """


### PR DESCRIPTION
The help message didn't mention that topology-name was a required parameter, thus giving the following error when not passing it:

```
Exception in thread "main" java.lang.IllegalArgumentException: No matching field found: IllegalArgumentException for class java.lang.String
	at clojure.lang.Reflector.getInstanceField(Reflector.java:271)
	at clojure.lang.Reflector.invokeNoArgInstanceMember(Reflector.java:315)
	at org.apache.storm.command.set_log_level$get_storm_id.invoke(set_log_level.clj:31)
	at org.apache.storm.command.set_log_level$_main.doInvoke(set_log_level.clj:75)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at org.apache.storm.command.set_log_level.main(Unknown Source)
```