### PR TITLE
STORM-1907: PartitionedTridentSpoutExecutor has incompatible types that cause ClassCastException

### DIFF
--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentWordCount.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentWordCount.java
@@ -22,8 +22,6 @@ import org.apache.storm.LocalCluster;
 import org.apache.storm.LocalDRPC;
 import org.apache.storm.StormSubmitter;
 import org.apache.storm.generated.StormTopology;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Values;
 import org.apache.storm.trident.TridentState;
 import org.apache.storm.trident.TridentTopology;
 import org.apache.storm.trident.operation.BaseFunction;
@@ -31,10 +29,11 @@ import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.operation.builtin.Count;
 import org.apache.storm.trident.operation.builtin.FilterNull;
 import org.apache.storm.trident.operation.builtin.MapGet;
-import org.apache.storm.trident.operation.builtin.Sum;
 import org.apache.storm.trident.testing.FixedBatchSpout;
 import org.apache.storm.trident.testing.MemoryMapState;
 import org.apache.storm.trident.tuple.TridentTuple;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
 
 
 public class TridentWordCount {
@@ -59,9 +58,11 @@ public class TridentWordCount {
         new Split(), new Fields("word")).groupBy(new Fields("word")).persistentAggregate(new MemoryMapState.Factory(),
         new Count(), new Fields("count")).parallelismHint(16);
 
-    topology.newDRPCStream("words", drpc).each(new Fields("args"), new Split(), new Fields("word")).groupBy(new Fields(
-        "word")).stateQuery(wordCounts, new Fields("word"), new MapGet(), new Fields("count")).each(new Fields("count"),
-        new FilterNull()).aggregate(new Fields("count"), new Sum(), new Fields("sum"));
+    topology.newDRPCStream("words", drpc).each(new Fields("args"), new Split(), new Fields("word"))
+            .groupBy(new Fields("word"))
+            .stateQuery(wordCounts, new Fields("word"), new MapGet(), new Fields("count"))
+            .each(new Fields("count"), new FilterNull())
+            .project(new Fields("word", "count"));
     return topology.build();
   }
 

--- a/storm-core/src/jvm/org/apache/storm/trident/spout/PartitionedTridentSpoutExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/spout/PartitionedTridentSpoutExecutor.java
@@ -18,30 +18,31 @@
 package org.apache.storm.trident.spout;
 
 import org.apache.storm.task.TopologyContext;
-import org.apache.storm.tuple.Fields;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.topology.TransactionAttempt;
 import org.apache.storm.trident.topology.state.RotatingTransactionalState;
 import org.apache.storm.trident.topology.state.TransactionalState;
+import org.apache.storm.tuple.Fields;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 public class PartitionedTridentSpoutExecutor implements ITridentSpout<Object> {
-    IPartitionedTridentSpout<Integer, ISpoutPartition, Object> _spout;
+    IPartitionedTridentSpout<Object, ISpoutPartition, Object> _spout;
     
-    public PartitionedTridentSpoutExecutor(IPartitionedTridentSpout<Integer, ISpoutPartition, Object> spout) {
+    public PartitionedTridentSpoutExecutor(IPartitionedTridentSpout<Object, ISpoutPartition, Object> spout) {
         _spout = spout;
     }
     
-    public IPartitionedTridentSpout<Integer, ISpoutPartition, Object> getPartitionedSpout() {
+    public IPartitionedTridentSpout<Object, ISpoutPartition, Object> getPartitionedSpout() {
         return _spout;
     }
     
     class Coordinator implements ITridentSpout.BatchCoordinator<Object> {
-        private IPartitionedTridentSpout.Coordinator<Integer> _coordinator;
+        private IPartitionedTridentSpout.Coordinator<Object> _coordinator;
         
         public Coordinator(Map conf, TopologyContext context) {
             _coordinator = _spout.getCoordinator(conf, context);
@@ -83,7 +84,7 @@ public class PartitionedTridentSpoutExecutor implements ITridentSpout<Object> {
     }
     
     class Emitter implements ITridentSpout.Emitter<Object> {
-        private IPartitionedTridentSpout.Emitter _emitter;
+        private IPartitionedTridentSpout.Emitter<Object, ISpoutPartition, Object> _emitter;
         private TransactionalState _state;
         private Map<String, EmitterPartitionState> _partitionStates = new HashMap<>();
         private int _index;
@@ -150,7 +151,7 @@ public class PartitionedTridentSpoutExecutor implements ITridentSpout<Object> {
     }    
 
     @Override
-    public ITridentSpout.BatchCoordinator getCoordinator(String txStateId, Map conf, TopologyContext context) {
+    public ITridentSpout.BatchCoordinator<Object> getCoordinator(String txStateId, Map conf, TopologyContext context) {
         return new Coordinator(conf, context);
     }
 


### PR DESCRIPTION
 - Generify on Object rather than Integer because example is broken
 - Fix TridentWordCount example to print more meaningful output