### PR TITLE
STORM-2100 Fix Trident SQL join tests to not rely on ordering

### DIFF
--- a/external/sql/storm-sql-core/pom.xml
+++ b/external/sql/storm-sql-core/pom.xml
@@ -111,6 +111,12 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>src/jvm</sourceDirectory>


### PR DESCRIPTION
Issue link: [STORM-2100](https://issues.apache.org/jira/browse/STORM-2100)

The join doesn't guarantee preserving order (Trident and SQL itself) so we shouldn't rely on that.

Before this patch, tests are failing with JDK7 (with 1.x-branch). I confirmed that this patch makes tests succeed with 1.x-branch & JDK 1.7 (1.7.0_79) combination.

@satishd Could you please review this? Thanks.