### PR TITLE
STORM-1977 Restore logic: give up leadership when elected as leader but doesn't have one or more topology codes on local (1.x)

### DIFF
--- a/storm-core/src/clj/org/apache/storm/command/shell_submission.clj
+++ b/storm-core/src/clj/org/apache/storm/command/shell_submission.clj
@@ -22,7 +22,8 @@
 
 (defn -main [^String tmpjarpath & args]
   (let [conf (read-storm-config)
-        zk-leader-elector (zk-leader-elector conf)
+        ; since this is not a purpose to add to leader lock queue, passing nil as blob-store is ok
+        zk-leader-elector (zk-leader-elector conf nil)
         leader-nimbus (.getLeader zk-leader-elector)
         host (.getHost leader-nimbus)
         port (.getPort leader-nimbus)

--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -176,7 +176,8 @@
     (get storm-conf STORM-CLUSTER-METRICS-CONSUMER-REGISTER)))
 
 (defn nimbus-data [conf inimbus]
-  (let [forced-scheduler (.getForcedScheduler inimbus)]
+  (let [forced-scheduler (.getForcedScheduler inimbus)
+        blob-store (Utils/getNimbusBlobStore conf (NimbusInfo/fromConf conf))]
     {:conf conf
      :nimbus-host-port-info (NimbusInfo/fromConf conf)
      :inimbus inimbus
@@ -194,7 +195,7 @@
      :heartbeats-cache (atom {})
      :downloaders (file-cache-map conf)
      :uploaders (file-cache-map conf)
-     :blob-store (Utils/getNimbusBlobStore conf (NimbusInfo/fromConf conf))
+     :blob-store blob-store
      :blob-downloaders (mk-blob-cache-map conf)
      :blob-uploaders (mk-blob-cache-map conf)
      :blob-listers (mk-bloblist-cache-map conf)
@@ -205,7 +206,7 @@
                                  (exit-process! 20 "Error when processing an event")
                                  ))
      :scheduler (mk-scheduler conf inimbus)
-     :leader-elector (zk-leader-elector conf)
+     :leader-elector (zk-leader-elector conf blob-store)
      :id->sched-status (atom {})
      :node-id->resources (atom {}) ;;resources of supervisors
      :id->resources (atom {}) ;;resources of topologies


### PR DESCRIPTION
PR for master: #1573 

* Nimbus H/A introduced condition for becoming a leader
* It got removed when BlobStore was introduced
* This patch is restoring previous logic with making logic compatible to BlobStore