### PR TITLE
STORM-1937 Fix WindowTridentProcessor cause NullPointerException

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/trident/windowing/WindowTridentProcessor.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/windowing/WindowTridentProcessor.java
@@ -163,9 +163,8 @@ public class WindowTridentProcessor implements TridentProcessor {
         Iterable<Object> triggerValues = null;
 
         if (retriedAttempt(batchId)) {
-            Object triggerIds = windowStore.get(inprocessTriggerKey(batchTxnId));
-            if (triggerIds != null) {
-                pendingTriggerIds = (List<Integer>) triggerIds;
+            pendingTriggerIds = (List<Integer>) windowStore.get(inprocessTriggerKey(batchTxnId));
+            if (pendingTriggerIds != null){
                 for (Integer pendingTriggerId : pendingTriggerIds) {
                     triggerKeys.add(triggerKey(pendingTriggerId));
                 }

--- a/storm-core/src/jvm/org/apache/storm/trident/windowing/WindowTridentProcessor.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/windowing/WindowTridentProcessor.java
@@ -164,7 +164,7 @@ public class WindowTridentProcessor implements TridentProcessor {
 
         if (retriedAttempt(batchId)) {
             pendingTriggerIds = (List<Integer>) windowStore.get(inprocessTriggerKey(batchTxnId));
-            if (pendingTriggerIds != null){
+            if (pendingTriggerIds != null) {
                 for (Integer pendingTriggerId : pendingTriggerIds) {
                     triggerKeys.add(triggerKey(pendingTriggerId));
                 }


### PR DESCRIPTION
I'm working with trident and try to use windowing  support, under the local model is fine, but in distributed mode we got the NullPointerException; This fixed the error in WindowTridentProcessor.java
