### PR TITLE
[STORM-2093] Fix permissions in multi-tenant, secure mode

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
@@ -506,6 +506,20 @@
       (-> (resp/response "Page not found")
           (resp/status 404)))))
 
+(defnk set-log-file-permissions [fname root-dir]
+  (let [file (.getCanonicalFile (File. root-dir fname))
+        run-as-user (*STORM-CONF* SUPERVISOR-RUN-WORKER-AS-USER)
+        parent (.getParent (File. root-dir fname))
+        md-file (if (nil? parent) nil (get-metadata-file-for-wroker-logdir parent))
+        topo-owner (if (nil? md-file) nil (get-topo-owner-from-metadata-file md-file))]
+    (if (and run-as-user
+             (not-nil? topo-owner)
+             (.exists file)
+             (not (Files/isReadable (.toPath file))))
+      (do
+        (log-debug "Setting permissions on file " fname " with topo-owner " topo-owner)
+        (SupervisorUtils/processLauncherAndWait *STORM-CONF* topo-owner ["code-dir" (.getCanonicalPath file)] nil (str "setup group read permissions for file: " fname))))))
+
 (defnk download-log-file [fname req resp user ^String root-dir :is-daemon false]
   (let [file (.getCanonicalFile (File. root-dir fname))]
     (if (.exists file)
@@ -1024,6 +1038,7 @@
             start (if (:start m) (parse-long-from-map m :start))
             length (if (:length m) (parse-long-from-map m :length))
             file (URLDecoder/decode (:file m))]
+        (set-log-file-permissions file log-root)
         (log-template (log-page file start length (:grep m) user log-root)
           file user))
       (catch InvalidRequestException ex
@@ -1100,6 +1115,7 @@
   (GET "/download" [:as {:keys [servlet-request servlet-response log-root]} & m]
     (try
       (.mark logviewer:num-download-log-file-http-requests)
+      (set-log-file-permissions file log-root)
       (let [user (.getUserName http-creds-handler servlet-request)
             file (URLDecoder/decode (:file m))]
         (download-log-file file servlet-request servlet-response user log-root))


### PR DESCRIPTION
Heap dumps created on OOM, when served through the logviewer in secure multitenant configurations have permssions set such that the logviewer cannot read them.

This change checks permissions in this case before serving and then runs the worker-launcher to enable the logviewer to serve them.
