### PR TITLE
STORM-1694: Kafka Spout Trident Implementation Using New Kafka Consumer API

### DIFF
--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -148,6 +148,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.storm</groupId>
+      <artifactId>storm-kafka-client</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.storm</groupId>
       <artifactId>storm-hdfs</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -163,7 +169,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>${storm.kafka.version}</version>
+      <version>${storm.kafka.client.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.storm</groupId>

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/DebugMemoryMapState.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/DebugMemoryMapState.java
@@ -54,7 +54,7 @@ public class DebugMemoryMapState<T> extends MemoryMapState<T> {
         for (int i = 0; i < keys.size(); i++) {
             ValueUpdater valueUpdater = updaters.get(i);
             Object arg = ((CombinerValueUpdater) valueUpdater).getArg();
-            LOG.debug("updateCount = {}, keys = {} => updaterArgs = {}", updateCount, keys.get(i), arg);
+            LOG.info("updateCount = {}, keys = {} => updaterArgs = {}", updateCount, keys.get(i), arg);
         }
     }
 

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentKafkaClientWordCountNamedTopics.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentKafkaClientWordCountNamedTopics.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.starter.trident;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.storm.kafka.spout.KafkaSpoutConfig;
+import org.apache.storm.kafka.spout.KafkaSpoutRetryExponentialBackoff;
+import org.apache.storm.kafka.spout.KafkaSpoutRetryService;
+import org.apache.storm.kafka.spout.KafkaSpoutStreams;
+import org.apache.storm.kafka.spout.KafkaSpoutStreamsNamedTopics;
+import org.apache.storm.kafka.spout.KafkaSpoutTupleBuilder;
+import org.apache.storm.kafka.spout.KafkaSpoutTuplesBuilder;
+import org.apache.storm.kafka.spout.KafkaSpoutTuplesBuilderNamedTopics;
+import org.apache.storm.kafka.spout.trident.KafkaTridentSpoutManager;
+import org.apache.storm.kafka.spout.trident.KafkaTridentSpoutOpaque;
+import org.apache.storm.trident.Stream;
+import org.apache.storm.trident.TridentState;
+import org.apache.storm.trident.TridentTopology;
+import org.apache.storm.trident.operation.builtin.Count;
+import org.apache.storm.trident.operation.builtin.Debug;
+import org.apache.storm.trident.testing.Split;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.EARLIEST;
+
+public class TridentKafkaClientWordCountNamedTopics extends TridentKafkaWordCount {
+    public TridentKafkaClientWordCountNamedTopics(String zkUrl, String brokerUrl) {
+        super(zkUrl, brokerUrl);
+    }
+
+    protected TridentState addTridentState(TridentTopology tridentTopology) {
+        final Stream spoutStream = tridentTopology.newStream("spout1", createOpaqueKafkaSpoutNew()).parallelismHint(1);
+
+        return spoutStream.each(spoutStream.getOutputFields(), new Debug(true))
+                .each(new Fields("str"), new Split(), new Fields("word"))
+                .groupBy(new Fields("word"))
+                .persistentAggregate(new DebugMemoryMapState.Factory(), new Count(), new Fields("count"));
+    }
+
+    private KafkaTridentSpoutOpaque<String, String> createOpaqueKafkaSpoutNew() {
+        return new KafkaTridentSpoutOpaque<String, String>(getKafkaTridentManager());
+    }
+
+    private KafkaTridentSpoutManager<String, String> getKafkaTridentManager() {
+        return new KafkaTridentSpoutManager<>(getKafkaSpoutConfig(getKafkaSpoutStreams()));
+    }
+
+    private KafkaSpoutConfig<String,String> getKafkaSpoutConfig(KafkaSpoutStreams kafkaSpoutStreams) {
+        return new KafkaSpoutConfig.Builder<String, String>(getKafkaConsumerProps(), kafkaSpoutStreams, getTuplesBuilder(), getRetryService())
+                .setOffsetCommitPeriodMs(10_000)
+                .setFirstPollOffsetStrategy(EARLIEST)
+                .setMaxUncommittedOffsets(250)
+                .build();
+    }
+
+    protected Map<String,Object> getKafkaConsumerProps() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(KafkaSpoutConfig.Consumer.BOOTSTRAP_SERVERS, "127.0.0.1:9092");
+        props.put(KafkaSpoutConfig.Consumer.GROUP_ID, "kafkaSpoutTestGroup");
+        props.put(KafkaSpoutConfig.Consumer.KEY_DESERIALIZER, "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put(KafkaSpoutConfig.Consumer.VALUE_DESERIALIZER, "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("max.partition.fetch.bytes", 200);
+        return props;
+    }
+
+    protected KafkaSpoutTuplesBuilder<String, String> getTuplesBuilder() {
+        return new KafkaSpoutTuplesBuilderNamedTopics.Builder<>(
+                new TopicsTupleBuilder<String, String>("test-trident","test-trident-1"))
+                .build();
+    }
+
+    protected KafkaSpoutRetryService getRetryService() {
+        return new KafkaSpoutRetryExponentialBackoff(getTimeInterval(500, TimeUnit.MICROSECONDS),
+                KafkaSpoutRetryExponentialBackoff.TimeInterval.milliSeconds(2), Integer.MAX_VALUE, KafkaSpoutRetryExponentialBackoff.TimeInterval.seconds(10));
+    }
+
+    private static KafkaSpoutRetryExponentialBackoff.TimeInterval getTimeInterval(long delay, TimeUnit timeUnit) {
+        return new KafkaSpoutRetryExponentialBackoff.TimeInterval(delay, timeUnit);
+    }
+
+    protected KafkaSpoutStreams getKafkaSpoutStreams() {
+        final Fields outputFields = new Fields("str");
+        return new KafkaSpoutStreamsNamedTopics.Builder(outputFields, new String[]{"test-trident","test-trident-1"}).build();
+    }
+
+    protected static class TopicsTupleBuilder<K, V> extends KafkaSpoutTupleBuilder<K,V> {
+        public TopicsTupleBuilder(String... topics) {
+            super(topics);
+        }
+        @Override
+        public List<Object> buildTuple(ConsumerRecord<K, V> consumerRecord) {
+            return new Values(consumerRecord.value());
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        final String[] zkBrokerUrl = parseUrl(args);
+        runMain(args, new TridentKafkaClientWordCountNamedTopics(zkBrokerUrl[0], zkBrokerUrl[1]));
+    }
+}

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentKafkaClientWordCountWildcardTopics.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentKafkaClientWordCountWildcardTopics.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.starter.trident;
+
+import org.apache.storm.kafka.spout.KafkaSpoutStream;
+import org.apache.storm.kafka.spout.KafkaSpoutStreams;
+import org.apache.storm.kafka.spout.KafkaSpoutStreamsWildcardTopics;
+import org.apache.storm.kafka.spout.KafkaSpoutTuplesBuilder;
+import org.apache.storm.kafka.spout.KafkaSpoutTuplesBuilderWildcardTopics;
+import org.apache.storm.tuple.Fields;
+
+import java.util.regex.Pattern;
+
+public class TridentKafkaClientWordCountWildcardTopics extends TridentKafkaClientWordCountNamedTopics {
+    private static final String TOPIC_WILDCARD_PATTERN = "test-trident(-1)?";
+
+    public TridentKafkaClientWordCountWildcardTopics(String zkUrl, String brokerUrl) {
+        super(zkUrl, brokerUrl);
+    }
+
+    public static void main(String[] args) throws Exception {
+        final String[] zkBrokerUrl = parseUrl(args);
+        runMain(args, new TridentKafkaClientWordCountWildcardTopics(zkBrokerUrl[0], zkBrokerUrl[1]));
+    }
+
+    protected KafkaSpoutTuplesBuilder<String, String> getTuplesBuilder() {
+        return new KafkaSpoutTuplesBuilderWildcardTopics<>(new TopicsTupleBuilder<>(TOPIC_WILDCARD_PATTERN));
+    }
+
+    protected KafkaSpoutStreams getKafkaSpoutStreams() {
+        final Fields outputFields = new Fields("str");
+        final KafkaSpoutStream kafkaSpoutStream = new KafkaSpoutStream(outputFields, Pattern.compile(TOPIC_WILDCARD_PATTERN));
+        return new KafkaSpoutStreamsWildcardTopics(kafkaSpoutStream);
+    }
+}

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentKafkaWordCount.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/TridentKafkaWordCount.java
@@ -222,6 +222,11 @@ public class TridentKafkaWordCount implements Serializable {
      * (word counts) by running an external drpc query against the drpc server.
      */
     public static void main(String[] args) throws Exception {
+        final String[] zkBrokerUrl = parseUrl(args);
+        runMain(args, new TridentKafkaWordCount(zkBrokerUrl[0], zkBrokerUrl[1]));
+    }
+
+    protected static String[] parseUrl(String[] args) {
         String zkUrl = "localhost:2181";        // the defaults.
         String brokerUrl = "localhost:9092";
 
@@ -237,8 +242,7 @@ public class TridentKafkaWordCount implements Serializable {
         }
 
         System.out.println("Using Kafka zookeeper url: " + zkUrl + " broker url: " + brokerUrl);
-
-        runMain(args, new TridentKafkaWordCount(zkUrl, brokerUrl));
+        return new String[]{zkUrl, brokerUrl};
     }
 
     protected static void runMain(String[] args, TridentKafkaWordCount wordCount) throws Exception {

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStream.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStream.java
@@ -58,7 +58,7 @@ public class KafkaSpoutStream implements Serializable {
     }
 
     /** Represents the specified outputFields and topic wild card with the default stream */
-    KafkaSpoutStream(Fields outputFields, Pattern topicWildcardPattern) {
+    public KafkaSpoutStream(Fields outputFields, Pattern topicWildcardPattern) {
         this(outputFields, Utils.DEFAULT_STREAM_ID, topicWildcardPattern);
     }
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsNamedTopics.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsNamedTopics.java
@@ -28,8 +28,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents the {@link KafkaSpoutStream} associated with each topic, and provides a public API to
@@ -56,6 +58,15 @@ public class KafkaSpoutStreamsNamedTopics implements KafkaSpoutStreams {
             return outputFields;
         }
         throw new IllegalStateException(this.getClass().getName() + " not configured for topic: " + topic);
+    }
+
+    @Override
+    public Fields getOutputFields() {
+        final Set<String> allFields = new HashSet<>();
+        for (KafkaSpoutStream kafkaSpoutStream : topicToStream.values()) {
+            allFields.addAll(kafkaSpoutStream.getOutputFields().toList());
+        }
+        return new Fields(new ArrayList<>(allFields));
     }
 
     /**

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsWildcardTopics.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsWildcardTopics.java
@@ -20,6 +20,7 @@ package org.apache.storm.kafka.spout;
 
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
 
 import java.util.List;
 import java.util.regex.Pattern;
@@ -42,6 +43,11 @@ public class KafkaSpoutStreamsWildcardTopics implements KafkaSpoutStreams {
     @Override
     public void emit(SpoutOutputCollector collector, List<Object> tuple, KafkaSpoutMessageId messageId) {
         kafkaSpoutStream.emit(collector, tuple, messageId);
+    }
+
+    @Override
+    public Fields getOutputFields() {
+        return kafkaSpoutStream.getOutputFields();
     }
 
     public KafkaSpoutStream getStream() {

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutBatchMetadata.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutBatchMetadata.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.trident;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Wraps transaction batch information
+ */
+public class KafkaTridentSpoutBatchMetadata<K,V> implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTridentSpoutBatchMetadata.class);
+
+    private TopicPartition topicPartition;  // topic partition of this batch
+    private long firstOffset;   // first offset of this batch
+    private long lastOffset;    // last offset of this batch
+
+    public KafkaTridentSpoutBatchMetadata(TopicPartition topicPartition, long firstOffset, long lastOffset) {
+        this.topicPartition = topicPartition;
+        this.firstOffset = firstOffset;
+        this.lastOffset = lastOffset;
+    }
+
+    public KafkaTridentSpoutBatchMetadata(TopicPartition topicPartition, ConsumerRecords<K, V> consumerRecords, KafkaTridentSpoutBatchMetadata<K, V> lastBatch) {
+        this.topicPartition = topicPartition;
+
+        List<ConsumerRecord<K, V>> records = consumerRecords.records(topicPartition);
+
+        if (records != null && !records.isEmpty()) {
+            firstOffset = records.get(0).offset();
+            lastOffset = records.get(records.size() - 1).offset();
+        } else {
+            if (lastBatch != null) {
+                firstOffset = lastBatch.firstOffset;
+                lastOffset = lastBatch.lastOffset;
+            }
+        }
+        LOG.debug("Created {}", this);
+    }
+
+    public long getFirstOffset() {
+        return firstOffset;
+    }
+
+    public long getLastOffset() {
+        return lastOffset;
+    }
+
+    public TopicPartition getTopicPartition() {
+        return topicPartition;
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaTridentSpoutBatchMetadata{" +
+                "topicPartition=" + topicPartition +
+                ", firstOffset=" + firstOffset +
+                ", lastOffset=" + lastOffset +
+                '}';
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutEmitter.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutEmitter.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.trident;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.kafka.spout.KafkaSpoutConfig;
+import org.apache.storm.kafka.spout.KafkaSpoutTuplesBuilder;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.spout.IOpaquePartitionedTridentSpout;
+import org.apache.storm.trident.topology.TransactionAttempt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.EARLIEST;
+import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.LATEST;
+import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.UNCOMMITTED_EARLIEST;
+import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.UNCOMMITTED_LATEST;
+
+public class KafkaTridentSpoutEmitter<K,V> implements IOpaquePartitionedTridentSpout.Emitter<List<TopicPartition>, KafkaTridentSpoutTopicPartition, KafkaTridentSpoutBatchMetadata<K,V>>, Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTridentSpoutEmitter.class);
+
+    // Kafka
+    private final KafkaConsumer<K, V> kafkaConsumer;
+
+    // Bookkeeping
+    private final KafkaTridentSpoutManager<K, V> kafkaManager;
+    // Declare some KafkaTridentSpoutManager references for convenience
+    private final KafkaSpoutTuplesBuilder<K, V> tuplesBuilder;
+    private final long pollTimeoutMs;
+    private final KafkaSpoutConfig.FirstPollOffsetStrategy firstPollOffsetStrategy;
+
+    public KafkaTridentSpoutEmitter(KafkaTridentSpoutManager<K,V> kafkaManager) {
+        this.kafkaManager = kafkaManager;
+        this.kafkaManager.subscribeKafkaConsumer();
+
+        //must subscribeKafkaConsumer before this line
+        kafkaConsumer = kafkaManager.getKafkaConsumer();
+
+        tuplesBuilder = kafkaManager.getTuplesBuilder();
+        final KafkaSpoutConfig<K, V> kafkaSpoutConfig = kafkaManager.getKafkaSpoutConfig();
+        pollTimeoutMs = kafkaSpoutConfig.getPollTimeoutMs();
+        firstPollOffsetStrategy = kafkaSpoutConfig.getFirstPollOffsetStrategy();
+        LOG.debug("Created {}", this);
+    }
+
+    @Override
+    public KafkaTridentSpoutBatchMetadata<K, V> emitPartitionBatch(TransactionAttempt tx, TridentCollector collector,
+            KafkaTridentSpoutTopicPartition partitionTs, KafkaTridentSpoutBatchMetadata<K, V> lastBatch) {
+        LOG.debug("Emitting batch: [transaction = {}], [partition = {}], [collector = {}], [lastBatchMetadata = {}]",
+                tx, partitionTs, collector, lastBatch);
+
+        final TopicPartition topicPartition = partitionTs.getTopicPartition();
+        KafkaTridentSpoutBatchMetadata<K, V> currentBatch = lastBatch;
+        Collection<TopicPartition> pausedTopicPartitions = Collections.emptySet();
+
+        try {
+            // pause other topic partitions to only poll from current topic partition
+            pausedTopicPartitions = pauseTopicPartitions(topicPartition);
+
+            seek(topicPartition, lastBatch);
+
+            // poll
+            final ConsumerRecords<K, V> records = kafkaConsumer.poll(pollTimeoutMs);
+            LOG.debug("Polled [{}] records from Kafka.", records.count());
+
+            if (!records.isEmpty()) {
+                emitTuples(collector, records);
+                // build new metadata
+                currentBatch = new KafkaTridentSpoutBatchMetadata<>(topicPartition, records, lastBatch);
+            }
+        } finally {
+            kafkaConsumer.resume(pausedTopicPartitions);
+            LOG.trace("Resumed topic partitions [{}]", pausedTopicPartitions);
+        }
+        LOG.debug("Current batch metadata {}", currentBatch);
+        return currentBatch;
+    }
+
+    private void emitTuples(TridentCollector collector, ConsumerRecords<K, V> records) {
+        for (ConsumerRecord<K, V> record : records) {
+            final List<Object> tuple = tuplesBuilder.buildTuple(record);
+            collector.emit(tuple);
+            LOG.debug("Emitted tuple [{}] for record: [{}]", tuple, record);
+        }
+    }
+
+    /**
+     * Determines the offset of the next fetch. For failed batches lastBatchMeta is not null and contains the fetch
+     * offset of the failed batch. In this scenario the next fetch will take place at the offset of the failed batch.
+     * When the previous batch is successful, lastBatchMeta is null, and the offset of the next fetch is either the
+     * offset of the last commit to kafka, or if no commit was yet made, the offset dictated by
+     * {@link KafkaSpoutConfig.FirstPollOffsetStrategy}
+     *
+     * @return the offset of the next fetch
+     */
+    private long seek(TopicPartition tp, KafkaTridentSpoutBatchMetadata<K, V> lastBatchMeta) {
+        if (lastBatchMeta != null) {
+            kafkaConsumer.seek(tp, lastBatchMeta.getLastOffset() + 1);  // seek next offset after last offset from previous batch
+            LOG.debug("Seeking fetch offset to next offset after last offset from previous batch");
+
+        } else {
+            LOG.debug("Seeking fetch offset from firstPollOffsetStrategy and last commit to Kafka");
+            final OffsetAndMetadata committedOffset = kafkaConsumer.committed(tp);
+            if (committedOffset != null) {             // offset was committed for this TopicPartition
+                if (firstPollOffsetStrategy.equals(EARLIEST)) {
+                    kafkaConsumer.seekToBeginning(toArrayList(tp));
+                } else if (firstPollOffsetStrategy.equals(LATEST)) {
+                    kafkaConsumer.seekToEnd(toArrayList(tp));
+                } else {
+                    // By default polling starts at the last committed offset. +1 to point fetch to the first uncommitted offset.
+                    kafkaConsumer.seek(tp, committedOffset.offset() + 1);
+                }
+            } else {    // no commits have ever been done, so start at the beginning or end depending on the strategy
+                if (firstPollOffsetStrategy.equals(EARLIEST) || firstPollOffsetStrategy.equals(UNCOMMITTED_EARLIEST)) {
+                    kafkaConsumer.seekToBeginning(toArrayList(tp));
+                } else if (firstPollOffsetStrategy.equals(LATEST) || firstPollOffsetStrategy.equals(UNCOMMITTED_LATEST)) {
+                    kafkaConsumer.seekToEnd(toArrayList(tp));
+                }
+            }
+        }
+        final long fetchOffset = kafkaConsumer.position(tp);
+        LOG.debug("Set [fetchOffset = {}]", fetchOffset);
+        return fetchOffset;
+    }
+
+    private Collection<TopicPartition> toArrayList(final TopicPartition tp) {
+        return new ArrayList<TopicPartition>(1){{add(tp);}};
+    }
+
+    // returns paused topic partitions
+    private Collection<TopicPartition> pauseTopicPartitions(TopicPartition excludedTp) {
+        final Set<TopicPartition> pausedTopicPartitions  = new HashSet<>(kafkaConsumer.assignment());
+        LOG.debug("Currently assigned topic partitions [{}]", pausedTopicPartitions);
+        pausedTopicPartitions.remove(excludedTp);
+        kafkaConsumer.pause(pausedTopicPartitions);
+        LOG.trace("Paused topic partitions [{}]", pausedTopicPartitions);
+        return pausedTopicPartitions;
+    }
+
+    @Override
+    public void refreshPartitions(List<KafkaTridentSpoutTopicPartition> partitionResponsibilities) {
+        LOG.debug("Refreshing topic partitions [{}]", partitionResponsibilities);
+    }
+
+    @Override
+    public List<KafkaTridentSpoutTopicPartition> getOrderedPartitions(List<TopicPartition> allPartitionInfo) {
+        final List<KafkaTridentSpoutTopicPartition> topicPartitionsTrident = new ArrayList<>(allPartitionInfo == null ? 0 : allPartitionInfo.size());
+        if (allPartitionInfo != null) {
+            for (TopicPartition topicPartition : allPartitionInfo) {
+                topicPartitionsTrident.add(new KafkaTridentSpoutTopicPartition(topicPartition));
+            }
+        }
+        LOG.debug("OrderedPartitions = {}", topicPartitionsTrident);
+        return topicPartitionsTrident;
+    }
+
+    @Override
+    public void close() {
+        kafkaConsumer.close();
+        LOG.debug("Closed");
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaTridentSpoutEmitter{" +
+                ", kafkaManager=" + kafkaManager +
+                '}';
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutManager.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutManager.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.trident;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.kafka.spout.KafkaSpoutConfig;
+import org.apache.storm.kafka.spout.KafkaSpoutStreams;
+import org.apache.storm.kafka.spout.KafkaSpoutStreamsNamedTopics;
+import org.apache.storm.kafka.spout.KafkaSpoutStreamsWildcardTopics;
+import org.apache.storm.kafka.spout.KafkaSpoutTuplesBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class KafkaTridentSpoutManager<K, V> implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTridentSpoutManager.class);
+
+    // Kafka
+    private transient KafkaConsumer<K, V> kafkaConsumer;
+
+    // Bookkeeping
+    private final KafkaSpoutConfig<K, V> kafkaSpoutConfig;
+    // Declare some KafkaSpoutConfig references for convenience
+    private KafkaSpoutStreams kafkaSpoutStreams;                // Object that wraps all the logic to declare output fields and emit tuples
+    private KafkaSpoutTuplesBuilder<K, V> tuplesBuilder;        // Object that contains the logic to build tuples for each ConsumerRecord
+
+    public KafkaTridentSpoutManager(KafkaSpoutConfig<K, V> kafkaSpoutConfig) {
+        this.kafkaSpoutConfig = kafkaSpoutConfig;
+        kafkaSpoutStreams = kafkaSpoutConfig.getKafkaSpoutStreams();
+        tuplesBuilder = kafkaSpoutConfig.getTuplesBuilder();
+        LOG.debug("Created {}", this);
+    }
+
+    void subscribeKafkaConsumer() {
+        kafkaConsumer = new KafkaConsumer<>(kafkaSpoutConfig.getKafkaProps(),
+                kafkaSpoutConfig.getKeyDeserializer(), kafkaSpoutConfig.getValueDeserializer());
+
+        if (kafkaSpoutStreams instanceof KafkaSpoutStreamsNamedTopics) {
+            final List<String> subTopics = kafkaSpoutConfig.getSubscribedTopics();
+            kafkaConsumer.subscribe(subTopics, new KafkaSpoutConsumerRebalanceListener());
+            LOG.info("Kafka consumer subscribed topics {}", subTopics);
+        } else if (kafkaSpoutStreams instanceof KafkaSpoutStreamsWildcardTopics) {
+            final Pattern pattern = kafkaSpoutConfig.getTopicWildcardPattern();
+            kafkaConsumer.subscribe(pattern, new KafkaSpoutConsumerRebalanceListener());
+            LOG.info("Kafka consumer subscribed topics matching wildcard pattern [{}]", pattern);
+        }
+
+        // Initial poll to get the consumer registration process going.
+        // KafkaSpoutConsumerRebalanceListener will be called following this poll, upon partition registration
+        kafkaConsumer.poll(0);
+    }
+
+    private class KafkaSpoutConsumerRebalanceListener implements ConsumerRebalanceListener {
+        @Override
+        public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+            LOG.info("Partitions revoked. [consumer-group={}, consumer={}, topic-partitions={}]",
+                    kafkaSpoutConfig.getConsumerGroupId(), kafkaConsumer, partitions);
+            KafkaTridentSpoutTopicPartitionRegistry.INSTANCE.removeAll(partitions);
+        }
+
+        @Override
+        public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+            KafkaTridentSpoutTopicPartitionRegistry.INSTANCE.addAll(partitions);
+            LOG.info("Partitions reassignment. [consumer-group={}, consumer={}, topic-partitions={}]",
+                    kafkaSpoutConfig.getConsumerGroupId(), kafkaConsumer, partitions);
+        }
+    }
+
+    KafkaConsumer<K, V> getKafkaConsumer() {
+        return kafkaConsumer;
+    }
+
+    KafkaSpoutTuplesBuilder<K, V> getTuplesBuilder() {
+        return tuplesBuilder;
+    }
+
+    Set<TopicPartition> getTopicPartitions() {
+        return KafkaTridentSpoutTopicPartitionRegistry.INSTANCE.getTopicPartitions();
+    }
+
+    KafkaSpoutStreams getKafkaSpoutStreams() {
+        return kafkaSpoutStreams;
+    }
+
+    KafkaSpoutConfig<K, V> getKafkaSpoutConfig() {
+        return kafkaSpoutConfig;
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaTridentSpoutManager{" +
+                "kafkaConsumer=" + kafkaConsumer +
+                ", kafkaSpoutConfig=" + kafkaSpoutConfig +
+                '}';
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaque.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaque.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.trident;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.trident.spout.IOpaquePartitionedTridentSpout;
+import org.apache.storm.tuple.Fields;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class KafkaTridentSpoutOpaque<K,V> implements IOpaquePartitionedTridentSpout<List<TopicPartition>, KafkaTridentSpoutTopicPartition, KafkaTridentSpoutBatchMetadata<K,V>> {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTridentSpoutOpaque.class);
+
+    private KafkaTridentSpoutManager<K, V> kafkaManager;
+    private KafkaTridentSpoutEmitter<K, V> kafkaTridentSpoutEmitter;
+    private KafkaTridentSpoutOpaqueCoordinator<K, V> coordinator;
+
+    public KafkaTridentSpoutOpaque(KafkaTridentSpoutManager<K, V> kafkaManager) {
+        this.kafkaManager = kafkaManager;
+        LOG.debug("Created {}", this);
+    }
+
+    @Override
+    public Emitter<List<TopicPartition>, KafkaTridentSpoutTopicPartition, KafkaTridentSpoutBatchMetadata<K,V>> getEmitter(Map conf, TopologyContext context) {
+        // Instance is created on first call rather than in constructor to avoid NotSerializableException caused by KafkaConsumer
+        if (kafkaTridentSpoutEmitter == null) {
+            kafkaTridentSpoutEmitter = new KafkaTridentSpoutEmitter<>(kafkaManager);
+        }
+        return kafkaTridentSpoutEmitter;
+    }
+
+    @Override
+    public Coordinator<List<TopicPartition>> getCoordinator(Map conf, TopologyContext context) {
+        if (coordinator == null) {
+            coordinator = new KafkaTridentSpoutOpaqueCoordinator<>(kafkaManager);
+        }
+        return coordinator;
+    }
+
+    @Override
+    public Map<String, Object> getComponentConfiguration() {
+        return null;
+    }
+
+    @Override
+    public Fields getOutputFields() {
+        final Fields outputFields = kafkaManager.getKafkaSpoutStreams().getOutputFields();
+        LOG.debug("OutputFields = {}", outputFields);
+        return outputFields;
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaTridentSpoutOpaque{" +
+                "kafkaManager=" + kafkaManager +
+                ", kafkaTridentSpoutEmitter=" + kafkaTridentSpoutEmitter +
+                ", coordinator=" + coordinator +
+                '}';
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaqueCoordinator.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaqueCoordinator.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.trident;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.trident.spout.IOpaquePartitionedTridentSpout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class KafkaTridentSpoutOpaqueCoordinator<K,V> implements IOpaquePartitionedTridentSpout.Coordinator<List<TopicPartition>>, Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTridentSpoutOpaqueCoordinator.class);
+
+    private KafkaTridentSpoutManager<K,V> kafkaManager;
+
+    public KafkaTridentSpoutOpaqueCoordinator(KafkaTridentSpoutManager<K, V> kafkaManager) {
+        this.kafkaManager = kafkaManager;
+        LOG.debug("Created {}", this);
+    }
+
+    @Override
+    public boolean isReady(long txid) {
+        LOG.debug("isReady = true");
+        return true;    // the "old" trident kafka spout always returns true, like this
+    }
+
+    @Override
+    public List<TopicPartition> getPartitionsForBatch() {
+        final ArrayList<TopicPartition> topicPartitions = new ArrayList<>(kafkaManager.getTopicPartitions());
+        LOG.debug("TopicPartitions for batch {}", topicPartitions);
+        return topicPartitions;
+    }
+
+    @Override
+    public void close() {
+        LOG.debug("Closed"); // the "old" trident kafka spout is no op like this
+    }
+
+    @Override
+    public String toString() {
+        return "KafkaTridentSpoutOpaqueCoordinator{" +
+                "kafkaManager=" + kafkaManager +
+                '}';
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTopicPartition.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTopicPartition.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.trident;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.trident.spout.ISpoutPartition;
+
+import java.io.Serializable;
+
+/**
+ * {@link ISpoutPartition} that wraps {@link TopicPartition} information
+ */
+public class KafkaTridentSpoutTopicPartition implements ISpoutPartition, Serializable {
+    private TopicPartition topicPartition;
+
+    public KafkaTridentSpoutTopicPartition(String topic, int partition) {
+        this(new TopicPartition(topic, partition));
+    }
+
+    public KafkaTridentSpoutTopicPartition(TopicPartition topicPartition) {
+        this.topicPartition = topicPartition;
+    }
+
+    public TopicPartition getTopicPartition() {
+        return topicPartition;
+    }
+
+    @Override
+    public String getId() {
+        return topicPartition.topic() + "/" + topicPartition.partition();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        KafkaTridentSpoutTopicPartition that = (KafkaTridentSpoutTopicPartition) o;
+
+        return topicPartition != null ? topicPartition.equals(that.topicPartition) : that.topicPartition == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return topicPartition != null ? topicPartition.hashCode() : 0;
+    }
+
+    @Override
+    public String toString()  {
+        return topicPartition.toString();
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTopicPartitionRegistry.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTopicPartitionRegistry.java
@@ -16,23 +16,33 @@
  *   limitations under the License.
  */
 
-package org.apache.storm.kafka.spout;
+package org.apache.storm.kafka.spout.trident;
 
-import org.apache.storm.spout.SpoutOutputCollector;
-import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.tuple.Fields;
+import org.apache.kafka.common.TopicPartition;
 
-import java.io.Serializable;
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
-/**
- * Represents the {@link KafkaSpoutStream} associated with each topic or topic pattern (wildcard), and provides
- * a public API to declare output streams and emmit tuples, on the appropriate stream, for all the topics specified.
- */
-public interface KafkaSpoutStreams extends Serializable {
-    void declareOutputFields(OutputFieldsDeclarer declarer);
+public enum KafkaTridentSpoutTopicPartitionRegistry {
+    INSTANCE;
 
-    void emit(SpoutOutputCollector collector, List<Object> tuple, KafkaSpoutMessageId messageId);
+    private Set<TopicPartition> topicPartitions;
 
-    Fields getOutputFields();
+    KafkaTridentSpoutTopicPartitionRegistry() {
+        this.topicPartitions = new HashSet<>();
+    }
+
+    public Set<TopicPartition> getTopicPartitions() {
+        return Collections.unmodifiableSet(topicPartitions);
+    }
+
+    public void addAll(Collection<? extends TopicPartition> topicPartitions) {
+        this.topicPartitions.addAll(topicPartitions);
+    }
+
+    public void removeAll(Collection<? extends TopicPartition> topicPartitions) {
+        this.topicPartitions.removeAll(topicPartitions);
+    }
 }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTransactional.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTransactional.java
@@ -16,23 +16,33 @@
  *   limitations under the License.
  */
 
-package org.apache.storm.kafka.spout;
+package org.apache.storm.kafka.spout.trident;
 
-import org.apache.storm.spout.SpoutOutputCollector;
-import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.trident.spout.IPartitionedTridentSpout;
 import org.apache.storm.tuple.Fields;
 
-import java.io.Serializable;
-import java.util.List;
+import java.util.Map;
 
-/**
- * Represents the {@link KafkaSpoutStream} associated with each topic or topic pattern (wildcard), and provides
- * a public API to declare output streams and emmit tuples, on the appropriate stream, for all the topics specified.
- */
-public interface KafkaSpoutStreams extends Serializable {
-    void declareOutputFields(OutputFieldsDeclarer declarer);
+// TODO
+public class KafkaTridentSpoutTransactional implements IPartitionedTridentSpout {
+    @Override
+    public Coordinator getCoordinator(Map conf, TopologyContext context) {
+        return null;
+    }
 
-    void emit(SpoutOutputCollector collector, List<Object> tuple, KafkaSpoutMessageId messageId);
+    @Override
+    public Emitter getEmitter(Map conf, TopologyContext context) {
+        return null;
+    }
 
-    Fields getOutputFields();
+    @Override
+    public Map<String, Object> getComponentConfiguration() {
+        return null;
+    }
+
+    @Override
+    public Fields getOutputFields() {
+        return null;
+    }
 }


### PR DESCRIPTION
The Kafka Trident implementation is on top of the Trident logs improvement patch because they are related, and it makes it easier to merge the patch. There is already another PR for STORM-2097
