### PR TITLE
STORM-2026 Inconsistency between (SpoutExecutor, BoltExecutor) and (spout-transfer-fn, bolt-transfer-fn)

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/Executor.java
@@ -204,8 +204,8 @@ public abstract class Executor implements Callable, EventHandler<Object> {
                 throw Utils.wrapInRuntime(ex);
             }
         }
-        executor.init(idToTask);
 
+        executor.idToTask = idToTask;
         return executor;
     }
 
@@ -242,8 +242,6 @@ public abstract class Executor implements Callable, EventHandler<Object> {
     }
 
     public abstract void tupleActionFn(int taskId, TupleImpl tuple) throws Exception;
-
-    public abstract void init(Map<Integer, Task> idToTask);
 
     @SuppressWarnings("unchecked")
     @Override

--- a/storm-core/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
@@ -53,9 +53,11 @@ public class BoltExecutor extends Executor {
         this.executeSampler = ConfigUtils.mkStatsSampler(stormConf);
     }
 
-    @Override
     public void init(Map<Integer, Task> idToTask) {
-        this.idToTask = idToTask;
+        while (!stormActive.get()) {
+            Utils.sleep(100);
+        }
+
         LOG.info("Preparing bolt {}:{}", componentId, idToTask.keySet());
         for (Map.Entry<Integer, Task> entry : idToTask.entrySet()) {
             Task taskData = entry.getValue();
@@ -88,9 +90,8 @@ public class BoltExecutor extends Executor {
 
     @Override
     public Callable<Object> call() throws Exception {
-        while (!stormActive.get()) {
-            Utils.sleep(100);
-        }
+        init(idToTask);
+
         return new Callable<Object>() {
             @Override
             public Object call() throws Exception {

--- a/storm-core/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
@@ -79,8 +79,11 @@ public class SpoutExecutor extends Executor {
         this.spoutThrottlingMetrics = new SpoutThrottlingMetrics();
     }
 
-    @Override
     public void init(final Map<Integer, Task> idToTask) {
+        while (!stormActive.get()) {
+            Utils.sleep(100);
+        }
+
         LOG.info("Opening spout {}:{}", componentId, idToTask.keySet());
         this.idToTask = idToTask;
         this.maxSpoutPending = Utils.getInt(stormConf.get(Config.TOPOLOGY_MAX_SPOUT_PENDING), 0) * idToTask.size();
@@ -126,9 +129,7 @@ public class SpoutExecutor extends Executor {
 
     @Override
     public Callable<Object> call() throws Exception {
-        while (!stormActive.get()) {
-            Utils.sleep(100);
-        }
+        init(idToTask);
 
         return new Callable<Object>() {
             @Override


### PR DESCRIPTION
* fix Executor, SpoutExecutor, BoltExecutor to not calling init() while creating Executor itself
* call init() for the first time in async loop

Please refer https://github.com/apache/storm/pull/1445#discussion_r72933087 and comment thread for this.