### PR TITLE
STORM-1910  One topology cannot use hdfs spout to read from two locations

### DIFF
--- a/external/storm-hdfs/README.md
+++ b/external/storm-hdfs/README.md
@@ -486,69 +486,58 @@ this once the DIRLOCK file becomes stale due to inactivity for hdfsspout.lock.ti
 The following example creates an HDFS spout that reads text files from HDFS path hdfs://localhost:54310/source.
 
 ```java
-// Instantiate spout
-HdfsSpout textReaderSpout = new HdfsSpout().withOutputFields(TextFileReader.defaultFields);
-// HdfsSpout seqFileReaderSpout = new HdfsSpout().withOutputFields(SequenceFileReader.defaultFields);
+// Instantiate spout to read text files
+HdfsSpout textReaderSpout = new HdfsSpout().setReaderType("text")
+                                           .withOutputFields(TextFileReader.defaultFields)                                      
+                                           .setHdfsUri("hdfs://localhost:54310")  // reqd
+                                           .setSourceDir("/data/in")              // reqd                                      
+                                           .setArchiveDir("/data/done")           // reqd
+                                           .setBadFilesDir("/data/badfiles");     // required                                      
+// If using Kerberos
+HashMap hdfsSettings = new HashMap();
+hdfsSettings.put("hdfs.keytab.file", "/path/to/keytab");
+hdfsSettings.put("hdfs.kerberos.principal","user@EXAMPLE.com");
 
-// textReaderSpout.withConfigKey("custom.keyname"); // Optional. Not required normally unless you need to change the keyname use to provide hds settings. This keyname defaults to 'hdfs.config' 
+textReaderSpout.setHdfsClientSettings(hdfsSettings);
 
-// Configure it
-Config conf = new Config();
-conf.put(Configs.HDFS_URI, "hdfs://localhost:54310");
-conf.put(Configs.SOURCE_DIR, "/data/in");
-conf.put(Configs.ARCHIVE_DIR, "/data/done");
-conf.put(Configs.BAD_DIR, "/data/badfiles");
-conf.put(Configs.READER_TYPE, "text"); // or 'seq' for sequence files
-
-// Create & configure topology
+// Create topology
 TopologyBuilder builder = new TopologyBuilder();
 builder.setSpout("hdfsspout", textReaderSpout, SPOUT_NUM);
 
-// Setup bolts and other topology configuration
+// Setup bolts and wire up topology
      ..snip..
 
 // Submit topology with config
+Config conf = new Config();
 StormSubmitter.submitTopologyWithProgressBar("topologyName", conf, builder.createTopology());
 ```
 
-See sample HdfsSpoutTopolgy in storm-starter.
+A sample topology HdfsSpoutTopology is provided in storm-starter module.
 
 ## Configuration Settings
-Class HdfsSpout provided following methods for configuration:
+Below is a list of HdfsSpout member functions used for configuration. The equivalent config is also possible via Config object passed in during submitting topology.
+However, the later mechanism is deprecated as it does not allow multiple Hdfs spouts with differing settings. :  
 
-`HdfsSpout withOutputFields(String... fields)` : This sets the names for the output fields. 
-The number of fields depends upon the reader being used. For convenience, built-in reader types 
-expose a static member called `defaultFields` that can be used for this. 
- 
- `HdfsSpout withConfigKey(String configKey)`
-Optional setting. It allows overriding the default key name ('hdfs.config') with new name for 
-specifying HDFS configs. Typically used to specify kerberos keytab and principal.
 
-**E.g:**
-```java
-    HashMap map = new HashMap();
-    map.put("hdfs.keytab.file", "/path/to/keytab");
-    map.put("hdfs.kerberos.principal","user@EXAMPLE.com");
-    conf.set("hdfs.config", map)
-```
+Only methods mentioned in **bold** are required.
 
-Only settings mentioned in **bold** are required.
-
-| Setting                      | Default     | Description |
-|------------------------------|-------------|-------------|
-|**hdfsspout.reader.type**     |             | Indicates the reader for the file format. Set to 'seq' for reading sequence files or 'text' for text files. Set to a fully qualified class name if using a custom type (that implements interface org.apache.storm.hdfs.spout.FileReader)|
-|**hdfsspout.hdfs**            |             | HDFS URI for the hdfs Name node. Example:  hdfs://namenodehost:8020|
-|**hdfsspout.source.dir**      |             | HDFS directory from where to read files. E.g. /data/inputfiles|
-|**hdfsspout.archive.dir**     |             | After a file is processed completely it will be moved to this HDFS directory. If this directory does not exist it will be created. E.g. /data/done|
-|**hdfsspout.badfiles.dir**    |             | if there is an error parsing a file's contents, the file is moved to this location.  If this directory does not exist it will be created. E.g. /data/badfiles  |
-|hdfsspout.lock.dir            | '.lock' subdirectory under hdfsspout.source.dir | Dir in which lock files will be created. Concurrent HDFS spout instances synchronize using *lock* files. Before processing a file the spout instance creates a lock file in this directory with same name as input file and deletes this lock file after processing the file. Spouts also periodically makes a note of their progress (wrt reading the input file) in the lock file so that another spout instance can resume progress on the same file if the spout dies for any reason.|
-|hdfsspout.ignore.suffix       |   .ignore   | File names with this suffix in the in the hdfsspout.source.dir location will not be processed|
-|hdfsspout.commit.count        |    20000    | Record progress in the lock file after these many records are processed. If set to 0, this criterion will not be used. |
-|hdfsspout.commit.sec          |    10       | Record progress in the lock file after these many seconds have elapsed. Must be greater than 0 |
-|hdfsspout.max.outstanding     |   10000     | Limits the number of unACKed tuples by pausing tuple generation (if ACKers are used in the topology) |
-|hdfsspout.lock.timeout.sec    |  5 minutes  | Duration of inactivity after which a lock file is considered to be abandoned and ready for another spout to take ownership |
-|hdfsspout.clocks.insync       |    true     | Indicates whether clocks on the storm machines are in sync (using services like NTP). Used for detecting stale locks. |
-|hdfs.config (unless changed)  |             | Set it to a Map of Key/value pairs indicating the HDFS settigns to be used. For example, keytab and principle could be set using this. See section **Using keytabs on all worker hosts** under HDFS bolt below.| 
+| Method                     | Alternative config name (deprecated) | Default     | Description |
+|----------------------------|--------------------------------------|-------------|-------------|
+| **.setReaderType()**       |~~hdfsspout.reader.type~~             |             | Determines which file reader to use. Set to 'seq' for reading sequence files or 'text' for text files. Set to a fully qualified class name if using a custom file reader class (that implements interface org.apache.storm.hdfs.spout.FileReader)|
+| **.withOutputFields()**    |                                      |             | Sets the names for the output fields for the spout. The number of fields depends upon the reader being used. For convenience, built-in reader types expose a static member called `defaultFields` that can be used for setting this.|
+| **.setHdfsUri()**          |~~hdfsspout.hdfs~~                    |             | HDFS URI for the hdfs Name node. Example:  hdfs://namenodehost:8020|
+| **.setSourceDir()**        |~~hdfsspout.source.dir~~              |             | HDFS directory from where to read files. E.g. /data/inputdir|
+| **.setArchiveDir()**       |~~hdfsspout.archive.dir~~             |             | After a file is processed completely it will be moved to this HDFS directory. If this directory does not exist it will be created. E.g. /data/done|
+| **.setBadFilesDir()**      |~~hdfsspout.badfiles.dir~~            |             | if there is an error parsing a file's contents, the file is moved to this location.  If this directory does not exist it will be created. E.g. /data/badfiles  |
+| .setLockDir()              |~~hdfsspout.lock.dir~~                | '.lock' subdirectory under hdfsspout.source.dir | Dir in which lock files will be created. Concurrent HDFS spout instances synchronize using *lock* files. Before processing a file the spout instance creates a lock file in this directory with same name as input file and deletes this lock file after processing the file. Spouts also periodically makes a note of their progress (wrt reading the input file) in the lock file so that another spout instance can resume progress on the same file if the spout dies for any reason.|
+| .setIgnoreSuffix()         |~~hdfsspout.ignore.suffix~~           |   .ignore   | File names with this suffix in the in the hdfsspout.source.dir location will not be processed|
+| .setCommitFrequencyCount() |~~hdfsspout.commit.count~~            |    20000    | Record progress in the lock file after these many records are processed. If set to 0, this criterion will not be used. |
+| .setCommitFrequencySec()   |~~hdfsspout.commit.sec~~              |    10       | Record progress in the lock file after these many seconds have elapsed. Must be greater than 0 |
+| .setMaxOutstanding()       |~~hdfsspout.max.outstanding~~         |   10000     | Limits the number of unACKed tuples by pausing tuple generation (if ACKers are used in the topology) |
+| .setLockTimeoutSec()       |~~hdfsspout.lock.timeout.sec~~        |  5 minutes  | Duration of inactivity after which a lock file is considered to be abandoned and ready for another spout to take ownership |
+| .setClocksInSync()         |~~hdfsspout.clocks.insync~~           |    true     | Indicates whether clocks on the storm machines are in sync (using services like NTP). Used for detecting stale locks. |
+| .withConfigKey()           |                                      |             | Optional setting. Overrides the default key name ('hdfs.config', see below) used for specifying HDFS client configs. |
+| .setHdfsClientSettings()   |~~hdfs.config~~ (unless changed via withConfigKey)| | Set it to a Map of Key/value pairs indicating the HDFS settings to be used. For example, keytab and principle could be set using this. See section **Using keytabs on all worker hosts** under HDFS bolt below.| 
 
 ---
 

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
@@ -198,7 +198,7 @@ public class HdfsSpout extends BaseRichSpout {
       return;
     }
 
-    if( ackEnabled  &&  tracker.size()>= maxOutstanding) {
+    if ( ackEnabled  &&  tracker.size()>= maxOutstanding ) {
       LOG.warn("Waiting for more ACKs before generating new tuples. " +
               "Progress tracker size has reached limit {}, SpoutID {}"
               , maxOutstanding, spoutId);
@@ -219,7 +219,7 @@ public class HdfsSpout extends BaseRichSpout {
             fileReadCompletely=false;
           }
         }
-        if( fileReadCompletely ) { // wait for more ACKs before proceeding
+        if ( fileReadCompletely ) { // wait for more ACKs before proceeding
           return;
         }
         // 4) Read record from file, emit to collector and record progress
@@ -230,7 +230,7 @@ public class HdfsSpout extends BaseRichSpout {
           MessageId msgId = new MessageId(tupleCounter, reader.getFilePath(), reader.getFileOffset());
           emitData(tuple, msgId);
 
-          if(!ackEnabled) {
+          if ( !ackEnabled ) {
             ++acksSinceLastCommit; // assume message is immediately ACKed in non-ack mode
             commitProgress(reader.getFileOffset());
           } else {
@@ -239,7 +239,7 @@ public class HdfsSpout extends BaseRichSpout {
           return;
         } else {
           fileReadCompletely = true;
-          if(!ackEnabled) {
+          if ( !ackEnabled ) {
             markFileAsDone(reader.getFilePath());
           }
         }
@@ -260,7 +260,7 @@ public class HdfsSpout extends BaseRichSpout {
 
   // will commit progress into lock file if commit threshold is reached
   private void commitProgress(FileOffset position) {
-    if(position==null) {
+    if ( position==null ) {
       return;
     }
     if ( lock!=null && canCommitNow() ) {
@@ -278,7 +278,7 @@ public class HdfsSpout extends BaseRichSpout {
   }
 
   private void setupCommitElapseTimer() {
-    if(commitFrequencySec<=0) {
+    if ( commitFrequencySec<=0 ) {
       return;
     }
     TimerTask timerTask = new TimerTask() {
@@ -334,7 +334,7 @@ public class HdfsSpout extends BaseRichSpout {
 
   private static void releaseLockAndLog(FileLock fLock, String spoutId) {
     try {
-      if(fLock!=null) {
+      if ( fLock!=null ) {
         fLock.release();
         LOG.debug("Spout {} released FileLock. SpoutId = {}", fLock.getLockFile(), spoutId);
       }
@@ -361,10 +361,10 @@ public class HdfsSpout extends BaseRichSpout {
     this.tupleCounter = 0;
 
     // Hdfs related settings
-    if(this.hdfsUri==null && conf.containsKey(Configs.HDFS_URI)) {
+    if ( this.hdfsUri==null && conf.containsKey(Configs.HDFS_URI) ) {
       this.hdfsUri = conf.get(Configs.HDFS_URI).toString();
     }
-    if(this.hdfsUri==null) {
+    if ( this.hdfsUri==null ) {
       throw new RuntimeException("HDFS Uri not set on spout");
     }
 
@@ -378,7 +378,7 @@ public class HdfsSpout extends BaseRichSpout {
 
     if ( conf.containsKey(configKey) ) {
       Map<String, Object> map = (Map<String, Object>)conf.get(configKey);
-        if(map != null) {
+        if ( map != null ) {
           for(String keyName : map.keySet()){
             LOG.info("HDFS Config override : {} = {} ", keyName, String.valueOf(map.get(keyName)));
             this.hdfsConfig.set(keyName, String.valueOf(map.get(keyName)));
@@ -389,11 +389,11 @@ public class HdfsSpout extends BaseRichSpout {
             LOG.error("HDFS Login failed ", e);
             throw new RuntimeException(e);
           }
-        } // if(map != null)
+        } // if (map != null)
       }
 
     // Reader type config
-    if( readerType==null && conf.containsKey(Configs.READER_TYPE) ) {
+    if ( readerType==null && conf.containsKey(Configs.READER_TYPE) ) {
       readerType = conf.get(Configs.READER_TYPE).toString();
     }
     checkValidReader(readerType);
@@ -402,7 +402,7 @@ public class HdfsSpout extends BaseRichSpout {
     if ( sourceDir==null && conf.containsKey(Configs.SOURCE_DIR) ) {
       sourceDir = conf.get(Configs.SOURCE_DIR).toString();
     }
-    if( sourceDir==null ) {
+    if ( sourceDir==null ) {
       LOG.error(Configs.SOURCE_DIR + " setting is required");
       throw new RuntimeException(Configs.SOURCE_DIR + " setting is required");
     }
@@ -423,7 +423,7 @@ public class HdfsSpout extends BaseRichSpout {
     if ( badFilesDir==null && conf.containsKey(Configs.BAD_DIR) ) {
       badFilesDir = conf.get(Configs.BAD_DIR).toString();
     }
-    if(badFilesDir==null) {
+    if ( badFilesDir==null ) {
       LOG.error(Configs.BAD_DIR + " setting is required");
       throw new RuntimeException(Configs.BAD_DIR + " setting is required");
     }
@@ -436,10 +436,10 @@ public class HdfsSpout extends BaseRichSpout {
     }
 
     // -- lock dir config
-    if( lockDir==null && conf.containsKey(Configs.LOCK_DIR) ) {
+    if ( lockDir==null && conf.containsKey(Configs.LOCK_DIR) ) {
       lockDir = conf.get(Configs.LOCK_DIR).toString();
     }
-    if(lockDir==null) {
+    if ( lockDir==null ) {
       lockDir = getDefaultLockDir(sourceDirPath);
     }
     this.lockDirPath = new Path(lockDir);
@@ -447,13 +447,13 @@ public class HdfsSpout extends BaseRichSpout {
 
 
     // -- lock timeout
-    if( conf.get(Configs.LOCK_TIMEOUT) !=null ) {
+    if ( conf.get(Configs.LOCK_TIMEOUT) !=null ) {
       this.lockTimeoutSec = Integer.parseInt(conf.get(Configs.LOCK_TIMEOUT).toString());
     }
 
     // -- enable/disable ACKing
     Object ackers = conf.get(Config.TOPOLOGY_ACKER_EXECUTORS);
-    if( ackers!=null ) {
+    if ( ackers!=null ) {
       int ackerCount = Integer.parseInt(ackers.toString());
       this.ackEnabled = (ackerCount>0);
       LOG.debug("ACKer count = {}", ackerCount);
@@ -466,25 +466,25 @@ public class HdfsSpout extends BaseRichSpout {
     LOG.info("ACK mode is {}", ackEnabled ? "enabled" : "disabled");
 
     // -- commit frequency - count
-    if( conf.get(Configs.COMMIT_FREQ_COUNT) != null ) {
+    if ( conf.get(Configs.COMMIT_FREQ_COUNT) != null ) {
       commitFrequencyCount = Integer.parseInt(conf.get(Configs.COMMIT_FREQ_COUNT).toString());
     }
 
     // -- commit frequency - seconds
-    if( conf.get(Configs.COMMIT_FREQ_SEC) != null ) {
+    if ( conf.get(Configs.COMMIT_FREQ_SEC) != null ) {
       commitFrequencySec = Integer.parseInt(conf.get(Configs.COMMIT_FREQ_SEC).toString());
-      if(commitFrequencySec<=0) {
+      if ( commitFrequencySec<=0 ) {
         throw new RuntimeException(Configs.COMMIT_FREQ_SEC + " setting must be greater than 0");
       }
     }
 
     // -- max outstanding tuples
-    if( conf.get(Configs.MAX_OUTSTANDING) !=null ) {
+    if ( conf.get(Configs.MAX_OUTSTANDING) !=null ) {
       maxOutstanding = Integer.parseInt(conf.get(Configs.MAX_OUTSTANDING).toString());
     }
 
     // -- clocks in sync
-    if( conf.get(Configs.CLOCKS_INSYNC) !=null ) {
+    if ( conf.get(Configs.CLOCKS_INSYNC) !=null ) {
       clocksInSync = Boolean.parseBoolean(conf.get(Configs.CLOCKS_INSYNC).toString());
     }
 
@@ -497,12 +497,12 @@ public class HdfsSpout extends BaseRichSpout {
 
   private static void validateOrMakeDir(FileSystem fs, Path dir, String dirDescription) {
     try {
-      if(fs.exists(dir)) {
-        if(! fs.isDirectory(dir) ) {
+      if ( fs.exists(dir) ) {
+        if ( !fs.isDirectory(dir) ) {
           LOG.error(dirDescription + " directory is a file, not a dir. " + dir);
           throw new RuntimeException(dirDescription + " directory is a file, not a dir. " + dir);
         }
-      } else if(! fs.mkdirs(dir) ) {
+      } else if ( ! fs.mkdirs(dir) ) {
         LOG.error("Unable to create " + dirDescription + " directory " + dir);
         throw new RuntimeException("Unable to create " + dirDescription + " directory " + dir);
       }
@@ -517,7 +517,7 @@ public class HdfsSpout extends BaseRichSpout {
   }
 
   private static void checkValidReader(String readerType) {
-    if(readerType.equalsIgnoreCase(Configs.TEXT)  || readerType.equalsIgnoreCase(Configs.SEQ) )
+    if ( readerType.equalsIgnoreCase(Configs.TEXT)  || readerType.equalsIgnoreCase(Configs.SEQ) )
       return;
     try {
       Class<?> classType = Class.forName(readerType);
@@ -535,7 +535,7 @@ public class HdfsSpout extends BaseRichSpout {
   @Override
   public void ack(Object msgId) {
     LOG.trace("Ack received for msg {} on spout {}", msgId, spoutId);
-    if(!ackEnabled) {
+    if ( !ackEnabled ) {
       return;
     }
     MessageId id = (MessageId) msgId;
@@ -543,7 +543,7 @@ public class HdfsSpout extends BaseRichSpout {
     ++acksSinceLastCommit;
     tracker.recordAckedOffset(id.offset);
     commitProgress(tracker.getCommitPosition());
-    if(fileReadCompletely && inflight.isEmpty()) {
+    if ( fileReadCompletely && inflight.isEmpty() ) {
       markFileAsDone(reader.getFilePath());
       reader = null;
     }
@@ -552,7 +552,7 @@ public class HdfsSpout extends BaseRichSpout {
 
   private boolean canCommitNow() {
 
-    if( commitFrequencyCount>0 &&  acksSinceLastCommit >= commitFrequencyCount ) {
+    if ( commitFrequencyCount>0 &&  acksSinceLastCommit >= commitFrequencyCount ) {
       return true;
     }
     return commitTimeElapsed.get();
@@ -562,7 +562,7 @@ public class HdfsSpout extends BaseRichSpout {
   public void fail(Object msgId) {
     LOG.trace("Fail received for msg id {} on spout {}", msgId, spoutId);
     super.fail(msgId);
-    if(ackEnabled) {
+    if ( ackEnabled ) {
       HdfsUtils.Pair<MessageId, List<Object>> item = HdfsUtils.Pair.of(msgId, inflight.remove(msgId));
       retryList.add(item);
     }
@@ -572,7 +572,7 @@ public class HdfsSpout extends BaseRichSpout {
     try {
       // 1) If there are any abandoned files, pick oldest one
       lock = getOldestExpiredLock();
-      if (lock != null) {
+      if ( lock!=null ) {
         LOG.debug("Spout {} now took over ownership of abandoned FileLock {}", spoutId, lock.getLockFile());
         Path file = getFileForLockFile(lock.getLockFile(), sourceDirPath);
         String resumeFromOffset = lock.getLastLogEntry().fileOffset;
@@ -641,20 +641,20 @@ public class HdfsSpout extends BaseRichSpout {
       }
 
       // 3 - if clocks are not in sync ..
-      if( lastExpiredLock == null ) {
+      if ( lastExpiredLock == null ) {
         // just make a note of the oldest expired lock now and check if its still unmodified after lockTimeoutSec
         lastExpiredLock = FileLock.locateOldestExpiredLock(hdfs, lockDirPath, lockTimeoutSec);
         lastExpiredLockTime = System.currentTimeMillis();
         return null;
       }
       // see if lockTimeoutSec time has elapsed since we last selected the lock file
-      if( hasExpired(lastExpiredLockTime) ) {
+      if ( hasExpired(lastExpiredLockTime) ) {
         return null;
       }
 
       // If lock file has expired, then own it
       FileLock.LogEntry lastEntry = FileLock.getLastEntry(hdfs, lastExpiredLock.getKey());
-      if( lastEntry.equals(lastExpiredLock.getValue()) ) {
+      if ( lastEntry.equals(lastExpiredLock.getValue()) ) {
         FileLock result = FileLock.takeOwnership(hdfs, lastExpiredLock.getKey(), lastEntry, spoutId);
         lastExpiredLock = null;
         return  result;
@@ -681,10 +681,10 @@ public class HdfsSpout extends BaseRichSpout {
    */
   private FileReader createFileReader(Path file)
           throws IOException {
-    if(readerType.equalsIgnoreCase(Configs.SEQ)) {
+    if ( readerType.equalsIgnoreCase(Configs.SEQ) ) {
       return new SequenceFileReader(this.hdfs, file, conf);
     }
-    if(readerType.equalsIgnoreCase(Configs.TEXT)) {
+    if ( readerType.equalsIgnoreCase(Configs.TEXT) ) {
       return new TextFileReader(this.hdfs, file, conf);
     }
     try {
@@ -707,10 +707,10 @@ public class HdfsSpout extends BaseRichSpout {
    */
   private FileReader createFileReader(Path file, String offset)
           throws IOException {
-    if(readerType.equalsIgnoreCase(Configs.SEQ)) {
+    if ( readerType.equalsIgnoreCase(Configs.SEQ) ) {
       return new SequenceFileReader(this.hdfs, file, conf, offset);
     }
-    if(readerType.equalsIgnoreCase(Configs.TEXT)) {
+    if ( readerType.equalsIgnoreCase(Configs.TEXT) ) {
       return new TextFileReader(this.hdfs, file, conf, offset);
     }
 
@@ -749,11 +749,11 @@ public class HdfsSpout extends BaseRichSpout {
           throws IOException {
     String lockFileName = lockFile.getName();
     Path dataFile = new Path(sourceDirPath + Path.SEPARATOR + lockFileName + inprogress_suffix);
-    if( hdfs.exists(dataFile) ) {
+    if ( hdfs.exists(dataFile) ) {
       return dataFile;
     }
     dataFile = new Path(sourceDirPath + Path.SEPARATOR +  lockFileName);
-    if(hdfs.exists(dataFile)) {
+    if ( hdfs.exists(dataFile) ) {
       return dataFile;
     }
     return null;
@@ -768,7 +768,7 @@ public class HdfsSpout extends BaseRichSpout {
 
     Path  newFile = new Path( archiveDirPath + Path.SEPARATOR + newName );
     LOG.info("Completed consuming file {}", fileNameMinusSuffix);
-    if (!hdfs.rename(file, newFile) ) {
+    if ( !hdfs.rename(file, newFile) ) {
       throw new IOException("Rename failed for file: " + file);
     }
     LOG.debug("Renamed file {} to {} ", file, newFile);
@@ -797,10 +797,10 @@ public class HdfsSpout extends BaseRichSpout {
 
     @Override
     public int compareTo(MessageId rhs) {
-      if (msgNumber<rhs.msgNumber) {
+      if ( msgNumber<rhs.msgNumber ) {
         return -1;
       }
-      if(msgNumber>rhs.msgNumber) {
+      if ( msgNumber>rhs.msgNumber ) {
         return 1;
       }
       return 0;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
@@ -51,9 +51,17 @@ public class HdfsSpout extends BaseRichSpout {
   private String hdfsUri;            // required
   private String readerType;         // required
   private Fields outputFields;       // required
+
+  private String sourceDir;        // required
   private Path sourceDirPath;        // required
+
+  private String archiveDir;       // required
   private Path archiveDirPath;       // required
+
+  private String badFilesDir;      // required
   private Path badFilesDirPath;      // required
+
+  private String lockDir;
   private Path lockDirPath;
 
   private int commitFrequencyCount = Configs.DEFAULT_COMMIT_FREQ_COUNT;
@@ -62,7 +70,7 @@ public class HdfsSpout extends BaseRichSpout {
   private int lockTimeoutSec = Configs.DEFAULT_LOCK_TIMEOUT;
   private boolean clocksInSync = true;
 
-  private String inprogress_suffix = ".inprogress";
+  private String inprogress_suffix = ".inprogress"; // not configurable to prevent change between topology restarts
   private String ignoreSuffix = ".ignore";
 
   // other members
@@ -97,7 +105,69 @@ public class HdfsSpout extends BaseRichSpout {
 
   public HdfsSpout() {
   }
-  /** Name of the output field names. Number of fields depends upon the reader type */
+
+  public HdfsSpout setHdfsUri(String hdfsUri) {
+    this.hdfsUri = hdfsUri;
+    return this;
+  }
+
+  public HdfsSpout setReaderType(String readerType) {
+    this.readerType = readerType;
+    return this;
+  }
+
+  public HdfsSpout setSourceDir(String sourceDir) {
+    this.sourceDir = sourceDir;
+    return this;
+  }
+
+  public HdfsSpout setArchiveDir(String archiveDir) {
+    this.archiveDir = archiveDir;
+    return this;
+  }
+
+  public HdfsSpout setBadFilesDir(String badFilesDir) {
+    this.badFilesDir = badFilesDir;
+    return this;
+  }
+
+  public HdfsSpout setLockDir(String lockDir) {
+    this.lockDir = lockDir;
+    return this;
+  }
+
+  public HdfsSpout setCommitFrequencyCount(int commitFrequencyCount) {
+    this.commitFrequencyCount = commitFrequencyCount;
+    return this;
+  }
+
+  public HdfsSpout setCommitFrequencySec(int commitFrequencySec) {
+    this.commitFrequencySec = commitFrequencySec;
+    return this;
+  }
+
+  public HdfsSpout setMaxOutstanding(int maxOutstanding) {
+    this.maxOutstanding = maxOutstanding;
+    return this;
+  }
+
+  public HdfsSpout setLockTimeoutSec(int lockTimeoutSec) {
+    this.lockTimeoutSec = lockTimeoutSec;
+    return this;
+  }
+
+  public HdfsSpout setClocksInSync(boolean clocksInSync) {
+    this.clocksInSync = clocksInSync;
+    return this;
+  }
+
+
+  public HdfsSpout setIgnoreSuffix(String ignoreSuffix) {
+    this.ignoreSuffix = ignoreSuffix;
+    return this;
+  }
+
+  /** Output field names. Number of fields depends upon the reader type */
   public HdfsSpout withOutputFields(String... fields) {
     outputFields = new Fields(fields);
     return this;
@@ -291,10 +361,11 @@ public class HdfsSpout extends BaseRichSpout {
     this.tupleCounter = 0;
 
     // Hdfs related settings
-    if( conf.containsKey(Configs.HDFS_URI)) {
+    if(this.hdfsUri==null && conf.containsKey(Configs.HDFS_URI)) {
       this.hdfsUri = conf.get(Configs.HDFS_URI).toString();
-    } else {
-      throw new RuntimeException(Configs.HDFS_URI + " setting is required");
+    }
+    if(this.hdfsUri==null) {
+      throw new RuntimeException("HDFS Uri not set on spout");
     }
 
     try {
@@ -322,33 +393,41 @@ public class HdfsSpout extends BaseRichSpout {
       }
 
     // Reader type config
-    if( conf.containsKey(Configs.READER_TYPE) ) {
+    if( readerType==null && conf.containsKey(Configs.READER_TYPE) ) {
       readerType = conf.get(Configs.READER_TYPE).toString();
-      checkValidReader(readerType);
     }
+    checkValidReader(readerType);
 
     // -- source dir config
-    if ( !conf.containsKey(Configs.SOURCE_DIR) ) {
+    if ( sourceDir==null && conf.containsKey(Configs.SOURCE_DIR) ) {
+      sourceDir = conf.get(Configs.SOURCE_DIR).toString();
+    }
+    if( sourceDir==null ) {
       LOG.error(Configs.SOURCE_DIR + " setting is required");
       throw new RuntimeException(Configs.SOURCE_DIR + " setting is required");
     }
-    this.sourceDirPath = new Path( conf.get(Configs.SOURCE_DIR).toString() );
+    this.sourceDirPath = new Path( sourceDir );
 
     // -- archive dir config
-    if ( !conf.containsKey(Configs.ARCHIVE_DIR) ) {
+    if ( archiveDir==null && conf.containsKey(Configs.ARCHIVE_DIR) ) {
+      archiveDir = conf.get(Configs.ARCHIVE_DIR).toString();
+    }
+    if ( archiveDir==null ) {
       LOG.error(Configs.ARCHIVE_DIR + " setting is required");
       throw new RuntimeException(Configs.ARCHIVE_DIR + " setting is required");
     }
-    this.archiveDirPath = new Path( conf.get(Configs.ARCHIVE_DIR).toString() );
+    this.archiveDirPath = new Path( archiveDir );
     validateOrMakeDir(hdfs, archiveDirPath, "Archive");
 
     // -- bad files dir config
-    if ( !conf.containsKey(Configs.BAD_DIR) ) {
+    if ( badFilesDir==null && conf.containsKey(Configs.BAD_DIR) ) {
+      badFilesDir = conf.get(Configs.BAD_DIR).toString();
+    }
+    if(badFilesDir==null) {
       LOG.error(Configs.BAD_DIR + " setting is required");
       throw new RuntimeException(Configs.BAD_DIR + " setting is required");
     }
-
-    this.badFilesDirPath = new Path(conf.get(Configs.BAD_DIR).toString());
+    this.badFilesDirPath = new Path(badFilesDir);
     validateOrMakeDir(hdfs, badFilesDirPath, "bad files");
 
     // -- ignore file names config
@@ -357,9 +436,15 @@ public class HdfsSpout extends BaseRichSpout {
     }
 
     // -- lock dir config
-    String lockDir = !conf.containsKey(Configs.LOCK_DIR) ? getDefaultLockDir(sourceDirPath) : conf.get(Configs.LOCK_DIR).toString() ;
+    if( lockDir==null && conf.containsKey(Configs.LOCK_DIR) ) {
+      lockDir = conf.get(Configs.LOCK_DIR).toString();
+    }
+    if(lockDir==null) {
+      lockDir = getDefaultLockDir(sourceDirPath);
+    }
     this.lockDirPath = new Path(lockDir);
-    validateOrMakeDir(hdfs,lockDirPath,"locks");
+    validateOrMakeDir(hdfs,lockDirPath, "locks");
+
 
     // -- lock timeout
     if( conf.get(Configs.LOCK_TIMEOUT) !=null ) {

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -118,11 +118,12 @@ public class TestHdfsSpout {
     Path file2 = new Path(source.toString() + "/file2.txt");
     createTextFile(file2, 5);
 
-    Map conf = getDefaultConfig();
-    conf.put(Configs.COMMIT_FREQ_COUNT, "1");
-    conf.put(Configs.COMMIT_FREQ_SEC, "1");
+    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    spout.setCommitFrequencyCount(1);
+    spout.setCommitFrequencySec(1);
 
-    HdfsSpout spout = makeSpout(0, conf, Configs.TEXT, TextFileReader.defaultFields);
+    Map conf = getCommonConfigs();
+    openSpout(spout, 0, conf);
 
     runSpout(spout,"r11");
 
@@ -139,11 +140,13 @@ public class TestHdfsSpout {
     Path file2 = new Path(source.toString() + "/file2.txt");
     createTextFile(file2, 5);
 
-    Map conf = getDefaultConfig();
-    conf.put(Configs.COMMIT_FREQ_COUNT, "1");
-    conf.put(Configs.COMMIT_FREQ_SEC, "1");
-    conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, "1"); // enable acking
-    HdfsSpout spout = makeSpout(0, conf, Configs.TEXT, TextFileReader.defaultFields);
+    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    spout.setCommitFrequencyCount(1);
+    spout.setCommitFrequencySec(1);
+
+    Map conf = getCommonConfigs();
+    conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, "1"); // enable ACKing
+    openSpout(spout, 0, conf);
 
     // consume file 1
     runSpout(spout, "r6", "a0", "a1", "a2", "a3", "a4");
@@ -162,16 +165,26 @@ public class TestHdfsSpout {
     createTextFile(file1, 6);
 
     final Integer lockExpirySec = 1;
-    Map conf = getDefaultConfig();
-    conf.put(Configs.COMMIT_FREQ_COUNT, "1");
-    conf.put(Configs.COMMIT_FREQ_SEC, "1000"); // basically disable it
-    conf.put(Configs.LOCK_TIMEOUT, lockExpirySec.toString());
-    HdfsSpout spout = makeSpout(0, conf, Configs.TEXT, TextFileReader.defaultFields);
-    HdfsSpout spout2 = makeSpout(1, conf, Configs.TEXT, TextFileReader.defaultFields);
+
+    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    spout.setCommitFrequencyCount(1);
+    spout.setCommitFrequencySec(1000);  // effectively disable commits based on time
+    spout.setLockTimeoutSec(lockExpirySec);
+
+
+    HdfsSpout spout2 = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    spout2.setCommitFrequencyCount(1);
+    spout2.setCommitFrequencySec(1000);  // effectively disable commits based on time
+    spout2.setLockTimeoutSec(lockExpirySec);
+
+    Map conf = getCommonConfigs();
+    openSpout(spout, 0, conf);
+    openSpout(spout2, 1, conf);
 
     // consume file 1 partially
     List<String> res = runSpout(spout, "r2");
     Assert.assertEquals(2, res.size());
+
     // abandon file
     FileLock lock = getField(spout, "lock");
     TestFileLock.closeUnderlyingLockFile(lock);
@@ -209,12 +222,21 @@ public class TestHdfsSpout {
     createSeqFile(fs, file1, 6);
 
     final Integer lockExpirySec = 1;
-    Map conf = getDefaultConfig();
-    conf.put(Configs.COMMIT_FREQ_COUNT, "1");
-    conf.put(Configs.COMMIT_FREQ_SEC, "1000"); // basically disable it
-    conf.put(Configs.LOCK_TIMEOUT, lockExpirySec.toString());
-    HdfsSpout spout = makeSpout(0, conf, Configs.SEQ, SequenceFileReader.defaultFields);
-    HdfsSpout spout2 = makeSpout(1, conf, Configs.SEQ, SequenceFileReader.defaultFields);
+
+    HdfsSpout spout = makeSpout(Configs.SEQ, SequenceFileReader.defaultFields);
+    spout.setCommitFrequencyCount(1);
+    spout.setCommitFrequencySec(1000); // effectively disable commits based on time
+    spout.setLockTimeoutSec(lockExpirySec);
+
+
+    HdfsSpout spout2 = makeSpout(Configs.SEQ, SequenceFileReader.defaultFields);
+    spout2.setCommitFrequencyCount(1);
+    spout2.setCommitFrequencySec(1000); // effectively disable commits based on time
+    spout2.setLockTimeoutSec(lockExpirySec);
+
+    Map conf = getCommonConfigs();
+    openSpout(spout, 0, conf);
+    openSpout(spout2, 1, conf);
 
     // consume file 1 partially
     List<String> res = runSpout(spout, "r2");
@@ -322,11 +344,14 @@ public class TestHdfsSpout {
     Path file1 = new Path(source.toString() + "/file1.txt");
     createTextFile(file1, 5);
 
-    Map conf = getDefaultConfig();
-    conf.put(Configs.COMMIT_FREQ_COUNT, "1");
-    conf.put(Configs.COMMIT_FREQ_SEC, "1");
+
+    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    spout.setCommitFrequencyCount(1);
+    spout.setCommitFrequencySec(1);
+
+    Map conf = getCommonConfigs();
     conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, "1"); // enable ACKing
-    HdfsSpout spout = makeSpout(0, conf, Configs.TEXT, TextFileReader.defaultFields);
+    openSpout(spout, 0, conf);
 
     // read few lines from file1 dont ack
     runSpout(spout, "r3");
@@ -401,8 +426,10 @@ public class TestHdfsSpout {
     Path file2 = new Path(source + "/file2.seq");
     createSeqFile(fs, file2, 5);
 
-    Map conf = getDefaultConfig();
-    HdfsSpout spout = makeSpout(0, conf, Configs.SEQ, SequenceFileReader.defaultFields);
+
+    HdfsSpout spout = makeSpout(Configs.SEQ, SequenceFileReader.defaultFields);
+    Map conf = getCommonConfigs();
+    openSpout(spout, 0, conf);
 
     // consume both files
     List<String> res = runSpout(spout, "r11");
@@ -428,8 +455,10 @@ public class TestHdfsSpout {
     Assert.assertEquals(2, listDir(source).size());
 
     // 2) run spout
-    Map conf = getDefaultConfig();
-    HdfsSpout spout = makeSpout(0, conf, MockTextFailingReader.class.getName(), MockTextFailingReader.defaultFields);
+    HdfsSpout spout = makeSpout(MockTextFailingReader.class.getName(), MockTextFailingReader.defaultFields);
+    Map conf = getCommonConfigs();
+    openSpout(spout, 0, conf);
+
     List<String> res = runSpout(spout, "r11");
     String[] expected = new String[] {"[line 0]","[line 1]","[line 2]","[line 0]","[line 1]","[line 2]"};
     Assert.assertArrayEquals(expected, res.toArray());
@@ -447,10 +476,14 @@ public class TestHdfsSpout {
      createTextFile(file1, 10);
 
      // 0) config spout to log progress in lock file for each tuple
-     Map conf = getDefaultConfig();
-     conf.put(Configs.COMMIT_FREQ_COUNT, "1");
-     conf.put(Configs.COMMIT_FREQ_SEC, "100"); // make it irrelvant
-     HdfsSpout spout = makeSpout(0, conf, Configs.TEXT, TextFileReader.defaultFields);
+
+     HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+     spout.setCommitFrequencyCount(1);
+     spout.setCommitFrequencySec(1000);  // effectively disable commits based on time
+
+
+     Map conf = getCommonConfigs();
+     openSpout(spout, 0, conf);
 
      // 1) read initial lines in file, then check if lock exists
      List<String> res = runSpout(spout, "r5");
@@ -494,10 +527,13 @@ public class TestHdfsSpout {
     createTextFile(file1, 10);
 
     // 0) config spout to log progress in lock file for each tuple
-    Map conf = getDefaultConfig();
-    conf.put(Configs.COMMIT_FREQ_COUNT, "2");  // 1 lock log entry every 2 tuples
-    conf.put(Configs.COMMIT_FREQ_SEC, "1000"); // make it irrelevant for this test
-    HdfsSpout spout = makeSpout(0, conf, Configs.TEXT, TextFileReader.defaultFields);
+
+    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    spout.setCommitFrequencyCount(2);   // 1 lock log entry every 2 tuples
+    spout.setCommitFrequencySec(1000);  // Effectively disable commits based on time
+
+    Map conf = getCommonConfigs();
+    openSpout(spout, 0, conf);
 
     // 1) read 5 lines in file,
     runSpout(spout, "r5");
@@ -519,11 +555,12 @@ public class TestHdfsSpout {
     createTextFile(file1, 10);
 
     // 0) config spout to log progress in lock file for each tuple
-    Map conf = getDefaultConfig();
-    conf.put(Configs.COMMIT_FREQ_COUNT, "0");  // disable it
-    conf.put(Configs.COMMIT_FREQ_SEC, "2"); // log every 2 sec
+    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    spout.setCommitFrequencyCount(0); // disable it
+    spout.setCommitFrequencySec(2);   // log every 2 sec
 
-    HdfsSpout spout = makeSpout(0, conf, Configs.TEXT, TextFileReader.defaultFields);
+    Map conf = getCommonConfigs();
+    openSpout(spout, 0, conf);
 
     // 1) read 5 lines in file
     runSpout(spout, "r5");
@@ -551,24 +588,27 @@ public class TestHdfsSpout {
     return result;
   }
 
-  private Map getDefaultConfig() {
+
+  private Map getCommonConfigs() {
     Map conf = new HashMap();
-    conf.put(Configs.SOURCE_DIR, source.toString());
-    conf.put(Configs.ARCHIVE_DIR, archive.toString());
-    conf.put(Configs.BAD_DIR, badfiles.toString());
-    conf.put(Configs.HDFS_URI, hdfsCluster.getURI().toString());
     conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, "0");
     return conf;
   }
 
+  private HdfsSpout makeSpout(String readerType, String[] outputFields) {
+    HdfsSpout spout = new HdfsSpout().withOutputFields(outputFields)
+                                    .setReaderType(readerType)
+                                    .setHdfsUri(hdfsCluster.getURI().toString())
+                                    .setSourceDir(source.toString())
+                                    .setArchiveDir(archive.toString())
+                                    .setBadFilesDir(badfiles.toString());
 
-  private static HdfsSpout makeSpout(int spoutId, Map conf, String readerType, String[] outputFields) {
-    HdfsSpout spout = new HdfsSpout().withOutputFields(outputFields);
-    MockCollector collector = new MockCollector();
-    conf.put(Configs.READER_TYPE, readerType);
-    spout.open(conf, new MockTopologyContext(spoutId), collector);
-    conf.put(Configs.HDFS_URI, hdfsCluster.getURI().toString());
     return spout;
+  }
+
+  private void openSpout(HdfsSpout spout, int spoutId, Map conf) {
+    MockCollector collector = new MockCollector();
+    spout.open(conf, new MockTopologyContext(spoutId), collector);
   }
 
   /**


### PR DESCRIPTION
Changing the way the spout is configured. Using member functions as the primary mode of config... still have to supporting the older mode  (via conf object ) for backward compatibility.
Updated test code.