### PR TITLE
STORM-1911 IClusterMetricsConsumer should use seconds to timestamp unit

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -289,7 +289,7 @@
                      (.getThisWorkerPort worker-context)
                      (:component-id executor-data)
                      task-id
-                     (long (/ (System/currentTimeMillis) 1000))
+                     (long (Time/currentTimeSecs))
                      interval)
          data-points (->> name->imetric
                           (map (fn [[name imetric]]

--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -1372,7 +1372,7 @@
 
 (defn extract-cluster-metrics [^ClusterSummary summ]
   (let [cluster-summ (ui/cluster-summary summ "nimbus")]
-    {:cluster-info (IClusterMetricsConsumer$ClusterInfo. (System/currentTimeMillis))
+    {:cluster-info (IClusterMetricsConsumer$ClusterInfo. (long (/ (System/currentTimeMillis) 1000)))
      :data-points  (map
                      (fn [[k v]] (DataPoint. k v))
                      (select-keys cluster-summ ["supervisors" "topologies" "slotsTotal" "slotsUsed" "slotsFree"
@@ -1384,7 +1384,7 @@
            {:supervisor-info (IClusterMetricsConsumer$SupervisorInfo.
                                (supervisor-summ "host")
                                (supervisor-summ "id")
-                               (System/currentTimeMillis))
+                               (long (/ (System/currentTimeMillis) 1000)))
             :data-points     (map
                                (fn [[k v]] (DataPoint. k v))
                                (select-keys supervisor-summ ["slotsTotal" "slotsUsed" "totalMem" "totalCpu"

--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -1372,7 +1372,7 @@
 
 (defn extract-cluster-metrics [^ClusterSummary summ]
   (let [cluster-summ (ui/cluster-summary summ "nimbus")]
-    {:cluster-info (IClusterMetricsConsumer$ClusterInfo. (long (/ (System/currentTimeMillis) 1000)))
+    {:cluster-info (IClusterMetricsConsumer$ClusterInfo. (long (Time/currentTimeSecs)))
      :data-points  (map
                      (fn [[k v]] (DataPoint. k v))
                      (select-keys cluster-summ ["supervisors" "topologies" "slotsTotal" "slotsUsed" "slotsFree"
@@ -1384,7 +1384,7 @@
            {:supervisor-info (IClusterMetricsConsumer$SupervisorInfo.
                                (supervisor-summ "host")
                                (supervisor-summ "id")
-                               (long (/ (System/currentTimeMillis) 1000)))
+                               (long (Time/currentTimeSecs)))
             :data-points     (map
                                (fn [[k v]] (DataPoint. k v))
                                (select-keys supervisor-summ ["slotsTotal" "slotsUsed" "totalMem" "totalCpu"


### PR DESCRIPTION
* to have consistency with IMetricsConsumer

PR for 1.x: #1499 