### PR TITLE
off-by-one error for UNCOMMITTED_LATEST and UNCOMMITTED_EARLIEST

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -167,7 +167,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                     fetchOffset = kafkaConsumer.position(tp);
                 } else {
                     // By default polling starts at the last committed offset. +1 to point fetch to the first uncommitted offset.
-                    fetchOffset = committedOffset.offset() + 1;
+                    fetchOffset = committedOffset.offset();
                     kafkaConsumer.seek(tp, fetchOffset);
                 }
             } else {    // no commits have ever been done, so start at the beginning or end depending on the strategy


### PR DESCRIPTION

In the source code documentation, it says for both UNCOMMITTED_LATEST
and UNCOMMITTED_EARLIEST it will fetch the last committed offset ( if it
exists ).  But the code fetches last committed + 1;

If a topology is killed/crashes and then is redeployed, this off-by-one
error causes one message per partition to be dropped.