### PR TITLE
TridentHiveTopology fails to run due to incompatibility between thrift dependencies

### DIFF
--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <version>0.9.0</version>
+      <version>0.9.3</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
 - hive-hcatalog-streaming:jar depends on thrift 0.9.3
 - storm-hive:jar depends on thrift 0.9.0
 - Update storm-hive thrift version to 0.9.3