### PR TITLE
STORM-2070 Fix sigar native binary download link

### DIFF
--- a/external/storm-metrics/pom.xml
+++ b/external/storm-metrics/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <!-- settings for downloading the sigar native binary complete archive, which is not available in Maven central-->
     <sigar.version>1.6.4</sigar.version>
-    <sigar.download.url>https://magelan.googlecode.com/files/hyperic-sigar-${sigar.version}.zip</sigar.download.url>
+    <sigar.download.url>https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/magelan/hyperic-sigar-${sigar.version}.zip</sigar.download.url>
     <sigar.SHA1>8f79d4039ca3ec6c88039d5897a80a268213e6b7</sigar.SHA1>
     <!-- this will download the sigar ZIP to the local maven repository next to the sigar dependencies,
          so we only download it once -->


### PR DESCRIPTION
* previous link goes 404, googlecode seems change archive url

This should be also merged back to 1.x, 1.0.x branches.