### PR TITLE
Fix STORM-2017

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/utils/ShellBoltMessageQueue.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/ShellBoltMessageQueue.java
@@ -55,9 +55,9 @@ public class ShellBoltMessageQueue implements Serializable {
      * @param taskIds task ids that received the tuples
      */
     public void putTaskIds(List<Integer> taskIds) {
-        taskIdsQueue.add(taskIds);
         takeLock.lock();
         try {
+            taskIdsQueue.add(taskIds);
             notEmpty.signal();
         } finally {
             takeLock.unlock();


### PR DESCRIPTION
Moving taskIdsQueue inside the lock should remove the race condition.