### PR TITLE
STORM-1966 Expand metric having Map type as value into multiple metrics based on entries (1.x)

### DIFF
--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -45,6 +45,11 @@
 ## - when none of configuration for metric filter are specified, it'll be treated as 'pass all'.
 ## - you need to specify either whitelist or blacklist, or none of them. You can't specify both of them.
 ## - you can specify multiple whitelist / blacklist with regular expression
+## expandMapType: expand metric with map type as value to multiple metrics
+## - set to true when you would like to apply filter to expanded metrics
+## - default value is false which is backward compatible value
+## metricNameSeparator: separator between origin metric name and key of entry from map
+## - only effective when expandMapType is set to true
 # topology.metrics.consumer.register:
 #   - class: "org.apache.storm.metric.LoggingMetricsConsumer"
 #     max.retain.metric.tuples: 100
@@ -57,6 +62,8 @@
 #     parallelism.hint: 1
 #     argument:
 #       - endpoint: "metrics-collector.mycompany.org"
+#     expandMapType: true
+#     metricNameSeparator: "."
 
 ## Cluster Metrics Consumers
 # storm.cluster.metrics.consumer.register:

--- a/storm-core/src/jvm/org/apache/storm/metric/MetricsConsumerBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/MetricsConsumerBolt.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.storm.Config;
 import org.apache.storm.metric.api.IMetricsConsumer;
+import org.apache.storm.metric.util.DataPointExpander;
 import org.apache.storm.task.IBolt;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -42,19 +43,21 @@ public class MetricsConsumerBolt implements IBolt {
     String _consumerClassName;
     OutputCollector _collector;
     Object _registrationArgument;
-    private Predicate<IMetricsConsumer.DataPoint> _filterPredicate;
     private final int _maxRetainMetricTuples;
+    private Predicate<IMetricsConsumer.DataPoint> _filterPredicate;
+    private final DataPointExpander _expander;
 
     private final BlockingQueue<MetricsTask> _taskQueue;
     private Thread _taskExecuteThread;
     private volatile boolean _running = true;
 
     public MetricsConsumerBolt(String consumerClassName, Object registrationArgument, int maxRetainMetricTuples,
-                               Predicate<IMetricsConsumer.DataPoint> filterPredicate) {
+                               Predicate<IMetricsConsumer.DataPoint> filterPredicate, DataPointExpander expander) {
         _consumerClassName = consumerClassName;
         _registrationArgument = registrationArgument;
         _maxRetainMetricTuples = maxRetainMetricTuples;
         _filterPredicate = filterPredicate;
+        _expander = expander;
 
         if (_maxRetainMetricTuples > 0) {
             _taskQueue = new LinkedBlockingDeque<>(_maxRetainMetricTuples);
@@ -82,7 +85,8 @@ public class MetricsConsumerBolt implements IBolt {
     public void execute(Tuple input) {
         IMetricsConsumer.TaskInfo taskInfo = (IMetricsConsumer.TaskInfo) input.getValue(0);
         Collection<IMetricsConsumer.DataPoint> dataPoints = (Collection) input.getValue(1);
-        List<IMetricsConsumer.DataPoint> filteredDataPoints = getFilteredDataPoints(dataPoints);
+        Collection<IMetricsConsumer.DataPoint> expandedDataPoints = _expander.expandDataPoints(dataPoints);
+        List<IMetricsConsumer.DataPoint> filteredDataPoints = getFilteredDataPoints(expandedDataPoints);
         MetricsTask metricsTask = new MetricsTask(taskInfo, filteredDataPoints);
 
         while (!_taskQueue.offer(metricsTask)) {

--- a/storm-core/src/jvm/org/apache/storm/metric/api/IMetricsConsumer.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/api/IMetricsConsumer.java
@@ -21,6 +21,7 @@ import org.apache.storm.task.IErrorReporter;
 import org.apache.storm.task.TopologyContext;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 
 public interface IMetricsConsumer {
     public static class TaskInfo {
@@ -54,6 +55,23 @@ public interface IMetricsConsumer {
         }
         public String name; 
         public Object value;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DataPoint)) return false;
+
+            DataPoint dataPoint = (DataPoint) o;
+
+            return Objects.equals(name, dataPoint.name) && Objects.deepEquals(value, dataPoint.value);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name != null ? name.hashCode() : 0;
+            result = 31 * result + (value != null ? value.hashCode() : 0);
+            return result;
+        }
     }
 
     void prepare(Map stormConf, Object registrationArgument, TopologyContext context, IErrorReporter errorReporter);

--- a/storm-core/src/jvm/org/apache/storm/metric/util/DataPointExpander.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/util/DataPointExpander.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.metric.util;
+
+import org.apache.storm.metric.api.IMetricsConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DataPointExpander implements Serializable {
+  public static final Logger LOG = LoggerFactory.getLogger(DataPointExpander.class);
+
+  private final boolean expandMapType;
+  private final String metricNameSeparator;
+
+  public DataPointExpander(boolean expandMapType, String metricNameSeparator) {
+    this.expandMapType = expandMapType;
+    this.metricNameSeparator = metricNameSeparator;
+  }
+
+  public Collection<IMetricsConsumer.DataPoint> expandDataPoints(Collection<IMetricsConsumer.DataPoint> dataPoints) {
+    if (!expandMapType) {
+      return dataPoints;
+    }
+
+    List<IMetricsConsumer.DataPoint> expandedDataPoints = new ArrayList<>();
+
+    for (IMetricsConsumer.DataPoint dataPoint : dataPoints) {
+      expandedDataPoints.addAll(expandDataPoint(dataPoint));
+    }
+
+    return expandedDataPoints;
+  }
+
+  public Collection<IMetricsConsumer.DataPoint> expandDataPoint(IMetricsConsumer.DataPoint dataPoint) {
+    if (!expandMapType) {
+      return Collections.singletonList(dataPoint);
+    }
+
+    List<IMetricsConsumer.DataPoint> dataPoints = new ArrayList<>();
+
+    if (dataPoint.value == null) {
+      LOG.warn("Data point with name {} is null. Discarding.", dataPoint.name);
+    } else if (dataPoint.value instanceof Map) {
+      Map<Object, Object> dataMap = (Map<Object, Object>) dataPoint.value;
+
+      for (Map.Entry<Object, Object> entry : dataMap.entrySet()) {
+        String expandedDataPointName = dataPoint.name + metricNameSeparator + String.valueOf(entry.getKey());
+        dataPoints.add(new IMetricsConsumer.DataPoint(expandedDataPointName, entry.getValue()));
+      }
+    } else {
+      dataPoints.add(dataPoint);
+    }
+
+    return dataPoints;
+  }
+
+}

--- a/storm-core/test/jvm/org/apache/storm/metric/util/DataPointExpanderTest.java
+++ b/storm-core/test/jvm/org/apache/storm/metric/util/DataPointExpanderTest.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.metric.util;
+
+import com.google.common.collect.Lists;
+import org.apache.storm.metric.api.IMetricsConsumer;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DataPointExpanderTest {
+
+  @Test
+  public void testExpandedataPointWithExpandDisabled() {
+    DataPointExpander expander = new DataPointExpander(false, ".");
+    Map<String, Object> value = getDummyMetricMapValue();
+    IMetricsConsumer.DataPoint point = new IMetricsConsumer.DataPoint("test", value);
+
+    Collection<IMetricsConsumer.DataPoint> expandedDataPoints = expander.expandDataPoint(point);
+    assertEquals(1, expandedDataPoints.size());
+    assertEquals(point, expandedDataPoints.iterator().next());
+  }
+
+  @Test
+  public void testExpandedataPointsWithExpandDisabled() {
+    DataPointExpander expander = new DataPointExpander(false, ".");
+    Map<String, Object> value = getDummyMetricMapValue();
+    IMetricsConsumer.DataPoint point = new IMetricsConsumer.DataPoint("test", value);
+
+    Collection<IMetricsConsumer.DataPoint> expandedDataPoints =
+        expander.expandDataPoints(Collections.singletonList(point));
+    assertEquals(1, expandedDataPoints.size());
+    assertEquals(point, expandedDataPoints.iterator().next());
+  }
+
+  @Test
+  public void testExpandedataPointWithVariousKindOfMetrics() {
+    DataPointExpander expander = new DataPointExpander(true, ".");
+
+    IMetricsConsumer.DataPoint point = new IMetricsConsumer.DataPoint("point", getDummyMetricMapValue());
+
+    Collection<IMetricsConsumer.DataPoint> expandedDataPoints =
+        expander.expandDataPoints(Collections.singletonList(point));
+    assertEquals(4, expandedDataPoints.size());
+    assertTrue(expandedDataPoints.contains(new IMetricsConsumer.DataPoint("point.a", 1.0)));
+    assertTrue(expandedDataPoints.contains(new IMetricsConsumer.DataPoint("point.b", 2.5)));
+    assertTrue(expandedDataPoints.contains(new IMetricsConsumer.DataPoint("point.c", null)));
+    assertTrue(expandedDataPoints.contains(new IMetricsConsumer.DataPoint("point.d", "hello")));
+  }
+
+  @Test
+  public void testExpandedataPointsWithVariousKindOfMetrics() {
+    DataPointExpander expander = new DataPointExpander(true, ":");
+
+    IMetricsConsumer.DataPoint point1 = new IMetricsConsumer.DataPoint("point1", 2.5);
+    IMetricsConsumer.DataPoint point2 = new IMetricsConsumer.DataPoint("point2", getDummyMetricMapValue());
+
+    Collection<IMetricsConsumer.DataPoint> expandedDataPoints =
+        expander.expandDataPoints(Lists.newArrayList(point1, point2));
+    // 1 for point1, 4 for point2
+    assertEquals(5, expandedDataPoints.size());
+    assertTrue(expandedDataPoints.contains(new IMetricsConsumer.DataPoint("point1", 2.5)));
+    assertTrue(expandedDataPoints.contains(new IMetricsConsumer.DataPoint("point2:a", 1.0)));
+    assertTrue(expandedDataPoints.contains(new IMetricsConsumer.DataPoint("point2:b", 2.5)));
+    assertTrue(expandedDataPoints.contains(new IMetricsConsumer.DataPoint("point2:c", null)));
+    assertTrue(expandedDataPoints.contains(new IMetricsConsumer.DataPoint("point2:d", "hello")));
+  }
+
+  @Test
+  public void testExpandedDataPointWithNullValueMetric() {
+    DataPointExpander expander = new DataPointExpander(true, ".");
+
+    IMetricsConsumer.DataPoint point = new IMetricsConsumer.DataPoint("point", null);
+    Collection<IMetricsConsumer.DataPoint> expandedDataPoints = expander.expandDataPoint(point);
+
+    assertEquals(0, expandedDataPoints.size());
+  }
+
+  private Map<String, Object> getDummyMetricMapValue() {
+    Map<String, Object> value = new HashMap<>();
+    value.put("a", 1.0);
+    value.put("b", 2.5);
+    value.put("c", null);
+    value.put("d", "hello"); // yes it's just a test purpose
+    return value;
+  }
+
+}


### PR DESCRIPTION
PR for master: #1560 

* populate metric before applying filter so that filter can play with populated metrics
* add relevant configs to metrics consumer registration and describe them to storm.config.yaml
* add unit test

Please refer https://issues.apache.org/jira/browse/STORM-1966 for more details.