### PR TITLE
(1.x) STORM-1911 IClusterMetricsConsumer should use seconds to timestamp unit

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -337,7 +337,7 @@
                      (.getThisWorkerPort worker-context)
                      (:component-id executor-data)
                      task-id
-                     (long (/ (System/currentTimeMillis) 1000))
+                     (long (Time/currentTimeSecs))
                      interval)
          data-points (->> name->imetric
                           (map (fn [[name imetric]]

--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -1369,7 +1369,7 @@
 
 (defn extract-cluster-metrics [^ClusterSummary summ]
   (let [cluster-summ (ui/cluster-summary summ "nimbus")]
-    {:cluster-info (IClusterMetricsConsumer$ClusterInfo. (System/currentTimeMillis))
+    {:cluster-info (IClusterMetricsConsumer$ClusterInfo. (long (/ (System/currentTimeMillis) 1000)))
      :data-points  (map
                      (fn [[k v]] (DataPoint. k v))
                      (select-keys cluster-summ ["supervisors" "topologies" "slotsTotal" "slotsUsed" "slotsFree"
@@ -1382,7 +1382,7 @@
            {:supervisor-info (IClusterMetricsConsumer$SupervisorInfo.
                                (supervisor-summ "host")
                                (supervisor-summ "id")
-                               (System/currentTimeMillis))
+                               (long (/ (System/currentTimeMillis) 1000)))
             :data-points     (map
                                (fn [[k v]] (DataPoint. k v))
                                (select-keys supervisor-summ ["slotsTotal" "slotsUsed" "totalMem" "totalCpu"

--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -58,7 +58,7 @@
   (:use [org.apache.storm.daemon common])
   (:use [org.apache.storm config])
   (:import [org.apache.zookeeper data.ACL ZooDefs$Ids ZooDefs$Perms])
-  (:import [org.apache.storm.utils VersionInfo]
+  (:import [org.apache.storm.utils VersionInfo Time]
            (org.apache.storm.metric ClusterMetricsConsumerExecutor)
            (org.apache.storm.metric.api IClusterMetricsConsumer$ClusterInfo DataPoint IClusterMetricsConsumer$SupervisorInfo)
            (org.apache.storm Config))
@@ -1369,7 +1369,7 @@
 
 (defn extract-cluster-metrics [^ClusterSummary summ]
   (let [cluster-summ (ui/cluster-summary summ "nimbus")]
-    {:cluster-info (IClusterMetricsConsumer$ClusterInfo. (long (/ (System/currentTimeMillis) 1000)))
+    {:cluster-info (IClusterMetricsConsumer$ClusterInfo. (long (Time/currentTimeSecs)))
      :data-points  (map
                      (fn [[k v]] (DataPoint. k v))
                      (select-keys cluster-summ ["supervisors" "topologies" "slotsTotal" "slotsUsed" "slotsFree"
@@ -1382,7 +1382,7 @@
            {:supervisor-info (IClusterMetricsConsumer$SupervisorInfo.
                                (supervisor-summ "host")
                                (supervisor-summ "id")
-                               (long (/ (System/currentTimeMillis) 1000)))
+                               (long (Time/currentTimeSecs)))
             :data-points     (map
                                (fn [[k v]] (DataPoint. k v))
                                (select-keys supervisor-summ ["slotsTotal" "slotsUsed" "totalMem" "totalCpu"


### PR DESCRIPTION
* to have consistency with IMetricsConsumer

PR for master: #1498