### PR TITLE
[STORM-1964] Unexpected behavior when using count window together with timestamp extraction

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
@@ -253,7 +253,7 @@ public class WindowedBoltExecutor implements IRichBolt {
                                                     WindowManager<Tuple> manager) {
         if (windowLengthCount != null) {
             if (isTupleTs()) {
-                return new WatermarkCountEvictionPolicy<>(windowLengthCount.value, manager);
+                return new WatermarkCountEvictionPolicy<>(windowLengthCount.value);
             } else {
                 return new CountEvictionPolicy<>(windowLengthCount.value);
             }

--- a/storm-core/src/jvm/org/apache/storm/windowing/CountEvictionPolicy.java
+++ b/storm-core/src/jvm/org/apache/storm/windowing/CountEvictionPolicy.java
@@ -17,7 +17,7 @@
  */
 package org.apache.storm.windowing;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * An eviction policy that tracks event counts and can
@@ -26,12 +26,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @param <T> the type of event tracked by this policy.
  */
 public class CountEvictionPolicy<T> implements EvictionPolicy<T> {
-    private final int threshold;
-    protected final AtomicInteger currentCount;
+    protected final int threshold;
+    protected final AtomicLong currentCount;
 
     public CountEvictionPolicy(int count) {
         this.threshold = count;
-        this.currentCount = new AtomicInteger();
+        this.currentCount = new AtomicLong();
     }
 
     @Override
@@ -41,7 +41,7 @@ public class CountEvictionPolicy<T> implements EvictionPolicy<T> {
          * return if the event should be evicted
          */
         while (true) {
-            int curVal = currentCount.get();
+            long curVal = currentCount.get();
             if (curVal > threshold) {
                 if (currentCount.compareAndSet(curVal, curVal - 1)) {
                     return Action.EXPIRE;
@@ -61,7 +61,7 @@ public class CountEvictionPolicy<T> implements EvictionPolicy<T> {
     }
 
     @Override
-    public void setContext(Object context) {
+    public void setContext(EvictionContext context) {
         // NOOP
     }
 

--- a/storm-core/src/jvm/org/apache/storm/windowing/CountTriggerPolicy.java
+++ b/storm-core/src/jvm/org/apache/storm/windowing/CountTriggerPolicy.java
@@ -44,7 +44,7 @@ public class CountTriggerPolicy<T> implements TriggerPolicy<T> {
     public void track(Event<T> event) {
         if (started && !event.isWatermark()) {
             if (currentCount.incrementAndGet() >= count) {
-                evictionPolicy.setContext(System.currentTimeMillis());
+                evictionPolicy.setContext(new DefaultEvictionContext(System.currentTimeMillis()));
                 handler.onTrigger();
             }
         }

--- a/storm-core/src/jvm/org/apache/storm/windowing/DefaultEvictionContext.java
+++ b/storm-core/src/jvm/org/apache/storm/windowing/DefaultEvictionContext.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.windowing;
+
+public class DefaultEvictionContext implements EvictionContext {
+    private final Long referenceTime;
+    private final Long currentCount;
+    private final Long slidingCount;
+
+    public DefaultEvictionContext(Long referenceTime) {
+        this(referenceTime, null);
+    }
+
+    public DefaultEvictionContext(Long referenceTime, Long currentCount) {
+        this(referenceTime, currentCount, null);
+    }
+
+    public DefaultEvictionContext(Long referenceTime, Long currentCount, Long slidingCount) {
+        this.referenceTime = referenceTime;
+        this.currentCount = currentCount;
+        this.slidingCount = slidingCount;
+    }
+
+    @Override
+    public Long getReferenceTime() {
+        return referenceTime;
+    }
+
+    @Override
+    public Long getCurrentCount() {
+        return currentCount;
+    }
+
+    @Override
+    public Long getSlidingCount() {
+        return slidingCount;
+    }
+}

--- a/storm-core/src/jvm/org/apache/storm/windowing/EvictionContext.java
+++ b/storm-core/src/jvm/org/apache/storm/windowing/EvictionContext.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.windowing;
+
+/**
+ * Context information that can be used by the eviction policy
+ */
+public interface EvictionContext {
+    /**
+     * Returns the reference time that the eviction policy could use to
+     * evict the events. In the case of event time processing, this would be
+     * the watermark time.
+     *
+     * @return the reference time in millis
+     */
+    Long getReferenceTime();
+
+    /**
+     * Returns the sliding count for count based windows
+     *
+     * @return the sliding count
+     */
+    Long getSlidingCount();
+
+    /**
+     * Returns the current count of events in the queue up to the reference tim
+     * based on which count based evictions can be performed.
+     *
+     * @return the current count
+     */
+    Long getCurrentCount();
+}

--- a/storm-core/src/jvm/org/apache/storm/windowing/EvictionPolicy.java
+++ b/storm-core/src/jvm/org/apache/storm/windowing/EvictionPolicy.java
@@ -70,5 +70,6 @@ public interface EvictionPolicy<T> {
      *
      * @param context
      */
-    void setContext(Object context);
+    void setContext(EvictionContext context);
+
 }

--- a/storm-core/src/jvm/org/apache/storm/windowing/TimeEvictionPolicy.java
+++ b/storm-core/src/jvm/org/apache/storm/windowing/TimeEvictionPolicy.java
@@ -57,8 +57,8 @@ public class TimeEvictionPolicy<T> implements EvictionPolicy<T> {
     }
 
     @Override
-    public void setContext(Object context) {
-        referenceTime = ((Number) context).longValue();
+    public void setContext(EvictionContext context) {
+        referenceTime = context.getReferenceTime();
     }
 
     @Override

--- a/storm-core/src/jvm/org/apache/storm/windowing/TimeTriggerPolicy.java
+++ b/storm-core/src/jvm/org/apache/storm/windowing/TimeTriggerPolicy.java
@@ -115,7 +115,7 @@ public class TimeTriggerPolicy<T> implements TriggerPolicy<T> {
                      * to evict the events
                      */
                     if (evictionPolicy != null) {
-                        evictionPolicy.setContext(System.currentTimeMillis());
+                        evictionPolicy.setContext(new DefaultEvictionContext(System.currentTimeMillis()));
                     }
                     handler.onTrigger();
                 } catch (Throwable th) {

--- a/storm-core/src/jvm/org/apache/storm/windowing/WatermarkCountTriggerPolicy.java
+++ b/storm-core/src/jvm/org/apache/storm/windowing/WatermarkCountTriggerPolicy.java
@@ -74,7 +74,7 @@ public class WatermarkCountTriggerPolicy<T> implements TriggerPolicy<T> {
         long watermarkTs = waterMarkEvent.getTimestamp();
         List<Long> eventTs = windowManager.getSlidingCountTimestamps(lastProcessedTs, watermarkTs, count);
         for (long ts : eventTs) {
-            evictionPolicy.setContext(ts);
+            evictionPolicy.setContext(new DefaultEvictionContext(ts, null, Long.valueOf(count)));
             handler.onTrigger();
             lastProcessedTs = ts;
         }

--- a/storm-core/src/jvm/org/apache/storm/windowing/WatermarkTimeTriggerPolicy.java
+++ b/storm-core/src/jvm/org/apache/storm/windowing/WatermarkTimeTriggerPolicy.java
@@ -75,7 +75,8 @@ public class WatermarkTimeTriggerPolicy<T> implements TriggerPolicy<T> {
         long windowEndTs = nextWindowEndTs;
         LOG.debug("Window end ts {} Watermark ts {}", windowEndTs, watermarkTs);
         while (windowEndTs <= watermarkTs) {
-            evictionPolicy.setContext(windowEndTs);
+            long currentCount = windowManager.getEventCount(windowEndTs);
+            evictionPolicy.setContext(new DefaultEvictionContext(windowEndTs, currentCount));
             if (handler.onTrigger()) {
                 windowEndTs += slidingIntervalMs;
             } else {


### PR DESCRIPTION
Do not use timestamp to determine the event count in WatermarkCountEvictionPolicy
when count based trigger is used.