### PR TITLE
STORM-1995: close input stream and other tweaks to downloadChunk

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -1793,16 +1793,16 @@
         (.mark nimbus:num-downloadChunk-calls)
         (check-authorization! nimbus nil nil "fileDownload")
         (let [downloaders (:downloaders nimbus)
-              ^BufferFileInputStream is (.get downloaders id)]
+              ^BufferInputStream is (.get downloaders id)]
           (when-not is
             (throw (RuntimeException.
-                    "Could not find input stream for that id")))
+                    "Could not find input stream for id " id)))
           (let [ret (.read is)]
             (.put downloaders id is)
             (when (empty? ret)
+              (.close is)
               (.remove downloaders id))
-            (ByteBuffer/wrap ret)
-            )))
+            (ByteBuffer/wrap ret))))
 
       (^String getNimbusConf [this]
         (.mark nimbus:num-getNimbusConf-calls)


### PR DESCRIPTION
When the input stream is being removed from its parent collection (after reading fully) in downloadChunk it isn't being closed, causing a leak.

Thanks to @tgravescs for making this change.