### PR TITLE
STORM-2072 Add map, flatMap with different outputs (T->V) in Trident

### DIFF
--- a/docs/Trident-API-Overview.md
+++ b/docs/Trident-API-Overview.md
@@ -139,6 +139,23 @@ Of course these operations can be chained, so a stream of uppercase words can be
 ```java
 mystream.flatMap(new Split()).map(new UpperCase())
 ```
+
+If you don't pass output fields as parameter, map and flatMap preserves the input fields to output fields.
+
+If you want to apply MapFunction or FlatMapFunction with replacing old fields with new output fields, 
+you can call map / flatMap with additional Fields parameter as follows,
+
+```java
+mystream.map(new UpperCase(), new Fields("uppercased"))
+```
+
+Output stream wil have only one output field "uppercased" regardless of what output fields previous stream had.
+Same thing applies to flatMap, so following is valid as well,
+ 
+```java
+mystream.flatMap(new Split(), new Fields("word"))
+```
+
 ### peek
 `peek` can be used to perform an additional action on each trident tuple as they flow through the stream.
  This could be useful for debugging to see the tuples as they flow past a certain point in a pipeline.

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentMapExample.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentMapExample.java
@@ -83,7 +83,7 @@ public class TridentMapExample {
         TridentTopology topology = new TridentTopology();
         TridentState wordCounts = topology.newStream("spout1", spout).parallelismHint(16)
                 .flatMap(split)
-                .map(toUpper)
+                .map(toUpper, new Fields("uppercased"))
                 .filter(theFilter)
                 .peek(new Consumer() {
                     @Override
@@ -91,14 +91,14 @@ public class TridentMapExample {
                         System.out.println(input.getString(0));
                     }
                 })
-                .groupBy(new Fields("word"))
+                .groupBy(new Fields("uppercased"))
                 .persistentAggregate(new MemoryMapState.Factory(), new Count(), new Fields("count"))
                 .parallelismHint(16);
 
         topology.newDRPCStream("words", drpc)
-                .flatMap(split)
-                .groupBy(new Fields("args"))
-                .stateQuery(wordCounts, new Fields("args"), new MapGet(), new Fields("count"))
+                .flatMap(split, new Fields("word"))
+                .groupBy(new Fields("word"))
+                .stateQuery(wordCounts, new Fields("word"), new MapGet(), new Fields("count"))
                 .filter(new FilterNull())
                 .aggregate(new Fields("count"), new Sum(), new Fields("sum"));
         return topology.build();
@@ -115,6 +115,7 @@ public class TridentMapExample {
                 System.out.println("DRPC RESULT: " + drpc.execute("words", "CAT THE DOG JUMPED"));
                 Thread.sleep(1000);
             }
+            cluster.shutdown();
         } else {
             conf.setNumWorkers(3);
             StormSubmitter.submitTopologyWithProgressBar(args[0], conf, buildTopology(null));

--- a/storm-core/src/jvm/org/apache/storm/trident/Stream.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/Stream.java
@@ -421,6 +421,25 @@ public class Stream implements IAggregatableStream, ResourceDeclarer<Stream> {
     }
 
     /**
+     * Returns a stream consisting of the result of applying the given mapping function to the values of this stream.
+     * This method replaces old output fields with new output fields, achieving T -> V conversion.
+     *
+     * @param function a mapping function to be applied to each value in this stream.
+     * @param outputFields new output fields
+     * @return the new stream
+     */
+    public Stream map(MapFunction function, Fields outputFields) {
+        projectionValidation(getOutputFields());
+        return _topology.addSourcedNode(this,
+                                        new ProcessorNode(
+                                                _topology.getUniqueStreamId(),
+                                                _name,
+                                                outputFields,
+                                                outputFields,
+                                                new MapProcessor(getOutputFields(), new MapFunctionExecutor(function))));
+    }
+
+    /**
      * Returns a stream consisting of the results of replacing each value of this stream with the contents
      * produced by applying the provided mapping function to each value. This has the effect of applying
      * a one-to-many transformation to the values of the stream, and then flattening the resulting elements into a new stream.
@@ -436,6 +455,27 @@ public class Stream implements IAggregatableStream, ResourceDeclarer<Stream> {
                                                 _name,
                                                 getOutputFields(),
                                                 getOutputFields(),
+                                                new MapProcessor(getOutputFields(), new FlatMapFunctionExecutor(function))));
+    }
+
+    /**
+     * Returns a stream consisting of the results of replacing each value of this stream with the contents
+     * produced by applying the provided mapping function to each value. This has the effect of applying
+     * a one-to-many transformation to the values of the stream, and then flattening the resulting elements into a new stream.
+     * This method replaces old output fields with new output fields, achieving T -> V conversion.
+     *
+     * @param function a mapping function to be applied to each value in this stream which produces new values.
+     * @param outputFields new output fields
+     * @return the new stream
+     */
+    public Stream flatMap(FlatMapFunction function, Fields outputFields) {
+        projectionValidation(getOutputFields());
+        return _topology.addSourcedNode(this,
+                                        new ProcessorNode(
+                                                _topology.getUniqueStreamId(),
+                                                _name,
+                                                outputFields,
+                                                outputFields,
                                                 new MapProcessor(getOutputFields(), new FlatMapFunctionExecutor(function))));
     }
 

--- a/storm-core/src/jvm/org/apache/storm/trident/operation/OperationAwareFlatMapFunction.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/operation/OperationAwareFlatMapFunction.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.trident.operation;
+
+/**
+ * A one to many transformation function which is aware of Operation (lifecycle of the Trident component)
+ */
+public interface OperationAwareFlatMapFunction extends FlatMapFunction, Operation {
+}

--- a/storm-core/src/jvm/org/apache/storm/trident/operation/OperationAwareMapFunction.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/operation/OperationAwareMapFunction.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.trident.operation;
+
+/**
+ * A one-one transformation function which is aware of Operation (lifecycle of the Trident component)
+ */
+public interface OperationAwareMapFunction extends MapFunction, Operation {
+}

--- a/storm-core/src/jvm/org/apache/storm/trident/operation/impl/FlatMapFunctionExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/operation/impl/FlatMapFunctionExecutor.java
@@ -20,6 +20,7 @@ package org.apache.storm.trident.operation.impl;
 import org.apache.storm.trident.operation.BaseOperation;
 import org.apache.storm.trident.operation.FlatMapFunction;
 import org.apache.storm.trident.operation.Function;
+import org.apache.storm.trident.operation.Operation;
 import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.operation.TridentOperationContext;
 import org.apache.storm.trident.tuple.TridentTuple;
@@ -32,6 +33,26 @@ public class FlatMapFunctionExecutor extends BaseOperation implements Function {
 
     public FlatMapFunctionExecutor(FlatMapFunction function) {
         this.function = function;
+    }
+
+    @Override
+    public void prepare(Map conf, TridentOperationContext context) {
+        // If FlatMapFunction is aware of prepare, let it handle preparation
+        if (function instanceof Operation) {
+            ((Operation) function).prepare(conf, context);
+        } else {
+            super.prepare(conf, context);
+        }
+    }
+
+    @Override
+    public void cleanup() {
+        // If FlatMapFunction is aware of cleanup, let it handle cleaning up
+        if (function instanceof Operation) {
+            ((Operation) function).cleanup();
+        } else {
+            super.cleanup();
+        }
     }
 
     @Override

--- a/storm-core/src/jvm/org/apache/storm/trident/operation/impl/MapFunctionExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/operation/impl/MapFunctionExecutor.java
@@ -20,6 +20,7 @@ package org.apache.storm.trident.operation.impl;
 import org.apache.storm.trident.operation.BaseOperation;
 import org.apache.storm.trident.operation.Function;
 import org.apache.storm.trident.operation.MapFunction;
+import org.apache.storm.trident.operation.Operation;
 import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.operation.TridentOperationContext;
 import org.apache.storm.trident.tuple.TridentTuple;
@@ -32,6 +33,26 @@ public class MapFunctionExecutor extends BaseOperation implements Function {
 
     public MapFunctionExecutor(MapFunction function) {
         this.function = function;
+    }
+
+    @Override
+    public void prepare(Map conf, TridentOperationContext context) {
+        // If MapFunction is aware of prepare, let it handle preparation
+        if (function instanceof Operation) {
+            ((Operation) function).prepare(conf, context);
+        } else {
+            super.prepare(conf, context);
+        }
+    }
+
+    @Override
+    public void cleanup() {
+        // If MapFunction is aware of cleanup, let it handle cleaning up
+        if (function instanceof Operation) {
+            ((Operation) function).cleanup();
+        } else {
+            super.cleanup();
+        }
     }
 
     @Override


### PR DESCRIPTION
* Introduce overloading methods of map and flatMap
  * Now users can specify new output fields which replace origin fields
* Introduce OperationMapFunction and OperationFlatMapFunction
  * which also extends Operation
  * Trident will automatically determine this and handle properly

Also updated example code and docs page.

This change is needed for optimizing Storm SQL on Trident mode to have minimized steps.
I'll work on optimization on top of this and submit that as well. 