### PR TITLE
STORM-1934 Fix race condition between sync-supervisor and sync-processes (1.x)

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
@@ -388,71 +388,11 @@
                 (get-worker-assignment-helper-msg assignment supervisor port id))
               nil)))))))
 
-(defn sync-processes [supervisor]
-  (let [conf (:conf supervisor)
-        ^LocalState local-state (:local-state supervisor)
-        storm-cluster-state (:storm-cluster-state supervisor)
-        assigned-executors (defaulted (ls-local-assignments local-state) {})
-        now (current-time-secs)
-        allocated (read-allocated-workers supervisor assigned-executors now)
-        keepers (filter-val
-                 (fn [[state _]] (= state :valid))
-                 allocated)
-        keep-ports (set (for [[id [_ hb]] keepers] (:port hb)))
-        reassign-executors (select-keys-pred (complement keep-ports) assigned-executors)
-        new-worker-ids (into
-                        {}
-                        (for [port (keys reassign-executors)]
-                          [port (uuid)]))]
-    ;; 1. to kill are those in allocated that are dead or disallowed
-    ;; 2. kill the ones that should be dead
-    ;;     - read pids, kill -9 and individually remove file
-    ;;     - rmr heartbeat dir, rmdir pid dir, rmdir id dir (catch exception and log)
-    ;; 3. of the rest, figure out what assignments aren't yet satisfied
-    ;; 4. generate new worker ids, write new "approved workers" to LS
-    ;; 5. create local dir for worker id
-    ;; 5. launch new workers (give worker-id, port, and supervisor-id)
-    ;; 6. wait for workers launch
-
-    (log-debug "Syncing processes")
-    (log-debug "Assigned executors: " assigned-executors)
-    (log-debug "Allocated: " allocated)
-    (doseq [[id [state heartbeat]] allocated]
-      (when (not= :valid state)
-        (log-message
-         "Shutting down and clearing state for id " id
-         ". Current supervisor time: " now
-         ". State: " state
-         ", Heartbeat: " (pr-str heartbeat))
-        (shutdown-worker supervisor id)))
-    (let [valid-new-worker-ids (get-valid-new-worker-ids conf supervisor reassign-executors new-worker-ids)]
-      (ls-approved-workers! local-state
-                        (merge
-                          (select-keys (ls-approved-workers local-state)
-                            (keys keepers))
-                          valid-new-worker-ids))
-      (wait-for-workers-launch conf (keys valid-new-worker-ids)))))
-
 (defn assigned-storm-ids-from-port-assignments [assignment]
   (->> assignment
        vals
        (map :storm-id)
        set))
-
-(defn shutdown-disallowed-workers [supervisor]
-  (let [conf (:conf supervisor)
-        ^LocalState local-state (:local-state supervisor)
-        assigned-executors (defaulted (ls-local-assignments local-state) {})
-        now (current-time-secs)
-        allocated (read-allocated-workers supervisor assigned-executors now)
-        disallowed (keys (filter-val
-                                  (fn [[state _]] (= state :disallowed))
-                                  allocated))]
-    (log-debug "Allocated workers " allocated)
-    (log-debug "Disallowed workers " disallowed)
-    (doseq [id disallowed]
-      (shutdown-worker supervisor id))
-    ))
 
 (defn get-blob-localname
   "Given the blob information either gets the localname field if it exists,
@@ -525,15 +465,60 @@
           (rm-topo-files conf storm-id localizer false)
           storm-id)))))
 
-(defn kill-existing-workers-with-change-in-components [supervisor existing-assignment new-assignment]
-  (let [assigned-executors (or (ls-local-assignments (:local-state supervisor)) {})
-        allocated (read-allocated-workers supervisor assigned-executors (Time/currentTimeSecs))
-        valid-allocated (filter-val (fn [[state _]] (= state :valid)) allocated)
-        port->worker-id (clojure.set/map-invert (map-val #((nth % 1) :port) valid-allocated))]
-    (doseq [p (set/intersection (set (keys existing-assignment))
-                                (set (keys new-assignment)))]
-      (if (not= (set (:executors (existing-assignment p))) (set (:executors (new-assignment p))))
-        (shutdown-worker supervisor (port->worker-id p))))))
+(defn sync-processes [supervisor]
+  (let [conf (:conf supervisor)
+        ^LocalState local-state (:local-state supervisor)
+        assigned-executors (defaulted (ls-local-assignments local-state) {})
+        assigned-storm-ids (assigned-storm-ids-from-port-assignments assigned-executors)
+        localizer (:localizer supervisor)
+        now (current-time-secs)
+        allocated (read-allocated-workers supervisor assigned-executors now)
+        keepers (filter-val
+                  (fn [[state _]] (= state :valid))
+                  allocated)
+        keep-ports (set (for [[id [_ hb]] keepers] (:port hb)))
+        reassign-executors (select-keys-pred (complement keep-ports) assigned-executors)
+        new-worker-ids (into
+                         {}
+                         (for [port (keys reassign-executors)]
+                           [port (uuid)]))
+        all-downloaded-storm-ids (set (read-downloaded-storm-ids conf))]
+    ;; 1. to kill are those in allocated that are dead or disallowed
+    ;; 2. kill the ones that should be dead
+    ;;     - read pids, kill -9 and individually remove file
+    ;;     - rmr heartbeat dir, rmdir pid dir, rmdir id dir (catch exception and log)
+    ;; 3. remove any downloaded code that's no longer assigned to this supervisor
+    ;; 4. of the rest, figure out what assignments aren't yet satisfied
+    ;; 5. generate new worker ids, write new "approved workers" to LS
+    ;; 6. create local dir for worker id
+    ;; 7. launch new workers (give worker-id, port, and supervisor-id)
+    ;; 8. wait for workers launch
+
+    (log-debug "Syncing processes")
+    (log-debug "Assigned executors: " assigned-executors)
+    (log-debug "Allocated: " allocated)
+    (doseq [[id [state heartbeat]] allocated]
+      (when (not= :valid state)
+        (log-message
+          "Shutting down and clearing state for id " id
+          ". Current supervisor time: " now
+          ". State: " state
+          ", Heartbeat: " (pr-str heartbeat))
+        (shutdown-worker supervisor id)))
+
+    (doseq [storm-id all-downloaded-storm-ids]
+      (when-not (assigned-storm-ids storm-id)
+        (log-message "Removing code for storm id "
+                     storm-id)
+        (rm-topo-files conf storm-id localizer true)))
+
+    (let [valid-new-worker-ids (get-valid-new-worker-ids conf supervisor reassign-executors new-worker-ids)]
+      (ls-approved-workers! local-state
+                            (merge
+                              (select-keys (ls-approved-workers local-state)
+                                           (keys keepers))
+                              valid-new-worker-ids))
+      (wait-for-workers-launch conf (keys valid-new-worker-ids)))))
 
 (defn mk-synchronize-supervisor [supervisor sync-processes event-manager processes-event-manager]
   (fn this []
@@ -592,24 +577,13 @@
       (doseq [p (set/difference (set (keys existing-assignment))
                                 (set (keys new-assignment)))]
         (.killedWorker isupervisor (int p)))
-      (kill-existing-workers-with-change-in-components supervisor existing-assignment new-assignment)
       (.assigned isupervisor (keys new-assignment))
       (ls-local-assignments! local-state
             new-assignment)
       (reset! (:assignment-versions supervisor) versions)
       (reset! (:stormid->profiler-actions supervisor) storm-id->profiler-actions)
-
       (reset! (:curr-assignment supervisor) new-assignment)
-      ;; remove any downloaded code that's no longer assigned or active
-      ;; important that this happens after setting the local assignment so that
-      ;; synchronize-supervisor doesn't try to launch workers for which the
-      ;; resources don't exist
-      (if on-windows? (shutdown-disallowed-workers supervisor))
-      (doseq [storm-id all-downloaded-storm-ids]
-        (when-not (storm-code-map storm-id)
-          (log-message "Removing code for storm id "
-                       storm-id)
-          (rm-topo-files conf storm-id localizer true)))
+
       (.add processes-event-manager sync-processes))))
 
 (defn mk-supervisor-capacities
@@ -724,9 +698,7 @@
             storm-home (System/getProperty "storm.home")
             profile-cmd (str (clojure.java.io/file storm-home
                                                    "bin"
-                                                   (conf WORKER-PROFILER-COMMAND)))
-            new-assignment @(:curr-assignment supervisor)
-            assigned-storm-ids (assigned-storm-ids-from-port-assignments new-assignment)]
+                                                   (conf WORKER-PROFILER-COMMAND)))]
         (doseq [[storm-id profiler-actions] stormid->profiler-actions]
           (when (not (empty? profiler-actions))
             (doseq [pro-action profiler-actions]

--- a/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/supervisor.clj
@@ -44,6 +44,9 @@
   (:gen-class
     :methods [^{:static true} [launch [org.apache.storm.scheduler.ISupervisor] void]]))
 
+; declare to avoid triggering forward reference issue
+(declare rm-topo-files assigned-storm-ids-from-port-assignments)
+
 (defmeter supervisor:num-workers-launched)
 
 (defmulti download-storm-code cluster-mode)
@@ -388,6 +391,63 @@
                 (get-worker-assignment-helper-msg assignment supervisor port id))
               nil)))))))
 
+(defn sync-processes [supervisor]
+  (let [conf (:conf supervisor)
+        ^LocalState local-state (:local-state supervisor)
+        assigned-executors (defaulted (ls-local-assignments local-state) {})
+        assigned-storm-ids (assigned-storm-ids-from-port-assignments assigned-executors)
+        localizer (:localizer supervisor)
+        now (current-time-secs)
+        allocated (read-allocated-workers supervisor assigned-executors now)
+        keepers (filter-val
+                 (fn [[state _]] (= state :valid))
+                 allocated)
+        keep-ports (set (for [[id [_ hb]] keepers] (:port hb)))
+        reassign-executors (select-keys-pred (complement keep-ports) assigned-executors)
+        new-worker-ids (into
+                        {}
+                        (for [port (keys reassign-executors)]
+                          [port (uuid)]))
+        all-downloaded-storm-ids (set (read-downloaded-storm-ids conf))]
+    ;; 1. to kill are those in allocated that are dead or disallowed
+    ;; 2. kill the ones that should be dead
+    ;;     - read pids, kill -9 and individually remove file
+    ;;     - rmr heartbeat dir, rmdir pid dir, rmdir id dir (catch exception and log)
+    ;; 3. remove any downloaded code that's no longer assigned to this supervisor
+    ;; 4. of the rest, figure out what assignments aren't yet satisfied
+    ;; 5. generate new worker ids, write new "approved workers" to LS
+    ;; 6. create local dir for worker id
+    ;; 7. launch new workers (give worker-id, port, and supervisor-id)
+    ;; 8. wait for workers launch
+    ;; Note: sync-processes runs based on local assignment, and avoid reading zk assignment.
+    ;; It's due to race condition between sync-supervisor and sync-processes.
+
+    (log-debug "Syncing processes")
+    (log-debug "Assigned executors: " assigned-executors)
+    (log-debug "Allocated: " allocated)
+    (doseq [[id [state heartbeat]] allocated]
+      (when (not= :valid state)
+        (log-message
+         "Shutting down and clearing state for id " id
+         ". Current supervisor time: " now
+         ". State: " state
+         ", Heartbeat: " (pr-str heartbeat))
+        (shutdown-worker supervisor id)))
+
+    (doseq [storm-id all-downloaded-storm-ids]
+      (when-not (assigned-storm-ids storm-id)
+        (log-message "Removing code for storm id "
+                     storm-id)
+        (rm-topo-files conf storm-id localizer true)))
+
+    (let [valid-new-worker-ids (get-valid-new-worker-ids conf supervisor reassign-executors new-worker-ids)]
+      (ls-approved-workers! local-state
+                        (merge
+                          (select-keys (ls-approved-workers local-state)
+                            (keys keepers))
+                          valid-new-worker-ids))
+      (wait-for-workers-launch conf (keys valid-new-worker-ids)))))
+
 (defn assigned-storm-ids-from-port-assignments [assignment]
   (->> assignment
        vals
@@ -464,63 +524,6 @@
           (log-debug "Files not present in topology directory")
           (rm-topo-files conf storm-id localizer false)
           storm-id)))))
-
-(defn sync-processes [supervisor]
-  (let [conf (:conf supervisor)
-        ^LocalState local-state (:local-state supervisor)
-        assigned-executors (defaulted (ls-local-assignments local-state) {})
-        assigned-storm-ids (assigned-storm-ids-from-port-assignments assigned-executors)
-        localizer (:localizer supervisor)
-        now (current-time-secs)
-        allocated (read-allocated-workers supervisor assigned-executors now)
-        keepers (filter-val
-                  (fn [[state _]] (= state :valid))
-                  allocated)
-        keep-ports (set (for [[id [_ hb]] keepers] (:port hb)))
-        reassign-executors (select-keys-pred (complement keep-ports) assigned-executors)
-        new-worker-ids (into
-                         {}
-                         (for [port (keys reassign-executors)]
-                           [port (uuid)]))
-        all-downloaded-storm-ids (set (read-downloaded-storm-ids conf))]
-    ;; 1. to kill are those in allocated that are dead or disallowed
-    ;; 2. kill the ones that should be dead
-    ;;     - read pids, kill -9 and individually remove file
-    ;;     - rmr heartbeat dir, rmdir pid dir, rmdir id dir (catch exception and log)
-    ;; 3. remove any downloaded code that's no longer assigned to this supervisor
-    ;; 4. of the rest, figure out what assignments aren't yet satisfied
-    ;; 5. generate new worker ids, write new "approved workers" to LS
-    ;; 6. create local dir for worker id
-    ;; 7. launch new workers (give worker-id, port, and supervisor-id)
-    ;; 8. wait for workers launch
-    ;; Note: sync-processes runs based on local assignment, and avoid reading zk assignment.
-    ;; It's due to race condition between sync-supervisor and sync-processes.
-
-    (log-debug "Syncing processes")
-    (log-debug "Assigned executors: " assigned-executors)
-    (log-debug "Allocated: " allocated)
-    (doseq [[id [state heartbeat]] allocated]
-      (when (not= :valid state)
-        (log-message
-          "Shutting down and clearing state for id " id
-          ". Current supervisor time: " now
-          ". State: " state
-          ", Heartbeat: " (pr-str heartbeat))
-        (shutdown-worker supervisor id)))
-
-    (doseq [storm-id all-downloaded-storm-ids]
-      (when-not (assigned-storm-ids storm-id)
-        (log-message "Removing code for storm id "
-                     storm-id)
-        (rm-topo-files conf storm-id localizer true)))
-
-    (let [valid-new-worker-ids (get-valid-new-worker-ids conf supervisor reassign-executors new-worker-ids)]
-      (ls-approved-workers! local-state
-                            (merge
-                              (select-keys (ls-approved-workers local-state)
-                                           (keys keepers))
-                              valid-new-worker-ids))
-      (wait-for-workers-launch conf (keys valid-new-worker-ids)))))
 
 (defn mk-synchronize-supervisor [supervisor sync-processes event-manager processes-event-manager]
   (fn this []


### PR DESCRIPTION
Please refer [STORM-1933](https://issues.apache.org/jira/browse/STORM-1933) and [STORM-1934](https://issues.apache.org/jira/browse/STORM-1934) to see reason of this issue and concept to fix.

* sync-supervisor just downloads new topology code and writes new local assignment
  * shutting down workers and removing topology code is moved to sync-processes
* sync-processes does all of jobs based on local assignment and allocated workers
* remove unused / unneeded codes

PR for master: #1529 

Here's my test result for this patch:

* `mvn clean install` 5 times: not met supervisor intermittent failure (STORM-1933)
  * will try more times
* kill worker via `kill`, `kill -9`, `restart worker` from UI: no issue on restarting worker
* rebalance topology to change workers (3 -> 2): to test that new assignment has same worker port but different executors compared to assigned workers
  * worker is recognized as :disallowed, and killed & relaunched

Rebalance test in details:

- Writing new assignment
```
6701 {:storm-id "test-topology2-4-1467185073", :executors ([7 7] [5 5] [3 3] [1 1]), :resources [0.0 0.0 0.0]}, 
6702 {:storm-id "test-topology2-4-1467185073", :executors ([6 6] [4 4] [2 2]), :resources [0.0 0.0 0.0]}
```

- Assigned executors:
```
6701 {:storm-id "test-topology2-4-1467185073", :executors [[7 7] [5 5] [3 3] [1 1]], :resources #object[org.apache.storm.generated.WorkerResources 0x40c4d31c "WorkerResources(mem_on_heap:0.0, mem_off_heap:0.0, cpu:0.0)"]}, 
6702 {:storm-id "test-topology2-4-1467185073", :executors [[6 6] [4 4] [2 2]], :resources #object[org.apache.storm.generated.WorkerResources 0x4ba861f4 "WorkerResources(mem_on_heap:0.0, mem_off_heap:0.0, cpu:0.0)"]}}
```

- Allocated:
```
"2e9bea10-02b7-4e55-88e7-b194b9917a63" [:disallowed {:time-secs 1467185407, :storm-id "test-topology2-4-1467185073", :executors [[3 3] [6 6] [-1 -1]], :port 6703}], 
"4630c4bf-9786-47ff-9f3b-6b42d9781b9d" [:disallowed {:time-secs 1467185407, :storm-id "test-topology2-4-1467185073", :executors [[7 7] [1 1] [-1 -1] [4 4]], :port 6701}], 
"b9a622d2-5e5b-4311-999c-8c8dd92da6b6" [:disallowed {:time-secs 1467185406, :storm-id "test-topology2-4-1467185073", :executors [[2 2] [-1 -1] [5 5]], :port 6702}]}
```

NOTE: Due to forward reference, I have to move `sync-processes` to just before `mk-synchronize-supervisor`. Major changes are done in sync-processes so reviewers need to compare before & after manually. Sorry about that.

Since supervisor.clj is already ported to Java in master branch, I should have time to read ported code, and modify to be in sync.

Please review and comment while I'm working against master branch. Thanks!