### PR TITLE
STORM-1742 More accurate 'complete latency'

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -492,11 +492,12 @@
                                    (when pending-for-id
                                      (.put pending id pending-for-id))) 
                               (let [id (.getValue tuple 0)
+                                    time-delta-ms (.getValue tuple 1)
                                     [stored-task-id spout-id tuple-finished-info start-time-ms] (.remove pending id)]
                                 (when spout-id
                                   (when-not (= stored-task-id task-id)
                                     (throw (RuntimeException. (str "Fatal error, mismatched task ids: " task-id " " stored-task-id))))
-                                  (let [time-delta (if start-time-ms (Time/deltaMs start-time-ms))]
+                                  (let [time-delta (if start-time-ms time-delta-ms)]
                                     (condp = stream-id
                                       Acker/ACKER_ACK_STREAM_ID (ack-spout-msg executor-data (get task-datas task-id)
                                                                                spout-id tuple-finished-info time-delta id)

--- a/storm-core/src/jvm/org/apache/storm/daemon/StormCommon.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/StormCommon.java
@@ -275,9 +275,9 @@ public class StormCommon {
         Map<GlobalStreamId, Grouping> inputs = ackerInputs(topology);
 
         Map<String, StreamInfo> outputStreams = new HashMap<String, StreamInfo>();
-        outputStreams.put(Acker.ACKER_ACK_STREAM_ID, Thrift.directOutputFields(Arrays.asList("id")));
-        outputStreams.put(Acker.ACKER_FAIL_STREAM_ID, Thrift.directOutputFields(Arrays.asList("id")));
-        outputStreams.put(Acker.ACKER_RESET_TIMEOUT_STREAM_ID, Thrift.directOutputFields(Arrays.asList("id")));
+        outputStreams.put(Acker.ACKER_ACK_STREAM_ID, Thrift.directOutputFields(Arrays.asList("id", "time-delta-ms")));
+        outputStreams.put(Acker.ACKER_FAIL_STREAM_ID, Thrift.directOutputFields(Arrays.asList("id", "time-delta-ms")));
+        outputStreams.put(Acker.ACKER_RESET_TIMEOUT_STREAM_ID, Thrift.directOutputFields(Arrays.asList("id", "time-delta-ms")));
 
         Map<String, Object> ackerConf = new HashMap<String, Object>();
         ackerConf.put(Config.TOPOLOGY_TASKS, ackerNum);


### PR DESCRIPTION
PR for 1.x: #1379 

* Acker computes 'complete latency' and sends back to Spout
  * start time: Acker receiving ACK_INIT from Spout
  * end time: Acker receiving ACK message which make the tuple tree completed
* When Acker provides complete latency, Spout just uses this value to record that latency
  * exception case: tuple timed out - Spout doesn't receive failed information from Acker

#1379 contains the result of functional test and performance test. Please refer that pull request.