### PR TITLE
[STORM-1927] Upgrade Jetty and Ring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,9 +221,9 @@
         <clj-time.version>0.8.0</clj-time.version>
         <curator.version>2.10.0</curator.version>
         <json-simple.version>1.1</json-simple.version>
-        <ring.version>1.3.0</ring.version>
-        <ring-json.version>0.3.1</ring-json.version>
-        <jetty.version>7.6.13.v20130916</jetty.version>
+        <ring.version>1.5.0</ring.version>
+        <ring-json.version>0.4.0</ring-json.version>
+        <jetty.version>9.3.10.v20160621</jetty.version>
         <clojure.tools.logging.version>0.2.3</clojure.tools.logging.version>
         <clojure.math.numeric-tower.version>0.0.1</clojure.math.numeric-tower.version>
         <carbonite.version>1.5.0</carbonite.version>


### PR DESCRIPTION
[STORM-1927](https://issues.apache.org/jira/browse/STORM-1927)

Jetty 7 is EOL , upgrade to Jetty 9 & Ring could also support it.
