### PR TITLE
STORM-2008: kafka jars must be part of the storm-kafka topology

### DIFF
--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -121,7 +121,6 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>${storm.kafka.artifact.id}</artifactId>
             <version>${storm.kafka.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
This is for solving following exception that we see when we try to run TridentKafkaWordCount topology.
``
    Exception in thread "main" java.lang.NoClassDefFoundError: kafka/api/OffsetRequest
        at org.apache.storm.kafka.KafkaConfig.<init>(KafkaConfig.java:48)
        at org.apache.storm.kafka.trident.TridentKafkaConfig.<init>(TridentKafkaConfig.java:30)
        at org.apache.storm.starter.trident.TridentKafkaWordCount.createTransactionalKafkaSpout(TridentKafkaWordCount.java:102)
        at org.apache.storm.starter.trident.TridentKafkaWordCount.addTridentState(TridentKafkaWordCount.java:131)
        at org.apache.storm.starter.trident.TridentKafkaWordCount.buildConsumerTopology(TridentKafkaWordCount.java:149)
        at org.apache.storm.starter.trident.TridentKafkaWordCount.runMain(TridentKafkaWordCount.java:249)
        at org.apache.storm.starter.trident.TridentKafkaWordCount.main(TridentKafkaWordCount.java:240)
    Caused by: java.lang.ClassNotFoundException: kafka.api.OffsetRequest
        at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 7 more
``