### PR TITLE
STORM-2101: fixes npe in compute-executors in nimbus

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -637,16 +637,17 @@
         storm-conf (read-storm-conf-as-nimbus storm-id blob-store)
         topology (read-storm-topology-as-nimbus storm-id blob-store)
         task->component (get-clojurified-task-info topology storm-conf)]
-    (->> (StormCommon/stormTaskInfo topology storm-conf)
-         (Utils/reverseMap)
-         clojurify-structure
-         (map-val sort)
-         ((fn [ & maps ] (Utils/joinMaps (into-array Map (into [component->executors] maps)))))
-         (clojurify-structure)
-         (map-val (partial apply (fn part-fixed [a b] (Utils/partitionFixed a b))))
-         (mapcat second)
-         (map to-executor-id)
-         )))
+    (if (nil? component->executors)
+      []
+      (->> (StormCommon/stormTaskInfo topology storm-conf)
+           (Utils/reverseMap)
+           clojurify-structure
+           (map-val sort)
+           ((fn [ & maps ] (Utils/joinMaps (into-array Map (into [component->executors] maps)))))
+           (clojurify-structure)
+           (map-val (partial apply (fn part-fixed [a b] (Utils/partitionFixed a b))))
+           (mapcat second)
+           (map to-executor-id)))))
 
 (defn- compute-executor->component [nimbus storm-id]
   (let [conf (:conf nimbus)


### PR DESCRIPTION
We observed compute-executors can throw NPE while shutting down a topology sporadically. 

joinMaps (join-maps) will NPE if one of the maps is nil. The only one that can be nil in this case is component->executors.