### PR TITLE
STORM-2087: storm-kafka-client - tuples not always being replayed

### DIFF
--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -53,6 +53,20 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${storm.kafka.client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--test dependencies -->
         <dependency>
@@ -64,6 +78,18 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.batey.kafka</groupId>
+            <artifactId>kafka-unit</artifactId>
+            <version>0.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${log4j-over-slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/SingleTopicKafkaSpoutTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/SingleTopicKafkaSpoutTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.apache.storm.kafka.spout;
+
+import info.batey.kafka.unit.KafkaUnitRule;
+import kafka.producer.KeyedMessage;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.storm.kafka.spout.builders.SingleTopicKafkaSpoutConfiguration;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.tuple.Values;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.*;
+
+import java.util.Map;
+import java.util.stream.IntStream;
+import static org.mockito.Mockito.*;
+import static org.apache.storm.kafka.spout.builders.SingleTopicKafkaSpoutConfiguration.*;
+
+public class SingleTopicKafkaSpoutTest {
+
+    private class SpoutContext {
+        public KafkaSpout<String, String> spout;
+        public SpoutOutputCollector collector;
+
+        public SpoutContext(KafkaSpout<String, String> spout,
+                            SpoutOutputCollector collector) {
+            this.spout = spout;
+            this.collector = collector;
+        }
+    }
+
+    @Rule
+    public KafkaUnitRule kafkaUnitRule = new KafkaUnitRule();
+
+    void populateTopicData(String topicName, int msgCount) {
+        kafkaUnitRule.getKafkaUnit().createTopic(topicName);
+
+        IntStream.range(0, msgCount).forEach(value -> {
+            KeyedMessage<String, String> keyedMessage = new KeyedMessage<>(
+                    topicName, Integer.toString(value),
+                    Integer.toString(value));
+
+            kafkaUnitRule.getKafkaUnit().sendMessages(keyedMessage);
+        });
+    }
+
+    SpoutContext initializeSpout(int msgCount) {
+        populateTopicData(SingleTopicKafkaSpoutConfiguration.TOPIC, msgCount);
+        int kafkaPort = kafkaUnitRule.getKafkaPort();
+
+        TopologyContext topology = mock(TopologyContext.class);
+        SpoutOutputCollector collector = mock(SpoutOutputCollector.class);
+        Map conf = mock(Map.class);
+
+        KafkaSpout<String, String> spout = new KafkaSpout<>(getKafkaSpoutConfig(getKafkaSpoutStreams(), kafkaPort));
+        spout.open(conf, topology, collector);
+        spout.activate();
+        return new SpoutContext(spout, collector);
+    }
+    /*
+     * Asserts that the next possible offset to commit or the committed offset is the provided offset.
+     * An offset that is ready to be committed is not guarenteed to be already committed.
+     */
+    private void assertOffsetCommitted(int offset, KafkaSpout.OffsetEntry entry) {
+
+        boolean currentOffsetMatch = entry.getCommittedOffset() == offset;
+        OffsetAndMetadata nextOffset = entry.findNextCommitOffset();
+        boolean nextOffsetMatch =  nextOffset != null && nextOffset.offset() == offset;
+        assertTrue("Next offset: " +
+                        entry.findNextCommitOffset() +
+                        " OR current offset: " +
+                        entry.getCommittedOffset() +
+                        " must equal desired offset: " +
+                        offset,
+                currentOffsetMatch | nextOffsetMatch);
+    }
+
+    @Test
+    public void shouldContinueWithSlowDoubleAcks() throws Exception {
+        int messageCount = 20;
+        SpoutContext context = initializeSpout(messageCount);
+
+        //play 1st tuple
+        ArgumentCaptor<Object> messageIdToDoubleAck = ArgumentCaptor.forClass(Object.class);
+        context.spout.nextTuple();
+        verify(context.collector).emit(anyObject(), anyObject(), messageIdToDoubleAck.capture());
+        context.spout.ack(messageIdToDoubleAck.getValue());
+
+        IntStream.range(0, messageCount/2).forEach(value -> {
+            context.spout.nextTuple();
+        });
+
+        context.spout.ack(messageIdToDoubleAck.getValue());
+
+        IntStream.range(0, messageCount).forEach(value -> {
+            context.spout.nextTuple();
+        });
+
+        ArgumentCaptor<Object> remainingIds = ArgumentCaptor.forClass(Object.class);
+
+        verify(context.collector, times(messageCount)).emit(
+                eq(SingleTopicKafkaSpoutConfiguration.STREAM),
+                anyObject(),
+                remainingIds.capture());
+        remainingIds.getAllValues().iterator().forEachRemaining(context.spout::ack);
+
+        context.spout.acked.values().forEach(item -> {
+            assertOffsetCommitted(messageCount - 1, (KafkaSpout.OffsetEntry) item);
+        });
+    }
+
+    @Test
+    public void shouldEmitAllMessages() throws Exception {
+        int messageCount = 10;
+        SpoutContext context = initializeSpout(messageCount);
+
+
+        IntStream.range(0, messageCount).forEach(value -> {
+            context.spout.nextTuple();
+            ArgumentCaptor<Object> messageId = ArgumentCaptor.forClass(Object.class);
+            verify(context.collector).emit(
+                    eq(SingleTopicKafkaSpoutConfiguration.STREAM),
+                    eq(new Values(SingleTopicKafkaSpoutConfiguration.TOPIC,
+                            Integer.toString(value),
+                            Integer.toString(value))),
+            messageId.capture());
+            context.spout.ack(messageId.getValue());
+            reset(context.collector);
+        });
+
+        context.spout.acked.values().forEach(item -> {
+            assertOffsetCommitted(messageCount - 1, (KafkaSpout.OffsetEntry) item);
+        });
+    }
+
+    @Test
+    public void shouldReplayInOrderFailedMessages() throws Exception {
+        int messageCount = 10;
+        SpoutContext context = initializeSpout(messageCount);
+
+        //play and ack 1 tuple
+        ArgumentCaptor<Object> messageIdAcked = ArgumentCaptor.forClass(Object.class);
+        context.spout.nextTuple();
+        verify(context.collector).emit(anyObject(), anyObject(), messageIdAcked.capture());
+        context.spout.ack(messageIdAcked.getValue());
+        reset(context.collector);
+
+        //play and fail 1 tuple
+        ArgumentCaptor<Object> messageIdFailed = ArgumentCaptor.forClass(Object.class);
+        context.spout.nextTuple();
+        verify(context.collector).emit(anyObject(), anyObject(), messageIdFailed.capture());
+        context.spout.fail(messageIdFailed.getValue());
+        reset(context.collector);
+
+        //pause so that failed tuples will be retried
+        Thread.sleep(200);
+
+
+        //allow for some calls to nextTuple() to fail to emit a tuple
+        IntStream.range(0, messageCount + 5).forEach(value -> {
+            context.spout.nextTuple();
+        });
+
+        ArgumentCaptor<Object> remainingMessageIds = ArgumentCaptor.forClass(Object.class);
+
+        //1 message replayed, messageCount - 2 messages emitted for the first time
+        verify(context.collector, times(messageCount - 1)).emit(
+                eq(SingleTopicKafkaSpoutConfiguration.STREAM),
+                anyObject(),
+                remainingMessageIds.capture());
+        remainingMessageIds.getAllValues().iterator().forEachRemaining(context.spout::ack);
+
+        context.spout.acked.values().forEach(item -> {
+            assertOffsetCommitted(messageCount - 1, (KafkaSpout.OffsetEntry) item);
+        });
+    }
+
+    @Test
+    public void shouldReplayFirstTupleFailedOutOfOrder() throws Exception {
+        int messageCount = 10;
+        SpoutContext context = initializeSpout(messageCount);
+
+
+        //play 1st tuple
+        ArgumentCaptor<Object> messageIdToFail = ArgumentCaptor.forClass(Object.class);
+        context.spout.nextTuple();
+        verify(context.collector).emit(anyObject(), anyObject(), messageIdToFail.capture());
+        reset(context.collector);
+
+        //play 2nd tuple
+        ArgumentCaptor<Object> messageIdToAck = ArgumentCaptor.forClass(Object.class);
+        context.spout.nextTuple();
+        verify(context.collector).emit(anyObject(), anyObject(), messageIdToAck.capture());
+        reset(context.collector);
+
+        //ack 2nd tuple
+        context.spout.ack(messageIdToAck.getValue());
+        //fail 1st tuple
+        context.spout.fail(messageIdToFail.getValue());
+
+        //pause so that failed tuples will be retried
+        Thread.sleep(200);
+
+        //allow for some calls to nextTuple() to fail to emit a tuple
+        IntStream.range(0, messageCount + 5).forEach(value -> {
+            context.spout.nextTuple();
+        });
+
+        ArgumentCaptor<Object> remainingIds = ArgumentCaptor.forClass(Object.class);
+        //1 message replayed, messageCount - 2 messages emitted for the first time
+        verify(context.collector, times(messageCount - 1)).emit(
+                eq(SingleTopicKafkaSpoutConfiguration.STREAM),
+                anyObject(),
+                remainingIds.capture());
+        remainingIds.getAllValues().iterator().forEachRemaining(context.spout::ack);
+
+        context.spout.acked.values().forEach(item -> {
+            assertOffsetCommitted(messageCount - 1, (KafkaSpout.OffsetEntry) item);
+        });
+    }
+}

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/builders/SingleTopicKafkaSpoutConfiguration.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/builders/SingleTopicKafkaSpoutConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.apache.storm.kafka.spout.builders;
+
+import org.apache.storm.Config;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.kafka.spout.*;
+import org.apache.storm.kafka.spout.test.KafkaSpoutTestBolt;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.tuple.Fields;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.EARLIEST;
+
+public class SingleTopicKafkaSpoutConfiguration {
+    public static final String STREAM = "test_stream";
+    public static final String TOPIC = "test";
+
+    public static Config getConfig() {
+        Config config = new Config();
+        config.setDebug(true);
+        return config;
+    }
+
+    public static StormTopology getTopologyKafkaSpout(int port) {
+        final TopologyBuilder tp = new TopologyBuilder();
+        tp.setSpout("kafka_spout", new KafkaSpout<>(getKafkaSpoutConfig(getKafkaSpoutStreams(), port)), 1);
+        tp.setBolt("kafka_bolt", new KafkaSpoutTestBolt()).shuffleGrouping("kafka_spout", STREAM);
+        return tp.createTopology();
+    }
+
+    public static KafkaSpoutConfig<String,String> getKafkaSpoutConfig(KafkaSpoutStreams kafkaSpoutStreams, int port) {
+        return new KafkaSpoutConfig.Builder<String, String>(getKafkaConsumerProps(port), kafkaSpoutStreams, getTuplesBuilder(), getRetryService())
+                .setOffsetCommitPeriodMs(10_000)
+                .setFirstPollOffsetStrategy(EARLIEST)
+                .setMaxUncommittedOffsets(250)
+                .setPollTimeoutMs(1000)
+                .build();
+    }
+
+    protected static KafkaSpoutRetryService getRetryService() {
+        return new KafkaSpoutRetryExponentialBackoff(KafkaSpoutRetryExponentialBackoff.TimeInterval.microSeconds(0),
+                KafkaSpoutRetryExponentialBackoff.TimeInterval.milliSeconds(0), Integer.MAX_VALUE, KafkaSpoutRetryExponentialBackoff.TimeInterval.milliSeconds(0));
+
+    }
+
+    protected static Map<String,Object> getKafkaConsumerProps(int port) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(KafkaSpoutConfig.Consumer.BOOTSTRAP_SERVERS, "127.0.0.1:" + port);
+        props.put(KafkaSpoutConfig.Consumer.GROUP_ID, "kafkaSpoutTestGroup");
+        props.put(KafkaSpoutConfig.Consumer.KEY_DESERIALIZER, "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put(KafkaSpoutConfig.Consumer.VALUE_DESERIALIZER, "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("max.poll.records", "5");
+        return props;
+    }
+
+    protected static KafkaSpoutTuplesBuilder<String, String> getTuplesBuilder() {
+        return new KafkaSpoutTuplesBuilderNamedTopics.Builder<>(
+                new TopicKeyValueTupleBuilder<String, String>(TOPIC))
+                .build();
+    }
+
+    public static KafkaSpoutStreams getKafkaSpoutStreams() {
+        final Fields outputFields = new Fields("topic", "key", "value");
+        return new KafkaSpoutStreamsNamedTopics.Builder(outputFields, STREAM, new String[]{TOPIC})  // contents of topics test sent to test_stream
+                .build();
+    }
+}

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/builders/TopicKeyValueTupleBuilder.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/builders/TopicKeyValueTupleBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.apache.storm.kafka.spout.builders;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.storm.kafka.spout.KafkaSpoutTupleBuilder;
+import org.apache.storm.tuple.Values;
+
+import java.util.List;
+
+public class TopicKeyValueTupleBuilder<K, V> extends KafkaSpoutTupleBuilder<K,V> {
+    /**
+     * @param topics list of topics that use this implementation to build tuples
+     */
+    public TopicKeyValueTupleBuilder(String... topics) {
+        super(topics);
+    }
+
+    @Override
+    public List<Object> buildTuple(ConsumerRecord<K, V> consumerRecord) {
+        return new Values(consumerRecord.topic(),
+                consumerRecord.key(),
+                consumerRecord.value());
+    }
+}


### PR DESCRIPTION
I am having issues with topologies that fail tuples. The kafka offsets seemed to get stuck and the kafka spout eventually halted even though the last committed offset was no where near the end of the topic. 

Here are a few unit tests that I believe replicate my situation. The last 2 are currently failing which is reflective of what I am seeing in my topologies. Let me know if I missed anything! This seems like a pretty big oversight, so I am getting the feeling that something in the test is wrong. Thanks!

I added tests for the following cases:
- All tuples being acked.
- A tuple being failed in order it was emitted
- A tuple being failed out of the order it was emitted

Update: Also Provided a fix now as well.
