### PR TITLE
STORM-1988 Kafka Offset not showing due to bad classpath

### DIFF
--- a/bin/storm-kafka-monitor
+++ b/bin/storm-kafka-monitor
@@ -40,4 +40,4 @@ else
   JAVA="$JAVA_HOME/bin/java"
 fi
 
-exec "$JAVA" -cp "$STORM_BASE_DIR/toollib/storm-kafka-monitor*.jar" org.apache.storm.kafka.monitor.KafkaOffsetLagUtil "$@"
+exec "$JAVA" -cp "$STORM_BASE_DIR/toollib/*" org.apache.storm.kafka.monitor.KafkaOffsetLagUtil "$@"


### PR DESCRIPTION
Adding prefix and/or postfix between * just doesn't work on classpath, which I didn't recognize that.

Confirmed from CentOS6 with OpenJDK 1.8.0_91 / Oracle JDK 1.8.0_77 and OSX 10.11.5 with Oracle JDK 1.8.0_66.

Patch can be ported back to 1.x-branch easily.