### PR TITLE
STORM-1946: initialize lastHeartbeatTimestamp before starting heartbeat task

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/task/ShellBolt.java
@@ -138,11 +138,11 @@ public class ShellBolt implements IBolt {
         _writerThread = new Thread(new BoltWriterRunnable());
         _writerThread.start();
 
-        heartBeatExecutorService = MoreExecutors.getExitingScheduledExecutorService(new ScheduledThreadPoolExecutor(1));
-        heartBeatExecutorService.scheduleAtFixedRate(new BoltHeartbeatTimerTask(this), 1, 1, TimeUnit.SECONDS);
-
         LOG.info("Start checking heartbeat...");
         setHeartbeat();
+
+        heartBeatExecutorService = MoreExecutors.getExitingScheduledExecutorService(new ScheduledThreadPoolExecutor(1));
+        heartBeatExecutorService.scheduleAtFixedRate(new BoltHeartbeatTimerTask(this), 1, 1, TimeUnit.SECONDS);
     }
 
     public void execute(Tuple input) {


### PR DESCRIPTION
When storm stars a large number of ShellBolt-s that consume a lot of CPU time to initialize, it creates a lot of contention between processes for CPU resource. That leads to BoltHeartbeatTimerTask being fired up after 1 second delay before setHeartbeat() assigns initial value to lastHeartbeatTimestamp variable.
As a result when BoltHeartbeatTimeTask fires up for the first time, getLastHeartbeat() returns value of 0. This in turn leads bolt to die with "subprocess heartbeat timeout" message.
The fix is to place setHeartBeat() before BoltHeartbeatTimerTask is created. The patch for this is attached.
