### PR TITLE
STORM-1941 Nimbus discovery can fail when zookeeper reconnect happens.

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
+++ b/storm-core/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
@@ -219,6 +219,8 @@ public class StormClusterStateImpl implements IStormClusterState {
                 LOG.info("Connection state listener invoked, zookeeper connection state has changed to {}", connectionState);
                 if (connectionState.equals(ConnectionState.RECONNECTED)) {
                     LOG.info("Connection state has changed to reconnected so setting nimbuses entry one more time");
+                    // explicit delete for ephmeral node to ensure this session creates the entry.
+                    stateStorage.delete_node(ClusterUtils.nimbusPath(nimbusId));
                     stateStorage.set_ephemeral_node(ClusterUtils.nimbusPath(nimbusId), Utils.serialize(nimbusSummary), acls);
                 }
 


### PR DESCRIPTION
* delete ephemeral node first when reconnected handler is called

PR for 1.x: #1534

Please read [STORM-1941](https://issues.apache.org/jira/browse/STORM-1941) before reviewing. I left full description from there.