### PR TITLE
Adding F#/FsShelter reference

### DIFF
--- a/docs/DSLs-and-multilang-adapters.md
+++ b/docs/DSLs-and-multilang-adapters.md
@@ -8,3 +8,5 @@ documentation: true
 * [Clojure DSL](Clojure-DSL.html)
 * [Storm/Esper integration](https://github.com/tomdz/storm-esper): Streaming SQL on top of Storm
 * [io-storm](https://github.com/dan-blanchard/io-storm): Perl multilang adapter
+* [FsShelter](https://github.com/Prolucid/FsShelter): F# DSL and runtime with protobuf multilang 
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,7 @@ Trident is an alternative interface to Storm. It provides exactly-once processin
 * [MQTT Integration](storm-mqtt.html)
 * [Mongodb Integration](storm-mongodb.html)
 * [Kestrel Integration](Kestrel-and-Storm.html)
+* [DSLs and multilang adapters](DSLs-and-multilang-adapters.html)
 
 ### Advanced
 


### PR DESCRIPTION
Adding [FsShelter](https://github.com/Prolucid/FsShelter) F# DSL to the multilang references.
Also adding DSLs reference to the index, as there seems to be no other way to get to it.
