### PR TITLE
STORM-1939 Ignore InterruptedException on ShellBoltMessageQueue

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/task/ShellBolt.java
@@ -158,8 +158,8 @@ public class ShellBolt implements IBolt {
 
             _pendingWrites.putBoltMsg(boltMsg);
         } catch(InterruptedException e) {
-            String processInfo = _process.getProcessInfoString() + _process.getProcessTerminationInfoString();
-            throw new RuntimeException("Error during multilang processing " + processInfo, e);
+            // It's likely that Bolt is shutting down so no need to throw RuntimeException
+            // just ignore
         }
     }
 
@@ -361,6 +361,8 @@ public class ShellBolt implements IBolt {
                             break;
                     }
                 } catch (InterruptedException e) {
+                    // It's likely that Bolt is shutting down so no need to die.
+                    // just ignore and loop will be terminated eventually
                 } catch (Throwable t) {
                     die(t);
                 }
@@ -384,10 +386,14 @@ public class ShellBolt implements IBolt {
                     if (write instanceof BoltMsg) {
                         _process.writeBoltMsg((BoltMsg) write);
                     } else if (write instanceof List<?>) {
-                        _process.writeTaskIds((List<Integer>)write);
+                        _process.writeTaskIds((List<Integer>) write);
                     } else if (write != null) {
-                        throw new RuntimeException("Unknown class type to write: " + write.getClass().getName());
+                        throw new RuntimeException(
+                            "Unknown class type to write: " + write.getClass().getName());
                     }
+                } catch (InterruptedException e) {
+                    // It's likely that Bolt is shutting down so no need to die.
+                    // just ignore and loop will be terminated eventually
                 } catch (Throwable t) {
                     die(t);
                 }


### PR DESCRIPTION
InterruptedException makes false alarm for ShellBolt shutting down.
Since it's likely throwing InterruptedException when ShellBolt is shutting down, so we're ok to just consume that and continue.

Please see https://issues.apache.org/jira/browse/STORM-1939 for more details.

It should be applied to master, 1.x, 1.0.x branches.