### PR TITLE
STORM-1886 Extend KeyValueState iface with delete

### DIFF
--- a/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
@@ -105,7 +105,7 @@ public class RedisKeyValueStateTest {
                 });
 
         keyValueState = new RedisKeyValueState<String, String>("test", mockContainer, new DefaultStateSerializer<String>(),
-                                                               new DefaultStateSerializer<Optional<String>>());
+                                                               new DefaultStateSerializer<String>());
     }
 
 

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.redis.state;
 
+import com.google.common.base.Optional;
 import org.apache.storm.state.DefaultStateSerializer;
 import org.apache.storm.redis.common.container.JedisCommandsInstanceContainer;
 import org.junit.Before;
@@ -104,7 +105,7 @@ public class RedisKeyValueStateTest {
                 });
 
         keyValueState = new RedisKeyValueState<String, String>("test", mockContainer, new DefaultStateSerializer<String>(),
-                                                               new DefaultStateSerializer<String>());
+                                                               new DefaultStateSerializer<Optional<String>>());
     }
 
 
@@ -124,7 +125,7 @@ public class RedisKeyValueStateTest {
         assertEquals("1", keyValueState.get("a"));
         assertEquals("2", keyValueState.get("b"));
         assertEquals(null, keyValueState.get("c"));
-        keyValueState.delete("a");
+        assertEquals("1", keyValueState.delete("a"));
         assertEquals(null, keyValueState.get("a"));
         assertEquals("2", keyValueState.get("b"));
         assertEquals(null, keyValueState.get("c"));
@@ -148,8 +149,8 @@ public class RedisKeyValueStateTest {
         keyValueState.rollback();
         assertArrayEquals(new String[]{"1", "2", null}, getValues());
         keyValueState.put("c", "3");
-        keyValueState.delete("b");
-        keyValueState.delete("c");
+        assertEquals("2", keyValueState.delete("b"));
+        assertEquals("3", keyValueState.delete("c"));
         assertArrayEquals(new String[]{"1", null, null}, getValues());
         keyValueState.prepareCommit(2);
         assertArrayEquals(new String[]{"1", null, null}, getValues());

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
@@ -32,10 +32,9 @@ import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.Tuple;
 
 import java.util.HashMap;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
-
 import static org.junit.Assert.*;
 
 /**
@@ -93,6 +92,17 @@ public class RedisKeyValueStateTest {
                     }
                 });
 
+        Mockito.when(mockCommands.hdel(Mockito.anyString(), Mockito.<String>anyVararg()))
+                .thenAnswer(new Answer<Long>() {
+                    @Override
+                    public Long answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        int argsSize = args.length;
+                        String[] fields = Arrays.asList(args).subList(1, argsSize).toArray(new String[argsSize - 1]);
+                        return hdel(mockMap, (String) args[0], fields);
+                    }
+                });
+
         keyValueState = new RedisKeyValueState<String, String>("test", mockContainer, new DefaultStateSerializer<String>(),
                                                                new DefaultStateSerializer<String>());
     }
@@ -103,6 +113,19 @@ public class RedisKeyValueStateTest {
         keyValueState.put("a", "1");
         keyValueState.put("b", "2");
         assertEquals("1", keyValueState.get("a"));
+        assertEquals("2", keyValueState.get("b"));
+        assertEquals(null, keyValueState.get("c"));
+    }
+
+    @Test
+    public void testPutAndDelete() throws Exception {
+        keyValueState.put("a", "1");
+        keyValueState.put("b", "2");
+        assertEquals("1", keyValueState.get("a"));
+        assertEquals("2", keyValueState.get("b"));
+        assertEquals(null, keyValueState.get("c"));
+        keyValueState.delete("a");
+        assertEquals(null, keyValueState.get("a"));
         assertEquals("2", keyValueState.get("b"));
         assertEquals(null, keyValueState.get("c"));
     }
@@ -124,6 +147,20 @@ public class RedisKeyValueStateTest {
         assertArrayEquals(new String[]{"1", "2", "3"}, getValues());
         keyValueState.rollback();
         assertArrayEquals(new String[]{"1", "2", null}, getValues());
+        keyValueState.put("c", "3");
+        keyValueState.delete("b");
+        keyValueState.delete("c");
+        assertArrayEquals(new String[]{"1", null, null}, getValues());
+        keyValueState.prepareCommit(2);
+        assertArrayEquals(new String[]{"1", null, null}, getValues());
+        keyValueState.commit(2);
+        assertArrayEquals(new String[]{"1", null, null}, getValues());
+        keyValueState.put("b", "2");
+        keyValueState.prepareCommit(3);
+        keyValueState.put("c", "3");
+        assertArrayEquals(new String[]{"1", "2", "3"}, getValues());
+        keyValueState.rollback();
+        assertArrayEquals(new String[]{"1", null, null}, getValues());
     }
 
     private String[] getValues() {
@@ -135,13 +172,20 @@ public class RedisKeyValueStateTest {
     }
 
     private String hmset(Map<String, Map<String, String>> mockMap, String key, Map value) {
-        mockMap.put(key, value);
+        Map<String, String> currentValue = mockMap.get(key);
+        if (currentValue == null) {
+            currentValue = new HashMap<>();
+        }
+        currentValue.putAll(value);
+        mockMap.put(key, currentValue);
         return "";
     }
 
     private Long del(Map<String, Map<String, String>> mockMap, String key) {
-        mockMap.remove(key);
-        return 0L;
+        if (mockMap.remove(key) == null)
+            return 0L;
+        else
+            return 1L;
     }
 
     private String hget(Map<String, Map<String, String>> mockMap, String namespace, String key) {
@@ -149,6 +193,14 @@ public class RedisKeyValueStateTest {
             return mockMap.get(namespace).get(key);
         }
         return null;
+    }
+
+    private Long hdel(Map<String, Map<String, String>> mockMap, String namespace, String ... keys) {
+        Long count = 0L;
+        for (String key: keys) {
+            if (mockMap.get(namespace).remove(key) != null) count++;
+        }
+        return count;
     }
 
 }

--- a/storm-core/src/jvm/org/apache/storm/state/DefaultStateSerializer.java
+++ b/storm-core/src/jvm/org/apache/storm/state/DefaultStateSerializer.java
@@ -20,6 +20,7 @@ package org.apache.storm.state;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +41,7 @@ public class DefaultStateSerializer<T> implements Serializer<T> {
      */
     public DefaultStateSerializer(List<Class<?>> classesToRegister) {
         kryo = new Kryo();
+        kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
         output = new Output(2000, 2000000000);
         for (Class<?> klazz : classesToRegister) {
             kryo.register(klazz);

--- a/storm-core/src/jvm/org/apache/storm/state/InMemoryKeyValueState.java
+++ b/storm-core/src/jvm/org/apache/storm/state/InMemoryKeyValueState.java
@@ -68,6 +68,11 @@ public class InMemoryKeyValueState<K, V> implements KeyValueState<K, V> {
     }
 
     @Override
+    public void delete(K key) {
+        state.remove(key);
+    }
+
+    @Override
     public void commit() {
         commitedState = new TxIdState<>(DEFAULT_TXID, new ConcurrentHashMap<>(state));
     }

--- a/storm-core/src/jvm/org/apache/storm/state/InMemoryKeyValueState.java
+++ b/storm-core/src/jvm/org/apache/storm/state/InMemoryKeyValueState.java
@@ -68,8 +68,8 @@ public class InMemoryKeyValueState<K, V> implements KeyValueState<K, V> {
     }
 
     @Override
-    public void delete(K key) {
-        state.remove(key);
+    public V delete(K key) {
+        return state.remove(key);
     }
 
     @Override

--- a/storm-core/src/jvm/org/apache/storm/state/KeyValueState.java
+++ b/storm-core/src/jvm/org/apache/storm/state/KeyValueState.java
@@ -51,5 +51,5 @@ public interface KeyValueState<K, V> extends State {
      *
      * @param key   the key
      */
-    void delete(K key);
+    V delete(K key);
 }

--- a/storm-core/src/jvm/org/apache/storm/state/KeyValueState.java
+++ b/storm-core/src/jvm/org/apache/storm/state/KeyValueState.java
@@ -45,4 +45,11 @@ public interface KeyValueState<K, V> extends State {
      * @return the value or defaultValue if no mapping is found
      */
     V get(K key, V defaultValue);
+
+    /**
+     * Deletes the value mapped to the key, if there is any
+     *
+     * @param key   the key
+     */
+    void delete(K key);
 }

--- a/storm-core/test/jvm/org/apache/storm/state/InMemoryKeyValueStateTest.java
+++ b/storm-core/test/jvm/org/apache/storm/state/InMemoryKeyValueStateTest.java
@@ -44,6 +44,19 @@ public class InMemoryKeyValueStateTest {
     }
 
     @Test
+    public void testPutAndDelete() throws Exception {
+        keyValueState.put("a", "1");
+        keyValueState.put("b", "2");
+        assertEquals("1", keyValueState.get("a"));
+        assertEquals("2", keyValueState.get("b"));
+        assertEquals(null, keyValueState.get("c"));
+        assertEquals("1", keyValueState.delete("a"));
+        assertEquals(null, keyValueState.get("a"));
+        assertEquals("2", keyValueState.get("b"));
+        assertEquals(null, keyValueState.get("c"));
+    }
+
+    @Test
     public void testPrepareCommitRollback() throws Exception {
         keyValueState.put("a", "1");
         keyValueState.put("b", "2");
@@ -60,6 +73,20 @@ public class InMemoryKeyValueStateTest {
         assertArrayEquals(new String[]{"1", "2", "3"}, getValues());
         keyValueState.rollback();
         assertArrayEquals(new String[]{"1", "2", null}, getValues());
+        keyValueState.put("c", "3");
+        assertEquals("2", keyValueState.delete("b"));
+        assertEquals("3", keyValueState.delete("c"));
+        assertArrayEquals(new String[]{"1", null, null}, getValues());
+        keyValueState.prepareCommit(2);
+        assertArrayEquals(new String[]{"1", null, null}, getValues());
+        keyValueState.commit(2);
+        assertArrayEquals(new String[]{"1", null, null}, getValues());
+        keyValueState.put("b", "2");
+        keyValueState.prepareCommit(3);
+        keyValueState.put("c", "3");
+        assertArrayEquals(new String[]{"1", "2", "3"}, getValues());
+        keyValueState.rollback();
+        assertArrayEquals(new String[]{"1", null, null}, getValues());
     }
 
     private String[] getValues() {


### PR DESCRIPTION
The patch also provides implementation for delete in
RedisKeyValueState and InMemoryKeyValueState.
