### PR TITLE
STORM-2040 Fix bug on assert-can-serialize

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/worker.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/worker.clj
@@ -135,8 +135,9 @@
 
 (defn- assert-can-serialize [^KryoTupleSerializer serializer tuple-batch]
   "Check that all of the tuples can be serialized by serializing them."
-  (fast-list-iter [[task tuple :as pair] tuple-batch]
-    (.serialize serializer tuple)))
+  (fast-list-iter [^AddressedTuple addressed-tuple tuple-batch]
+    (let [tuple (.getTuple addressed-tuple)]
+      (.serialize serializer tuple))))
 
 (defn- mk-backpressure-handler [executors]
   "make a handler that checks and updates worker's backpressure flag"

--- a/storm-core/test/clj/integration/org/apache/storm/integration_test.clj
+++ b/storm-core/test/clj/integration/org/apache/storm/integration_test.clj
@@ -51,7 +51,8 @@
             results (complete-topology cluster
                                        topology
                                        :mock-sources {"1" [["nathan"] ["bob"] ["joey"] ["nathan"]]}
-                                       :storm-conf {TOPOLOGY-WORKERS 2})]
+                                       :storm-conf {TOPOLOGY-WORKERS 2
+                                                    TOPOLOGY-TESTING-ALWAYS-TRY-SERIALIZE true})]
         (is (ms= [["nathan"] ["bob"] ["joey"] ["nathan"]]
                  (read-tuples results "1")))
         (is (ms= [["nathan" 1] ["nathan" 2] ["bob" 1] ["joey" 1]]


### PR DESCRIPTION
* type of element of tuple-batch is changed to AddressedTuple but not reflected to assert-can-serialize
* it only raises issue when topology.testing.always.try.serialize is true

This should also be ported back to 1.x and 1.0.x branches.