### PR TITLE
Sending the Data to Kafka as a batch, instead of sending one tuple ea…

### DIFF
--- a/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
@@ -77,7 +77,7 @@ public class TridentKafkaState implements State {
         producer = new Producer(config);
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked", "unused"})
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public void updateState(List<TridentTuple> tuples, TridentCollector collector) {
         String topic = null;
         List<KeyedMessage> batchList = new ArrayList<KeyedMessage>(tuples.size());
@@ -101,12 +101,8 @@ public class TridentKafkaState implements State {
         }
         // Sending Batch
         try {
-            if (batchList != null) {
-                producer.send(batchList);
-                LOG.debug("Sending the Batch " + batchList.hashCode());
-            } else {
-                LOG.warn("BatchList is null " + batchList);
-            }
+            producer.send(batchList);
+            LOG.debug("Sending the Batch " + batchList);
         } catch (Exception ex) {
             String errorMsg = "Could not send messages = " + tuples + " to topic = " + topic;
             LOG.warn(errorMsg, ex);

--- a/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
@@ -85,10 +85,13 @@ public class TridentKafkaState implements State {
 		for (TridentTuple tuple : tuples) {
 			try {
 				topic = topicSelector.getTopic(tuple);
-				batchList
-						.add(new KeyedMessage(topic, mapper.getKeyFromTuple(tuple), 
-						mapper.getMessageFromTuple(tuple)));
-				LOG.debug("Updated Batch");
+				if (topic != null) {
+					batchList.add(
+							new KeyedMessage(topic, mapper.getKeyFromTuple(tuple), mapper.getMessageFromTuple(tuple)));
+					LOG.debug("Updated Batch");
+				} else {
+					LOG.warn("skipping key = " + mapper.getKeyFromTuple(tuple) + ", topic selector returned null.");
+				}
 			} catch (Exception ex) {
 				String errorMsg = "Error while filling up List for Batching";
 				LOG.warn(errorMsg, ex);
@@ -104,8 +107,7 @@ public class TridentKafkaState implements State {
 				LOG.warn("BatchList is null " + batchList);
 			}
 		} catch (Exception ex) {
-			String errorMsg = "Could not send messages = " + tuples + " to topic = "
-					+ topic;
+			String errorMsg = "Could not send messages = " + tuples + " to topic = " + topic;
 			LOG.warn(errorMsg, ex);
 			throw new FailedException(errorMsg, ex);
 		}

--- a/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
@@ -77,41 +77,40 @@ public class TridentKafkaState implements State {
         producer = new Producer(config);
     }
 
-    @SuppressWarnings("rawtypes")
-	public void updateState(List<TridentTuple> tuples, TridentCollector collector) {
-		String topic = null;
-		List<KeyedMessage> batchList = new ArrayList<KeyedMessage>(tuples.size());
-		// Creating Batch
-		for (TridentTuple tuple : tuples) {
-			try {
-				topic = topicSelector.getTopic(tuple);
-				if (topic != null) {
-					batchList.add(
-							new KeyedMessage(topic, mapper.getKeyFromTuple(tuple), mapper.getMessageFromTuple(tuple)));
-					LOG.debug("Updated Batch");
-				} else {
-					LOG.warn("skipping key = " + mapper.getKeyFromTuple(tuple) + ", topic selector returned null.");
-				}
-			} catch (Exception ex) {
-				String errorMsg = "Error while filling up List for Batching";
-				LOG.warn(errorMsg, ex);
-				throw new FailedException(errorMsg, ex);
-			}
-		}
-		// Sending Batch
-		try {
-			if (batchList != null) {
-				producer.send(batchList);
-				LOG.debug("Sending the Batch " + batchList.hashCode());
-			} else {
-				LOG.warn("BatchList is null " + batchList);
-			}
-		} catch (Exception ex) {
-			String errorMsg = "Could not send messages = " + tuples + " to topic = " + topic;
-			LOG.warn(errorMsg, ex);
-			throw new FailedException(errorMsg, ex);
-		}
-
-	} 
-    
+    @SuppressWarnings({"rawtypes", "unchecked", "unused"})
+    public void updateState(List<TridentTuple> tuples, TridentCollector collector) {
+        String topic = null;
+        List<KeyedMessage> batchList = new ArrayList<KeyedMessage>(tuples.size());
+        // Creating Batch
+        for (TridentTuple tuple : tuples) {
+            try {
+                topic = topicSelector.getTopic(tuple);
+                if (topic != null) {
+                    batchList.add(new KeyedMessage(topic, mapper.getKeyFromTuple(tuple),
+                            mapper.getMessageFromTuple(tuple)));
+                    LOG.debug("Updated Batch");
+                } else {
+                    LOG.warn("skipping key = " + mapper.getKeyFromTuple(tuple)
+                            + ", topic selector returned null.");
+                }
+            } catch (Exception ex) {
+                String errorMsg = "Error while filling up List for Batching";
+                LOG.warn(errorMsg, ex);
+                throw new FailedException(errorMsg, ex);
+            }
+        }
+        // Sending Batch
+        try {
+            if (batchList != null) {
+                producer.send(batchList);
+                LOG.debug("Sending the Batch " + batchList.hashCode());
+            } else {
+                LOG.warn("BatchList is null " + batchList);
+            }
+        } catch (Exception ex) {
+            String errorMsg = "Could not send messages = " + tuples + " to topic = " + topic;
+            LOG.warn(errorMsg, ex);
+            throw new FailedException(errorMsg, ex);
+        }
+    }
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
@@ -31,6 +31,7 @@ import storm.trident.operation.TridentCollector;
 import storm.trident.state.State;
 import storm.trident.tuple.TridentTuple;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -76,24 +77,39 @@ public class TridentKafkaState implements State {
         producer = new Producer(config);
     }
 
-    public void updateState(List<TridentTuple> tuples, TridentCollector collector) {
-        String topic = null;
-        for (TridentTuple tuple : tuples) {
-            try {
-                topic = topicSelector.getTopic(tuple);
+    @SuppressWarnings("rawtypes")
+	public void updateState(List<TridentTuple> tuples, TridentCollector collector) {
+		String topic = null;
+		List<KeyedMessage> batchList = new ArrayList<KeyedMessage>(tuples.size());
+		// Creating Batch
+		for (TridentTuple tuple : tuples) {
+			try {
+				topic = topicSelector.getTopic(tuple);
+				batchList
+						.add(new KeyedMessage(topic, mapper.getKeyFromTuple(tuple), 
+						mapper.getMessageFromTuple(tuple)));
+				LOG.debug("Updated Batch");
+			} catch (Exception ex) {
+				String errorMsg = "Error while filling up List for Batching";
+				LOG.warn(errorMsg, ex);
+				throw new FailedException(errorMsg, ex);
+			}
+		}
+		// Sending Batch
+		try {
+			if (batchList != null) {
+				producer.send(batchList);
+				LOG.debug("Sending the Batch " + batchList.hashCode());
+			} else {
+				LOG.warn("BatchList is null " + batchList);
+			}
+		} catch (Exception ex) {
+			String errorMsg = "Could not send messages = " + tuples + " to topic = "
+					+ topic;
+			LOG.warn(errorMsg, ex);
+			throw new FailedException(errorMsg, ex);
+		}
 
-                if(topic != null) {
-                    producer.send(new KeyedMessage(topic, mapper.getKeyFromTuple(tuple),
-                            mapper.getMessageFromTuple(tuple)));
-                } else {
-                    LOG.warn("skipping key = " + mapper.getKeyFromTuple(tuple) + ", topic selector returned null.");
-                }
-            } catch (Exception ex) {
-                String errorMsg = "Could not send message with key = " + mapper.getKeyFromTuple(tuple)
-                        + " to topic = " + topic;
-                LOG.warn(errorMsg, ex);
-                throw new FailedException(errorMsg, ex);
-            }
-        }
-    }
+	} 
+    
 }

--- a/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
+++ b/external/storm-kafka/src/jvm/storm/kafka/trident/TridentKafkaState.java
@@ -88,7 +88,6 @@ public class TridentKafkaState implements State {
                 if (topic != null) {
                     batchList.add(new KeyedMessage(topic, mapper.getKeyFromTuple(tuple),
                             mapper.getMessageFromTuple(tuple)));
-                    LOG.debug("Updated Batch");
                 } else {
                     LOG.warn("skipping key = " + mapper.getKeyFromTuple(tuple)
                             + ", topic selector returned null.");
@@ -102,7 +101,7 @@ public class TridentKafkaState implements State {
         // Sending Batch
         try {
             producer.send(batchList);
-            LOG.debug("Sending the Batch " + batchList);
+            LOG.debug("Sending the Batch " + batchList.size());
         } catch (Exception ex) {
             String errorMsg = "Could not send messages = " + tuples + " to topic = " + topic;
             LOG.warn(errorMsg, ex);


### PR DESCRIPTION
Sending the Data to Kafka as a batch, instead of sending one tuple each. 0.10 storm-kafka version uses Producer.scala (kafka-client) class which has two methods, we are using now the second method which sends in batch.

Ref : https://github.com/apache/kafka/blob/623ab1e7c6497c000bc9c9978637f20542a3191c/core/src/main/scala/kafka/javaapi/producer/Producer.scala