### PR TITLE
STORM-2063: turn on thread name in worker.xml

### DIFF
--- a/log4j2/worker.xml
+++ b/log4j2/worker.xml
@@ -18,7 +18,7 @@
 
 <configuration monitorInterval="60">
 <properties>
-    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} [%p] %msg%n</property>
+    <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %msg%n</property>
     <property name="patternNoTime">%msg%n</property>
     <property name="patternMetrics">%d %-8r %m%n</property>
 </properties>


### PR DESCRIPTION
Bring the change in:
https://github.com/apache/storm/pull/1652

To 2.x. Only the worker.xml, since we were already checking for empty thread names in 2.x