### PR TITLE
[STORM-1971] HDFS Timed Synchronous Policy

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/sync/TimedSyncPolicy.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/sync/TimedSyncPolicy.java
@@ -15,32 +15,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.hdfs.trident.sync;
+package org.apache.storm.hdfs.bolt.sync;
 
-
-import org.apache.storm.trident.tuple.TridentTuple;
+import org.apache.storm.tuple.Tuple;
 
 /**
- * SyncPolicy implementation that will trigger a
- * file system sync after a certain number of tuples
- * have been processed.
+ * SyncPolicy implementation that flush to HDFS periodically.
  */
-public class CountSyncPolicy implements SyncPolicy {
-    private final int count;
-    private int executeCount = 0;
+public class TimedSyncPolicy implements SyncPolicy {
+    private final long interval;
+    private long lastPoint;
 
-    public CountSyncPolicy(int count){
-        this.count = count;
+    public TimedSyncPolicy(long interval) {
+        this.interval = interval;
+        this.lastPoint = System.currentTimeMillis();
     }
 
     @Override
-    public boolean mark(TridentTuple tuple, long offset) {
-        this.executeCount++;
-        return this.executeCount >= this.count;
+    public boolean mark(Tuple tuple, long offset) {
+        long currentPoint = System.currentTimeMillis();
+        if ((currentPoint - lastPoint) > interval) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override
     public void reset() {
-        this.executeCount = 0;
+        this.lastPoint = System.currentTimeMillis();
     }
 }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/trident/sync/TimedSyncPolicy.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/trident/sync/TimedSyncPolicy.java
@@ -17,30 +17,32 @@
  */
 package org.apache.storm.hdfs.trident.sync;
 
-
 import org.apache.storm.trident.tuple.TridentTuple;
 
 /**
- * SyncPolicy implementation that will trigger a
- * file system sync after a certain number of tuples
- * have been processed.
+ * SyncPolicy implementation that flush to HDFS periodically.
  */
-public class CountSyncPolicy implements SyncPolicy {
-    private final int count;
-    private int executeCount = 0;
+public class TimedSyncPolicy implements SyncPolicy {
+    private final long interval;
+    private long lastPoint;
 
-    public CountSyncPolicy(int count){
-        this.count = count;
+    public TimedSyncPolicy(long interval) {
+        this.interval = interval;
+        this.lastPoint = System.currentTimeMillis();
     }
 
     @Override
     public boolean mark(TridentTuple tuple, long offset) {
-        this.executeCount++;
-        return this.executeCount >= this.count;
+        long currentPoint = System.currentTimeMillis();
+        if ((currentPoint - lastPoint) > interval) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override
     public void reset() {
-        this.executeCount = 0;
+        this.lastPoint = System.currentTimeMillis();
     }
 }


### PR DESCRIPTION
[STORM-1971 HDFS Timed Synchronous Policy](https://issues.apache.org/jira/browse/STORM-1971)

When the data need to be wrote to HDFS is not very large in quantity . 

We need a timed synchronous policy to flush cached date into HDFS periodically.
