### PR TITLE
STORM-2099 Introduce new sql external module: storm-sql-redis

### DIFF
--- a/external/sql/pom.xml
+++ b/external/sql/pom.xml
@@ -40,5 +40,6 @@
         <module>storm-sql-core</module>
         <module>storm-sql-runtime</module>
         <module>storm-sql-external/storm-sql-kafka</module>
+        <module>storm-sql-external/storm-sql-redis</module>
     </modules>
 </project>

--- a/external/sql/storm-sql-external/storm-sql-redis/pom.xml
+++ b/external/sql/storm-sql-external/storm-sql-redis/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>storm</artifactId>
+        <groupId>org.apache.storm</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../../../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>storm-sql-redis</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-sql-runtime</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-sql-runtime</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-redis</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <sourceDirectory>src/jvm</sourceDirectory>
+        <testSourceDirectory>src/test</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/resources</directory>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/external/sql/storm-sql-external/storm-sql-redis/src/jvm/org/apache/storm/sql/redis/RedisDataSourcesProvider.java
+++ b/external/sql/storm-sql-external/storm-sql-redis/src/jvm/org/apache/storm/sql/redis/RedisDataSourcesProvider.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.sql.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import org.apache.storm.redis.common.config.JedisClusterConfig;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
+import org.apache.storm.redis.common.mapper.RedisDataTypeDescription;
+import org.apache.storm.redis.common.mapper.RedisStoreMapper;
+import org.apache.storm.redis.trident.state.RedisClusterState;
+import org.apache.storm.redis.trident.state.RedisClusterStateUpdater;
+import org.apache.storm.redis.trident.state.RedisState;
+import org.apache.storm.redis.trident.state.RedisStateUpdater;
+import org.apache.storm.sql.runtime.DataSource;
+import org.apache.storm.sql.runtime.DataSourcesProvider;
+import org.apache.storm.sql.runtime.FieldInfo;
+import org.apache.storm.sql.runtime.IOutputSerializer;
+import org.apache.storm.sql.runtime.ISqlTridentDataSource;
+import org.apache.storm.sql.runtime.SimpleSqlTridentConsumer;
+import org.apache.storm.sql.runtime.serde.json.JsonSerializer;
+import org.apache.storm.trident.spout.ITridentDataSource;
+import org.apache.storm.trident.state.StateFactory;
+import org.apache.storm.trident.state.StateUpdater;
+import org.apache.storm.tuple.ITuple;
+import redis.clients.util.JedisURIHelper;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Create a Redis sink based on the URI and properties. The URI has the format of
+ * redis://:[password]@[host]:[port]/[dbIdx]. Only host is mandatory and others can be set to default.
+ *
+ * The properties are in JSON format which specifies the config of the Redis data type and etc.
+ * Please note that when "use.redis.cluster" is "true", cluster discovery is only done from given URI.
+ */
+public class RedisDataSourcesProvider implements DataSourcesProvider {
+  private static final int DEFAULT_REDIS_PORT = 6379;
+  private static final int DEFAULT_TIMEOUT = 2000;
+
+  private static class FieldNameExtractor implements Function<FieldInfo, String>, Serializable {
+    @Override
+    public String apply(FieldInfo fieldInfo) {
+      return fieldInfo.name();
+    }
+  }
+
+  private abstract static class AbstractRedisTridentDataSource implements ISqlTridentDataSource, Serializable {
+    protected abstract StateFactory newStateFactory();
+    protected abstract StateUpdater newStateUpdater(RedisStoreMapper storeMapper);
+
+    private final Properties props;
+    private final List<FieldInfo> fields;
+
+    AbstractRedisTridentDataSource(Properties props, List<FieldInfo> fields) {
+      this.props = props;
+      this.fields = fields;
+    }
+
+    @Override
+    public ITridentDataSource getProducer() {
+      throw new UnsupportedOperationException(this.getClass().getName() + " doesn't provide Producer");
+    }
+
+    @Override
+    public SqlTridentConsumer getConsumer() {
+      RedisDataTypeDescription dataTypeDescription = getDataTypeDesc(props);
+      List<String> fieldNames = Lists.transform(fields, new FieldNameExtractor());
+
+      RedisStoreMapper storeMapper = new TridentRedisStoreMapper(dataTypeDescription, fields, new JsonSerializer(fieldNames));
+
+      StateFactory stateFactory = newStateFactory();
+      StateUpdater stateUpdater = newStateUpdater(storeMapper);
+
+      return new SimpleSqlTridentConsumer(stateFactory, stateUpdater);
+    }
+
+    private RedisDataTypeDescription getDataTypeDesc(Properties props) {
+      Preconditions.checkArgument(props.containsKey("data.type"),
+              "Redis data source must contain \"data.type\" config");
+
+      RedisDataTypeDescription.RedisDataType dataType = RedisDataTypeDescription.RedisDataType.valueOf(props.getProperty("data.type").toUpperCase());
+      String additionalKey = props.getProperty("data.additional.key");
+
+      return new RedisDataTypeDescription(dataType, additionalKey);
+    }
+  }
+
+  private static class RedisClusterTridentDataSource extends AbstractRedisTridentDataSource {
+    private final JedisClusterConfig config;
+
+    RedisClusterTridentDataSource(JedisClusterConfig config, Properties props, List<FieldInfo> fields) {
+      super(props, fields);
+      this.config = config;
+    }
+
+    @Override
+    protected StateFactory newStateFactory() {
+      return new RedisClusterState.Factory(config);
+    }
+
+    @Override
+    protected StateUpdater newStateUpdater(RedisStoreMapper storeMapper) {
+      return new RedisClusterStateUpdater(storeMapper);
+    }
+  }
+
+  private static class RedisTridentDataSource extends AbstractRedisTridentDataSource {
+    private final JedisPoolConfig config;
+
+    RedisTridentDataSource(JedisPoolConfig config, Properties props, List<FieldInfo> fields) {
+      super(props, fields);
+      this.config = config;
+    }
+
+    @Override
+    protected StateFactory newStateFactory() {
+      return new RedisState.Factory(config);
+    }
+
+    @Override
+    protected StateUpdater newStateUpdater(RedisStoreMapper storeMapper) {
+      return new RedisStateUpdater(storeMapper);
+    }
+  }
+
+  @Override
+  public String scheme() {
+    return "redis";
+  }
+
+  @Override
+  public DataSource construct(URI uri, String inputFormatClass, String outputFormatClass, List<FieldInfo> fields) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ISqlTridentDataSource constructTrident(URI uri, String inputFormatClass, String outputFormatClass, String properties, List<FieldInfo> fields) {
+    Preconditions.checkArgument(JedisURIHelper.isValid(uri), "URI is not valid for Redis: " + uri);
+
+    String host = uri.getHost();
+    int port = uri.getPort() != -1 ? uri.getPort() : DEFAULT_REDIS_PORT;
+    int dbIdx = JedisURIHelper.getDBIndex(uri);
+    String password = JedisURIHelper.getPassword(uri);
+
+    Properties props = new Properties();
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      @SuppressWarnings("unchecked")
+      HashMap<String, Object> map = mapper.readValue(properties, HashMap.class);
+      props.putAll(map);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    int timeout = Integer.parseInt(props.getProperty("redis.timeout", String.valueOf(DEFAULT_TIMEOUT)));
+
+    boolean clusterMode = Boolean.valueOf(props.getProperty("use.redis.cluster", "false"));
+
+    if (clusterMode) {
+      JedisClusterConfig config = new JedisClusterConfig.Builder()
+              .setNodes(Collections.singleton(new InetSocketAddress(host, port)))
+              .setTimeout(timeout)
+              .build();
+      return new RedisClusterTridentDataSource(config, props, fields);
+    } else {
+      JedisPoolConfig config = new JedisPoolConfig(host, port, timeout, password, dbIdx);
+      return new RedisTridentDataSource(config, props, fields);
+    }
+  }
+
+  private static class TridentRedisStoreMapper implements RedisStoreMapper {
+    private final RedisDataTypeDescription dataTypeDescription;
+    private final FieldInfo primaryKeyField;
+    private final IOutputSerializer outputSerializer;
+
+    private TridentRedisStoreMapper(RedisDataTypeDescription dataTypeDescription, List<FieldInfo> fields, IOutputSerializer outputSerializer) {
+      this.dataTypeDescription = dataTypeDescription;
+      this.outputSerializer = outputSerializer;
+
+      // find primary key from constructor
+      FieldInfo pkField = findPrimaryKeyField(fields);
+      Preconditions.checkArgument(pkField != null, "Primary key must be presented to field list");
+
+      this.primaryKeyField = pkField;
+    }
+
+    private FieldInfo findPrimaryKeyField(List<FieldInfo> fields) {
+      FieldInfo pkField = null;
+      for (FieldInfo field : fields) {
+        if (field.isPrimary()) {
+          // TODO: this assumes key is only from the one field
+          // if not we need to have order of fields in PK
+          pkField = field;
+          break;
+        }
+      }
+      return pkField;
+    }
+
+    @Override
+    public RedisDataTypeDescription getDataTypeDescription() {
+      return dataTypeDescription;
+    }
+
+    @Override
+    public String getKeyFromTuple(ITuple tuple) {
+      String keyFieldName = primaryKeyField.name();
+      Object key = tuple.getValueByField(keyFieldName);
+      if (key == null) {
+        throw new NullPointerException("key field " + keyFieldName + " is null");
+      }
+      return String.valueOf(key);
+    }
+
+    @Override
+    public String getValueFromTuple(ITuple tuple) {
+      byte[] array = outputSerializer.write(tuple.getValues(), null).array();
+      return new String(array);
+    }
+  }
+}

--- a/external/sql/storm-sql-external/storm-sql-redis/src/resources/META-INF/services/org.apache.storm.sql.runtime.DataSourcesProvider
+++ b/external/sql/storm-sql-external/storm-sql-redis/src/resources/META-INF/services/org.apache.storm.sql.runtime.DataSourcesProvider
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.storm.sql.redis.RedisDataSourcesProvider

--- a/external/sql/storm-sql-external/storm-sql-redis/src/test/org/apache/storm/sql/redis/TestRedisDataSourcesProvider.java
+++ b/external/sql/storm-sql-external/storm-sql-redis/src/test/org/apache/storm/sql/redis/TestRedisDataSourcesProvider.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.sql.redis;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.apache.storm.redis.trident.state.RedisClusterState;
+import org.apache.storm.redis.trident.state.RedisClusterStateUpdater;
+import org.apache.storm.redis.trident.state.RedisState;
+import org.apache.storm.redis.trident.state.RedisStateUpdater;
+import org.apache.storm.sql.runtime.DataSourcesRegistry;
+import org.apache.storm.sql.runtime.FieldInfo;
+import org.apache.storm.sql.runtime.ISqlTridentDataSource;
+import org.apache.storm.sql.runtime.serde.json.JsonSerializer;
+import org.apache.storm.trident.state.StateUpdater;
+import org.apache.storm.trident.tuple.TridentTuple;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Pipeline;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestRedisDataSourcesProvider {
+  private static final List<FieldInfo> FIELDS = ImmutableList.of(
+      new FieldInfo("ID", int.class, true),
+      new FieldInfo("val", String.class, false));
+  private static final List<String> FIELD_NAMES = ImmutableList.of("ID", "val");
+  private static final String ADDITIONAL_KEY = "hello";
+  private static final JsonSerializer SERIALIZER = new JsonSerializer(FIELD_NAMES);
+  private static final String TBL_PROPERTIES = Joiner.on('\n').join(
+      "{",
+      "\"data.type\": \"HASH\",",
+      "\"data.additional.key\": \"" + ADDITIONAL_KEY + "\"",
+      "}"
+  );
+
+  private static final String CLUSTER_TBL_PROPERTIES = Joiner.on('\n').join(
+          "{",
+          "\"data.type\": \"HASH\",",
+          "\"data.additional.key\": \"" + ADDITIONAL_KEY + "\",",
+          "\"use.redis.cluster\": \"true\"",
+          "}"
+  );
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testRedisSink() {
+    ISqlTridentDataSource ds = DataSourcesRegistry.constructTridentDataSource(
+        URI.create("redis://:foobared@localhost:6380/2"), null, null, TBL_PROPERTIES, FIELDS);
+    Assert.assertNotNull(ds);
+
+    ISqlTridentDataSource.SqlTridentConsumer consumer = ds.getConsumer();
+
+    Assert.assertEquals(RedisState.Factory.class, consumer.getStateFactory().getClass());
+    Assert.assertEquals(RedisStateUpdater.class, consumer.getStateUpdater().getClass());
+
+    RedisState state = (RedisState) consumer.getStateFactory().makeState(Collections.emptyMap(), null, 0, 1);
+    StateUpdater stateUpdater = consumer.getStateUpdater();
+
+    JedisPool mockJedisPool = mock(JedisPool.class);
+    Jedis mockJedis = mock(Jedis.class);
+    Pipeline mockPipeline = mock(Pipeline.class);
+
+    Whitebox.setInternalState(state, "jedisPool", mockJedisPool);
+    when(mockJedisPool.getResource()).thenReturn(mockJedis);
+    when(mockJedis.pipelined()).thenReturn(mockPipeline);
+
+    List<TridentTuple> tupleList = mockTupleList();
+
+    stateUpdater.updateState(state, tupleList, null);
+    for (TridentTuple t : tupleList) {
+      // PK goes to the key
+      String id = String.valueOf(t.getValueByField("ID"));
+      String serializedValue = new String(SERIALIZER.write(t.getValues(), null).array());
+      verify(mockPipeline).hset(eq(ADDITIONAL_KEY), eq(id), eq(serializedValue));
+    }
+
+    verify(mockPipeline).sync();
+    verify(mockJedis).close();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testRedisClusterSink() throws IOException {
+    ISqlTridentDataSource ds = DataSourcesRegistry.constructTridentDataSource(
+        URI.create("redis://localhost:6380"), null, null, CLUSTER_TBL_PROPERTIES, FIELDS);
+    Assert.assertNotNull(ds);
+
+    ISqlTridentDataSource.SqlTridentConsumer consumer = ds.getConsumer();
+
+    Assert.assertEquals(RedisClusterState.Factory.class, consumer.getStateFactory().getClass());
+    Assert.assertEquals(RedisClusterStateUpdater.class, consumer.getStateUpdater().getClass());
+
+    RedisClusterState state = (RedisClusterState) consumer.getStateFactory().makeState(Collections.emptyMap(), null, 0, 1);
+    StateUpdater stateUpdater = consumer.getStateUpdater();
+
+    JedisCluster mockJedisCluster = mock(JedisCluster.class);
+
+    Whitebox.setInternalState(state, "jedisCluster", mockJedisCluster);
+
+    List<TridentTuple> tupleList = mockTupleList();
+
+    stateUpdater.updateState(state, tupleList, null);
+    for (TridentTuple t : tupleList) {
+      // PK goes to the key
+      String id = String.valueOf(t.getValueByField("ID"));
+      String serializedValue = new String(SERIALIZER.write(t.getValues(), null).array());
+      verify(mockJedisCluster).hset(eq(ADDITIONAL_KEY), eq(id), eq(serializedValue));
+    }
+
+    verify(mockJedisCluster, never()).close();
+  }
+
+  private static List<TridentTuple> mockTupleList() {
+    List<TridentTuple> tupleList = new ArrayList<>();
+    TridentTuple t0 = mock(TridentTuple.class);
+    TridentTuple t1 = mock(TridentTuple.class);
+    when(t0.getValueByField("ID")).thenReturn(1);
+    when(t0.getValueByField("val")).thenReturn("2");
+    doReturn(Lists.<Object>newArrayList(1, "2")).when(t0).getValues();
+
+    when(t1.getValueByField("ID")).thenReturn(2);
+    when(t1.getValueByField("val")).thenReturn("3");
+    doReturn(Lists.<Object>newArrayList(2, "3")).when(t1).getValues();
+
+    tupleList.add(t0);
+    tupleList.add(t1);
+    return tupleList;
+  }
+
+}

--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -305,6 +305,13 @@
             </includes>
         </fileSet>
         <fileSet>
+            <directory>${project.basedir}/../../external/sql/storm-sql-external/storm-sql-redis/target</directory>
+            <outputDirectory>external/sql/storm-sql-external/storm-sql-redis</outputDirectory>
+            <includes>
+                <include>storm*jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
             <directory>${project.basedir}/../../external/sql/storm-sql-runtime/target/app-assembler/repo</directory>
             <outputDirectory>external/sql/storm-sql-runtime</outputDirectory>
             <includes>


### PR DESCRIPTION
This patch is on top of [STORM-2089](https://issues.apache.org/jira/browse/STORM-2089) (#1682)

I moved JsonScheme and JsonSerializer to storm-sql-runtime since it's used from storm-sql-kafka and storm-sql-redis. In result, additional dependency (jackson-databind) for storm-sql-runtime is introduced.

Below is the example of defining Redis table:

```
CREATE EXTERNAL TABLE LARGE_ORDERS (ID INT PRIMARY KEY, TOTAL INT) LOCATION 'redis://localhost:7379' TBLPROPERTIES '{"data.type": "STRING", "data.additional.key": "addkey", "redis.timeout": "3000", "use.redis.cluster": "true"}'
```

LOCATION can be set to `redis://:[password]@[host]:[port]/[dbIdx]`.
Default mode is JedisPool (for single Redis). If you want to enable cluster mode you need to specify option "use.redis.cluster" to "true".

In cluster mode password and dbIdx is ignored. DB index is not valid for Cluster mode, but recently password for Cluster mode of Redis becomes valid. 
This will be addressed from storm-redis and addressed to storm-sql-redis later.

Please note that Redis(Cluster)State only supports STRING and HASH since State stores key and value.

Please review and comment. Thanks in advance!