### PR TITLE
STORM-2113 [Storm SQL] fix 'OR' and 'AND' operators handle more than 2 operands

### DIFF
--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/ExprCompiler.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/ExprCompiler.java
@@ -196,6 +196,8 @@ public class ExprCompiler implements RexVisitor<String> {
           .put(builtInMethod(CHAR_LENGTH, BuiltInMethod.CHAR_LENGTH, NullPolicy.STRICT))
           .put(builtInMethod(CONCAT, BuiltInMethod.STRING_CONCAT, NullPolicy.STRICT))
           .put(builtInMethod(ITEM, BuiltInMethod.ANY_ITEM, NullPolicy.STRICT))
+          .put(builtInMethod(LIKE, BuiltInMethod.LIKE, NullPolicy.STRICT))
+          .put(builtInMethod(SIMILAR_TO, BuiltInMethod.SIMILAR, NullPolicy.STRICT))
           .put(infixBinary(LESS_THAN, "<", "lt"))
           .put(infixBinary(LESS_THAN_OR_EQUAL, "<=", "le"))
           .put(infixBinary(GREATER_THAN, ">", "gt"))
@@ -405,7 +407,7 @@ public class ExprCompiler implements RexVisitor<String> {
           String s;
           if (rhsNullable) {
             s = foldNullExpr(
-                String.format("(%2$s != null && !(%2$s)) ? Boolean.FALSE : ((%1$s == null || %2$s == null) ? null : Boolean.TRUE)",
+                String.format("(%2$s != null && !(%2$s)) ? Boolean.FALSE : ((%1$s == null || %2$s == null) ? ((Boolean) null) : Boolean.TRUE)",
                               lhs, rhs), "null", op1);
           } else {
             s = String.format("!(%2$s) ? Boolean.FALSE : %1$s", lhs, rhs);
@@ -446,7 +448,7 @@ public class ExprCompiler implements RexVisitor<String> {
           String s;
           if (rhsNullable) {
             s = foldNullExpr(
-                String.format("(%2$s != null && %2$s) ? Boolean.TRUE : ((%1$s == null || %2$s == null) ? null : Boolean.FALSE)",
+                String.format("(%2$s != null && %2$s) ? Boolean.TRUE : ((%1$s == null || %2$s == null) ? ((Boolean) null) : Boolean.FALSE)",
                               lhs, rhs),
                 "null", op1);
           } else {
@@ -463,6 +465,7 @@ public class ExprCompiler implements RexVisitor<String> {
       @Override
       public String translate(
           ExprCompiler compiler, RexCall call) {
+        Boolean b = new Boolean(false);
         String val = compiler.reserveName();
         PrintWriter pw = compiler.pw;
         RexNode op = call.getOperands().get(0);
@@ -474,7 +477,7 @@ public class ExprCompiler implements RexVisitor<String> {
           pw.print(String.format("%1$s = !(%2$s);\n", val, lhs));
         } else {
           String s = foldNullExpr(
-              String.format("%1$s == null ? null : !(%1$s)", lhs), "null", op);
+              String.format("(%1$s == null) ? ((%2$s) null) : !(%1$s)", lhs, compiler.javaTypeName(call)), "null", op);
           pw.print(String.format("%1$s = %2$s;\n", val, s));
         }
         return val;

--- a/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/backends/trident/TestPlanCompiler.java
+++ b/external/sql/storm-sql-core/src/test/org/apache/storm/sql/compiler/backends/trident/TestPlanCompiler.java
@@ -29,7 +29,6 @@ import org.apache.storm.ILocalCluster;
 import org.apache.storm.LocalCluster;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.sql.TestUtils;
-import org.apache.storm.sql.TestUtils.MockSqlTridentDataSource.CollectDataFunction;
 import org.apache.storm.sql.compiler.TestCompilerUtils;
 import org.apache.storm.sql.runtime.ISqlTridentDataSource;
 import org.apache.storm.sql.runtime.trident.AbstractTridentProcessor;
@@ -46,7 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import static org.apache.storm.sql.TestUtils.MockSqlTridentDataSource.CollectDataFunction.getCollectedValues;
+import static org.apache.storm.sql.TestUtils.MockState.getCollectedValues;
 
 public class TestPlanCompiler {
   private final JavaTypeFactory typeFactory = new JavaTypeFactoryImpl(
@@ -68,7 +67,8 @@ public class TestPlanCompiler {
     final AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
     Assert.assertArrayEquals(new Values[] { new Values(3), new Values(4)}, getCollectedValues().toArray());
   }
@@ -84,7 +84,8 @@ public class TestPlanCompiler {
     final AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
 
     Assert.assertArrayEquals(new Values[] { new Values(0, 5L, 5, 1, 3, 4)}, getCollectedValues().toArray());
@@ -101,7 +102,8 @@ public class TestPlanCompiler {
     final AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
 
     Assert.assertArrayEquals(new Values[] { new Values(0, 5L, 39)}, getCollectedValues().toArray());
@@ -119,7 +121,8 @@ public class TestPlanCompiler {
     final AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
 
     assertListsAreEqualIgnoringOrder(Lists.newArrayList(new Values(1, 2L), new Values(0, 2L)), getCollectedValues());
@@ -137,7 +140,8 @@ public class TestPlanCompiler {
     final AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
 
     assertListsAreEqualIgnoringOrder(Lists.newArrayList(new Values(2, null), new Values(3, null), new Values(4, null)), getCollectedValues());
@@ -155,7 +159,8 @@ public class TestPlanCompiler {
     final AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
 
     assertListsAreEqualIgnoringOrder(Lists.newArrayList(new Values(2, null), new Values(3, null), new Values(4, null)), getCollectedValues());
@@ -173,7 +178,8 @@ public class TestPlanCompiler {
     final AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
 
     assertListsAreEqualIgnoringOrder(Lists.newArrayList(new Values(null, "dept-2"), new Values(null, "dept-3"), new Values(null, "dept-4"),
@@ -207,7 +213,8 @@ public class TestPlanCompiler {
     AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
     Assert.assertArrayEquals(new Values[] { new Values(true, false, true) }, getCollectedValues().toArray());
   }
@@ -225,7 +232,8 @@ public class TestPlanCompiler {
     AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
     Assert.assertArrayEquals(new Values[] { new Values(5) }, getCollectedValues().toArray());
   }
@@ -241,7 +249,8 @@ public class TestPlanCompiler {
     AbstractTridentProcessor proc = compiler.compileForTest(state.tree());
     final TridentTopology topo = proc.build(data);
     Fields f = proc.outputStream().getOutputFields();
-    proc.outputStream().each(f, new CollectDataFunction(), new Fields()).toStream();
+    proc.outputStream().partitionPersist(new TestUtils.MockStateFactory(),
+            f, new TestUtils.MockStateUpdater(), new Fields());
     runTridentTopology(EXPECTED_VALUE_SIZE, proc, topo);
     Assert.assertArrayEquals(new Values[] { new Values(0, 5L, 15L, 15L) }, getCollectedValues().toArray());
   }

--- a/external/sql/storm-sql-external/storm-sql-kafka/src/jvm/org/apache/storm/sql/kafka/KafkaDataSourcesProvider.java
+++ b/external/sql/storm-sql-external/storm-sql-kafka/src/jvm/org/apache/storm/sql/kafka/KafkaDataSourcesProvider.java
@@ -17,6 +17,8 @@
  */
 package org.apache.storm.sql.kafka;
 
+import org.apache.storm.kafka.trident.TridentKafkaStateFactory;
+import org.apache.storm.kafka.trident.TridentKafkaUpdater;
 import org.apache.storm.spout.SchemeAsMultiScheme;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -24,14 +26,10 @@ import org.apache.storm.sql.runtime.*;
 import org.apache.storm.kafka.ZkHosts;
 import org.apache.storm.kafka.trident.OpaqueTridentKafkaSpout;
 import org.apache.storm.kafka.trident.TridentKafkaConfig;
-import org.apache.storm.kafka.trident.TridentKafkaState;
 import org.apache.storm.kafka.trident.mapper.TridentTupleToKafkaMapper;
 import org.apache.storm.kafka.trident.selector.DefaultTopicSelector;
-import org.apache.storm.kafka.trident.selector.KafkaTopicSelector;
-import org.apache.storm.trident.operation.BaseFunction;
-import org.apache.storm.trident.operation.Function;
-import org.apache.storm.trident.operation.TridentCollector;
-import org.apache.storm.trident.operation.TridentOperationContext;
+import org.apache.storm.sql.runtime.serde.json.JsonScheme;
+import org.apache.storm.sql.runtime.serde.json.JsonSerializer;
 import org.apache.storm.trident.spout.ITridentDataSource;
 import org.apache.storm.trident.tuple.TridentTuple;
 
@@ -68,42 +66,6 @@ public class KafkaDataSourcesProvider implements DataSourcesProvider {
     }
   }
 
-  static class KafkaTridentSink extends BaseFunction {
-    private transient TridentKafkaState state;
-    private final String topic;
-    private final int primaryKeyIndex;
-    private final Properties producerProperties;
-    private final List<String> fieldNames;
-
-    private KafkaTridentSink(String topic, int primaryKeyIndex, Properties producerProperties,
-                             List<String> fieldNames) {
-      this.topic = topic;
-      this.primaryKeyIndex = primaryKeyIndex;
-      this.producerProperties = producerProperties;
-      this.fieldNames = fieldNames;
-    }
-
-    @Override
-    public void cleanup() {
-      super.cleanup();
-    }
-
-    @Override
-    public void prepare(Map conf, TridentOperationContext context) {
-      JsonSerializer serializer = new JsonSerializer(fieldNames);
-      SqlKafkaMapper m = new SqlKafkaMapper(primaryKeyIndex, serializer);
-      state = new TridentKafkaState()
-          .withKafkaTopicSelector(new DefaultTopicSelector(topic))
-          .withTridentTupleToKafkaMapper(m);
-      state.prepare(producerProperties);
-    }
-
-    @Override
-    public void execute(TridentTuple tuple, TridentCollector collector) {
-      state.updateState(Collections.singletonList(tuple), collector);
-    }
-  }
-
   private static class KafkaTridentDataSource implements ISqlTridentDataSource {
     private final TridentKafkaConfig conf;
     private final String topic;
@@ -125,7 +87,7 @@ public class KafkaDataSourcesProvider implements DataSourcesProvider {
     }
 
     @Override
-    public Function getConsumer() {
+    public SqlTridentConsumer getConsumer() {
       Preconditions.checkNotNull(producerProperties,
           "Writable Kafka Table " + topic + " must contain producer config");
       Properties props = new Properties();
@@ -141,7 +103,18 @@ public class KafkaDataSourcesProvider implements DataSourcesProvider {
       }
       Preconditions.checkState(props.containsKey("bootstrap.servers"),
           "Writable Kafka Table " + topic + " must contain \"bootstrap.servers\" config");
-      return new KafkaTridentSink(topic, primaryKeyIndex, props, fields);
+
+      JsonSerializer serializer = new JsonSerializer(fields);
+      SqlKafkaMapper mapper = new SqlKafkaMapper(primaryKeyIndex, serializer);
+
+      TridentKafkaStateFactory stateFactory = new TridentKafkaStateFactory()
+              .withKafkaTopicSelector(new DefaultTopicSelector(topic))
+              .withProducerProperties(props)
+              .withTridentTupleToKafkaMapper(mapper);
+
+      TridentKafkaUpdater stateUpdater = new TridentKafkaUpdater();
+
+      return new SqlTridentConsumer(stateFactory, stateUpdater);
     }
   }
 

--- a/external/sql/storm-sql-runtime/pom.xml
+++ b/external/sql/storm-sql-runtime/pom.xml
@@ -73,6 +73,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
         <!-- janino -->
         <dependency>
             <groupId>org.codehaus.janino</groupId>

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/FieldInfo.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/FieldInfo.java
@@ -17,10 +17,12 @@
  */
 package org.apache.storm.sql.runtime;
 
+import java.io.Serializable;
+
 /**
  * Describe each column of the field
  */
-public class FieldInfo {
+public class FieldInfo implements Serializable {
   private final String name;
   private final Class<?> type;
   private final boolean isPrimary;

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/ISqlTridentDataSource.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/ISqlTridentDataSource.java
@@ -17,14 +17,62 @@
  */
 package org.apache.storm.sql.runtime;
 
-import org.apache.storm.trident.operation.Function;
-import org.apache.storm.trident.spout.IBatchSpout;
 import org.apache.storm.trident.spout.ITridentDataSource;
+import org.apache.storm.trident.state.StateFactory;
+import org.apache.storm.trident.state.StateUpdater;
 
 /**
  * A ISqlTridentDataSource specifies how an external data source produces and consumes data.
  */
 public interface ISqlTridentDataSource {
+  /**
+   * SqlTridentConsumer is a data structure containing StateFactory and StateUpdater for consuming tuples with State.
+   *
+   * Please note that StateFactory and StateUpdater should use same class which implements State.
+   *
+   * @see org.apache.storm.trident.state.StateFactory
+   * @see org.apache.storm.trident.state.StateUpdater
+   */
+  class SqlTridentConsumer {
+    private StateFactory stateFactory;
+    private StateUpdater stateUpdater;
+
+    public SqlTridentConsumer(StateFactory stateFactory, StateUpdater stateUpdater) {
+      this.stateFactory = stateFactory;
+      this.stateUpdater = stateUpdater;
+    }
+
+    public StateFactory getStateFactory() {
+      return stateFactory;
+    }
+
+    public StateUpdater getStateUpdater() {
+      return stateUpdater;
+    }
+  }
+
+  /**
+   * Provides instance of ITridentDataSource which can be used as producer in Trident.
+   *
+   * Since ITridentDataSource is a marker interface for Trident Spout interfaces, this method should effectively
+   * return an instance of one of these interfaces (can be changed if Trident API evolves) or descendants:
+   * - IBatchSpout
+   * - ITridentSpout
+   * - IPartitionedTridentSpout
+   * - IOpaquePartitionedTridentSpout
+   *
+   * @see org.apache.storm.trident.spout.ITridentDataSource
+   * @see org.apache.storm.trident.spout.IBatchSpout
+   * @see org.apache.storm.trident.spout.ITridentSpout
+   * @see org.apache.storm.trident.spout.IPartitionedTridentSpout
+   * @see org.apache.storm.trident.spout.IOpaquePartitionedTridentSpout
+   */
   ITridentDataSource getProducer();
-  Function getConsumer();
+
+  /**
+   * Provides instance of SqlTridentConsumer which can be used as consumer (State) in Trident.
+   *
+   * @see SqlTridentConsumer
+   */
+  SqlTridentConsumer getConsumer();
 }

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/serde/json/JsonScheme.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/serde/json/JsonScheme.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.sql.kafka;
+package org.apache.storm.sql.runtime.serde.json;
 
 import org.apache.storm.spout.Scheme;
 import org.apache.storm.tuple.Fields;
@@ -31,7 +31,7 @@ import java.util.List;
 public class JsonScheme implements Scheme {
   private final List<String> fields;
 
-  JsonScheme(List<String> fields) {
+  public JsonScheme(List<String> fields) {
     this.fields = fields;
   }
 

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/serde/json/JsonSerializer.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/serde/json/JsonSerializer.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.sql.kafka;
+package org.apache.storm.sql.runtime.serde.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -23,16 +23,17 @@ import com.google.common.base.Preconditions;
 import org.apache.storm.sql.runtime.IOutputSerializer;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-class JsonSerializer implements IOutputSerializer {
+public class JsonSerializer implements IOutputSerializer, Serializable {
   private final List<String> fieldNames;
-  private transient final JsonFactory jsonFactory;
+  private final JsonFactory jsonFactory;
 
-  JsonSerializer(List<String> fieldNames) {
+  public JsonSerializer(List<String> fieldNames) {
     this.fieldNames = fieldNames;
     jsonFactory = new JsonFactory();
   }

--- a/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestJsonRepresentation.java
+++ b/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestJsonRepresentation.java
@@ -15,8 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.sql.kafka;
+package org.apache.storm.sql;
 
+import org.apache.storm.sql.runtime.serde.json.JsonScheme;
+import org.apache.storm.sql.runtime.serde.json.JsonSerializer;
 import org.apache.storm.utils.Utils;
 import com.google.common.collect.Lists;
 import org.junit.Test;

--- a/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
+++ b/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
@@ -235,9 +235,11 @@ public class TestUtils {
       private final Fields OUTPUT_FIELDS = new Fields("ID", "NAME", "ADDR");
 
       public MockSpout() {
-        for (int i = 0; i < 5; ++i) {
-          RECORDS.add(new Values(i, "x", "y"));
-        }
+        RECORDS.add(new Values(0, "a", "y"));
+        RECORDS.add(new Values(1, "ab", "y"));
+        RECORDS.add(new Values(2, "abc", "y"));
+        RECORDS.add(new Values(3, "abcd", "y"));
+        RECORDS.add(new Values(4, "abcde", "y"));
       }
 
       private boolean emitted = false;

--- a/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
+++ b/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/TestUtils.java
@@ -21,7 +21,12 @@ package org.apache.storm.sql;
 
 import org.apache.storm.ILocalCluster;
 import org.apache.storm.LocalCluster;
+import org.apache.storm.task.IMetricsContext;
 import org.apache.storm.task.TopologyContext;
+import org.apache.storm.trident.operation.TridentOperationContext;
+import org.apache.storm.trident.state.State;
+import org.apache.storm.trident.state.StateFactory;
+import org.apache.storm.trident.state.StateUpdater;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Values;
 import org.apache.storm.sql.runtime.ChannelContext;
@@ -160,6 +165,60 @@ public class TestUtils {
     }
   }
 
+  public static class MockState implements State {
+    /**
+     * Collect all values in a static variable as the instance will go through serialization and deserialization.
+     * NOTE: This should be cleared before or after running each test.
+     */
+    private transient static final List<List<Object> > VALUES = new ArrayList<>();
+
+    public static List<List<Object>> getCollectedValues() {
+      return VALUES;
+    }
+
+    @Override
+    public void beginCommit(Long txid) {
+      // NOOP
+    }
+
+    @Override
+    public void commit(Long txid) {
+      // NOOP
+    }
+
+    public void updateState(List<TridentTuple> tuples, TridentCollector collector) {
+      for (TridentTuple tuple : tuples) {
+        VALUES.add(tuple.getValues());
+      }
+    }
+  }
+
+  public static class MockStateFactory implements StateFactory {
+
+    @Override
+    public State makeState(Map conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
+      return new MockState();
+    }
+  }
+
+  public static class MockStateUpdater implements StateUpdater<MockState> {
+
+    @Override
+    public void updateState(MockState state, List<TridentTuple> tuples, TridentCollector collector) {
+      state.updateState(tuples, collector);
+    }
+
+    @Override
+    public void prepare(Map conf, TridentOperationContext context) {
+      // NOOP
+    }
+
+    @Override
+    public void cleanup() {
+      // NOOP
+    }
+  }
+
   public static class MockSqlTridentDataSource implements ISqlTridentDataSource {
     @Override
     public IBatchSpout getProducer() {
@@ -167,23 +226,8 @@ public class TestUtils {
     }
 
     @Override
-    public Function getConsumer() {
-      return new CollectDataFunction();
-    }
-
-    public static class CollectDataFunction extends BaseFunction {
-      /**
-       * Collect all values in a static variable as the instance will go through serialization and deserialization.
-       */
-      private transient static final List<List<Object> > VALUES = new ArrayList<>();
-      public static List<List<Object>> getCollectedValues() {
-        return VALUES;
-      }
-
-      @Override
-      public void execute(TridentTuple tuple, TridentCollector collector) {
-        VALUES.add(tuple.getValues());
-      }
+    public SqlTridentConsumer getConsumer() {
+      return new SqlTridentConsumer(new MockStateFactory(), new MockStateUpdater());
     }
 
     private static class MockSpout implements IBatchSpout {
@@ -241,23 +285,8 @@ public class TestUtils {
     }
 
     @Override
-    public Function getConsumer() {
-      return new CollectDataFunction();
-    }
-
-    public static class CollectDataFunction extends BaseFunction {
-      /**
-       * Collect all values in a static variable as the instance will go through serialization and deserialization.
-       */
-      private transient static final List<List<Object> > VALUES = new ArrayList<>();
-      public static List<List<Object>> getCollectedValues() {
-        return VALUES;
-      }
-
-      @Override
-      public void execute(TridentTuple tuple, TridentCollector collector) {
-        VALUES.add(tuple.getValues());
-      }
+    public SqlTridentConsumer getConsumer() {
+      return new SqlTridentConsumer(new MockStateFactory(), new MockStateUpdater());
     }
 
     private static class MockGroupedSpout implements IBatchSpout {
@@ -315,23 +344,8 @@ public class TestUtils {
     }
 
     @Override
-    public Function getConsumer() {
-      return new CollectDataFunction();
-    }
-
-    public static class CollectDataFunction extends BaseFunction {
-      /**
-       * Collect all values in a static variable as the instance will go through serialization and deserialization.
-       */
-      private transient static final List<List<Object> > VALUES = new ArrayList<>();
-      public static List<List<Object>> getCollectedValues() {
-        return VALUES;
-      }
-
-      @Override
-      public void execute(TridentTuple tuple, TridentCollector collector) {
-        VALUES.add(tuple.getValues());
-      }
+    public SqlTridentConsumer getConsumer() {
+      return new SqlTridentConsumer(new MockStateFactory(), new MockStateUpdater());
     }
 
     private static class MockSpout implements IBatchSpout {
@@ -392,23 +406,8 @@ public class TestUtils {
     }
 
     @Override
-    public Function getConsumer() {
-      return new CollectDataFunction();
-    }
-
-    public static class CollectDataFunction extends BaseFunction {
-      /**
-       * Collect all values in a static variable as the instance will go through serialization and deserialization.
-       */
-      private transient static final List<List<Object> > VALUES = new ArrayList<>();
-      public static List<List<Object>> getCollectedValues() {
-        return VALUES;
-      }
-
-      @Override
-      public void execute(TridentTuple tuple, TridentCollector collector) {
-        VALUES.add(tuple.getValues());
-      }
+    public SqlTridentConsumer getConsumer() {
+      return new SqlTridentConsumer(new MockStateFactory(), new MockStateUpdater());
     }
 
     private static class MockSpout implements IBatchSpout {
@@ -489,9 +488,5 @@ public class TestUtils {
   public static long monotonicNow() {
     final long NANOSECONDS_PER_MILLISECOND = 1000000;
     return System.nanoTime() / NANOSECONDS_PER_MILLISECOND;
-  }
-
-  public static ILocalCluster newLocalCluster() {
-    return new LocalCluster();
   }
 }


### PR DESCRIPTION
NOTE: This is on top of STORM-2089 and STORM-2111 since this requires the ExprCompiler bugfix introduced on STORM-2111.

After the patch 'IN' and 'NOT IN' operator works properly. It also respects 'short circuit'.