### PR TITLE
fix parent version of storm-druid pom in 1.x branch

### DIFF
--- a/external/storm-druid/pom.xml
+++ b/external/storm-druid/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>1.1.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
It breaks the build against 1.x-branch pull requests, and it's not about code itself, I'll just merge this right now. Please revert if you think it should get +1.
(Same reason for kinesis)