### PR TITLE
STORM-1950 Change response json of "Topology Lag" REST API to keyed by spoutId, topic, partition

### DIFF
--- a/bin/storm-kafka-monitor
+++ b/bin/storm-kafka-monitor
@@ -40,4 +40,4 @@ else
   JAVA="$JAVA_HOME/bin/java"
 fi
 
-exec "$JAVA" -cp "$STORM_BASE_DIR/toollib/*" org.apache.storm.kafka.monitor.KafkaOffsetLagUtil "$@"
+exec "$JAVA" -cp "$STORM_BASE_DIR/toollib/storm-kafka-monitor*.jar" org.apache.storm.kafka.monitor.KafkaOffsetLagUtil "$@"

--- a/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaPartitionOffsetLag.java
+++ b/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaPartitionOffsetLag.java
@@ -1,0 +1,54 @@
+package org.apache.storm.kafka.monitor;
+
+public class KafkaPartitionOffsetLag {
+  private long consumerCommittedOffset;
+  private long logHeadOffset;
+  private long lag;
+
+  public KafkaPartitionOffsetLag(long consumerCommittedOffset, long logHeadOffset) {
+    this.consumerCommittedOffset = consumerCommittedOffset;
+    this.logHeadOffset = logHeadOffset;
+    this.lag = logHeadOffset - consumerCommittedOffset;
+  }
+
+  public long getConsumerCommittedOffset() {
+    return consumerCommittedOffset;
+  }
+
+  public long getLogHeadOffset() {
+    return logHeadOffset;
+  }
+
+  public long getLag() {
+    return lag;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof KafkaPartitionOffsetLag)) return false;
+
+    KafkaPartitionOffsetLag that = (KafkaPartitionOffsetLag) o;
+
+    if (getConsumerCommittedOffset() != that.getConsumerCommittedOffset()) return false;
+    if (getLogHeadOffset() != that.getLogHeadOffset()) return false;
+    return getLag() == that.getLag();
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (getConsumerCommittedOffset() ^ (getConsumerCommittedOffset() >>> 32));
+    result = 31 * result + (int) (getLogHeadOffset() ^ (getLogHeadOffset() >>> 32));
+    result = 31 * result + (int) (getLag() ^ (getLag() >>> 32));
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    // JSONAware not working for nested element on Map so write JSON format from here
+    return "{\"consumerCommittedOffset\": " + consumerCommittedOffset + ", " +
+        "\"logHeadOffset\": " + logHeadOffset + ", " +
+        "\"lag\": " + lag + "}";
+  }
+}

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -283,7 +283,7 @@
       <tr>
         <td>{{spoutId}}</td>
         <td>{{spoutType}}</td>
-        <td>{{spoutLagResult}}</td>
+        <td>{{errorInfo}}</td>
       </tr>
       {{/spoutsLagErrorResults}}
     </tbody>
@@ -603,3 +603,4 @@
       </table>
   </div>
 </script>
+

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -392,44 +392,52 @@ $(document).ready(function() {
 
             var lagUrl = "/api/v1/topology/"+topologyId+"/lag";
             $.getJSON(lagUrl,function(lagResponse,status,jqXHR) {
-              if (lagResponse !== null && lagResponse !== undefined && lagResponse instanceof Array && lagResponse.length > 0) {
-                var kafkaSpoutsLagTemplate = $(template).filter("#topology-kafka-spouts-lag-template").html();
-                var spoutsErrorTemplate = $(template).filter("#topology-spouts-lag-error-template").html();
+                if (lagResponse !== null && lagResponse !== undefined) {
+                    var kafkaSpoutsLagTemplate = $(template).filter("#topology-kafka-spouts-lag-template").html();
+                    var spoutsErrorTemplate = $(template).filter("#topology-spouts-lag-error-template").html();
 
-                var kafkaSpoutLags = lagResponse.filter(function(ele) {return ele.spoutType === "KAFKA";});
-                var isJson = function (input) {
-                  try {
-                    JSON.parse(input);
-                  } catch (e) {
-                    return false;
-                  }
-                  return true;
-                };
-                var kafkaSpoutsValidResults = kafkaSpoutLags.filter(function (ele) {return isJson(ele.spoutLagResult);});
-                var kafkaSpoutsErrorResults = kafkaSpoutLags.filter(function (ele) {return !isJson(ele.spoutLagResult);});
-                var data = {};
-                if (kafkaSpoutsValidResults.length > 0) {
-                  data.kafkaSpoutsLagResults = [];
-                  kafkaSpoutsValidResults.forEach(function(ele) {
-                    var spoutLagResult = JSON.parse(ele.spoutLagResult);
-                    spoutLagResult.forEach(function(ele2) {
-                      data.kafkaSpoutsLagResults.push({
-                        id: ele.spoutId,
-                        topic: ele2.topic,
-                        partition: ele2.partition,
-                        logHeadOffset: ele2.logHeadOffset,
-                        consumerCommittedOffset: ele2.consumerCommittedOffset,
-                        lag: ele2.lag
-                      });
-                    });
-                  });
-                  topologySpoutsLag.append(Mustache.render(kafkaSpoutsLagTemplate,data));
+                    var data = {};
+                    data.kafkaSpoutsLagResults = [];
+                    data.spoutsLagErrorResults = [];
+                    for (var spoutId in lagResponse) {
+                        var spout = lagResponse[spoutId];
+                        var spoutType = spout.spoutType;
+                        if (spoutType !== "KAFKA") {
+                            continue;
+                        }
+                        var spoutLagResult = spout.spoutLagResult;
+                        var errorInfo = spout.errorInfo;
+                        if (spoutLagResult !== undefined) {
+                            for (var topicName in spoutLagResult) {
+                                var topicLagResult = spoutLagResult[topicName];
+                                for (var partitionId in topicLagResult) {
+                                    var partitionLagResult = topicLagResult[partitionId];
+                                    data.kafkaSpoutsLagResults.push({
+                                        id: spoutId,
+                                        topic: topicName,
+                                        partition: partitionId,
+                                        logHeadOffset: partitionLagResult.logHeadOffset,
+                                        consumerCommittedOffset: partitionLagResult.consumerCommittedOffset,
+                                        lag: partitionLagResult.lag
+                                    });
+                                }
+                            }
+                        } else if (errorInfo !== undefined) {
+                            data.spoutsLagErrorResults.push({
+                                spoutId: spoutId,
+                                spoutType: spout.spoutType,
+                                errorInfo: errorInfo
+                            });
+                        }
+                    }
+
+                    if (data.kafkaSpoutsLagResults.length > 0) {
+                        topologySpoutsLag.append(Mustache.render(kafkaSpoutsLagTemplate, data));
+                    }
+                    if (data.spoutsLagErrorResults.length > 0) {
+                        topologySpoutsLag.append(Mustache.render(spoutsErrorTemplate, data));
+                    }
                 }
-                if (kafkaSpoutsErrorResults.length > 0) {
-                  data.spoutsLagErrorResults = kafkaSpoutsErrorResults;
-                  topologySpoutsLag.append(Mustache.render(spoutsErrorTemplate,data));
-                }
-              }
             });
       }});
     });
@@ -437,3 +445,4 @@ $(document).ready(function() {
  });
 </script>
 </html>
+


### PR DESCRIPTION
* bin/storm-kafka-monitor: guard classpath to only uses storm-kafka-monitor*.jar
* KafkaOffsetLagUtil: when succeed to get, output is keyed by topic and partition
* TopologySpoutLag: modify JSON response keyed by spoutId
* reflect changes on topology page

Here's sample JSON response from /lag API
```
{
   "kafka-spout":{
      "spoutLagResult":{
         "myKafkaTopic":{
            "0":{
               "consumerCommittedOffset":749491,
               "logHeadOffset":911511,
               "lag":162020
            },
            "1":{
               "consumerCommittedOffset":1168,
               "logHeadOffset":1168,
               "lag":0
            },
            "2":{
               "consumerCommittedOffset":159339,
               "logHeadOffset":159339,
               "lag":0
            }
         }
      },
      "spoutId":"kafka-spout",
      "spoutType":"KAFKA"
   }
}
```

@harshach Please review and comment. Thanks!