### PR TITLE
STORM-1930: Kafka New Client API - Support for Topic Wildcards

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -45,6 +45,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.EARLIEST;
 import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.LATEST;
@@ -343,7 +344,16 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
     private void subscribeKafkaConsumer() {
         kafkaConsumer = new KafkaConsumer<>(kafkaSpoutConfig.getKafkaProps(),
                 kafkaSpoutConfig.getKeyDeserializer(), kafkaSpoutConfig.getValueDeserializer());
-        kafkaConsumer.subscribe(kafkaSpoutConfig.getSubscribedTopics(), new KafkaSpoutConsumerRebalanceListener());
+
+        if (kafkaSpoutStreams instanceof KafkaSpoutStreamsNamedTopics) {
+            final List<String> topics = ((KafkaSpoutStreamsNamedTopics) kafkaSpoutStreams).getTopics();
+            kafkaConsumer.subscribe(topics, new KafkaSpoutConsumerRebalanceListener());
+            LOG.info("Kafka consumer subscribed topics {}", topics);
+        } else if (kafkaSpoutStreams instanceof KafkaSpoutStreamsWildcardTopics) {
+            final Pattern pattern = ((KafkaSpoutStreamsWildcardTopics) kafkaSpoutStreams).getTopicWildcardPattern();
+            kafkaConsumer.subscribe(pattern, new KafkaSpoutConsumerRebalanceListener());
+            LOG.info("Kafka consumer subscribed topics matching wildcard pattern [{}]", pattern);
+        }
         // Initial poll to get the consumer registration process going.
         // KafkaSpoutConsumerRebalanceListener will be called following this poll, upon partition registration
         kafkaConsumer.poll(0);
@@ -388,14 +398,28 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
             configuration = new HashMap<>();
         }
         String configKeyPrefix = "config.";
+
+        if (kafkaSpoutStreams instanceof KafkaSpoutStreamsNamedTopics) {
+            configuration.put(configKeyPrefix + "topics", getNamedTopics());
+        } else if (kafkaSpoutStreams instanceof KafkaSpoutStreamsWildcardTopics) {
+            configuration.put(configKeyPrefix + "topics", getWildCardTopics());
+        }
+
+        configuration.put(configKeyPrefix + "groupid", kafkaSpoutConfig.getConsumerGroupId());
+        configuration.put(configKeyPrefix + "bootstrap.servers", kafkaSpoutConfig.getKafkaProps().get("bootstrap.servers"));
+        return configuration;
+    }
+
+    private String getNamedTopics() {
         StringBuilder topics = new StringBuilder();
-        for (String topic: this.kafkaSpoutConfig.getSubscribedTopics()) {
+        for (String topic: kafkaSpoutConfig.getSubscribedTopics()) {
             topics.append(topic).append(",");
         }
-        configuration.put(configKeyPrefix + "topics", topics.toString());
-        configuration.put(configKeyPrefix + "groupid", this.kafkaSpoutConfig.getConsumerGroupId());
-        configuration.put(configKeyPrefix + "bootstrap.servers", this.kafkaSpoutConfig.getKafkaProps().get("bootstrap.servers"));
-        return configuration;
+        return topics.toString();
+    }
+
+    private String getWildCardTopics() {
+        return kafkaSpoutConfig.getTopicWildcardPattern().toString();
     }
 
     // ======= Offsets Commit Management ==========

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * KafkaSpoutConfig defines the required configuration to connect a consumer to a consumer group, as well as the subscribing topics
@@ -263,10 +264,23 @@ public class KafkaSpoutConfig<K, V> implements Serializable {
     }
 
     /**
-     * @return list of topics subscribed and emitting tuples to a stream as configured by {@link KafkaSpoutStream}
+     * @return list of topics subscribed and emitting tuples to a stream as configured by {@link KafkaSpoutStream},
+     * or null if this stream is associated with a wildcard pattern topic
      */
     public List<String> getSubscribedTopics() {
-        return new ArrayList<>(kafkaSpoutStreams.getTopics());
+        return kafkaSpoutStreams instanceof KafkaSpoutStreamsNamedTopics ?
+            new ArrayList<>(((KafkaSpoutStreamsNamedTopics) kafkaSpoutStreams).getTopics()) :
+            null;
+    }
+
+    /**
+     * @return the wildcard pattern topic associated with this {@link KafkaSpoutStream}, or null
+     * if this stream is associated with a specific named topic
+     */
+    public Pattern getTopicWildcardPattern() {
+        return kafkaSpoutStreams instanceof KafkaSpoutStreamsWildcardTopics ?
+                ((KafkaSpoutStreamsWildcardTopics)kafkaSpoutStreams).getTopicWildcardPattern() :
+                null;
     }
 
     public int getMaxTupleRetries() {
@@ -300,6 +314,7 @@ public class KafkaSpoutConfig<K, V> implements Serializable {
                 ", keyDeserializer=" + keyDeserializer +
                 ", valueDeserializer=" + valueDeserializer +
                 ", topics=" + getSubscribedTopics() +
+                ", topicWildcardPattern=" + getTopicWildcardPattern() +
                 ", firstPollOffsetStrategy=" + firstPollOffsetStrategy +
                 ", pollTimeoutMs=" + pollTimeoutMs +
                 ", offsetCommitPeriodMs=" + offsetCommitPeriodMs +

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStream.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStream.java
@@ -18,26 +18,35 @@
 
 package org.apache.storm.kafka.spout;
 
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Represents the stream and output fields used by a topic
  */
 public class KafkaSpoutStream implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSpoutStream.class);
+
     private final Fields outputFields;
     private final String streamId;
     private final String topic;
+    private Pattern topicWildcardPattern;
 
     /** Represents the specified outputFields and topic with the default stream */
-    KafkaSpoutStream(Fields outputFields, String topic) {
+    public KafkaSpoutStream(Fields outputFields, String topic) {
         this(outputFields, Utils.DEFAULT_STREAM_ID, topic);
     }
 
     /** Represents the specified outputFields and topic with the specified stream */
-    KafkaSpoutStream(Fields outputFields, String streamId, String topic) {
+    public KafkaSpoutStream(Fields outputFields, String streamId, String topic) {
         if (outputFields == null || streamId == null || topic == null) {
             throw new IllegalArgumentException(String.format("Constructor parameters cannot be null. " +
                     "[outputFields=%s, streamId=%s, topic=%s]", outputFields, streamId, topic));
@@ -45,18 +54,59 @@ public class KafkaSpoutStream implements Serializable {
         this.outputFields = outputFields;
         this.streamId = streamId;
         this.topic = topic;
+        this.topicWildcardPattern = null;
     }
 
-    Fields getOutputFields() {
+    /** Represents the specified outputFields and topic wild card with the default stream */
+    KafkaSpoutStream(Fields outputFields, Pattern topicWildcardPattern) {
+        this(outputFields, Utils.DEFAULT_STREAM_ID, topicWildcardPattern);
+    }
+
+    /** Represents the specified outputFields and topic wild card with the specified stream */
+    public KafkaSpoutStream(Fields outputFields, String streamId, Pattern topicWildcardPattern) {
+
+        if (outputFields == null || streamId == null || topicWildcardPattern == null) {
+            throw new IllegalArgumentException(String.format("Constructor parameters cannot be null. " +
+                    "[outputFields=%s, streamId=%s, topicWildcardPattern=%s]", outputFields, streamId, topicWildcardPattern));
+        }
+        this.outputFields = outputFields;
+        this.streamId = streamId;
+        this.topic = null;
+        this.topicWildcardPattern = topicWildcardPattern;
+    }
+
+    public void emit(SpoutOutputCollector collector, List<Object> tuple, KafkaSpoutMessageId messageId) {
+        collector.emit(streamId, tuple, messageId);
+    }
+
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        LOG.info("Declared [streamId = {}], [outputFields = {}] for [topic = {}]", streamId, outputFields, topic);
+        declarer.declareStream(streamId, outputFields);
+    }
+
+
+    public Fields getOutputFields() {
         return outputFields;
     }
 
-    String getStreamId() {
+    public String getStreamId() {
         return streamId;
     }
 
-    String getTopic() {
+    /**
+     * @return the topic associated with this {@link KafkaSpoutStream}, or null
+     * if this stream is associated with a wildcard pattern topic
+     */
+    public String getTopic() {
         return topic;
+    }
+
+    /**
+     * @return the wildcard pattern topic associated with this {@link KafkaSpoutStream}, or null
+     * if this stream is associated with a specific named topic
+     */
+    public Pattern getTopicWildcardPattern() {
+        return topicWildcardPattern;
     }
 
     @Override
@@ -65,6 +115,7 @@ public class KafkaSpoutStream implements Serializable {
                 "outputFields=" + outputFields +
                 ", streamId='" + streamId + '\'' +
                 ", topic='" + topic + '\'' +
+                ", topicWildcardPattern=" + topicWildcardPattern +
                 '}';
     }
 }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreams.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreams.java
@@ -20,139 +20,16 @@ package org.apache.storm.kafka.spout;
 
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.topology.OutputFieldsGetter;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.utils.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
- * Represents the {@link KafkaSpoutStream} associated with each topic, and provides a public API to
- * declare output streams and emmit tuples, on the appropriate stream, for all the topics specified.
+ * Represents the {@link KafkaSpoutStream} associated with each topic or topic pattern (wildcard), and provides
+ * a public API to declare output streams and emmit tuples, on the appropriate stream, for all the topics specified.
  */
-public class KafkaSpoutStreams implements Serializable {
-    protected static final Logger LOG = LoggerFactory.getLogger(KafkaSpoutStreams.class);
+public interface KafkaSpoutStreams extends Serializable {
+    void declareOutputFields(OutputFieldsDeclarer declarer);
 
-    private final Map<String, KafkaSpoutStream> topicToStream;
-
-    private KafkaSpoutStreams(Builder builder) {
-        this.topicToStream = builder.topicToStream;
-        LOG.debug("Built {}", this);
-    }
-
-    /**
-     * @param topic the topic for which to get output fields
-     * @return the declared output fields
-     */
-    public Fields getOutputFields(String topic) {
-        if (topicToStream.containsKey(topic)) {
-            final Fields outputFields = topicToStream.get(topic).getOutputFields();
-            LOG.trace("Topic [{}] has output fields [{}]", topic, outputFields);
-            return outputFields;
-        }
-        throw new IllegalStateException(this.getClass().getName() + " not configured for topic: " + topic);
-    }
-
-    /**
-     * @param topic the topic to for which to get the stream id
-     * @return the id of the stream to where the tuples are emitted
-     */
-    public String getStreamId(String topic) {
-        if (topicToStream.containsKey(topic)) {
-            final String streamId = topicToStream.get(topic).getStreamId();
-            LOG.trace("Topic [{}] emitting in stream [{}]", topic, streamId);
-            return streamId;
-        }
-        throw new IllegalStateException(this.getClass().getName() + " not configured for topic: " + topic);
-    }
-
-    /**
-     * @return list of topics subscribed and emitting tuples to a stream as configured by {@link KafkaSpoutStream}
-     */
-    public List<String> getTopics() {
-        return new ArrayList<>(topicToStream.keySet());
-    }
-
-    public void declareOutputFields(OutputFieldsDeclarer declarer) {
-        for (KafkaSpoutStream stream : topicToStream.values()) {
-            if (!((OutputFieldsGetter)declarer).getFieldsDeclaration().containsKey(stream.getStreamId())) {
-                declarer.declareStream(stream.getStreamId(), stream.getOutputFields());
-                LOG.debug("Declared " + stream);
-            }
-        }
-    }
-
-    public void emit(SpoutOutputCollector collector, List<Object> tuple, KafkaSpoutMessageId messageId) {
-        collector.emit(getStreamId(messageId.topic()), tuple, messageId);
-    }
-
-    @Override
-    public String toString() {
-        return "KafkaSpoutStreams{" +
-                "topicToStream=" + topicToStream +
-                '}';
-    }
-
-    public static class Builder {
-        private final Map<String, KafkaSpoutStream> topicToStream = new HashMap<>();;
-
-        /**
-         * Creates a {@link KafkaSpoutStream} with the given output Fields for each topic specified.
-         * All topics will have the same stream id and output fields.
-         */
-        public Builder(Fields outputFields, String... topics) {
-            addStream(outputFields, topics);
-        }
-
-        /**
-         * Creates a {@link KafkaSpoutStream} with this particular stream for each topic specified.
-         * All the topics will have the same stream id and output fields.
-         */
-        public Builder (Fields outputFields, String streamId, String... topics) {
-            addStream(outputFields, streamId, topics);
-        }
-
-        /**
-         * Adds this stream to the state representing the streams associated with each topic
-         */
-        public Builder(KafkaSpoutStream stream) {
-            addStream(stream);
-        }
-
-        /**
-         * Adds this stream to the state representing the streams associated with each topic
-         */
-        public Builder addStream(KafkaSpoutStream stream) {
-            topicToStream.put(stream.getTopic(), stream);
-            return this;
-        }
-
-        /**
-         * Please refer to javadoc in {@link #Builder(Fields, String...)}
-         */
-        public Builder addStream(Fields outputFields, String... topics) {
-            addStream(outputFields, Utils.DEFAULT_STREAM_ID, topics);
-            return this;
-        }
-
-        /**
-         * Please refer to javadoc in {@link #Builder(Fields, String, String...)}
-         */
-        public Builder addStream(Fields outputFields, String streamId, String... topics) {
-            for (String topic : topics) {
-                topicToStream.put(topic, new KafkaSpoutStream(outputFields, streamId, topic));
-            }
-            return this;
-        }
-
-        public KafkaSpoutStreams build() {
-            return new KafkaSpoutStreams(this);
-        }
-    }
+    void emit(SpoutOutputCollector collector, List<Object> tuple, KafkaSpoutMessageId messageId);
 }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsNamedTopics.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsNamedTopics.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout;
+
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.OutputFieldsGetter;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents the {@link KafkaSpoutStream} associated with each topic, and provides a public API to
+ * declare output streams and emmit tuples, on the appropriate stream, for all the topics specified.
+ */
+public class KafkaSpoutStreamsNamedTopics implements KafkaSpoutStreams {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSpoutStreamsNamedTopics.class);
+
+    private final Map<String, KafkaSpoutStream> topicToStream;
+
+    private KafkaSpoutStreamsNamedTopics(Builder builder) {
+        this.topicToStream = builder.topicToStream;
+        LOG.debug("Built {}", this);
+    }
+
+    /**
+     * @param topic the topic for which to get output fields
+     * @return the declared output fields
+     */
+    public Fields getOutputFields(String topic) {
+        if (topicToStream.containsKey(topic)) {
+            final Fields outputFields = topicToStream.get(topic).getOutputFields();
+            LOG.trace("Topic [{}] has output fields [{}]", topic, outputFields);
+            return outputFields;
+        }
+        throw new IllegalStateException(this.getClass().getName() + " not configured for topic: " + topic);
+    }
+
+    /**
+     * @param topic the topic to for which to get the stream id
+     * @return the id of the stream to where the tuples are emitted
+     */
+    public KafkaSpoutStream getStream(String topic) {
+        if (topicToStream.containsKey(topic)) {
+            return topicToStream.get(topic);
+        }
+        throw new IllegalStateException(this.getClass().getName() + " not configured for topic: " + topic);
+    }
+
+    /**
+     * @return list of topics subscribed and emitting tuples to a stream as configured by {@link KafkaSpoutStream}
+     */
+    public List<String> getTopics() {
+        return new ArrayList<>(topicToStream.keySet());
+    }
+
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        for (KafkaSpoutStream stream : topicToStream.values()) {
+            if (!((OutputFieldsGetter)declarer).getFieldsDeclaration().containsKey(stream.getStreamId())) {
+                stream.declareOutputFields(declarer);
+            }
+        }
+    }
+
+    public void emit(SpoutOutputCollector collector, List<Object> tuple, KafkaSpoutMessageId messageId) {
+        getStream(messageId.topic()).emit(collector, tuple, messageId);
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaSpoutStreamsNamedTopics{" +
+                "topicToStream=" + topicToStream +
+                '}';
+    }
+
+    public static class Builder {
+        private final Map<String, KafkaSpoutStream> topicToStream = new HashMap<>();;
+
+        /**
+         * Creates a {@link KafkaSpoutStream} with the given output Fields for each topic specified.
+         * All topics will have the default stream id and the same output fields.
+         */
+        public Builder(Fields outputFields, String... topics) {
+            addStream(outputFields, topics);
+        }
+
+        /**
+         * Creates a {@link KafkaSpoutStream} with this particular stream for each topic specified.
+         * All the topics will have the specified stream id and the same output fields.
+         */
+        public Builder (Fields outputFields, String streamId, String... topics) {
+            addStream(outputFields, streamId, topics);
+        }
+
+        /**
+         * Adds this stream to the state representing the streams associated with each topic
+         */
+        public Builder(KafkaSpoutStream stream) {
+            addStream(stream);
+        }
+
+        /**
+         * Adds this stream to the state representing the streams associated with each topic
+         */
+        public Builder addStream(KafkaSpoutStream stream) {
+            topicToStream.put(stream.getTopic(), stream);
+            return this;
+        }
+
+        /**
+         * Please refer to javadoc in {@link #Builder(Fields, String...)}
+         */
+        public Builder addStream(Fields outputFields, String... topics) {
+            addStream(outputFields, Utils.DEFAULT_STREAM_ID, topics);
+            return this;
+        }
+
+        /**
+         * Please refer to javadoc in {@link #Builder(Fields, String, String...)}
+         */
+        public Builder addStream(Fields outputFields, String streamId, String... topics) {
+            for (String topic : topics) {
+                topicToStream.put(topic, new KafkaSpoutStream(outputFields, streamId, topic));
+            }
+            return this;
+        }
+
+        public KafkaSpoutStreamsNamedTopics build() {
+            return new KafkaSpoutStreamsNamedTopics(this);
+        }
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsWildcardTopics.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsWildcardTopics.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout;
+
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class KafkaSpoutStreamsWildcardTopics implements KafkaSpoutStreams {
+    private KafkaSpoutStream kafkaSpoutStream;
+
+    public KafkaSpoutStreamsWildcardTopics(KafkaSpoutStream kafkaSpoutStream) {
+        this.kafkaSpoutStream = kafkaSpoutStream;
+        if (kafkaSpoutStream.getTopicWildcardPattern() == null) {
+            throw new IllegalStateException("KafkaSpoutStream must be configured for wildcard topic");
+        }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        kafkaSpoutStream.declareOutputFields(declarer);
+    }
+
+    @Override
+    public void emit(SpoutOutputCollector collector, List<Object> tuple, KafkaSpoutMessageId messageId) {
+        kafkaSpoutStream.emit(collector, tuple, messageId);
+    }
+
+    public KafkaSpoutStream getStream() {
+        return kafkaSpoutStream;
+    }
+
+    public Pattern getTopicWildcardPattern() {
+        return kafkaSpoutStream.getTopicWildcardPattern();
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaSpoutStreamsWildcardTopics{" +
+                "kafkaSpoutStream=" + kafkaSpoutStream +
+                '}';
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutTuplesBuilderNamedTopics.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutTuplesBuilderNamedTopics.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KafkaSpoutTuplesBuilderNamedTopics<K,V> implements KafkaSpoutTuplesBuilder<K,V> {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSpoutTuplesBuilderNamedTopics.class);
+
+    private Map<String, KafkaSpoutTupleBuilder<K, V>> topicToTupleBuilders;
+
+    private KafkaSpoutTuplesBuilderNamedTopics(Builder<K,V> builder) {
+        this.topicToTupleBuilders = builder.topicToTupleBuilders;
+        LOG.debug("Instantiated {}", this);
+    }
+
+    public static class Builder<K,V> {
+        private List<KafkaSpoutTupleBuilder<K, V>> tupleBuilders;
+        private Map<String, KafkaSpoutTupleBuilder<K, V>> topicToTupleBuilders;
+
+        @SafeVarargs
+        public Builder(KafkaSpoutTupleBuilder<K,V>... tupleBuilders) {
+            if (tupleBuilders == null || tupleBuilders.length == 0) {
+                throw new IllegalArgumentException("Must specify at last one tuple builder per topic declared in KafkaSpoutStreams");
+            }
+
+            this.tupleBuilders = Arrays.asList(tupleBuilders);
+            topicToTupleBuilders = new HashMap<>();
+        }
+
+        public KafkaSpoutTuplesBuilderNamedTopics<K,V> build() {
+            for (KafkaSpoutTupleBuilder<K, V> tupleBuilder : tupleBuilders) {
+                for (String topic : tupleBuilder.getTopics()) {
+                    if (!topicToTupleBuilders.containsKey(topic)) {
+                        topicToTupleBuilders.put(topic, tupleBuilder);
+                    }
+                }
+            }
+            return new KafkaSpoutTuplesBuilderNamedTopics<>(this);
+        }
+    }
+
+    public List<Object>buildTuple(ConsumerRecord<K,V> consumerRecord) {
+        final String topic = consumerRecord.topic();
+        return topicToTupleBuilders.get(topic).buildTuple(consumerRecord);
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaSpoutTuplesBuilderNamedTopics {" +
+                "topicToTupleBuilders=" + topicToTupleBuilders +
+                '}';
+    }
+
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutTuplesBuilderWildcardTopics.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutTuplesBuilderWildcardTopics.java
@@ -20,13 +20,17 @@ package org.apache.storm.kafka.spout;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import java.io.Serializable;
 import java.util.List;
 
-/**
- * {@link KafkaSpoutTuplesBuilder} wraps all the logic that builds tuples from {@link ConsumerRecord}s.
- * The logic is provided by the user by implementing the appropriate number of {@link KafkaSpoutTupleBuilder} instances
- */
-public interface KafkaSpoutTuplesBuilder<K,V> extends Serializable {
-    List<Object> buildTuple(ConsumerRecord<K, V> consumerRecord);
+public class KafkaSpoutTuplesBuilderWildcardTopics<K,V> implements KafkaSpoutTuplesBuilder<K,V> {
+    private KafkaSpoutTupleBuilder<K, V> tupleBuilder;
+
+    public KafkaSpoutTuplesBuilderWildcardTopics(KafkaSpoutTupleBuilder<K, V> tupleBuilder) {
+        this.tupleBuilder = tupleBuilder;
+    }
+
+    @Override
+    public List<Object> buildTuple(ConsumerRecord<K, V> consumerRecord) {
+        return tupleBuilder.buildTuple(consumerRecord);
+    }
 }

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainWildcardTopics.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainWildcardTopics.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.test;
+
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.kafka.spout.KafkaSpout;
+import org.apache.storm.kafka.spout.KafkaSpoutStream;
+import org.apache.storm.kafka.spout.KafkaSpoutStreams;
+import org.apache.storm.kafka.spout.KafkaSpoutStreamsWildcardTopics;
+import org.apache.storm.kafka.spout.KafkaSpoutTupleBuilder;
+import org.apache.storm.kafka.spout.KafkaSpoutTuplesBuilder;
+import org.apache.storm.kafka.spout.KafkaSpoutTuplesBuilderWildcardTopics;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.tuple.Fields;
+
+import java.util.regex.Pattern;
+
+public class KafkaSpoutTopologyMainWildcardTopics extends KafkaSpoutTopologyMainNamedTopics {
+    private static final String STREAM = "test_wildcard_stream";
+    private static final String TOPIC_WILDCARD_PATTERN = "test[1|2]";
+
+    public static void main(String[] args) throws Exception {
+        new KafkaSpoutTopologyMainWildcardTopics().runMain(args);
+    }
+
+    protected StormTopology getTopolgyKafkaSpout() {
+        final TopologyBuilder tp = new TopologyBuilder();
+        tp.setSpout("kafka_spout", new KafkaSpout<>(getKafkaSpoutConfig(getKafkaSpoutStreams())), 1);
+        tp.setBolt("kafka_bolt", new KafkaSpoutTestBolt()).shuffleGrouping("kafka_spout", STREAM);
+        return tp.createTopology();
+    }
+
+    protected KafkaSpoutTuplesBuilder<String, String> getTuplesBuilder() {
+        return new KafkaSpoutTuplesBuilderWildcardTopics<>(getTupleBuilder());
+    }
+
+    protected KafkaSpoutTupleBuilder<String, String> getTupleBuilder() {
+        return new TopicsTest0Test1TupleBuilder<>(TOPIC_WILDCARD_PATTERN);
+    }
+
+    protected KafkaSpoutStreams getKafkaSpoutStreams() {
+        final Fields outputFields = new Fields("topic", "partition", "offset", "key", "value");
+        final KafkaSpoutStream kafkaSpoutStream = new KafkaSpoutStream(outputFields, STREAM, Pattern.compile(TOPIC_WILDCARD_PATTERN));
+        return new KafkaSpoutStreamsWildcardTopics(kafkaSpoutStream);
+    }
+}


### PR DESCRIPTION
 - Interfaces for TuplesBuilder and KafkaSpoutStreams and implementations for named topics and wildcards
 - Test topologies for named topics and wildcards