### PR TITLE
STORM-1444 Support EXPLAIN statement in StormSQL

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -323,9 +323,10 @@ def jar(jarfile, klass, *args):
                     ["-Dstorm.dependency.artifacts=" + json.dumps(artifact_to_file_jars)])
 
 def sql(sql_file, topology_name):
-    """Syntax: [storm sql sql-file topology-name]
+    """Syntax: [storm sql sql-file topology-name], or [storm sql sql-file --explain] when activating explain mode
 
     Compiles the SQL statements into a Trident topology and submits it to Storm.
+    If user activates explain mode, SQL Runner analyzes each query statement and shows query plan instead of submitting topology.
 
     --jars and --artifacts options available for jar are also applied to sql command.
     Please refer "help jar" to see how to use --jars and --artifacts options.
@@ -349,11 +350,16 @@ def sql(sql_file, topology_name):
     # include this for running StormSqlRunner, but not for generated topology
     extrajars.extend(sql_core_jars)
 
+    if topology_name == "--explain":
+        args = ["--file", sql_file, "--explain"]
+    else:
+        args = ["--file", sql_file, "--topology", topology_name]
+
     exec_storm_class(
         "org.apache.storm.sql.StormSqlRunner",
         jvmtype="-client",
         extrajars=extrajars,
-        args=[sql_file, topology_name],
+        args=args,
         daemon=False,
         jvmopts=["-Dstorm.dependency.jars=" + ",".join(local_jars)] +
                 ["-Dstorm.dependency.artifacts=" + json.dumps(artifact_to_file_jars)])

--- a/docs/storm-sql.md
+++ b/docs/storm-sql.md
@@ -18,6 +18,8 @@ $ bin/storm sql <sql-file> <topo-name>
 
 In which `sql-file` contains a list of SQL statements to be executed, and `topo-name` is the name of the topology.
 
+StormSQL activates `explain mode` and shows query plan instead of submitting topology when user specifies `topo-name` as `--explain`.
+Detailed explanation is available from `Showing Query Plan (explain mode)` section.
 
 ## Supported Features
 
@@ -125,6 +127,49 @@ $ bin/storm sql order_filtering.sql order_filtering --artifacts "org.apache.stor
 Above command submits the SQL statements to StormSQL. Users need to modify each artifacts' version if users are using different version of Storm or Kafka. 
 
 By now you should be able to see the `order_filtering` topology in the Storm UI.
+
+## Showing Query Plan (explain mode)
+
+Like `explain` on SQL statement, StormSQL provides `explain mode` when running Storm SQL Runner. In explain mode, StormSQL analyzes each query statement (only DML) and show plan instead of submitting topology.
+
+In order to run `explain mode`, you need to provide topology name as `--explain` and run `storm sql` as same as submitting.
+
+For example, when you run the example seen above with explain mode:
+ 
+```
+$ bin/storm sql order_filtering.sql --explain --artifacts "org.apache.storm:storm-sql-kafka:2.0.0-SNAPSHOT,org.apache.storm:storm-kafka:2.0.0-SNAPSHOT,org.apache.kafka:kafka_2.10:0.8.2.2\!org.slf4j:slf4j-log4j12,org.apache.kafka:kafka-clients:0.8.2.2"
+```
+
+StormSQL prints out like below:
+ 
+```
+
+===========================================================
+query>
+CREATE EXTERNAL TABLE ORDERS (ID INT PRIMARY KEY, UNIT_PRICE INT, QUANTITY INT) LOCATION 'kafka://localhost:2181/brokers?topic=orders' TBLPROPERTIES '{"producer":{"bootstrap.servers":"localhost:9092","acks":"1","key.serializer":"org.apache.storm.kafka.IntSerializer","value.serializer":"org.apache.storm.kafka.ByteBufferSerializer"}}'
+-----------------------------------------------------------
+16:53:43.951 [main] INFO  o.a.s.s.r.DataSourcesRegistry - Registering scheme kafka with org.apache.storm.sql.kafka.KafkaDataSourcesProvider@4d1bf319
+No plan presented on DDL
+===========================================================
+===========================================================
+query>
+CREATE EXTERNAL TABLE LARGE_ORDERS (ID INT PRIMARY KEY, TOTAL INT) LOCATION 'kafka://localhost:2181/brokers?topic=large_orders' TBLPROPERTIES '{"producer":{"bootstrap.servers":"localhost:9092","acks":"1","key.serializer":"org.apache.storm.kafka.IntSerializer","value.serializer":"org.apache.storm.kafka.ByteBufferSerializer"}}'
+-----------------------------------------------------------
+No plan presented on DDL
+===========================================================
+===========================================================
+query>
+INSERT INTO LARGE_ORDERS SELECT ID, UNIT_PRICE * QUANTITY AS TOTAL FROM ORDERS WHERE UNIT_PRICE * QUANTITY > 50
+-----------------------------------------------------------
+plan>
+LogicalTableModify(table=[[LARGE_ORDERS]], operation=[INSERT], updateColumnList=[[]], flattened=[true]), id = 8
+  LogicalProject(ID=[$0], TOTAL=[*($1, $2)]), id = 7
+    LogicalFilter(condition=[>(*($1, $2), 50)]), id = 6
+      EnumerableTableScan(table=[[ORDERS]]), id = 5
+
+===========================================================
+
+```
 
 ## Current Limitations
 

--- a/external/sql/README.md
+++ b/external/sql/README.md
@@ -12,6 +12,9 @@ $ bin/storm sql <sql-file> <topo-name>
 
 In which `sql-file` contains a list of SQL statements to be executed, and `topo-name` is the name of the topology.
 
+StormSQL activates `explain mode` and shows query plan instead of submitting topology when user specifies `topo-name` as `--explain`.
+Detailed explanation is available from `Showing Query Plan (explain mode)` section.
+
 ## Supported Features
 
 The following features are supported in the current repository:
@@ -121,6 +124,49 @@ $ bin/storm sql order_filtering.sql order_filtering --artifacts "org.apache.stor
 Above command submits the SQL statements to StormSQL. Users need to modify each artifacts' version if users are using different version of Storm or Kafka. 
 
 By now you should be able to see the `order_filtering` topology in the Storm UI.
+
+## Showing Query Plan (explain mode)
+
+Like `explain` on SQL statement, StormSQL provides `explain mode` when running Storm SQL Runner. In explain mode, StormSQL analyzes each query statement (only DML) and show plan instead of submitting topology.
+
+In order to run `explain mode`, you need to provide topology name as `--explain` and run `storm sql` as same as submitting.
+
+For example, when you run the example seen above with explain mode:
+ 
+```
+$ bin/storm sql order_filtering.sql --explain --artifacts "org.apache.storm:storm-sql-kafka:2.0.0-SNAPSHOT,org.apache.storm:storm-kafka:2.0.0-SNAPSHOT,org.apache.kafka:kafka_2.10:0.8.2.2\!org.slf4j:slf4j-log4j12,org.apache.kafka:kafka-clients:0.8.2.2"
+```
+
+StormSQL prints out like below:
+ 
+```
+
+===========================================================
+query>
+CREATE EXTERNAL TABLE ORDERS (ID INT PRIMARY KEY, UNIT_PRICE INT, QUANTITY INT) LOCATION 'kafka://localhost:2181/brokers?topic=orders' TBLPROPERTIES '{"producer":{"bootstrap.servers":"localhost:9092","acks":"1","key.serializer":"org.apache.storm.kafka.IntSerializer","value.serializer":"org.apache.storm.kafka.ByteBufferSerializer"}}'
+-----------------------------------------------------------
+16:53:43.951 [main] INFO  o.a.s.s.r.DataSourcesRegistry - Registering scheme kafka with org.apache.storm.sql.kafka.KafkaDataSourcesProvider@4d1bf319
+No plan presented on DDL
+===========================================================
+===========================================================
+query>
+CREATE EXTERNAL TABLE LARGE_ORDERS (ID INT PRIMARY KEY, TOTAL INT) LOCATION 'kafka://localhost:2181/brokers?topic=large_orders' TBLPROPERTIES '{"producer":{"bootstrap.servers":"localhost:9092","acks":"1","key.serializer":"org.apache.storm.kafka.IntSerializer","value.serializer":"org.apache.storm.kafka.ByteBufferSerializer"}}'
+-----------------------------------------------------------
+No plan presented on DDL
+===========================================================
+===========================================================
+query>
+INSERT INTO LARGE_ORDERS SELECT ID, UNIT_PRICE * QUANTITY AS TOTAL FROM ORDERS WHERE UNIT_PRICE * QUANTITY > 50
+-----------------------------------------------------------
+plan>
+LogicalTableModify(table=[[LARGE_ORDERS]], operation=[INSERT], updateColumnList=[[]], flattened=[true]), id = 8
+  LogicalProject(ID=[$0], TOTAL=[*($1, $2)]), id = 7
+    LogicalFilter(condition=[>(*($1, $2), 50)]), id = 6
+      EnumerableTableScan(table=[[ORDERS]]), id = 5
+
+===========================================================
+
+```
 
 ## Current Limitations
 

--- a/external/sql/storm-sql-core/pom.xml
+++ b/external/sql/storm-sql-core/pom.xml
@@ -97,6 +97,10 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <scope>runtime</scope>

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSql.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSql.java
@@ -47,6 +47,11 @@ public abstract class StormSql {
       StormSubmitter.ProgressListener progressListener, String asUser)
       throws Exception;
 
+  /**
+   * Print out query plan for each query.
+   */
+  public abstract void explain(Iterable<String> statements) throws Exception;
+
   public static StormSql construct() {
     return new StormSqlImpl();
   }

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSqlRunner.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSqlRunner.java
@@ -17,6 +17,11 @@
  */
 package org.apache.storm.sql;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
 import org.apache.storm.generated.SubmitOptions;
 import org.apache.storm.generated.TopologyInitialStatus;
 import org.apache.storm.utils.Utils;
@@ -28,17 +33,53 @@ import java.util.List;
 import java.util.Map;
 
 public class StormSqlRunner {
+    private static final String OPTION_SQL_FILE_SHORT = "f";
+    private static final String OPTION_SQL_FILE_LONG = "file";
+    private static final String OPTION_SQL_TOPOLOGY_NAME_SHORT = "t";
+    private static final String OPTION_SQL_TOPOLOGY_NAME_LONG = "topology";
+    private static final String OPTION_SQL_EXPLAIN_SHORT = "e";
+    private static final String OPTION_SQL_EXPLAIN_LONG = "explain";
+
     public static void main(String[] args) throws Exception {
-        if (args.length != 2) {
-            System.err.println("storm-sql <sql-file> <topo-name>");
-            return;
+        Options options = buildOptions();
+        CommandLineParser parser = new DefaultParser();
+        CommandLine commandLine = parser.parse(options, args);
+
+        if (!commandLine.hasOption(OPTION_SQL_FILE_LONG)) {
+            printUsageAndExit(options, OPTION_SQL_FILE_LONG + " is required");
         }
-        List<String> stmts = Files.readAllLines(Paths.get(args[0]), StandardCharsets.UTF_8);
-        String topoName = args[1];
+
+        String filePath = commandLine.getOptionValue(OPTION_SQL_FILE_LONG);
+        List<String> stmts = Files.readAllLines(Paths.get(filePath), StandardCharsets.UTF_8);
         StormSql sql = StormSql.construct();
         @SuppressWarnings("unchecked")
         Map<String, ?> conf = Utils.readStormConfig();
-        SubmitOptions options = new SubmitOptions(TopologyInitialStatus.ACTIVE);
-        sql.submit(topoName, stmts, conf, options, null, null);
+
+        if (commandLine.hasOption(OPTION_SQL_EXPLAIN_LONG)) {
+            sql.explain(stmts);
+        } else if (commandLine.hasOption(OPTION_SQL_TOPOLOGY_NAME_LONG)) {
+            String topoName = commandLine.getOptionValue(OPTION_SQL_TOPOLOGY_NAME_LONG);
+            SubmitOptions submitOptions = new SubmitOptions(TopologyInitialStatus.ACTIVE);
+            sql.submit(topoName, stmts, conf, submitOptions, null, null);
+        } else {
+            printUsageAndExit(options, "Either " + OPTION_SQL_TOPOLOGY_NAME_LONG + " or " + OPTION_SQL_EXPLAIN_LONG +
+                    " must be presented");
+        }
     }
+
+    private static void printUsageAndExit(Options options, String message) {
+        System.out.println(message);
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("storm-sql-runner ", options);
+        System.exit(1);
+    }
+
+    private static Options buildOptions() {
+        Options options = new Options();
+        options.addOption(OPTION_SQL_FILE_SHORT, OPTION_SQL_FILE_LONG, true, "REQUIRED SQL file which has sql statements");
+        options.addOption(OPTION_SQL_TOPOLOGY_NAME_SHORT, OPTION_SQL_TOPOLOGY_NAME_LONG, true, "Topology name to submit");
+        options.addOption(OPTION_SQL_EXPLAIN_SHORT, OPTION_SQL_EXPLAIN_LONG, false, "Activate explain mode (topology name will be ignored)");
+        return options;
+    }
+
 }


### PR DESCRIPTION
* when '--explain' is specified to topology name, activate explain mode
* when explain mode is activated, it analyzes each query statement, and shows query plan
  * it doesn't submit topologies
* Showing plan is provided by Calcite: it just uses that feature

As I also described to the doc, query plan for below query 
```
INSERT INTO LARGE_ORDERS SELECT ID, UNIT_PRICE * QUANTITY AS TOTAL FROM ORDERS 
WHERE UNIT_PRICE * QUANTITY > 50
```

is shown as: 

```
LogicalTableModify(table=[[LARGE_ORDERS]], operation=[INSERT], updateColumnList=[[]], flattened=[true]), id = 8
  LogicalProject(ID=[$0], TOTAL=[*($1, $2)]), id = 7
    LogicalFilter(condition=[>(*($1, $2), 50)]), id = 6
      EnumerableTableScan(table=[[ORDERS]]), id = 5
```

FYI, $0 is column index 0 (starting from 0), and so on. Expression is printed as prefix notation.
Calcite just provides this functionality, though I'm not clear whether this is friendly (acceptable by end-user) or not.
There's staled issue from Calcite ([CALCITE-155](https://issues.apache.org/jira/browse/CALCITE-155)) for displaying actual column names/aliases in explain plan.

Please have a look and share your opinion about this.
Thanks in advance!