### PR TITLE
STORM-1941 Nimbus discovery can fail when zookeeper reconnect happens. (1.x)

### DIFF
--- a/storm-core/src/clj/org/apache/storm/cluster.clj
+++ b/storm-core/src/clj/org/apache/storm/cluster.clj
@@ -334,6 +334,8 @@
                           (if (.equals newState ConnectionState/RECONNECTED)
                             (do
                               (log-message "Connection state has changed to reconnected so setting nimbuses entry one more time")
+                              ;explicit delete for ephmeral node to ensure this session creates the entry.
+                              (.delete_node cluster-state (nimbus-path nimbus-id))
                               (.set_ephemeral_node cluster-state (nimbus-path nimbus-id) (Utils/serialize nimbus-summary) acls))))))
         
         (.set_ephemeral_node cluster-state (nimbus-path nimbus-id) (Utils/serialize nimbus-summary) acls))


### PR DESCRIPTION
PR for master: #1535 

* delete ephemeral node first when reconnected handler is called

This also deletes node if session is alive but reconnected.
If we really need to avoid deleting node, we could check ephemeral owner before deleting. Zookeeper reconnect is not happening so often, so I guess it's fine to not applying. If you think we should, please let me know.

Btw, blobstore also uses ephemeral nodes so I'm curious they should be recreated too.