### PR TITLE
Fix code in KafkaSpoutRetryExponentialBackoff.java

### DIFF
--- a/external/storm-kafka-client/README.md
+++ b/external/storm-kafka-client/README.md
@@ -35,7 +35,7 @@ kafkaConsumerProps.put(KafkaSpoutConfig.Consumer.GROUP_ID,"kafkaSpoutTestGroup")
 kafkaConsumerProps.put(KafkaSpoutConfig.Consumer.KEY_DESERIALIZER,"org.apache.kafka.common.serialization.StringDeserializer");
 kafkaConsumerProps.put(KafkaSpoutConfig.Consumer.VALUE_DESERIALIZER,"org.apache.kafka.common.serialization.StringDeserializer");
 
-KafkaSpoutRetryService retryService = new KafkaSpoutRetryExponentialBackoff(new KafkaSpoutRetryExponentialBackoff.TimeInterval(500, TimeUnit.MICROSECONDS),
+KafkaSpoutRetryService retryService = new KafkaSpoutRetryExponentialBackoff(KafkaSpoutRetryExponentialBackoff.TimeInterval.microSeconds(500),
         KafkaSpoutRetryExponentialBackoff.TimeInterval.milliSeconds(2), Integer.MAX_VALUE, KafkaSpoutRetryExponentialBackoff.TimeInterval.seconds(10));
 ```
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryExponentialBackoff.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryExponentialBackoff.java
@@ -117,7 +117,7 @@ public class KafkaSpoutRetryExponentialBackoff implements KafkaSpoutRetryService
         }
 
         public static TimeInterval microSeconds(long length) {
-            return new TimeInterval(length, TimeUnit.MILLISECONDS);
+            return new TimeInterval(length, TimeUnit.MICROSECONDS);
         }
 
         public long lengthNanos() {

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainNamedTopics.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainNamedTopics.java
@@ -104,12 +104,8 @@ public class KafkaSpoutTopologyMainNamedTopics {
     }
 
     protected KafkaSpoutRetryService getRetryService() {
-            return new KafkaSpoutRetryExponentialBackoff(getTimeInterval(500, TimeUnit.MICROSECONDS),
+            return new KafkaSpoutRetryExponentialBackoff(TimeInterval.microSeconds(500),
                     TimeInterval.milliSeconds(2), Integer.MAX_VALUE, TimeInterval.seconds(10));
-    }
-
-    protected TimeInterval getTimeInterval(long delay, TimeUnit timeUnit) {
-        return new TimeInterval(delay, timeUnit);
     }
 
     protected Map<String,Object> getKafkaConsumerProps() {


### PR DESCRIPTION
Additionally, Is there some reasons for use as below in README.md.
`
new KafkaSpoutRetryExponentialBackoff.TimeInterval(500, TimeUnit.MICROSECONDS)
`

I think this is better.
`
KafkaSpoutRetryExponentialBackoff.TimeInterval.microSeconds(500)
`