### PR TITLE
STORM-2006 Storm metrics feature improvement: support per-worker level metrics aggregation (1.x)

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -260,6 +260,10 @@ topology.disruptor.batch.size: 100
 topology.disruptor.batch.timeout.millis: 1
 topology.disable.loadaware: false
 topology.state.checkpoint.interval.ms: 1000
+topology.metrics.aggregate.per.worker: false
+topology.metrics.aggregate.metric.evict.secs: 5
+topology.metrics.expand.map.type: false
+topology.metrics.metric.name.separator: "."
 
 # Configs for Resource Aware Scheduler
 # topology priority describing the importance of the topology in decreasing importance starting from 0 (i.e. 0 is the highest priority and the priority importance decreases as the priority number increases).

--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -38,18 +38,38 @@
 #     - "server1"
 #     - "server2"
 
+## Topology Metrics
+##
+## topology.metrics.aggregate.per.worker: aggregate task level metrics per worker
+## - set to true when you want to get list of task level metrics per worker
+## - srcTaskId on TaskInfo will be changed to SYSTEM_TASK_ID
+##
+## topology.metrics.aggregate.metric.evict.secs: set the limit time difference of holding metric for aggregation
+## - Metric will be evicted from SystemBolt if it is not aggregated and such condition has been met:
+## (current timestamp secs - metric timestamp secs) > topology.metrics.aggregate.metric.evict.secs
+##
+## topology.metrics.expand.map.type: expand metric with map type as value to multiple metrics
+## - set to true when you would like to apply filter to expanded metrics
+## - default value is false which is backward compatible value
+##
+## topology.metrics.metric.name.separator: separator between origin metric name and key of entry from map
+## - only effective when expandMapType is set to true
+##
+# topology.metrics.aggregate.per.worker: true
+# topology.metrics.aggregate.metric.evict.secs: 5
+# topology.metrics.expand.map.type: true
+# topology.metrics.metric.name.separator: "."
+
 ## Metrics Consumers
+##
 ## max.retain.metric.tuples
 ## - task queue will be unbounded when max.retain.metric.tuples is equal or less than 0.
+##
 ## whitelist / blacklist
 ## - when none of configuration for metric filter are specified, it'll be treated as 'pass all'.
 ## - you need to specify either whitelist or blacklist, or none of them. You can't specify both of them.
 ## - you can specify multiple whitelist / blacklist with regular expression
-## expandMapType: expand metric with map type as value to multiple metrics
-## - set to true when you would like to apply filter to expanded metrics
-## - default value is false which is backward compatible value
-## metricNameSeparator: separator between origin metric name and key of entry from map
-## - only effective when expandMapType is set to true
+##
 # topology.metrics.consumer.register:
 #   - class: "org.apache.storm.metric.LoggingMetricsConsumer"
 #     max.retain.metric.tuples: 100
@@ -62,8 +82,6 @@
 #     parallelism.hint: 1
 #     argument:
 #       - endpoint: "metrics-collector.mycompany.org"
-#     expandMapType: true
-#     metricNameSeparator: "."
 
 ## Cluster Metrics Consumers
 # storm.cluster.metrics.consumer.register:

--- a/storm-core/src/clj/org/apache/storm/daemon/executor.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/executor.clj
@@ -328,7 +328,8 @@
 
 (defn metrics-tick
   [executor-data task-data ^TupleImpl tuple]
-   (let [{:keys [interval->task->metric-registry ^WorkerTopologyContext worker-context]} executor-data
+   (let [{:keys [interval->task->metric-registry ^WorkerTopologyContext worker-context worker]} executor-data
+         system-bolt-receive-queue ((:executor-receive-queue-map worker) [Constants/SYSTEM_TASK_ID Constants/SYSTEM_TASK_ID])
          interval (.getInteger tuple 0)
          task-id (:task-id task-data)
          name->imetric (-> interval->task->metric-registry (get interval) (get task-id))
@@ -346,8 +347,8 @@
                                      (IMetricsConsumer$DataPoint. name value)))))
                           (filter identity)
                           (into []))]
-     (when (seq data-points)
-       (task/send-unanchored task-data Constants/METRICS_STREAM_ID [task-info data-points]))))
+     (let [val [(AddressedTuple. Constants/SYSTEM_TASK_ID (TupleImpl. worker-context [task-info data-points] Constants/SYSTEM_TASK_ID Constants/METRICS_STREAM_ID))]]
+       (disruptor/publish system-bolt-receive-queue val))))
 
 (defn setup-ticks! [worker executor-data]
   (let [storm-conf (:storm-conf executor-data)

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -2251,6 +2251,36 @@ public class Config extends HashMap<String, Object> {
     @isString
     public static final Object CLIENT_JAR_TRANSFORMER = "client.jartransformer.class";
 
+    /**
+     * Aggregate task level metrics per worker.
+     * If this is set to true, the type of value of DataPoint will be List, which are having task level values.
+     * srcTaskId on {@link org.apache.storm.metric.api.IMetricsConsumer.TaskInfo} will be changed to Constants.SYSTEM_TASK_ID.
+     */
+    @isBoolean
+    public static final String TOPOLOGY_METRICS_AGGREGATE_PER_WORKER = "topology.metrics.aggregate.per.worker";
+
+    /**
+     * Set the limit time difference of holding metric for aggregation.
+     * Metric will be evicted from SystemBolt if it is not aggregated and such condition has been met:
+     * (current timestamp secs - metric timestamp secs) > topology.metrics.aggregate.metric.evict.secs.
+     */
+    @isPositiveNumber
+    public static final String TOPOLOGY_METRICS_AGGREGATE_METRIC_EVICT_SECS = "topology.metrics.aggregate.metric.evict.secs";
+
+    /**
+     * Expand metric with map type as value to multiple metrics.
+     * If you would like to apply filter to expanded metrics, set this to true.
+     */
+    @isBoolean
+    public static final String TOPOLOGY_METRICS_EXPAND_MAP_TYPE = "topology.metrics.expand.map.type";
+
+    /**
+     * Separator between origin metric name and key of entry from map.
+     * Only effective when topology.metrics.expand.map.type is set to true.
+     */
+    @isString
+    public static final String TOPOLOGY_METRICS_METRIC_NAME_SEPARATOR = "topology.metrics.metric.name.separator";
+
     public static void setClasspath(Map conf, String cp) {
         conf.put(Config.TOPOLOGY_CLASSPATH, cp);
     }

--- a/storm-core/src/jvm/org/apache/storm/Constants.java
+++ b/storm-core/src/jvm/org/apache/storm/Constants.java
@@ -30,6 +30,7 @@ public class Constants {
     public static final String SYSTEM_TICK_STREAM_ID = "__tick";
     public static final String METRICS_COMPONENT_ID_PREFIX = "__metrics";
     public static final String METRICS_STREAM_ID = "__metrics";
+    public static final String METRICS_AGGREGATE_STREAM_ID = "__metrics_aggregate";
     public static final String METRICS_TICK_STREAM_ID = "__metrics_tick";
     public static final String CREDENTIALS_CHANGED_STREAM_ID = "__credentials";
 }

--- a/storm-core/src/jvm/org/apache/storm/metric/MetricsConsumerBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/MetricsConsumerBolt.java
@@ -45,19 +45,17 @@ public class MetricsConsumerBolt implements IBolt {
     Object _registrationArgument;
     private final int _maxRetainMetricTuples;
     private Predicate<IMetricsConsumer.DataPoint> _filterPredicate;
-    private final DataPointExpander _expander;
 
     private final BlockingQueue<MetricsTask> _taskQueue;
     private Thread _taskExecuteThread;
     private volatile boolean _running = true;
 
     public MetricsConsumerBolt(String consumerClassName, Object registrationArgument, int maxRetainMetricTuples,
-                               Predicate<IMetricsConsumer.DataPoint> filterPredicate, DataPointExpander expander) {
+                               Predicate<IMetricsConsumer.DataPoint> filterPredicate) {
         _consumerClassName = consumerClassName;
         _registrationArgument = registrationArgument;
         _maxRetainMetricTuples = maxRetainMetricTuples;
         _filterPredicate = filterPredicate;
-        _expander = expander;
 
         if (_maxRetainMetricTuples > 0) {
             _taskQueue = new LinkedBlockingDeque<>(_maxRetainMetricTuples);
@@ -85,8 +83,7 @@ public class MetricsConsumerBolt implements IBolt {
     public void execute(Tuple input) {
         IMetricsConsumer.TaskInfo taskInfo = (IMetricsConsumer.TaskInfo) input.getValue(0);
         Collection<IMetricsConsumer.DataPoint> dataPoints = (Collection) input.getValue(1);
-        Collection<IMetricsConsumer.DataPoint> expandedDataPoints = _expander.expandDataPoints(dataPoints);
-        List<IMetricsConsumer.DataPoint> filteredDataPoints = getFilteredDataPoints(expandedDataPoints);
+        List<IMetricsConsumer.DataPoint> filteredDataPoints = getFilteredDataPoints(dataPoints);
         MetricsTask metricsTask = new MetricsTask(taskInfo, filteredDataPoints);
 
         while (!_taskQueue.offer(metricsTask)) {

--- a/storm-core/src/jvm/org/apache/storm/metric/api/IMetricsConsumer.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/api/IMetricsConsumer.java
@@ -39,7 +39,47 @@ public interface IMetricsConsumer {
         public String srcComponentId; 
         public int srcTaskId; 
         public long timestamp;
-        public int updateIntervalSecs; 
+        public int updateIntervalSecs;
+
+        @Override
+        public String toString() {
+            return "TaskInfo{" +
+                    "srcWorkerHost='" + srcWorkerHost + '\'' +
+                    ", srcWorkerPort=" + srcWorkerPort +
+                    ", srcComponentId='" + srcComponentId + '\'' +
+                    ", srcTaskId=" + srcTaskId +
+                    ", timestamp=" + timestamp +
+                    ", updateIntervalSecs=" + updateIntervalSecs +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof TaskInfo)) return false;
+
+            TaskInfo taskInfo = (TaskInfo) o;
+
+            if (srcWorkerPort != taskInfo.srcWorkerPort) return false;
+            if (srcTaskId != taskInfo.srcTaskId) return false;
+            if (timestamp != taskInfo.timestamp) return false;
+            if (updateIntervalSecs != taskInfo.updateIntervalSecs) return false;
+            if (srcWorkerHost != null ? !srcWorkerHost.equals(taskInfo.srcWorkerHost) : taskInfo.srcWorkerHost != null)
+                return false;
+            return srcComponentId != null ? srcComponentId.equals(taskInfo.srcComponentId) : taskInfo.srcComponentId == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = srcWorkerHost != null ? srcWorkerHost.hashCode() : 0;
+            result = 31 * result + srcWorkerPort;
+            result = 31 * result + (srcComponentId != null ? srcComponentId.hashCode() : 0);
+            result = 31 * result + srcTaskId;
+            result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+            result = 31 * result + updateIntervalSecs;
+            return result;
+        }
     }
 
     // We can't move this to outside without breaking backward compatibility.


### PR DESCRIPTION
PR for master: #1595
- SystemBolt handles task level metrics via two mode
  - non-aggregate: same to previous, just applying expansion and pass to MetricConsumerBolts
  - aggregate: apply expansion, do aggregation, pass aggregated metrics to MetricConsumerBolts
- all task level metrics should pass by SystemBolt within its worker
  - it drops all connections between tasks and MetricsConsumerBolts
  - only SystemBolts and MetricConsumerBolts will be connected
- move configurations: expandMapType and metricNameSeparator to global
  - since SystemBolt needs to handle expansion when both worker level aggregation and expandMapType are turned on

Manually tested via matrix of options : aggregate x expand

I'm not sure how to create unit tests playing with SystemBolt, but will try to come up unit tests.
