### PR TITLE
ConcurrentModificationExceptions in WindowedBoltExecutorTest

### DIFF
--- a/storm-core/test/jvm/org/apache/storm/topology/WindowedBoltExecutorTest.java
+++ b/storm-core/test/jvm/org/apache/storm/topology/WindowedBoltExecutorTest.java
@@ -220,7 +220,6 @@ public class WindowedBoltExecutorTest {
             Time.sleep(10);
         }
 
-        System.out.println(testWindowedBolt.tupleWindows);
         Tuple tuple = tuples.get(tuples.size() - 1);
         Mockito.verify(outputCollector).emit("$late", Arrays.asList(tuple), new Values(tuple));
     }


### PR DESCRIPTION
Printing testWindowedBolt.tupleWindows results in tupleWindows being iterated while being modified at same time.
