### PR TITLE
[STORM-2013] Upgrade Netty to 3.10.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <disruptor.version>3.3.2</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>16.0.1</guava.version>
-        <netty.version>3.9.0.Final</netty.version>
+        <netty.version>3.10.6.Final</netty.version>
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
         <log4j.version>2.1</log4j.version>


### PR DESCRIPTION
[STORM-2013 Upgrade Netty to 3.10.6](https://issues.apache.org/jira/browse/STORM-2013)

Since Netty 3.9 , it have fix some bugs and improve performance .