### PR TITLE
STORM-2057 Support JOIN statement in Storm SQL

### DIFF
--- a/docs/storm-sql.md
+++ b/docs/storm-sql.md
@@ -28,6 +28,7 @@ The following features are supported in the current repository:
 * Projections
 * Aggregations (Grouping)
 * User defined function (scalar and aggregate)
+* Join (Inner, Left outer, Right outer, Full outer)
 
 ## Specifying External Data Sources
 
@@ -94,7 +95,7 @@ and class for aggregate function is here:
   }
 ```
 
-If users doesn't define `result` method, result is the last return value of `add` method.
+If users don't define `result` method, result is the last return value of `add` method.
 Users need to define `result` method only when we need to transform accumulated value.
 
 ## Example: Filtering Kafka Stream
@@ -127,6 +128,13 @@ By now you should be able to see the `order_filtering` topology in the Storm UI.
 
 ## Current Limitations
 
-Aggregation, windowing and joining tables are yet to be implemented. Specifying parallelism hints in the topology is not yet supported. All processors have a parallelism hint of 1.
-
-The current implementation of the Kafka connector in StormSQL assumes both the input and the output are in JSON formats. The connector has not yet recognized the `INPUTFORMAT` and `OUTPUTFORMAT` clauses yet.
+- Windowing is yet to be implemented.
+- Only equi-join (single field equality) is supported for joining table.
+- Joining table only applies within each small batch that comes off of the spout.
+  - Not across batches.
+  - Limitation came from `join` feature of Trident.
+  - Please refer this doc: `Trident API Overview` for details.
+- Specifying parallelism hints in the topology is not yet supported. 
+  - All processors have a parallelism hint of 1.
+- The current implementation of the Kafka connector in StormSQL assumes both the input and the output are in JSON formats. 
+  - The connector has not yet recognized the `INPUTFORMAT` and `OUTPUTFORMAT` clauses yet.

--- a/external/sql/README.md
+++ b/external/sql/README.md
@@ -21,6 +21,7 @@ The following features are supported in the current repository:
 * Projections
 * Aggregations (Grouping)
 * User defined function (scalar and aggregate)
+* Join (Inner, Left outer, Right outer, Full outer)
 
 ## Specifying External Data Sources
 
@@ -80,7 +81,7 @@ and class for aggregate function is here:
   }
 ```
 
-If users doesn't define `result` method, result is the last return value of `add` method.
+If users don't define `result` method, result is the last return value of `add` method.
 Users need to define `result` method only when we need to transform accumulated value.
 
 ## Example: Filtering Kafka Stream
@@ -124,7 +125,14 @@ By now you should be able to see the `order_filtering` topology in the Storm UI.
 
 ## Current Limitations
 
-Windowing and joining tables are yet to be implemented. Specifying parallelism hints in the topology is not yet supported. All processors have a parallelism hint of 1.
+- Windowing is yet to be implemented.
+- Only equi-join (single field equality) is supported for joining table.
+- Joining table only applies within each small batch that comes off of the spout.
+  - Not across batches.
+  - Limitation came from `join` feature of Trident.
+  - Please refer this doc: `Trident API Overview` for details.
+- Specifying parallelism hints in the topology is not yet supported. 
+  - All processors have a parallelism hint of 1.
 
 ## License
 

--- a/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
+++ b/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
@@ -308,6 +308,157 @@ public class TestUtils {
     }
   }
 
+  public static class MockSqlTridentJoinDataSourceEmp implements ISqlTridentDataSource {
+    @Override
+    public IBatchSpout getProducer() {
+      return new MockSpout();
+    }
+
+    @Override
+    public Function getConsumer() {
+      return new CollectDataFunction();
+    }
+
+    public static class CollectDataFunction extends BaseFunction {
+      /**
+       * Collect all values in a static variable as the instance will go through serialization and deserialization.
+       */
+      private transient static final List<List<Object> > VALUES = new ArrayList<>();
+      public static List<List<Object>> getCollectedValues() {
+        return VALUES;
+      }
+
+      @Override
+      public void execute(TridentTuple tuple, TridentCollector collector) {
+        VALUES.add(tuple.getValues());
+      }
+    }
+
+    private static class MockSpout implements IBatchSpout {
+      private final ArrayList<Values> RECORDS = new ArrayList<>();
+      private final Fields OUTPUT_FIELDS = new Fields("EMPID", "EMPNAME", "DEPTID");
+
+      public MockSpout() {
+        for (int i = 0; i < 5; ++i) {
+          RECORDS.add(new Values(i, "emp-" + i, i % 2));
+        }
+        for (int i = 10; i < 15; ++i) {
+          RECORDS.add(new Values(i, "emp-" + i, i));
+        }
+      }
+
+      private boolean emitted = false;
+
+      @Override
+      public void open(Map conf, TopologyContext context) {
+      }
+
+      @Override
+      public void emitBatch(long batchId, TridentCollector collector) {
+        if (emitted) {
+          return;
+        }
+
+        for (Values r : RECORDS) {
+          collector.emit(r);
+        }
+        emitted = true;
+      }
+
+      @Override
+      public void ack(long batchId) {
+      }
+
+      @Override
+      public void close() {
+      }
+
+      @Override
+      public Map<String, Object> getComponentConfiguration() {
+        return null;
+      }
+
+      @Override
+      public Fields getOutputFields() {
+        return OUTPUT_FIELDS;
+      }
+    }
+  }
+
+  public static class MockSqlTridentJoinDataSourceDept implements ISqlTridentDataSource {
+    @Override
+    public IBatchSpout getProducer() {
+      return new MockSpout();
+    }
+
+    @Override
+    public Function getConsumer() {
+      return new CollectDataFunction();
+    }
+
+    public static class CollectDataFunction extends BaseFunction {
+      /**
+       * Collect all values in a static variable as the instance will go through serialization and deserialization.
+       */
+      private transient static final List<List<Object> > VALUES = new ArrayList<>();
+      public static List<List<Object>> getCollectedValues() {
+        return VALUES;
+      }
+
+      @Override
+      public void execute(TridentTuple tuple, TridentCollector collector) {
+        VALUES.add(tuple.getValues());
+      }
+    }
+
+    private static class MockSpout implements IBatchSpout {
+      private final ArrayList<Values> RECORDS = new ArrayList<>();
+      private final Fields OUTPUT_FIELDS = new Fields("DEPTID", "DEPTNAME");
+
+      public MockSpout() {
+        for (int i = 0; i < 5; ++i) {
+          RECORDS.add(new Values(i, "dept-" + i));
+        }
+      }
+
+      private boolean emitted = false;
+
+      @Override
+      public void open(Map conf, TopologyContext context) {
+      }
+
+      @Override
+      public void emitBatch(long batchId, TridentCollector collector) {
+        if (emitted) {
+          return;
+        }
+
+        for (Values r : RECORDS) {
+          collector.emit(r);
+        }
+        emitted = true;
+      }
+
+      @Override
+      public void ack(long batchId) {
+      }
+
+      @Override
+      public void close() {
+      }
+
+      @Override
+      public Map<String, Object> getComponentConfiguration() {
+        return null;
+      }
+
+      @Override
+      public Fields getOutputFields() {
+        return OUTPUT_FIELDS;
+      }
+    }
+  }
+
   public static class CollectDataChannelHandler implements ChannelHandler {
     private final List<Values> values;
 

--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -29,7 +29,7 @@
            [java.util Collections List HashMap]
            [org.apache.storm.generated NimbusSummary])
   (:import [java.nio ByteBuffer]
-           [java.util Collections List HashMap ArrayList Iterator])
+           [java.util Collections List HashMap ArrayList Iterator Map])
   (:import [org.apache.storm.blobstore AtomicOutputStream BlobStoreAclHandler
             InputStreamWithMeta KeyFilter KeySequenceNumber BlobSynchronizer BlobStoreUtils])
   (:import [java.io File FileOutputStream FileInputStream])
@@ -641,7 +641,7 @@
          (Utils/reverseMap)
          clojurify-structure
          (map-val sort)
-         ((fn [ & maps ] (Utils/joinMaps (into-array (into [component->executors] maps)))))
+         ((fn [ & maps ] (Utils/joinMaps (into-array Map (into [component->executors] maps)))))
          (clojurify-structure)
          (map-val (partial apply (fn part-fixed [a b] (Utils/partitionFixed a b))))
          (mapcat second)

--- a/storm-core/src/jvm/org/apache/storm/trident/JoinOutFieldsMode.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/JoinOutFieldsMode.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.trident;
+
+/**
+ * This enum defines how the output fields of JOIN is constructed.
+ *
+ * If user specifies COMPACT while calling JOIN, the tuples emitted from the join will contain:
+ * First, the list of join fields. Please note that joining fields are exposed only once from emitted tuples.
+ * Next, a list of all non-join fields from all streams, in order of how the streams were passed to the join method.
+ *
+ * If user specifies PRESERVE while calling JOIN, the tuples emitted from the join will contain:
+ * a list of all fields from all streams, in order of how the streams were passed to the join method.
+ */
+public enum JoinOutFieldsMode {
+    COMPACT,
+    PRESERVE
+}

--- a/storm-core/src/jvm/org/apache/storm/trident/operation/impl/JoinState.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/operation/impl/JoinState.java
@@ -1,0 +1,22 @@
+package org.apache.storm.trident.operation.impl;
+
+import org.apache.storm.trident.tuple.TridentTuple;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JoinState {
+    List<List>[] sides;
+    int numSidesReceived = 0;
+    int[] indices;
+    TridentTuple group;
+
+    public JoinState(int numSides, TridentTuple group) {
+        sides = new List[numSides];
+        indices = new int[numSides];
+        this.group = group;
+        for(int i=0; i<numSides; i++) {
+            sides[i] = new ArrayList<List>();
+        }
+    }
+}


### PR DESCRIPTION
> * Note for merger
>
>This is on top of STORM-2067 which is not applicable for 1.x-branch. So in order to make porting back easier, STORM-2067 should be handled first and this pull request should be rebased to updated master.

This pull request accomplishes supporting JOIN statement in Storm SQL for Trident mode.
INNER, LEFT OUTER, RIGHT OUTER, FULL OUTER JOIN are supported.

Since this feature is based on Trident join, some limitations follow:

- Only equi-join is supported.
- Joining will be occurred for each batch, not across batches.
  - http://storm.apache.org/releases/1.0.2/Trident-API-Overview.html
  - Please refer `Merges & Joins` section
- Trident join provides only one value for joining fields (two)
  - For inner join, that would be OK
  - For outer joins, one of values should be null, which might be not OK
    - applied dirty workaround: if whole values of non-joining fields are null, value of joining field is also null
    - will try to handle it properly (TODO)

TODO
- [x] Update documentation (with limitation)
- [x] Try to fork Trident join feature to fit to SQL join column output