### PR TITLE
Fix emitting of tuples from bolts with Python 3

### DIFF
--- a/storm-multilang/python/src/main/resources/resources/storm.py
+++ b/storm-multilang/python/src/main/resources/resources/storm.py
@@ -109,7 +109,7 @@ def emitBolt(tup, stream=None, anchors = [], directTask=None):
     m = {"command": "emit"}
     if stream is not None:
         m["stream"] = stream
-    m["anchors"] = map(lambda a: a.id, anchors)
+    m["anchors"] = list(map(lambda a: a.id, anchors))
     if directTask is not None:
         m["task"] = directTask
     m["tuple"] = tup


### PR DESCRIPTION
In Python 3, the map() function no longer returns a list, but instead an iterable object, which is not JSON serializable.  To fix this, convert the result of the map() call to a list with the list() function.  This is still compatible with Python 2 (although will create a copy of the list).