### PR TITLE
STORM-2054 DependencyResolver should be aware of relative path and absolute path

### DIFF
--- a/external/storm-submit-tools/src/main/java/org/apache/storm/submit/command/DependencyResolverMain.java
+++ b/external/storm-submit-tools/src/main/java/org/apache/storm/submit/command/DependencyResolverMain.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/Booter.java
+++ b/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/Booter.java
@@ -1,12 +1,13 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,16 +38,8 @@ public class Booter {
             RepositorySystem system, String localRepoPath) {
         MavenRepositorySystemSession session = new MavenRepositorySystemSession();
 
-        // find homedir
-        String home = System.getProperty("storm.home");
-        if (home == null) {
-            home = ".";
-        }
-
-        String path = home + "/" + localRepoPath;
-
         LocalRepository localRepo =
-                new LocalRepository(new File(path).getAbsolutePath());
+                new LocalRepository(new File(localRepoPath).getAbsolutePath());
         session.setLocalRepositoryManager(system.newLocalRepositoryManager(localRepo));
 
         return session;

--- a/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/DependencyResolver.java
+++ b/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/DependencyResolver.java
@@ -1,12 +1,13 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,6 +31,7 @@ import org.sonatype.aether.resolution.DependencyResolutionException;
 import org.sonatype.aether.util.artifact.JavaScopes;
 import org.sonatype.aether.util.filter.DependencyFilterUtils;
 
+import java.io.File;
 import java.net.MalformedURLException;
 import java.util.Collections;
 import java.util.List;
@@ -41,7 +43,23 @@ public class DependencyResolver {
     private RemoteRepository mavenLocal = Booter.newLocalRepository();
 
     public DependencyResolver(String localRepoPath) {
+        localRepoPath = handleRelativePath(localRepoPath);
+
         session = Booter.newRepositorySystemSession(system, localRepoPath);
+    }
+
+    private String handleRelativePath(String localRepoPath) {
+        File repoDir = new File(localRepoPath);
+        if (!repoDir.isAbsolute()) {
+            // find homedir
+            String home = System.getProperty("storm.home");
+            if (home == null) {
+                home = ".";
+            }
+
+            localRepoPath = home + "/" + localRepoPath;
+        }
+        return localRepoPath;
     }
 
     public List<ArtifactResult> resolve(List<Dependency> dependencies) throws MalformedURLException,

--- a/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/RepositorySystemFactory.java
+++ b/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/RepositorySystemFactory.java
@@ -1,12 +1,13 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/external/storm-submit-tools/src/test/java/org/apache/storm/submit/dependency/DependencyResolverTest.java
+++ b/external/storm-submit-tools/src/test/java/org/apache/storm/submit/dependency/DependencyResolverTest.java
@@ -18,6 +18,8 @@
 package org.apache.storm.submit.dependency;
 
 import com.google.common.collect.Lists;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -26,7 +28,6 @@ import org.sonatype.aether.resolution.ArtifactResult;
 import org.sonatype.aether.util.artifact.DefaultArtifact;
 import org.sonatype.aether.util.artifact.JavaScopes;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -40,8 +41,12 @@ public class DependencyResolverTest {
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        String tempDir = System.getProperty("java.io.tmpdir", ".");
-        tempDirForTest = Files.createTempDirectory(new File(tempDir).toPath(), "dr-test");
+        tempDirForTest = Files.createTempDirectory("dr-test");
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        FileUtils.deleteQuietly(tempDirForTest.toFile());
     }
 
     @Before


### PR DESCRIPTION
* Fix Booter to handle the path with awareness of relative vs absolute
* Modify DependencyResolverTest to remove temporary directory after tests for that class are done

This breaks whole builds for master and 1.x branch due to RAT failing.

It should be also applied to 1.x-branch.