### PR TITLE
Making class TextFileReader public as it is part of the public API for HDFS Spout

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 // Todo: Track file offsets instead of line number
-class TextFileReader extends AbstractFileReader {
+public class TextFileReader extends AbstractFileReader {
   public static final String[] defaultFields = {"line"};
   public static final String CHARSET = "hdfsspout.reader.charset";
   public static final String BUFFER_SIZE = "hdfsspout.reader.buffer.bytes";


### PR DESCRIPTION
minor change