### PR TITLE
STORM-2067 Fix "array element type mismatch" from compute-executors in nimbus.clj

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -29,7 +29,7 @@
            [java.util Collections List HashMap]
            [org.apache.storm.generated NimbusSummary])
   (:import [java.nio ByteBuffer]
-           [java.util Collections List HashMap ArrayList Iterator])
+           [java.util Collections List HashMap ArrayList Iterator Map])
   (:import [org.apache.storm.blobstore AtomicOutputStream BlobStoreAclHandler
             InputStreamWithMeta KeyFilter KeySequenceNumber BlobSynchronizer BlobStoreUtils])
   (:import [java.io File FileOutputStream FileInputStream])
@@ -641,7 +641,7 @@
          (Utils/reverseMap)
          clojurify-structure
          (map-val sort)
-         ((fn [ & maps ] (Utils/joinMaps (into-array (into [component->executors] maps)))))
+         ((fn [ & maps ] (Utils/joinMaps (into-array Map (into [component->executors] maps)))))
          (clojurify-structure)
          (map-val (partial apply (fn part-fixed [a b] (Utils/partitionFixed a b))))
          (mapcat second)


### PR DESCRIPTION
* force set type to Map when calling into-array with seq which has Maps
  * Clojure optimization occurs type mismatch: PersistentArrayMap vs PersistentHashMap

Please refer http://issues.apache.org/jira/browse/STORM-2067 for more details.

This code only resides on master branch. No need to backport.