### PR TITLE
STORM-2006 Storm metrics feature improvement: support per-worker level metrics aggregation

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -259,6 +259,10 @@ topology.disruptor.batch.size: 100
 topology.disruptor.batch.timeout.millis: 1
 topology.disable.loadaware: false
 topology.state.checkpoint.interval.ms: 1000
+topology.metrics.aggregate.per.worker: false
+topology.metrics.aggregate.metric.evict.secs: 5
+topology.metrics.expand.map.type: false
+topology.metrics.metric.name.separator: "."
 
 # Configs for Resource Aware Scheduler
 # topology priority describing the importance of the topology in decreasing importance starting from 0 (i.e. 0 is the highest priority and the priority importance decreases as the priority number increases).

--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -38,19 +38,38 @@
 #     - "server1"
 #     - "server2"
 
+## Topology Metrics
+##
+## topology.metrics.aggregate.per.worker: aggregate task level metrics per worker
+## - set to true when you want to get list of task level metrics per worker
+## - srcTaskId on TaskInfo will be changed to SYSTEM_TASK_ID
+##
+## topology.metrics.aggregate.metric.evict.secs: set the limit time difference of holding metric for aggregation
+## - Metric will be evicted from SystemBolt if it is not aggregated and such condition has been met:
+## (current timestamp secs - metric timestamp secs) > topology.metrics.aggregate.metric.evict.secs
+##
+## topology.metrics.expand.map.type: expand metric with map type as value to multiple metrics
+## - set to true when you would like to apply filter to expanded metrics
+## - default value is false which is backward compatible value
+##
+## topology.metrics.metric.name.separator: separator between origin metric name and key of entry from map
+## - only effective when expandMapType is set to true
+##
+# topology.metrics.aggregate.per.worker: true
+# topology.metrics.aggregate.metric.evict.secs: 5
+# topology.metrics.expand.map.type: true
+# topology.metrics.metric.name.separator: "."
+
 ## Metrics Consumers
+##
 ## max.retain.metric.tuples
 ## - task queue will be unbounded when max.retain.metric.tuples is equal or less than 0.
+##
 ## whitelist / blacklist
 ## - when none of configuration for metric filter are specified, it'll be treated as 'pass all'.
 ## - you need to specify either whitelist or blacklist, or none of them. You can't specify both of them.
 ## - you can specify multiple whitelist / blacklist with regular expression
-## expandMapType: expand metric with map type as value to multiple metrics
-## - set to true when you would like to apply filter to expanded metrics
-## - default value is false which is backward compatible value
-## metricNameSeparator: separator between origin metric name and key of entry from map
-## - only effective when expandMapType is set to true
-## - default value is "."
+##
 # topology.metrics.consumer.register:
 #   - class: "org.apache.storm.metric.LoggingMetricsConsumer"
 #     max.retain.metric.tuples: 100
@@ -63,8 +82,6 @@
 #     parallelism.hint: 1
 #     argument:
 #       - endpoint: "metrics-collector.mycompany.org"
-#     expandMapType: true
-#     metricNameSeparator: "."
 
 ## Cluster Metrics Consumers
 # storm.cluster.metrics.consumer.register:

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -2259,6 +2259,35 @@ public class Config extends HashMap<String, Object> {
     @isString
     public static final Object CLIENT_JAR_TRANSFORMER = "client.jartransformer.class";
 
+    /**
+     * Aggregate task level metrics per worker.
+     * If this is set to true, the type of value of DataPoint will be List, which are having task level values.
+     * srcTaskId on {@link org.apache.storm.metric.api.IMetricsConsumer.TaskInfo} will be changed to Constants.SYSTEM_TASK_ID.
+     */
+    @isBoolean
+    public static final String TOPOLOGY_METRICS_AGGREGATE_PER_WORKER = "topology.metrics.aggregate.per.worker";
+
+    /**
+     * Set the limit time difference of holding metric for aggregation.
+     * Metric will be evicted from SystemBolt if it is not aggregated and such condition has been met:
+     * (current timestamp secs - metric timestamp secs) > topology.metrics.aggregate.metric.evict.secs.
+     */
+    @isPositiveNumber
+    public static final String TOPOLOGY_METRICS_AGGREGATE_METRIC_EVICT_SECS = "topology.metrics.aggregate.metric.evict.secs";
+
+    /**
+     * Expand metric with map type as value to multiple metrics.
+     * If you would like to apply filter to expanded metrics, set this to true.
+     */
+    @isBoolean
+    public static final String TOPOLOGY_METRICS_EXPAND_MAP_TYPE = "topology.metrics.expand.map.type";
+
+    /**
+     * Separator between origin metric name and key of entry from map.
+     * Only effective when topology.metrics.expand.map.type is set to true.
+     */
+    @isString
+    public static final String TOPOLOGY_METRICS_METRIC_NAME_SEPARATOR = "topology.metrics.metric.name.separator";
 
     /**
      * The plugin to be used for resource isolation

--- a/storm-core/src/jvm/org/apache/storm/Constants.java
+++ b/storm-core/src/jvm/org/apache/storm/Constants.java
@@ -30,6 +30,7 @@ public class Constants {
     public static final String SYSTEM_TICK_STREAM_ID = "__tick";
     public static final String METRICS_COMPONENT_ID_PREFIX = "__metrics";
     public static final String METRICS_STREAM_ID = "__metrics";
+    public static final String METRICS_AGGREGATE_STREAM_ID = "__metrics_aggregate";
     public static final String METRICS_TICK_STREAM_ID = "__metrics_tick";
     public static final String CREDENTIALS_CHANGED_STREAM_ID = "__credentials";
 

--- a/storm-core/src/jvm/org/apache/storm/metric/SystemBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/SystemBolt.java
@@ -18,18 +18,33 @@
 package org.apache.storm.metric;
 
 import org.apache.storm.Config;
+import org.apache.storm.Constants;
 import org.apache.storm.metric.api.IMetric;
+import org.apache.storm.metric.api.IMetricsConsumer;
+import org.apache.storm.metric.util.DataPointExpander;
 import org.apache.storm.task.IBolt;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Time;
 import org.apache.storm.utils.Utils;
 import clojure.lang.AFn;
 import clojure.lang.IFn;
 import clojure.lang.RT;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.lang.management.*;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.lang.management.RuntimeMXBean;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 
@@ -37,7 +52,40 @@ import java.util.Map;
 // TaskID is always -1, therefore you can only send-unanchored tuples to co-located SystemBolt.
 // This bolt was conceived to export worker stats via metrics api.
 public class SystemBolt implements IBolt {
+    private static final Logger LOG = LoggerFactory.getLogger(SystemBolt.class);
+    public static final int MAX_ALLOW_DELAY_SECS_OF_TASK_METRICS = 5;
+
     private static boolean _prepareWasCalled = false;
+    private OutputCollector collector;
+    private TopologyContext context;
+    private int metricEvictSecs;
+    private DataPointExpander expander;
+    private boolean aggregateMode;
+    private Map<Integer, Map<Integer, TaskInfoToDataPointsPair>> intervalToTaskToMetricTupleMap;
+
+    private static class TaskInfoToDataPointsPair extends ImmutablePair<IMetricsConsumer.TaskInfo, Collection<IMetricsConsumer.DataPoint>> {
+        public TaskInfoToDataPointsPair(IMetricsConsumer.TaskInfo left, Collection<IMetricsConsumer.DataPoint> right) {
+            super(left, right);
+        }
+    }
+
+    private static class ImmutablePair<L, R> {
+        private L left;
+        private R right;
+
+        public ImmutablePair(L left, R right) {
+            this.left = left;
+            this.right = right;
+        }
+
+        public L getLeft() {
+            return left;
+        }
+
+        public R getRight() {
+            return right;
+        }
+    }
 
     private static class MemoryUsageMetric implements IMetric {
         IFn _getUsage;
@@ -87,10 +135,19 @@ public class SystemBolt implements IBolt {
 
     @Override
     public void prepare(final Map stormConf, TopologyContext context, OutputCollector collector) {
+        this.collector = collector;
+        this.context = context;
+
+        setupMetricsExpander(stormConf);
+        aggregateMode = Utils.getBoolean(stormConf.get(Config.TOPOLOGY_METRICS_AGGREGATE_PER_WORKER), false);
+        metricEvictSecs = Utils.getInt(stormConf.get(Config.TOPOLOGY_METRICS_AGGREGATE_METRIC_EVICT_SECS), MAX_ALLOW_DELAY_SECS_OF_TASK_METRICS);
+
         if(_prepareWasCalled && !"local".equals(stormConf.get(Config.STORM_CLUSTER_MODE))) {
             throw new RuntimeException("A single worker should have 1 SystemBolt instance.");
         }
         _prepareWasCalled = true;
+
+        intervalToTaskToMetricTupleMap = new HashMap<>();
 
         int bucketSize = RT.intCast(stormConf.get(Config.TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS));
 
@@ -143,6 +200,12 @@ public class SystemBolt implements IBolt {
         registerMetrics(context, (Map<String,String>)stormConf.get(Config.TOPOLOGY_WORKER_METRICS), bucketSize);
     }
 
+    private void setupMetricsExpander(Map stormConf) {
+        boolean expandMapType = Utils.getBoolean(stormConf.get(Config.TOPOLOGY_METRICS_EXPAND_MAP_TYPE), false);
+        String metricNameSeparator = Utils.getString(stormConf.get(Config.TOPOLOGY_METRICS_METRIC_NAME_SEPARATOR), ".");
+        this.expander = new DataPointExpander(expandMapType, metricNameSeparator);
+    }
+
     private void registerMetrics(TopologyContext context, Map<String, String> metrics, int bucketSize) {
         if (metrics == null) return;
         for (Map.Entry<String, String> metric: metrics.entrySet()) {
@@ -156,7 +219,107 @@ public class SystemBolt implements IBolt {
 
     @Override
     public void execute(Tuple input) {
-        throw new RuntimeException("Non-system tuples should never be sent to __system bolt.");
+        if (!input.getSourceStreamId().equals(Constants.METRICS_STREAM_ID)) {
+            throw new RuntimeException("Non-metric tuples should never be sent to __system bolt.");
+        }
+
+        IMetricsConsumer.TaskInfo taskInfo = (IMetricsConsumer.TaskInfo) input.getValue(0);
+        Collection<IMetricsConsumer.DataPoint> dataPoints = (Collection) input.getValue(1);
+        Collection<IMetricsConsumer.DataPoint> expandedDataPoints = expander.expandDataPoints(dataPoints);
+
+        if (aggregateMode) {
+            handleMetricTupleInAggregateMode(taskInfo, expandedDataPoints);
+        } else {
+            collector.emit(Constants.METRICS_AGGREGATE_STREAM_ID, new Values(taskInfo, expandedDataPoints));
+        }
+    }
+
+    private void handleMetricTupleInAggregateMode(IMetricsConsumer.TaskInfo taskInfo, Collection<IMetricsConsumer.DataPoint> expandedDataPoints) {
+        Map<Integer, TaskInfoToDataPointsPair> taskToMetricTupleMap = intervalToTaskToMetricTupleMap.get(taskInfo.updateIntervalSecs);
+        if (taskToMetricTupleMap == null) {
+            taskToMetricTupleMap = new HashMap<>();
+            intervalToTaskToMetricTupleMap.put(taskInfo.updateIntervalSecs, taskToMetricTupleMap);
+        }
+
+        taskToMetricTupleMap.put(taskInfo.srcTaskId, new TaskInfoToDataPointsPair(taskInfo, expandedDataPoints));
+
+        int currentTimeSec = Time.currentTimeSecs();
+        removeOldPendingMetricTuples(taskToMetricTupleMap, currentTimeSec);
+
+        // since we're removing old metric tuples, this means we're OK to aggregate here
+        if (isOKtoAggregateMetricsTuples(taskToMetricTupleMap)) {
+            Map<IMetricsConsumer.TaskInfo, Collection<IMetricsConsumer.DataPoint>> taskInfoToMetricTupleMap = convertMetricsTupleMapKeyedByTaskInfo(taskToMetricTupleMap, currentTimeSec);
+
+            // let's aggregate by metric name again
+            for (Map.Entry<IMetricsConsumer.TaskInfo, Collection<IMetricsConsumer.DataPoint>> taskInfoToDataPointsEntry : taskInfoToMetricTupleMap.entrySet()) {
+                IMetricsConsumer.TaskInfo taskInfoEntry = taskInfoToDataPointsEntry.getKey();
+                Collection<IMetricsConsumer.DataPoint> dataPointsEntry = taskInfoToDataPointsEntry.getValue();
+                Collection<IMetricsConsumer.DataPoint> aggregatedDataPoints = aggregateDataPointsByMetricName(dataPointsEntry);
+                collector.emit(Constants.METRICS_AGGREGATE_STREAM_ID, new Values(taskInfoEntry, aggregatedDataPoints));
+            }
+
+            // clear out already aggregated metrics
+            taskToMetricTupleMap.clear();
+        }
+    }
+
+    private void removeOldPendingMetricTuples(Map<Integer, TaskInfoToDataPointsPair> taskToMetricTupleMap, int currentTimeSec) {
+        // Remove all tuples which is recorded earlier than currentTimeSec - metricEvictSecs
+        for(Iterator<Map.Entry<Integer, TaskInfoToDataPointsPair>> it = taskToMetricTupleMap.entrySet().iterator(); it.hasNext(); ) {
+            Map.Entry<Integer, TaskInfoToDataPointsPair> taskToMetricTupleEntry = it.next();
+            TaskInfoToDataPointsPair taskInfoToDataPointsPair = taskToMetricTupleEntry.getValue();
+            IMetricsConsumer.TaskInfo taskInfoInEntry = taskInfoToDataPointsPair.getLeft();
+
+            if (currentTimeSec - taskInfoInEntry.timestamp > metricEvictSecs) {
+                it.remove();
+            }
+        }
+    }
+
+    private boolean isOKtoAggregateMetricsTuples(Map<Integer, TaskInfoToDataPointsPair> taskToMetricTupleMap) {
+        return taskToMetricTupleMap.size() == context.getThisWorkerTasks().size();
+    }
+
+    private Map<IMetricsConsumer.TaskInfo, Collection<IMetricsConsumer.DataPoint>> convertMetricsTupleMapKeyedByTaskInfo(Map<Integer, TaskInfoToDataPointsPair> taskToMetricTupleMap, int currentTimeSec) {
+        Map<IMetricsConsumer.TaskInfo, Collection<IMetricsConsumer.DataPoint>> taskInfoToDataPointsMap = new HashMap<>();
+        for (TaskInfoToDataPointsPair taskInfoToDataPoints : taskToMetricTupleMap.values()) {
+            IMetricsConsumer.TaskInfo taskInfoForEntry = taskInfoToDataPoints.getLeft();
+
+            // change task id to system task - the boundary of task id is integer so it is safe
+            // also change timestamp to have same value
+            // others are same, so it would be effectively keyed by component name
+            taskInfoForEntry.srcTaskId = (int) Constants.SYSTEM_TASK_ID;
+            taskInfoForEntry.timestamp = currentTimeSec;
+
+            Collection<IMetricsConsumer.DataPoint> taskInfoToDataPointsList = taskInfoToDataPointsMap.get(taskInfoForEntry);
+            if (taskInfoToDataPointsList == null) {
+                taskInfoToDataPointsList = new ArrayList<>();
+                taskInfoToDataPointsMap.put(taskInfoForEntry, taskInfoToDataPointsList);
+            }
+            taskInfoToDataPointsList.addAll(taskInfoToDataPoints.getRight());
+        }
+        return taskInfoToDataPointsMap;
+    }
+
+    private Collection<IMetricsConsumer.DataPoint> aggregateDataPointsByMetricName(Collection<IMetricsConsumer.DataPoint> dataPoints) {
+        Map<String, List<Object>> aggregatedMap = new HashMap<>();
+        for (IMetricsConsumer.DataPoint dataPoint : dataPoints) {
+            String name = dataPoint.name;
+            List<Object> values = aggregatedMap.get(name);
+            if (values == null) {
+                values = new ArrayList<>();
+                aggregatedMap.put(name, values);
+            }
+            values.add(dataPoint.value);
+        }
+
+        Collection<IMetricsConsumer.DataPoint> ret = new ArrayList<>();
+        for (Map.Entry<String, List<Object>> nameToDataPoints : aggregatedMap.entrySet()) {
+            IMetricsConsumer.DataPoint dataPoint = new IMetricsConsumer.DataPoint(nameToDataPoints.getKey(), nameToDataPoints.getValue());
+            ret.add(dataPoint);
+        }
+
+        return ret;
     }
 
     @Override

--- a/storm-core/src/jvm/org/apache/storm/metric/api/IMetricsConsumer.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/api/IMetricsConsumer.java
@@ -40,7 +40,47 @@ public interface IMetricsConsumer {
         public String srcComponentId; 
         public int srcTaskId; 
         public long timestamp;
-        public int updateIntervalSecs; 
+        public int updateIntervalSecs;
+
+        @Override
+        public String toString() {
+            return "TaskInfo{" +
+                    "srcWorkerHost='" + srcWorkerHost + '\'' +
+                    ", srcWorkerPort=" + srcWorkerPort +
+                    ", srcComponentId='" + srcComponentId + '\'' +
+                    ", srcTaskId=" + srcTaskId +
+                    ", timestamp=" + timestamp +
+                    ", updateIntervalSecs=" + updateIntervalSecs +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof TaskInfo)) return false;
+
+            TaskInfo taskInfo = (TaskInfo) o;
+
+            if (srcWorkerPort != taskInfo.srcWorkerPort) return false;
+            if (srcTaskId != taskInfo.srcTaskId) return false;
+            if (timestamp != taskInfo.timestamp) return false;
+            if (updateIntervalSecs != taskInfo.updateIntervalSecs) return false;
+            if (srcWorkerHost != null ? !srcWorkerHost.equals(taskInfo.srcWorkerHost) : taskInfo.srcWorkerHost != null)
+                return false;
+            return srcComponentId != null ? srcComponentId.equals(taskInfo.srcComponentId) : taskInfo.srcComponentId == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = srcWorkerHost != null ? srcWorkerHost.hashCode() : 0;
+            result = 31 * result + srcWorkerPort;
+            result = 31 * result + (srcComponentId != null ? srcComponentId.hashCode() : 0);
+            result = 31 * result + srcTaskId;
+            result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+            result = 31 * result + updateIntervalSecs;
+            return result;
+        }
     }
 
     // We can't move this to outside without breaking backward compatibility.


### PR DESCRIPTION
PR for 1.x : #1594 
- SystemBolt handles task level metrics via two mode
  - non-aggregate: same to previous, just applying expansion and pass to MetricConsumerBolts
  - aggregate: apply expansion, do aggregation, pass aggregated metrics to MetricConsumerBolts
- all task level metrics should pass by SystemBolt within its worker
  - it drops all connections between tasks and MetricsConsumerBolts
  - only SystemBolts and MetricConsumerBolts will be connected
- move configurations: expandMapType and metricNameSeparator to global
  - since SystemBolt needs to handle expansion when both worker level aggregation and expandMapType are turned on

This could break #1445 and it's already broken. We ideally want to stop adding new feature on 1.x and concentrate on 2.x but life is not easy.
I can volunteer to fix the conflict if this PR breaks #1445 in many places.
