### PR TITLE
STORM-1945 Fix NPE bugs on topology spout lag for storm-kafka-monitor

### DIFF
--- a/bin/storm-kafka-monitor
+++ b/bin/storm-kafka-monitor
@@ -40,4 +40,4 @@ else
   JAVA="$JAVA_HOME/bin/java"
 fi
 
-exec "$JAVA" -cp "$STORM_BASE_DIR/extlib/*" org.apache.storm.kafka.monitor.KafkaOffsetLagUtil "$@"
+exec "$JAVA" -cp "$STORM_BASE_DIR/toollib/*" org.apache.storm.kafka.monitor.KafkaOffsetLagUtil "$@"

--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -340,10 +340,10 @@
         </fileSet>
         <!-- $STORM_HOME/extlib -->
         <fileSet>
-            <directory>${project.basedir}/../../external/storm-kafka-monitor/target</directory>
+            <directory></directory>
             <outputDirectory>extlib</outputDirectory>
             <includes>
-                <include>storm*jar</include>
+                <include></include>
             </includes>
         </fileSet>
         <!-- $STORM_HOME/extlib-daemon, for daemons only -->
@@ -352,6 +352,14 @@
             <outputDirectory>extlib-daemon</outputDirectory>
             <includes>
                 <include></include>
+            </includes>
+        </fileSet>
+        <!-- $STORM_HOME/toollib -->
+        <fileSet>
+            <directory>${project.basedir}/../../external/storm-kafka-monitor/target</directory>
+            <outputDirectory>toollib</outputDirectory>
+            <includes>
+                <include>storm*jar</include>
             </includes>
         </fileSet>
 


### PR DESCRIPTION
PR for 1.x-branch: #1541

* Fix several spots which are throwing NPE on TopologySpoutLag
  * Use a trick to get classname of Spout without requiring storm-kafka and storm-kafka-client
* Move storm-kafka-monitor jar to toollib directory
  * since jars in extlib are added to worker classpath which we don't want for this jar

@priyank5485 @harshach Please take a look and comment. Thanks!