### PR TITLE
STORM-2064: add function, storm name and auth result to thrift access…

### DIFF
--- a/external/storm-submit-tools/pom.xml
+++ b/external/storm-submit-tools/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/storm-core/src/clj/org/apache/storm/daemon/drpc.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/drpc.clj
@@ -57,7 +57,7 @@
 (defn check-authorization
   ([aclHandler mapping operation context function]
     (if (not-nil? context)
-      (log-thrift-access (.requestID context) (.remoteAddress context) (.principal context) operation nil function))
+      (log-thrift-access-function (.requestID context) (.remoteAddress context) (.principal context) operation function))
     (if aclHandler
       (let [context (or context (ReqContext/context))]
         (if-not (.permit aclHandler context operation mapping)

--- a/storm-core/src/clj/org/apache/storm/daemon/drpc.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/drpc.clj
@@ -55,9 +55,9 @@
   (@queues-atom function))
 
 (defn check-authorization
-  ([aclHandler mapping operation context]
+  ([aclHandler mapping operation context function]
     (if (not-nil? context)
-      (log-thrift-access (.requestID context) (.remoteAddress context) (.principal context) operation))
+      (log-thrift-access (.requestID context) (.remoteAddress context) (.principal context) operation nil function))
     (if aclHandler
       (let [context (or context (ReqContext/context))]
         (if-not (.permit aclHandler context operation mapping)
@@ -66,8 +66,8 @@
               (throw (AuthorizationException.
                        (str "DRPC request '" operation "' for '"
                             user "' user is not authorized"))))))))
-  ([aclHandler mapping operation]
-    (check-authorization aclHandler mapping operation (ReqContext/context))))
+  ([aclHandler mapping operation function]
+    (check-authorization aclHandler mapping operation (ReqContext/context) function)))
 
 ;; TODO: change this to use TimeCacheMap
 (defn service-handler [conf]
@@ -102,7 +102,8 @@
         (log-debug "Received DRPC request for " function " (" args ") at " (System/currentTimeMillis))
         (check-authorization drpc-acl-handler
                              {DRPCAuthorizerBase/FUNCTION_NAME function}
-                             "execute")
+                             "execute"
+                             function)
         (let [id (str (swap! ctr (fn [v] (mod (inc v) 1000000000))))
               ^Semaphore sem (Semaphore. 0)
               req (DRPCRequest. args id)
@@ -132,7 +133,8 @@
         (when-let [func (@id->function id)]
           (check-authorization drpc-acl-handler
                                {DRPCAuthorizerBase/FUNCTION_NAME func}
-                               "result")
+                               "result" 
+                               func)
           (let [^Semaphore sem (@id->sem id)]
             (log-debug "Received result " result " for " id " at " (System/currentTimeMillis))
             (when sem
@@ -146,7 +148,8 @@
         (when-let [func (@id->function id)]
           (check-authorization drpc-acl-handler
                                {DRPCAuthorizerBase/FUNCTION_NAME func}
-                               "failRequest")
+                               "failRequest"
+                               func)
           (let [^Semaphore sem (@id->sem id)]
             (when sem
               (swap! id->result assoc id (DRPCExecutionException. "Request failed"))
@@ -157,7 +160,8 @@
         (mark! drpc:num-fetchRequest-calls)
         (check-authorization drpc-acl-handler
                              {DRPCAuthorizerBase/FUNCTION_NAME func}
-                             "fetchRequest")
+                             "fetchRequest"
+                             func)
         (let [^ConcurrentLinkedQueue queue (acquire-queue request-queues func)
               ret (.poll queue)]
           (if ret

--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -1111,12 +1111,12 @@
            impersonation-authorizer (:impersonation-authorization-handler nimbus)
            ctx (or context (ReqContext/context))
            check-conf (if storm-conf storm-conf (if storm-name {TOPOLOGY-NAME storm-name}))]
-       (log-thrift-access (.requestID ctx) (.remoteAddress ctx) (.principal ctx) operation)
        (if (.isImpersonating ctx)
          (do
           (log-warn "principal: " (.realPrincipal ctx) " is trying to impersonate principal: " (.principal ctx))
           (if impersonation-authorizer
-           (if-not (.permit impersonation-authorizer ctx operation check-conf)
+           (when-not (.permit impersonation-authorizer ctx operation check-conf)
+             (log-thrift-access (.requestID ctx) (.remoteAddress ctx) (.principal ctx) operation storm-name "access-denied")
              (throw (AuthorizationException. (str "principal " (.realPrincipal ctx) " is not authorized to impersonate
                         principal " (.principal ctx) " from host " (.remoteAddress ctx) " Please see SECURITY.MD to learn
                         how to configure impersonation acls."))))
@@ -1125,8 +1125,10 @@
 
        (if aclHandler
          (if-not (.permit aclHandler ctx operation check-conf)
-           (throw (AuthorizationException. (str operation (if storm-name (str " on topology " storm-name)) " is not authorized")))
-           ))))
+           (do
+             (log-thrift-access (.requestID ctx) (.remoteAddress ctx) (.principal ctx) operation storm-name "access-denied")
+             (throw (AuthorizationException. (str operation (if storm-name (str " on topology " storm-name)) " is not authorized"))))
+           (log-thrift-access (.requestID ctx) (.remoteAddress ctx) (.principal ctx) operation storm-name "access-granted")))))
   ([nimbus storm-name storm-conf operation]
      (check-authorization! nimbus storm-name storm-conf operation (ReqContext/context))))
 

--- a/storm-core/src/clj/org/apache/storm/util.clj
+++ b/storm-core/src/clj/org/apache/storm/util.clj
@@ -1096,20 +1096,30 @@
     (assoc coll k (apply str (repeat (count (coll k)) "#")))
     coll))
 
+(defn- log-thrift-access-base
+  [request-id remoteAddress principal operation]
+  (str "Request ID: " request-id 
+       " access from: " remoteAddress 
+       " principal: " principal 
+       " operation: " operation))
+
 (defn log-thrift-access
-  [request-id remoteAddress principal operation storm-name arg]
+  [request-id remoteAddress principal operation storm-name access-result]
   (doto
     (ThriftAccessLogger.)
-    (.log (str "Request ID: " request-id 
-               " access from: " remoteAddress 
-               " principal: " principal 
-               " operation: " operation
-              (if storm-name 
-                (str " storm-name: " storm-name) "")
-              (if (and (not-nil? arg)
-                       (.startsWith arg "access"))
-                (str " access result: " arg)
-                (str " function: " arg))))))
+    (.log (str (log-thrift-access-base request-id remoteAddress principal operation)
+               (if storm-name 
+                 (str " storm-name: " storm-name) "")
+               (if access-result
+                 (str " access result: " access-result) "")))))
+
+(defn log-thrift-access-function
+  [request-id remoteAddress principal operation function]
+  (doto
+    (ThriftAccessLogger.)
+    (.log (str (log-thrift-access-base request-id remoteAddress principal operation)
+               (if function 
+                 (str " function: " function) "")))))
 
 (def DISALLOWED-KEY-NAME-STRS #{"/" "." ":" "\\"})
 

--- a/storm-core/src/clj/org/apache/storm/util.clj
+++ b/storm-core/src/clj/org/apache/storm/util.clj
@@ -1097,10 +1097,19 @@
     coll))
 
 (defn log-thrift-access
-  [request-id remoteAddress principal operation]
+  [request-id remoteAddress principal operation storm-name arg]
   (doto
     (ThriftAccessLogger.)
-    (.log (str "Request ID: " request-id " access from: " remoteAddress " principal: " principal " operation: " operation))))
+    (.log (str "Request ID: " request-id 
+               " access from: " remoteAddress 
+               " principal: " principal 
+               " operation: " operation
+              (if storm-name 
+                (str " storm-name: " storm-name) "")
+              (if (and (not-nil? arg)
+                       (.startsWith arg "access"))
+                (str " access result: " arg)
+                (str " function: " arg))))))
 
 (def DISALLOWED-KEY-NAME-STRS #{"/" "." ":" "\\"})
 


### PR DESCRIPTION
… log

Apparently the 1.x-branch build was broken completely due to an issue with the storm-submit-tools pom.xml. Fixed that.

The actual PR is for improvement to logging in DRPC and thrift access. Original work by @schintap.

drpc logs now show the function:

2016-08-29 09:08:27.571 o.a.s.l.ThriftAccessLogger [INFO] Request ID: 5 access from: [ip]  principal: [principal] operation: fetchRequest **function: exclamation**

nimbus logs now show the access result:

2016-08-29 09:20:48.489 o.a.s.l.ThriftAccessLogger [INFO] Request ID: 24 access from: [ip]  principal: [principal] operation: getClusterInfo **access result: access-granted**

and the storm-name, if looking at a topology:

2016-08-29 09:22:32.474 o.a.s.l.ThriftAccessLogger [INFO] Request ID: 17 access from: [ip]  principal: [principal] operation: getTopologyConf **storm-name: wc access result: access-granted**