### PR TITLE
[STORM-2037] debug operation should be whitelisted in SimpleAclAuthorizer

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizer.java
+++ b/storm-core/src/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizer.java
@@ -65,6 +65,7 @@ public class SimpleACLAuthorizer implements IAuthorizer {
             "dumpProfile",
             "dumpJstack",
             "dumpHeap",
+            "debug",
             "getLogConfig"));
 
     protected Set<String> _admins;


### PR DESCRIPTION
While enabling/disabling topology event logging, theres a call to assert-authorized-user with "debug" as the operation in ui/core.clj.
This needs to be whitelisted in SimpleAclAuthorizer to get it working in secure mode.