### PR TITLE
[STORM-1957] Support Storm JDBC batch insert

### DIFF
--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/trident/state/JdbcState.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/trident/state/JdbcState.java
@@ -59,6 +59,7 @@ public class JdbcState implements State {
         private String insertQuery;
         private String selectQuery;
         private Integer queryTimeoutSecs;
+        private int batchSize;
 
         public Options withConnectionProvider(ConnectionProvider connectionProvider) {
             this.connectionProvider = connectionProvider;
@@ -72,6 +73,14 @@ public class JdbcState implements State {
 
         public Options withInsertQuery(String insertQuery) {
             this.insertQuery = insertQuery;
+            return this;
+        }
+
+        public Options withBatchSize(int batchSize) {
+            if (batchSize < 0) {
+                throw new IllegalArgumentException("Batch size should be a positive number. ");
+            }
+            this.batchSize = batchSize;
             return this;
         }
 
@@ -130,9 +139,9 @@ public class JdbcState implements State {
 
         try {
             if(!StringUtils.isBlank(options.tableName)) {
-                jdbcClient.insert(options.tableName, columnsLists);
+                jdbcClient.insert(options.tableName, columnsLists, options.batchSize);
             } else {
-                jdbcClient.executeInsertQuery(options.insertQuery, columnsLists);
+                jdbcClient.executeInsertQuery(options.insertQuery, columnsLists, options.batchSize);
             }
         } catch (Exception e) {
             LOG.warn("Batch write failed but some requests might have succeeded. Triggering replay.", e);

--- a/external/storm-jdbc/src/test/java/org/apache/storm/jdbc/common/JdbcClientTest.java
+++ b/external/storm-jdbc/src/test/java/org/apache/storm/jdbc/common/JdbcClientTest.java
@@ -57,7 +57,7 @@ public class JdbcClientTest {
         List<Column> row2 = createRow(2, "alice");
 
         List<List<Column>> rows = Lists.newArrayList(row1, row2);
-        client.insert(tableName, rows);
+        client.insert(tableName, rows, 0);
 
         List<List<Column>> selectedRows = client.select("select * from user_details where id = ?", Lists.newArrayList(new Column("id", 1, Types.INTEGER)));
         List<List<Column>> expectedRows = Lists.newArrayList();
@@ -67,7 +67,7 @@ public class JdbcClientTest {
         List<Column> row3 = createRow(3, "frank");
         List<List<Column>> moreRows  = new ArrayList<List<Column>>();
         moreRows.add(row3);
-        client.executeInsertQuery("insert into user_details values(?,?,?)", moreRows);
+        client.executeInsertQuery("insert into user_details values(?,?,?)", moreRows, 0);
 
         selectedRows = client.select("select * from user_details where id = ?", Lists.newArrayList(new Column("id", 3, Types.INTEGER)));
         expectedRows = Lists.newArrayList();


### PR DESCRIPTION
[STORM-1957 Support Storm JDBC batch insert](https://issues.apache.org/jira/browse/STORM-1957?jql=project%20%3D%20STORM)

Batch insert support execute grouped SQL a batch and submit into one call . It can reduce the amount of communication , improving performance.
