### PR TITLE
STORM-2120 - Emit to _spoutConfig.outputStreamId

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
@@ -164,7 +164,7 @@ public class PartitionManager {
             if ((tups != null) && tups.iterator().hasNext()) {
                if (!Strings.isNullOrEmpty(_spoutConfig.outputStreamId)) {
                     for (List<Object> tup : tups) {
-                        collector.emit(_spoutConfig.topic, tup, new KafkaMessageId(_partition, toEmit.offset()));
+                        collector.emit(_spoutConfig.outputStreamId, tup, new KafkaMessageId(_partition, toEmit.offset()));
                     }
                 } else {
                     for (List<Object> tup : tups) {


### PR DESCRIPTION
Even though KafkaSpout.declareOutputFields declaresStream using outputStreamId (if present), the message gets emitted to a stream matching the Kafka topic it was read from. Looks like it may have been a merge conflict between the fix for STORM-1210 and STORM-1379.