### PR TITLE
[STORM-2003] Make sure config contains TOPIC before get it

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/bolt/KafkaBolt.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/bolt/KafkaBolt.java
@@ -98,7 +98,11 @@ public class KafkaBolt<K, V> extends BaseRichBolt {
 
         //for backward compatibility.
         if(topicSelector == null) {
-            this.topicSelector = new DefaultTopicSelector((String) stormConf.get(TOPIC));
+            if(stormConf.containsKey(TOPIC)) {
+                this.topicSelector = new DefaultTopicSelector((String) stormConf.get(TOPIC));
+            } else {
+                throw new IllegalArgumentException("topic should be specified in bolt's configuration");
+            }
         }
 
         producer = new KafkaProducer<>(boltSpecfiedProperties);


### PR DESCRIPTION
[STORM-2003 Make sure config contains TOPIC before get it](https://issues.apache.org/jira/browse/STORM-2003)

When topic selector is not specified, KafkaBolt will get topic name from storm config . We should make sure the topic name is not null .