### PR TITLE
[STORM-1974] Using System.lineSeparator to replacement write a new line

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/metric/FileBasedEventLogger.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/FileBasedEventLogger.java
@@ -102,8 +102,7 @@ public class FileBasedEventLogger implements IEventLogger {
     public void log(EventInfo event) {
         try {
             //TODO: file rotation
-            eventLogWriter.write(event.toString());
-            eventLogWriter.newLine();
+            eventLogWriter.write(event.toString()+System.lineSeparator());
             dirty = true;
         } catch (IOException ex) {
             LOG.error("Error logging event {}", event, ex);


### PR DESCRIPTION
[STORM-1974 : Using System.lineSeparator to replacement write a new line](https://issues.apache.org/jira/browse/STORM-1974)

Using System.lineSeparator to replacement write a new line . 

It will write message in once and reduce writer synchroniz .
