### PR TITLE
[STORM-1968] Storm logviewer does not work for nimbus.log in secure cluster

### DIFF
--- a/storm-core/src/clj/org/apache/storm/util.clj
+++ b/storm-core/src/clj/org/apache/storm/util.clj
@@ -1055,7 +1055,7 @@
     (with-open [reader (java.io.FileReader. yamlFile)]
       (clojurify-structure (.load (Yaml. (SafeConstructor.)) reader)))
     (catch Exception ex
-      (log-error ex))))
+      (log-error ex) {})))
 
 (defn hashmap-to-persistent [^HashMap m]
   (zipmap (.keySet m) (.values m)))

--- a/storm-core/test/clj/org/apache/storm/utils_test.clj
+++ b/storm-core/test/clj/org/apache/storm/utils_test.clj
@@ -108,3 +108,8 @@
   (is (= 10100 (secs-to-millis-long 10.1)))
 )
 
+(deftest test-clojure-from-yaml-file
+  (is (= {} (clojure-from-yaml-file nil)))
+  (is (= {} (clojure-from-yaml-file "foo-bar-file")))
+  )
+


### PR DESCRIPTION
logviewer invokes "get-log-user-group-whitelist" which tries to get the worker metadata file by invoking "get-log-metadata-file". In the case of nimbus.log clojure-from-yaml-file  returns nil and the authorization fails.

Modify clojure-from-yaml-file to return an empty map in case of failures so that the authorization can continue.