### PR TITLE
STORM-2050 [storm-sql] Support User Defined Aggregate Function for Trident mode

### DIFF
--- a/external/sql/README.md
+++ b/external/sql/README.md
@@ -20,6 +20,7 @@ The following features are supported in the current repository:
 * Filtering tuples
 * Projections
 * Aggregations (Grouping)
+* User defined function (scalar and aggregate)
 
 ## Specifying External Data Sources
 
@@ -38,6 +39,49 @@ The syntax of `CREATE EXTERNAL TABLE` closely follows the one defined in
 Users plug in external data sources through implementing the `ISqlTridentDataSource` interface and registers them using
 the mechanisms of Java's service loader. The external data source will be chosen based on the scheme of the URI of the
 tables. Please refer to the implementation of `storm-sql-kafka` for more details.
+
+## Specifying User Defined Function (UDF)
+
+Users can define user defined function (scalar or aggregate) using `CREATE FUNCTION` statement.
+For example, the following statement defines `MYPLUS` function which uses `org.apache.storm.sql.TestUtils$MyPlus` class.
+
+```
+CREATE FUNCTION MYPLUS AS 'org.apache.storm.sql.TestUtils$MyPlus'
+```
+
+Storm SQL determines whether the function as scalar or aggregate by checking which methods are defined.
+If the class defines `evaluate` method, Storm SQL treats the function as `scalar`,
+and if the class defines `add` method, Storm SQL treats the function as `aggregate`.
+
+Example of class for scalar function is here:
+
+```
+  public class MyPlus {
+    public static Integer evaluate(Integer x, Integer y) {
+      return x + y;
+    }
+  }
+
+```
+
+and class for aggregate function is here:
+
+```
+  public class MyConcat {
+    public static String init() {
+      return "";
+    }
+    public static String add(String accumulator, String val) {
+      return accumulator + val;
+    }
+    public static String result(String accumulator) {
+      return accumulator;
+    }
+  }
+```
+
+If users doesn't define `result` method, result is the last return value of `add` method.
+Users need to define `result` method only when we need to transform accumulated value.
 
 ## Example: Filtering Kafka Stream
 
@@ -80,10 +124,7 @@ By now you should be able to see the `order_filtering` topology in the Storm UI.
 
 ## Current Limitations
 
-Windowing and joining tables are yet to be implemented. Specifying parallelism hints in the topology is not yet supported. Supported aggregation functions are 'SUM', 'AVG', 'COUNT', 'MIN', 'MAX'. (Planned to address UDF - user defined functions.)
-
-Users also need to provide the dependency of the external data sources in the `extlib` directory. Otherwise the topology
-will fail to run because of `ClassNotFoundException`.
+Windowing and joining tables are yet to be implemented. Specifying parallelism hints in the topology is not yet supported. All processors have a parallelism hint of 1.
 
 ## License
 

--- a/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/backends/trident/TestPlanCompiler.java
+++ b/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/backends/trident/TestPlanCompiler.java
@@ -50,7 +50,7 @@ import static org.apache.storm.sql.TestUtils.MockSqlTridentDataSource.CollectDat
 
 public class TestPlanCompiler {
   private final JavaTypeFactory typeFactory = new JavaTypeFactoryImpl(
-      RelDataTypeSystem.DEFAULT);
+          RelDataTypeSystem.DEFAULT);
 
   @Before
   public void setUp() {
@@ -88,6 +88,23 @@ public class TestPlanCompiler {
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
 
     Assert.assertArrayEquals(new Values[] { new Values(0, 5L, 5, 1, 3, 4)}, getCollectedValues().toArray());
+  }
+
+  @Test
+  public void testCompileGroupByExpWithExprInAggCall() throws Exception {
+    final int EXPECTED_VALUE_SIZE = 1;
+    final Map<String, ISqlTridentDataSource> data = new HashMap<>();
+    data.put("FOO", new TestUtils.MockSqlTridentGroupedDataSource());
+    String sql = "SELECT GRPID, COUNT(*) AS CNT, MAX(SCORE - AGE) AS MAX_SCORE_MINUS_AGE FROM FOO GROUP BY GRPID";
+    TestCompilerUtils.CalciteState state = TestCompilerUtils.sqlOverDummyGroupByTable(sql);
+    PlanCompiler compiler = new PlanCompiler(data, typeFactory);
+    final AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
+    final TridentTopology topo = proc.build(data);
+    Fields f = proc.outputStream().getOutputFields();
+    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
+
+    Assert.assertArrayEquals(new Values[] { new Values(0, 5L, 39)}, getCollectedValues().toArray());
   }
 
   @Test
@@ -137,6 +154,22 @@ public class TestPlanCompiler {
     proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
     Assert.assertArrayEquals(new Values[] { new Values(5) }, getCollectedValues().toArray());
+  }
+
+  @Test
+  public void testUdaf() throws Exception {
+    int EXPECTED_VALUE_SIZE = 1;
+    String sql = "SELECT GRPID, COUNT(*) AS CNT, MYSTATICSUM(AGE) AS MY_STATIC_SUM, MYSUM(AGE) AS MY_SUM FROM FOO GROUP BY GRPID";
+    TestCompilerUtils.CalciteState state = TestCompilerUtils.sqlOverDummyGroupByTable(sql);
+    Map<String, ISqlTridentDataSource> data = new HashMap<>();
+    data.put("FOO", new TestUtils.MockSqlTridentGroupedDataSource());
+    PlanCompiler compiler = new PlanCompiler(data, typeFactory);
+    AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
+    final TridentTopology topo = proc.build(data);
+    Fields f = proc.outputStream().getOutputFields();
+    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
+    Assert.assertArrayEquals(new Values[] { new Values(0, 5L, 15L, 15L) }, getCollectedValues().toArray());
   }
 
   private void runTridentTopology(final int expectedValueSize, AbstractTridentProcessor proc,

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/trident/functions/UDAFWrappedAggregator.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/trident/functions/UDAFWrappedAggregator.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.storm.sql.runtime.trident.functions;
+
+import org.apache.storm.sql.runtime.trident.NumberConverter;
+import org.apache.storm.sql.runtime.trident.TridentUtils;
+import org.apache.storm.trident.operation.BaseAggregator;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.operation.TridentOperationContext;
+import org.apache.storm.trident.tuple.TridentTuple;
+import org.apache.storm.tuple.Values;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+class UDAFAggregateState {
+    private Object accumulator;
+
+    public UDAFAggregateState(Object accumulator) {
+        this.accumulator = accumulator;
+    }
+
+    public Object getAccumulator() {
+        return accumulator;
+    }
+
+    public void setAccumulator(Object accumulator) {
+        this.accumulator = accumulator;
+    }
+}
+
+public class UDAFWrappedAggregator extends BaseAggregator<UDAFAggregateState> {
+
+    private final String declaringClassName;
+    private final boolean isMethodsStatic;
+    private final String inputFieldName;
+    private final Class<?> targetClazz;
+
+    private transient Method initMethod;
+    private transient Method addMethod;
+    private transient Method resultMethod;
+
+    private transient Object aggrInstance;
+
+    public UDAFWrappedAggregator(String declaringClassName, boolean isMethodsStatic, String inputFieldName, Class<?> targetClazz) {
+        this.declaringClassName = declaringClassName;
+        this.isMethodsStatic = isMethodsStatic;
+        this.inputFieldName = inputFieldName;
+        this.targetClazz = targetClazz;
+    }
+
+    @Override
+    public void prepare(Map conf, TridentOperationContext context) {
+        Class<?> declaringClass;
+        try {
+            declaringClass = Class.forName(declaringClassName);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("UDAF class is not located to classpath: " + declaringClassName);
+        }
+
+        setupAggregateMethods(declaringClass);
+
+        if (!isMethodsStatic) {
+            try {
+                aggrInstance = declaringClass.newInstance();
+            } catch (InstantiationException | IllegalAccessException e) {
+                throw new RuntimeException("Failed to instantiate an instance of the UDAF class");
+            }
+        }
+    }
+
+    private void setupAggregateMethods(Class<?> declaringClass) {
+        initMethod = findMethod(declaringClass, "init");
+        addMethod = findMethod(declaringClass, "add");
+        resultMethod = findMethod(declaringClass, "result");
+
+        if (initMethod == null || addMethod == null) {
+            throw new RuntimeException("UDAF class must implement both 'init' and 'add' methods");
+        }
+    }
+
+    @Override
+    public UDAFAggregateState init(Object batchId, TridentCollector collector) {
+        Object val = invokeMethod(initMethod);
+        return new UDAFAggregateState(val);
+    }
+
+    @Override
+    public void aggregate(UDAFAggregateState state, TridentTuple tuple, TridentCollector collector) {
+        Object fieldValue = TridentUtils.valueFromTuple(tuple, inputFieldName);
+        Object newValue = invokeMethod(addMethod, state.getAccumulator(), fieldValue);
+        state.setAccumulator(newValue);
+    }
+
+    @Override
+    public void complete(UDAFAggregateState state, TridentCollector collector) {
+        Object emitValue = state.getAccumulator();
+        if (resultMethod != null) {
+            emitValue = invokeMethod(resultMethod, emitValue);
+        }
+
+        if (Number.class.isAssignableFrom(targetClazz)) {
+            if (emitValue instanceof Number) {
+                emitValue = NumberConverter.convert((Number) emitValue, (Class<? extends Number>) targetClazz);
+            } else {
+                throw new RuntimeException("Type of aggregated value should be Number");
+            }
+        } else if (!targetClazz.isAssignableFrom(emitValue.getClass())) {
+            throw new RuntimeException("Type of aggregated value should be " + targetClazz.getCanonicalName());
+        }
+
+        collector.emit(new Values(emitValue));
+    }
+
+    private Method findMethod(Class<?> clazz, String methodName) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.getName().equals(methodName)) {
+                return method;
+            }
+        }
+
+        return null;
+    }
+
+    private Object invokeMethod(Method method, Object...params) {
+        try {
+            if (isMethodsStatic) {
+                return method.invoke(null, params);
+            } else {
+                return method.invoke(aggrInstance, params);
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
+++ b/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
@@ -262,11 +262,11 @@ public class TestUtils {
 
     private static class MockGroupedSpout implements IBatchSpout {
       private final ArrayList<Values> RECORDS = new ArrayList<>();
-      private final Fields OUTPUT_FIELDS = new Fields("ID", "GRPID", "NAME", "ADDR", "AGE");
+      private final Fields OUTPUT_FIELDS = new Fields("ID", "GRPID", "NAME", "ADDR", "AGE", "SCORE");
 
       public MockGroupedSpout() {
         for (int i = 0; i < 5; ++i) {
-          RECORDS.add(new Values(i, 0, "x", "y", 5 - i));
+          RECORDS.add(new Values(i, 0, "x", "y", 5 - i, i * 10));
         }
       }
 


### PR DESCRIPTION
NOTE: This pull request is on top of STORM-1434 (#1635)

After this patch, below sql statement runs fine for cluster mode (Trident).
(MyConcat is an user defined aggregate function.)

```
CREATE EXTERNAL TABLE ORDERS (ID INT PRIMARY KEY, NAME VARCHAR, UNIT_PRICE INT, QUANTITY INT) LOCATION 'kafka://localhost:2181/brokers?topic=orders' TBLPROPERTIES '{"producer":{"bootstrap.servers":"localhost:9092","acks":"1","key.serializer":"org.apache.storm.kafka.IntSerializer","value.serializer":"org.apache.storm.kafka.ByteBufferSerializer"}}'
CREATE EXTERNAL TABLE SUMMARY_ORDERS (ID INT PRIMARY KEY, ID_PLUS_3 INT, CNT INT, NAME_CONCAT VARCHAR) LOCATION 'kafka://localhost:2181/brokers?topic=large_orders' TBLPROPERTIES '{"producer":{"bootstrap.servers":"localhost:9092","acks":"1","key.serializer":"org.apache.storm.kafka.IntSerializer","value.serializer":"org.apache.storm.kafka.ByteBufferSerializer"}}'
CREATE FUNCTION MYPLUS AS 'org.apache.storm.sql.TestUtils$MyPlus'
CREATE FUNCTION MYCONCAT AS 'org.apache.storm.sql.TestUtils$MyConcat'
INSERT INTO SUMMARY_ORDERS SELECT ID, MYPLUS(ID, 3) AS ID_PLUS_3, COUNT(*) AS CNT, MYCONCAT(NAME) AS NAME_CONCAT FROM ORDERS GROUP BY ID
```