### PR TITLE
STORM-1902 (1.x): add a simple & flexible FileNameFormat for storm-hdfs

### DIFF
--- a/external/storm-hdfs/README.md
+++ b/external/storm-hdfs/README.md
@@ -158,8 +158,20 @@ For example:
 
 By default, prefix is empty and extenstion is ".txt".
 
+**New FileNameFormat:**
 
-The provided `org.apache.storm.hdfs.format.SimpleFileNameFormat` is flexible, supports parameters such as `$TIME` `$NUM` `$HOST` etc.
+The new provided `org.apache.storm.hdfs.format.SimpleFileNameFormat` and `org.apache.storm.hdfs.trident.format.SimpleFileNameFormat` are more flexible, and the `withName` method support parameters as following:
+
+* $TIME - current time. use `withTimeFormat` to format.
+* $NUM - rotation number
+* $HOST - local host name
+* $PARTITION - partition index (`org.apache.storm.hdfs.trident.format.SimpleFileNameFormat` only)
+* $COMPONENT - component id (`org.apache.storm.hdfs.format.SimpleFileNameFormat` only)
+* $TASK - task id (`org.apache.storm.hdfs.format.SimpleFileNameFormat` only)
+
+eg: `seq.$TIME.$HOST.$COMPONENT.$NUM.dat`
+
+The default file `name` is `$TIME.$NUM.txt`, and the default `timeFormat` is `yyyyMMddHHmmss`.
 
 
 ### Sync Policies

--- a/external/storm-hdfs/README.md
+++ b/external/storm-hdfs/README.md
@@ -159,6 +159,8 @@ For example:
 By default, prefix is empty and extenstion is ".txt".
 
 
+The provided `org.apache.storm.hdfs.format.SimpleFileNameFormat` is flexible, supports parameters such as `$TIME` `$NUM` `$HOST` etc.
+
 
 ### Sync Policies
 Sync policies allow you to control when buffered data is flushed to the underlying filesystem (thus making it available

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/format/SimpleFileNameFormat.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/format/SimpleFileNameFormat.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.bolt.format;
+
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.utils.Utils;
+
+public class SimpleFileNameFormat implements FileNameFormat {
+
+    private static final long serialVersionUID = 1L;
+
+    private String componentId;
+    private int taskId;
+    private String host;
+    private String path = "/storm";
+    private String name = "$TIME.$NUM.txt";
+    private String timeFormat = "yyyyMMddHHmmss";
+
+    @Override
+    public String getName(long rotation, long timeStamp) {
+        // compile parameters
+        SimpleDateFormat dateFormat = new SimpleDateFormat(timeFormat);
+        String ret = name
+                .replace("$TIME", dateFormat.format(new Date(timeStamp)))
+                .replace("$NUM", String.valueOf(rotation))
+                .replace("$HOST", host)
+                .replace("$COMPONENT", componentId)
+                .replace("$TASK", String.valueOf(taskId));
+        return ret;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void prepare(Map conf, TopologyContext topologyContext) {
+        this.componentId = topologyContext.getThisComponentId();
+        this.taskId = topologyContext.getThisTaskId();
+        try {
+            this.host = Utils.localHostname();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SimpleFileNameFormat withPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    /**
+     * support parameters:<br/>
+     * $TIME - current time. use <code>withTimeFormat</code> to format.<br/>
+     * $NUM - rotation number<br/>
+     * $HOST - local host name<br/>
+     * $COMPONENT - component id<br/>
+     * $TASK - task id<br/>
+     * 
+     * @param name
+     *            file name
+     * @return
+     */
+    public SimpleFileNameFormat withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public SimpleFileNameFormat withTimeFormat(String timeFormat) {
+        //check format
+        try{
+            new SimpleDateFormat(timeFormat);
+        }catch (Exception e) {
+            throw new IllegalArgumentException("invalid timeFormat: "+e.getMessage());
+        }
+        this.timeFormat = timeFormat;
+        return this;
+    }
+
+}

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/trident/format/SimpleFileNameFormat.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/trident/format/SimpleFileNameFormat.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.trident.format;
+
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+
+import org.apache.storm.utils.Utils;
+
+public class SimpleFileNameFormat implements FileNameFormat {
+
+    private static final long serialVersionUID = 1L;
+
+    private int partitionIndex;
+    private String host;
+    private String path = "/storm";
+    private String name = "$TIME.$NUM.txt";
+    private String timeFormat = "yyyyMMddHHmmss";
+
+    @Override
+    public String getName(long rotation, long timeStamp) {
+        // compile parameters
+        SimpleDateFormat dateFormat = new SimpleDateFormat(timeFormat);
+        String ret = name
+                .replace("$TIME", dateFormat.format(new Date(timeStamp)))
+                .replace("$NUM", String.valueOf(rotation))
+                .replace("$HOST", host)
+                .replace("$PARTITION", String.valueOf(partitionIndex));
+        return ret;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void prepare(Map conf, int partitionIndex, int numPartitions) {
+        this.partitionIndex = partitionIndex;
+        try {
+            this.host = Utils.localHostname();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SimpleFileNameFormat withPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    /**
+     * support parameters:<br/>
+     * $TIME - current time. use <code>withTimeFormat</code> to format.<br/>
+     * $NUM - rotation number<br/>
+     * $HOST - local host name<br/>
+     * $PARTITION - partition index<br/>
+     * 
+     * @param name
+     *            file name
+     * @return
+     */
+    public SimpleFileNameFormat withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public SimpleFileNameFormat withTimeFormat(String timeFormat) {
+        //check format
+        try{
+            new SimpleDateFormat(timeFormat);
+        }catch (Exception e) {
+            throw new IllegalArgumentException("invalid timeFormat: "+e.getMessage());
+        }
+        this.timeFormat = timeFormat;
+        return this;
+    }
+
+}

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/format/TestSimpleFileNameFormat.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/format/TestSimpleFileNameFormat.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.bolt.format;
+
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.utils.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSimpleFileNameFormat {
+
+    @Test
+    public void testDefaults() {
+        SimpleFileNameFormat format = new SimpleFileNameFormat();
+        format.prepare(null, createTopologyContext());
+        long now = System.currentTimeMillis();
+        String path = format.getPath();
+        String name = format.getName(1, now);
+
+        Assert.assertEquals("/storm", path);
+        String time = new SimpleDateFormat("yyyyMMddHHmmss").format(now);
+        Assert.assertEquals(time+".1.txt", name);
+    }
+
+    @Test
+    public void testParameters() {
+        SimpleFileNameFormat format = new SimpleFileNameFormat()
+            .withName("$TIME.$HOST.$COMPONENT.$TASK.$NUM.txt")
+            .withPath("/mypath")
+            .withTimeFormat("yyyy-MM-dd HH:mm:ss");
+        format.prepare(null, createTopologyContext());
+        long now = System.currentTimeMillis();
+        String path = format.getPath();
+        String name = format.getName(1, now);
+    
+        Assert.assertEquals("/mypath", path);
+        String time = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(now);
+        String host = null;
+        try {
+            host = Utils.localHostname();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+        Assert.assertEquals(time+"."+host+".Xcom.7.1.txt", name);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testTimeFormat() {
+        SimpleFileNameFormat format = new SimpleFileNameFormat()
+        	.withTimeFormat("xyz");
+        format.prepare(null, createTopologyContext());
+    }
+    
+    private TopologyContext createTopologyContext(){
+    	Map<Integer, String> taskToComponent = new HashMap<Integer, String>();
+        taskToComponent.put(7, "Xcom");
+    	return new TopologyContext(null, null, taskToComponent, null, null, null, null, null, 7, 6703, null, null, null, null, null, null);
+    }
+}

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/trident/format/TestSimpleFileNameFormat.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/trident/format/TestSimpleFileNameFormat.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.hdfs.trident.format;
+
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+
+import org.apache.storm.utils.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSimpleFileNameFormat {
+
+    @Test
+    public void testDefaults() {
+        SimpleFileNameFormat format = new SimpleFileNameFormat();
+        format.prepare(null, 3, 5);
+        long now = System.currentTimeMillis();
+        String path = format.getPath();
+        String name = format.getName(1, now);
+
+        Assert.assertEquals("/storm", path);
+        String time = new SimpleDateFormat("yyyyMMddHHmmss").format(now);
+        Assert.assertEquals(time+".1.txt", name);
+    }
+
+    @Test
+    public void testParameters() {
+        SimpleFileNameFormat format = new SimpleFileNameFormat()
+            .withName("$TIME.$HOST.$PARTITION.$NUM.txt")
+            .withPath("/mypath")
+            .withTimeFormat("yyyy-MM-dd HH:mm:ss");
+        format.prepare(null, 3, 5);
+        long now = System.currentTimeMillis();
+        String path = format.getPath();
+        String name = format.getName(1, now);
+    
+        Assert.assertEquals("/mypath", path);
+        String time = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(now);
+        String host = null;
+        try {
+            host = Utils.localHostname();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+        Assert.assertEquals(time+"."+host+".3.1.txt", name);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testTimeFormat() {
+        SimpleFileNameFormat format = new SimpleFileNameFormat()
+        	.withTimeFormat("xyz");
+        format.prepare(null, 3, 5);
+    }
+}

--- a/storm-core/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/Utils.java
@@ -29,9 +29,12 @@ import org.apache.storm.localizer.Localizer;
 import org.apache.storm.nimbus.NimbusInfo;
 import org.apache.storm.serialization.DefaultSerializationDelegate;
 import org.apache.storm.serialization.SerializationDelegate;
+
 import clojure.lang.IFn;
 import clojure.lang.RT;
+
 import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.input.ClassLoaderObjectInputStream;
@@ -74,8 +77,10 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
 import java.io.Serializable;
+import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -1410,6 +1415,10 @@ public class Utils {
      */
     public static int toPositive(int number) {
         return number & Integer.MAX_VALUE;
+    }
+
+    public static String localHostname() throws UnknownHostException {
+        return InetAddress.getLocalHost().getCanonicalHostName();
     }
 }
 


### PR DESCRIPTION
1. flexible. not fixed as `{prefix}{componentId}-{taskId}-{rotationNum}-{timestamp}{extension}`
2. support parameters. such as `$TIME` `$NUM` `$HOST` etc.