### PR TITLE
STORM-1969 Modify HiveTopology to show usage of non-partition table

### DIFF
--- a/external/storm-hive/src/test/java/org/apache/storm/hive/bolt/HiveTopology.java
+++ b/external/storm-hive/src/test/java/org/apache/storm/hive/bolt/HiveTopology.java
@@ -51,7 +51,6 @@ public class HiveTopology {
         config.setNumWorkers(1);
         UserDataSpout spout = new UserDataSpout();
         DelimitedRecordHiveMapper mapper = new DelimitedRecordHiveMapper()
-                .withTimeAsPartitionField("yyyy/MM/dd/hh")
                 .withColumnFields(new Fields(colNames));
         HiveOptions hiveOptions;
         if (args.length == 6) {


### PR DESCRIPTION
There're some kinds of topology in storm-hive, but all of them uses partition so we don't have example for accessing non-partition table. It would be better to have one for automated tests.

Instead of creating a new topology, we can modify HiveTopology to not use partition at all. BucketTestHiveTopology and TridentHiveTopology also use DelimitedRecordHiveMapper.withTimeAsPartitionField() so I think usage of withTimeAsPartitionField() is covered.

It can be ported back easily so I don't create pull requests for other branches.
We would be better to have this to 1.x and maybe 1.0.x, too.

Please review and comment. Thanks!