### PR TITLE
STORM-1870 Allow FluxShellBolt/Spout set custom "componentConfig" via yaml

### DIFF
--- a/external/flux/flux-core/src/test/java/org/apache/storm/flux/TCKTest.java
+++ b/external/flux/flux-core/src/test/java/org/apache/storm/flux/TCKTest.java
@@ -50,6 +50,16 @@ public class TCKTest {
         topology.validate();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadShellComponents() throws Exception {
+        TopologyDef topologyDef = FluxParser.parseResource("/configs/bad_shell_test.yaml", false, true, null, false);
+        Config conf = FluxBuilder.buildConfig(topologyDef);
+        ExecutionContext context = new ExecutionContext(topologyDef, conf);
+        StormTopology topology = FluxBuilder.buildTopology(context);
+        assertNotNull(topology);
+        topology.validate();
+    }
+
     @Test
     public void testKafkaSpoutConfig() throws Exception {
         TopologyDef topologyDef = FluxParser.parseResource("/configs/kafka_test.yaml", false, true, null, false);

--- a/external/flux/flux-core/src/test/resources/configs/bad_shell_test.yaml
+++ b/external/flux/flux-core/src/test/resources/configs/bad_shell_test.yaml
@@ -55,11 +55,11 @@ spouts:
       - ["word"]
     configMethods:
       - name: "addComponentConfig"
-        args: ["rabbitmq.configfile", "etc/rabbit.yml"]
+        args: ["rabbitmq.configfile", "etc/rabbit.yml", "hello"]
       - name: "addComponentConfig"
         args:
         - "publisher.data_paths"
-        - ["actions"]
+        - ["actions", "hello"]
     parallelism: 1
     # ...
 
@@ -74,11 +74,11 @@ bolts:
       - ["word"]
     configMethods:
       - name: "addComponentConfig"
-        args: ["rabbitmq.configfile", "etc/rabbit.yml"]
+        args: ["rabbitmq.configfile", "etc/rabbit.yml", "hello"]
       - name: "addComponentConfig"
         args:
         - "publisher.data_paths"
-        - ["actions"]
+        - ["actions", "hello"]
     parallelism: 1
     # ...
 

--- a/external/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/bolts/FluxShellBolt.java
+++ b/external/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/bolts/FluxShellBolt.java
@@ -22,9 +22,10 @@ import org.apache.storm.topology.IRichBolt;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 
-import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A generic `ShellBolt` implementation that allows you specify output fields
@@ -56,8 +57,59 @@ public class FluxShellBolt extends ShellBolt implements IRichBolt{
         this(command);
         this.setDefaultStream(outputFields);
     }
-    
-    
+
+    /**
+     * Add configuration for this bolt. This method is called from YAML file:
+     *
+     * ```
+     * className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
+     * constructorArgs:
+     * # command line
+     * - ["python", "splitsentence.py"]
+     * # output fields
+     * - ["word"]
+     * configMethods:
+     * - name: "addComponentConfig"
+     *   args: ["publisher.data_paths", "actions"]
+     * ```
+     *
+     * @param key
+     * @param value
+     */
+    public void addComponentConfig(String key, Object value) {
+        if (this.componentConfig == null) {
+            this.componentConfig = new HashMap<String, Object>();
+        }
+        this.componentConfig.put(key, value);
+    }
+
+    /**
+     * Add configuration for this bolt. This method is called from YAML file:
+     *
+     * ```
+     * className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
+     * constructorArgs:
+     * # command line
+     * - ["python", "splitsentence.py"]
+     * # output fields
+     * - ["word"]
+     * configMethods:
+     * - name: "addComponentConfig"
+     *   args:
+     *   - "publisher.data_paths"
+     *   - ["actions"]
+     * ```
+     *
+     * @param key
+     * @param values
+     */
+    public void addComponentConfig(String key, List<Object> values) {
+        if (this.componentConfig == null) {
+            this.componentConfig = new HashMap<String, Object>();
+        }
+        this.componentConfig.put(key, values);
+    }
+
     /**
      * Set default stream outputFields, this method is called from YAML file:
      * 

--- a/external/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/spouts/FluxShellSpout.java
+++ b/external/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/spouts/FluxShellSpout.java
@@ -22,6 +22,7 @@ import org.apache.storm.topology.IRichSpout;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -56,7 +57,59 @@ public class FluxShellSpout extends ShellSpout implements IRichSpout {
         this(args);
         this.setDefaultStream(outputFields);
     }
-    
+
+    /**
+     * Add configuration for this spout. This method is called from YAML file:
+     *
+     * ```
+     * className: "org.apache.storm.flux.wrappers.bolts.FluxShellSpout"
+     * constructorArgs:
+     * # command line
+     * - ["python", "splitsentence.py"]
+     * # output fields
+     * - ["word"]
+     * configMethods:
+     * - name: "addComponentConfig"
+     *   args: ["publisher.data_paths", "actions"]
+     * ```
+     *
+     * @param key
+     * @param value
+     */
+    public void addComponentConfig(String key, Object value) {
+        if (this.componentConfig == null) {
+            this.componentConfig = new HashMap<String, Object>();
+        }
+        this.componentConfig.put(key, value);
+    }
+
+    /**
+     * Add configuration for this spout. This method is called from YAML file:
+     *
+     * ```
+     * className: "org.apache.storm.flux.wrappers.bolts.FluxShellSpout"
+     * constructorArgs:
+     * # command line
+     * - ["python", "splitsentence.py"]
+     * # output fields
+     * - ["word"]
+     * configMethods:
+     * - name: "addComponentConfig"
+     *   args:
+     *   - "publisher.data_paths"
+     *   - ["actions"]
+     * ```
+     *
+     * @param key
+     * @param values
+     */
+    public void addComponentConfig(String key, List<Object> values) {
+        if (this.componentConfig == null) {
+            this.componentConfig = new HashMap<String, Object>();
+        }
+        this.componentConfig.put(key, values);
+    }
+
     /**
      * Set default stream outputFields, this method is called from YAML file:
      * 


### PR DESCRIPTION
* add addComponentConfig methods to FluxShellSpout and FluxShellBolt
* address unit tests

This also addresses Parsely/streamparse#263 and Parsely/streamparse#266 

cc. @Darkless012

This can be easily backported to 1.x-branch, which means it can be included to upcoming 1.1.0 release.