### PR TITLE
Storm 2124 show requested cpu mem for each component

### DIFF
--- a/docs/STORM-UI-REST-API.md
+++ b/docs/STORM-UI-REST-API.md
@@ -457,6 +457,16 @@ Response fields:
 |msgTimeout| Integer | Number of seconds a tuple has before the spout considers it failed |
 |windowHint| String | window param value in "hh mm ss" format. Default value is "All Time"|
 |schedulerDisplayResource| Boolean | Whether to display scheduler resource information|
+|replicationCount| Integer |Number of nimbus hosts on which this topology code is replicated|
+|debug| Boolean | If debug is enabled for the topology|
+|samplingPct| Double| Controls downsampling of events before they are sent to event log (percentage)|
+|assignedMemOnHeap| Double|Assigned On-Heap Memory by Scheduler (MB)
+|assignedMemOffHeap| Double|Assigned Off-Heap Memory by Scheduler (MB)|
+|assignedTotalMem| Double|Assigned Off-Heap + On-Heap Memory by Scheduler(MB)|
+|assignedCpu| Double|Assigned CPU by Scheduler(%)|
+|requestedMemOnHeap| Double|Requested On-Heap Memory by User (MB)
+|requestedMemOffHeap| Double|Requested Off-Heap Memory by User (MB)|
+|requestedCpu| Double|Requested CPU by User (%)|
 |topologyStats| Array | Array of all the topology related stats per time window|
 |topologyStats.windowPretty| String |Duration passed in HH:MM:SS format|
 |topologyStats.window| String |User requested time window for metrics|
@@ -465,6 +475,20 @@ Response fields:
 |topologyStats.completeLatency| String (double value returned in String format) |Total latency for processing the message|
 |topologyStats.acked| Long |Number of messages acked in given window|
 |topologyStats.failed| Long |Number of messages failed in given window|
+|workers| Array | Array of workers in topology|
+|workers.supervisorId | String| Supervisor's id|
+|workers.host | String | Worker's host name|
+|workers.port | Integer | Worker's port|
+|workers.topologyId | String | Topology Id|
+|workers.topologyName | String | Topology Name|
+|workers.executorsTotal | Integer | Number of executors used by the topology in this worker|
+|workers.assignedMemOnHeap | Double | Assigned On-Heap Memory by Scheduler (MB)|
+|workers.assignedMemOffHeap | Double | Assigned Off-Heap Memory by Scheduler (MB)|
+|workers.assignedCpu | Number | Assigned CPU by Scheduler (%)| 
+|workers.componentNumTasks | Dictionary | Components -> # of executing tasks|
+|workers.uptime| String| Shows how long the worker is running|
+|workers.uptimeSeconds| Integer| Shows how long the worker is running in seconds|
+|workers.workerLogLink | String | Link to worker log viewer page|
 |spouts| Array | Array of all the spout components in the topology|
 |spouts.spoutId| String |Spout id|
 |spouts.executors| Integer |Number of executors for the spout|
@@ -477,6 +501,9 @@ Response fields:
 |spouts.errorWorkerLogLink| String | Link to the worker log that reported the exception |
 |spouts.acked| Long |Number of messages acked|
 |spouts.failed| Long |Number of messages failed|
+|spouts.requestedMemOnHeap| Double|Requested On-Heap Memory by User (MB)
+|spouts.requestedMemOffHeap| Double|Requested Off-Heap Memory by User (MB)|
+|spouts.requestedCpu| Double|Requested CPU by User (%)|
 |bolts| Array | Array of bolt components in the topology|
 |bolts.boltId| String |Bolt id|
 |bolts.capacity| String (double value returned in String format) |This value indicates number of messages executed * average execute latency / time window|
@@ -490,7 +517,9 @@ Response fields:
 |bolts.errorLapsedSecs| Integer |Number of seconds elapsed since that last error happened in a bolt|
 |bolts.errorWorkerLogLink| String | Link to the worker log that reported the exception |
 |bolts.emitted| Long |Number of tuples emitted|
-|replicationCount| Integer |Number of nimbus hosts on which this topology code is replicated|
+|bolts.requestedMemOnHeap| Double|Requested On-Heap Memory by User (MB)
+|bolts.requestedMemOffHeap| Double|Requested Off-Heap Memory by User (MB)|
+|bolts.requestedCpu| Double|Requested CPU by User (%)|
 
 Examples:
 
@@ -554,6 +583,23 @@ Sample response:
             "failed": 0
         }
     ],
+    "workers":[{
+        "topologyName":"WordCount3",
+        "topologyId":"WordCount3-1-1402960825",
+        "host":"192.168.10.237",
+        "supervisorId":"bdfe8eff-f1d8-4bce-81f5-9d3ae1bf432e-169.254.129.212",
+        "uptime":"2m 47s",
+        "uptimeSeconds":167,
+        "port":6707,
+        "workerLogLink":"http:\/\/192.168.10.237:8000\/log?file=WordCount3-1-1402960825%2F6707%2Fworker.log",
+        "componentNumTasks": {
+            "spout":5
+        },
+        "executorsTotal":8,
+        "assignedMemOnHeap":704.0,
+        "assignedCpu":130.0,
+        "assignedMemOffHeap":80.0
+    }],
     "spouts": [
         {
             "executors": 5,
@@ -936,11 +982,28 @@ Response fields:
 
 |Field  |Value |Description|
 |---	|---	|---
+|user   | String | Topology owner|
 |id   | String | Component id|
+|encodedId   | String | URL encoded component id|
 |name | String | Topology name|
+|executors| Integer |Number of executor tasks in the component|
+|tasks| Integer |Number of instances of component|
+|requestedMemOnHeap| Double|Requested On-Heap Memory by User (MB)
+|requestedMemOffHeap| Double|Requested Off-Heap Memory by User (MB)|
+|requestedCpu| Double|Requested CPU by User (%)|
+|schedulerDisplayResource| Boolean | Whether to display scheduler resource information|
+|topologyId| String | Topology id|
+|topologyStatus| String | Topology status|
+|encodedTopologyId| String | URL encoded topology id|
+|window    |String. Default value "All Time" | window duration for metrics in seconds|
 |componentType | String | component type: SPOUT or BOLT|
 |windowHint| String | window param value in "hh mm ss" format. Default value is "All Time"|
-|executors| Integer |Number of executor tasks in the component|
+|debug| Boolean | If debug is enabled for the component|
+|samplingPct| Double| Controls downsampling of events before they are sent to event log (percentage)|
+|eventLogLink| String| URL viewer link to event log (debug mode)|
+|profilingAndDebuggingCapable| Boolean |true if there is support for Profiling and Debugging Actions|
+|profileActionEnabled| Boolean |true if worker profiling (Java Flight Recorder) is enabled|
+|profilerActive| Array |Array of currently active Profiler Actions|
 |componentErrors| Array of Errors | List of component errors|
 |componentErrors.errorTime| Long | Timestamp when the exception occurred (Prior to 0.11.0, this field was named 'time'.)|
 |componentErrors.errorHost| String | host name for the error|
@@ -948,27 +1011,34 @@ Response fields:
 |componentErrors.error| String |Shows the error happened in a component|
 |componentErrors.errorLapsedSecs| Integer | Number of seconds elapsed since the error happened in a component |
 |componentErrors.errorWorkerLogLink| String | Link to the worker log that reported the exception |
-|topologyId| String | Topology id|
-|tasks| Integer |Number of instances of component|
-|window    |String. Default value "All Time" | window duration for metrics in seconds|
-|spoutSummary or boltStats| Array |Array of component stats. **Please note this element tag can be spoutSummary or boltStats depending on the componentType**|
+|spoutSummary| Array | (only for spouts) Array of component stats, one element per window.| 
 |spoutSummary.windowPretty| String |Duration passed in HH:MM:SS format|
 |spoutSummary.window| String | window duration for metrics in seconds|
 |spoutSummary.emitted| Long |Number of messages emitted in given window |
 |spoutSummary.completeLatency| String (double value returned in String format) |Total latency for processing the message|
-|spoutSummary.transferred| Long |Total number of messages  transferred in given window|
+|spoutSummary.transferred| Long |Total number of messages transferred in given window|
 |spoutSummary.acked| Long |Number of messages acked|
 |spoutSummary.failed| Long |Number of messages failed|
+|boltStats| Array | (only for bolts) Array of component stats, one element per window.| 
 |boltStats.windowPretty| String |Duration passed in HH:MM:SS format|
-|boltStats..window| String | window duration for metrics in seconds|
+|boltStats.window| String| window duration for metrics in seconds|
 |boltStats.transferred| Long |Total number of messages  transferred in given window|
 |boltStats.processLatency| String (double value returned in String format)  |Average time of the bolt to ack a message after it was received|
 |boltStats.acked| Long |Number of messages acked|
 |boltStats.failed| Long |Number of messages failed|
-|profilingAndDebuggingCapable| Boolean |true if there is support for Profiling and Debugging Actions|
-|profileActionEnabled| Boolean |true if worker profiling (Java Flight Recorder) is enabled|
-|profilerActive| Array |Array of currently active Profiler Actions|
-
+|inputStats| Array | (only for bolts) Array of input stats|
+|inputStats.component| String |Component id|
+|inputStats.encodedComponentId| String |URL encoded component id|
+|inputStats.executeLatency| Long | The average time a tuple spends in the execute method|
+|inputStats.processLatency| Long | The average time it takes to ack a tuple after it is first received|
+|inputStats.executed| Long |The number of incoming tuples processed|
+|inputStats.acked| Long |Number of messages acked|
+|inputStats.failed| Long |Number of messages failed|
+|inputStats.stream| String |The name of the tuple stream given in the topology, or "default" if none specified|
+|outputStats| Array | Array of output stats|
+|outputStats.transferred| Long |Number of tuples emitted that sent to one ore more bolts|
+|outputStats.emitted| Long |Number of tuples emitted|
+|outputStats.stream| String |The name of the tuple stream given in the topology, or "default" if none specified|
 
 Examples:
 

--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -41,6 +41,7 @@
   (:import [org.apache.storm.scheduler INimbus SupervisorDetails WorkerSlot TopologyDetails
             Cluster Topologies SchedulerAssignment SchedulerAssignmentImpl DefaultScheduler ExecutorDetails])
   (:import [org.apache.storm.nimbus NimbusInfo])
+  (:import [org.apache.storm.scheduler.resource ResourceUtils])
   (:import [org.apache.storm.utils TimeCacheMap Time TimeCacheMap$ExpiredCallback Utils ConfigUtils TupleUtils ThriftTopologyUtils
             BufferFileInputStream BufferInputStream])
   (:import [org.apache.storm.generated NotAliveException AlreadyAliveException StormTopology ErrorInfo ClusterWorkerHeartbeat
@@ -48,7 +49,7 @@
             KillOptions RebalanceOptions ClusterSummary SupervisorSummary TopologySummary TopologyInfo TopologyHistoryInfo
             ExecutorSummary AuthorizationException GetInfoOptions NumErrorsChoice SettableBlobMeta ReadableBlobMeta
             BeginDownloadResult ListBlobsResult ComponentPageInfo TopologyPageInfo LogConfig LogLevel LogLevelAction
-            ProfileRequest ProfileAction NodeInfo LSTopoHistory SupervisorPageInfo WorkerSummary WorkerResources])
+            ProfileRequest ProfileAction NodeInfo LSTopoHistory SupervisorPageInfo WorkerSummary WorkerResources ComponentType])
   (:import [org.apache.storm.daemon Shutdownable StormCommon DaemonCommon])
   (:import [org.apache.storm.validation ConfigValidation])
   (:import [org.apache.storm.cluster ClusterStateContext DaemonType StormClusterStateImpl ClusterUtils])
@@ -1619,8 +1620,14 @@
                :assignment assignment
                :beats (or beats {})
                :topology topology
+               :topology-conf topology-conf
                :task->component task->component
                :base base}))
+        set-resources-default-if-not-set
+          (fn [^HashMap component-resources-map component-id topology-conf]
+              (let [resource-map (or (.get component-resources-map component-id) (HashMap.))]
+                (ResourceUtils/checkIntialization resource-map component-id topology-conf)
+                resource-map))
         get-last-error (fn [storm-cluster-state storm-id component-id]
                          (if-let [e (clojurify-error  (.lastError storm-cluster-state
                                                  storm-id
@@ -2197,6 +2204,7 @@
                       beats
                       task->component
                       topology
+                      topology-conf
                       base]} topo-info
               exec->node+port (:executor->node+port assignment)
               node->host (:node->host assignment)
@@ -2218,6 +2226,17 @@
                                                           window
                                                           include-sys?
                                                           storm-cluster-state)]
+
+          (doseq [[spout-id component-aggregate-stats] (.get_id_to_spout_agg_stats topo-page-info)]
+            (let [common-stats (.get_common_stats component-aggregate-stats)
+                  resources (ResourceUtils/getSpoutsResources topology topology-conf)]
+              (.set_resources_map common-stats (set-resources-default-if-not-set resources spout-id topology-conf))))
+
+          (doseq [[bolt-id component-aggregate-stats] (.get_id_to_bolt_agg_stats topo-page-info)]
+            (let [common-stats (.get_common_stats component-aggregate-stats)
+                  resources (ResourceUtils/getBoltsResources topology topology-conf)]
+              (.set_resources_map common-stats (set-resources-default-if-not-set resources bolt-id topology-conf))))
+
           (.set_workers topo-page-info worker-summaries)
           (when-let [owner (:owner base)]
             (.set_owner topo-page-info owner))
@@ -2300,6 +2319,7 @@
          ^boolean include-sys?]
         (.mark nimbus:num-getComponentPageInfo-calls)
         (let [info (get-common-topo-info topo-id "getComponentPageInfo")
+              {:keys [topology topology-conf]} info
               {:keys [executor->node+port node->host]} (:assignment info)
               ;TODO: when translating this function, you should replace the map-val with a proper for loop HERE
               executor->host+port (map-val (fn [[node port]]
@@ -2313,6 +2333,12 @@
                                                          topo-id
                                                          (:topology info)
                                                          component-id)]
+          (if (.equals (.get_component_type comp-page-info) ComponentType/SPOUT)
+            (.set_resources_map comp-page-info 
+              (set-resources-default-if-not-set (ResourceUtils/getSpoutsResources topology topology-conf) component-id topology-conf))
+            (.set_resources_map comp-page-info
+              (set-resources-default-if-not-set (ResourceUtils/getBoltsResources topology topology-conf) component-id topology-conf)))
+
           (doto comp-page-info
             (.set_topology_name (:storm-name info))
             (.set_errors (get-errors (:storm-cluster-state info)

--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -613,7 +613,10 @@
    "emitted" (.get_emitted common-stats)
    "transferred" (.get_transferred common-stats)
    "acked" (.get_acked common-stats)
-   "failed" (.get_failed common-stats)})
+   "failed" (.get_failed common-stats)
+   "requestedMemOnHeap" (.get (.get_resources_map common-stats) Config/TOPOLOGY_COMPONENT_RESOURCES_ONHEAP_MEMORY_MB)
+   "requestedMemOffHeap" (.get (.get_resources_map common-stats) Config/TOPOLOGY_COMPONENT_RESOURCES_OFFHEAP_MEMORY_MB)
+   "requestedCpu" (.get (.get_resources_map common-stats) Config/TOPOLOGY_COMPONENT_CPU_PCORE_PERCENT)})
 
 (defmulti comp-agg-stats-json
   "Returns a JSON representation of aggregated statistics."
@@ -1036,6 +1039,10 @@
        "name" (.get_topology_name comp-page-info)
        "executors" (.get_num_executors comp-page-info)
        "tasks" (.get_num_tasks comp-page-info)
+       "requestedMemOnHeap" (.get (.get_resources_map comp-page-info) Config/TOPOLOGY_COMPONENT_RESOURCES_ONHEAP_MEMORY_MB)
+       "requestedMemOffHeap" (.get (.get_resources_map comp-page-info) Config/TOPOLOGY_COMPONENT_RESOURCES_OFFHEAP_MEMORY_MB)
+       "requestedCpu" (.get (.get_resources_map comp-page-info) Config/TOPOLOGY_COMPONENT_CPU_PCORE_PERCENT)
+       "schedulerDisplayResource" (*STORM-CONF* Config/SCHEDULER_DISPLAY_RESOURCE)
        "topologyId" topology-id
        "topologyStatus" (.get_topology_status comp-page-info)
        "encodedTopologyId" (URLEncoder/encode topology-id)

--- a/storm-core/src/jvm/org/apache/storm/generated/Assignment.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/Assignment.java
@@ -787,15 +787,15 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
           case 2: // NODE_HOST
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map598 = iprot.readMapBegin();
-                struct.node_host = new HashMap<String,String>(2*_map598.size);
-                String _key599;
-                String _val600;
-                for (int _i601 = 0; _i601 < _map598.size; ++_i601)
+                org.apache.thrift.protocol.TMap _map618 = iprot.readMapBegin();
+                struct.node_host = new HashMap<String,String>(2*_map618.size);
+                String _key619;
+                String _val620;
+                for (int _i621 = 0; _i621 < _map618.size; ++_i621)
                 {
-                  _key599 = iprot.readString();
-                  _val600 = iprot.readString();
-                  struct.node_host.put(_key599, _val600);
+                  _key619 = iprot.readString();
+                  _val620 = iprot.readString();
+                  struct.node_host.put(_key619, _val620);
                 }
                 iprot.readMapEnd();
               }
@@ -807,26 +807,26 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
           case 3: // EXECUTOR_NODE_PORT
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map602 = iprot.readMapBegin();
-                struct.executor_node_port = new HashMap<List<Long>,NodeInfo>(2*_map602.size);
-                List<Long> _key603;
-                NodeInfo _val604;
-                for (int _i605 = 0; _i605 < _map602.size; ++_i605)
+                org.apache.thrift.protocol.TMap _map622 = iprot.readMapBegin();
+                struct.executor_node_port = new HashMap<List<Long>,NodeInfo>(2*_map622.size);
+                List<Long> _key623;
+                NodeInfo _val624;
+                for (int _i625 = 0; _i625 < _map622.size; ++_i625)
                 {
                   {
-                    org.apache.thrift.protocol.TList _list606 = iprot.readListBegin();
-                    _key603 = new ArrayList<Long>(_list606.size);
-                    long _elem607;
-                    for (int _i608 = 0; _i608 < _list606.size; ++_i608)
+                    org.apache.thrift.protocol.TList _list626 = iprot.readListBegin();
+                    _key623 = new ArrayList<Long>(_list626.size);
+                    long _elem627;
+                    for (int _i628 = 0; _i628 < _list626.size; ++_i628)
                     {
-                      _elem607 = iprot.readI64();
-                      _key603.add(_elem607);
+                      _elem627 = iprot.readI64();
+                      _key623.add(_elem627);
                     }
                     iprot.readListEnd();
                   }
-                  _val604 = new NodeInfo();
-                  _val604.read(iprot);
-                  struct.executor_node_port.put(_key603, _val604);
+                  _val624 = new NodeInfo();
+                  _val624.read(iprot);
+                  struct.executor_node_port.put(_key623, _val624);
                 }
                 iprot.readMapEnd();
               }
@@ -838,25 +838,25 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
           case 4: // EXECUTOR_START_TIME_SECS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map609 = iprot.readMapBegin();
-                struct.executor_start_time_secs = new HashMap<List<Long>,Long>(2*_map609.size);
-                List<Long> _key610;
-                long _val611;
-                for (int _i612 = 0; _i612 < _map609.size; ++_i612)
+                org.apache.thrift.protocol.TMap _map629 = iprot.readMapBegin();
+                struct.executor_start_time_secs = new HashMap<List<Long>,Long>(2*_map629.size);
+                List<Long> _key630;
+                long _val631;
+                for (int _i632 = 0; _i632 < _map629.size; ++_i632)
                 {
                   {
-                    org.apache.thrift.protocol.TList _list613 = iprot.readListBegin();
-                    _key610 = new ArrayList<Long>(_list613.size);
-                    long _elem614;
-                    for (int _i615 = 0; _i615 < _list613.size; ++_i615)
+                    org.apache.thrift.protocol.TList _list633 = iprot.readListBegin();
+                    _key630 = new ArrayList<Long>(_list633.size);
+                    long _elem634;
+                    for (int _i635 = 0; _i635 < _list633.size; ++_i635)
                     {
-                      _elem614 = iprot.readI64();
-                      _key610.add(_elem614);
+                      _elem634 = iprot.readI64();
+                      _key630.add(_elem634);
                     }
                     iprot.readListEnd();
                   }
-                  _val611 = iprot.readI64();
-                  struct.executor_start_time_secs.put(_key610, _val611);
+                  _val631 = iprot.readI64();
+                  struct.executor_start_time_secs.put(_key630, _val631);
                 }
                 iprot.readMapEnd();
               }
@@ -868,17 +868,17 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
           case 5: // WORKER_RESOURCES
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map616 = iprot.readMapBegin();
-                struct.worker_resources = new HashMap<NodeInfo,WorkerResources>(2*_map616.size);
-                NodeInfo _key617;
-                WorkerResources _val618;
-                for (int _i619 = 0; _i619 < _map616.size; ++_i619)
+                org.apache.thrift.protocol.TMap _map636 = iprot.readMapBegin();
+                struct.worker_resources = new HashMap<NodeInfo,WorkerResources>(2*_map636.size);
+                NodeInfo _key637;
+                WorkerResources _val638;
+                for (int _i639 = 0; _i639 < _map636.size; ++_i639)
                 {
-                  _key617 = new NodeInfo();
-                  _key617.read(iprot);
-                  _val618 = new WorkerResources();
-                  _val618.read(iprot);
-                  struct.worker_resources.put(_key617, _val618);
+                  _key637 = new NodeInfo();
+                  _key637.read(iprot);
+                  _val638 = new WorkerResources();
+                  _val638.read(iprot);
+                  struct.worker_resources.put(_key637, _val638);
                 }
                 iprot.readMapEnd();
               }
@@ -910,10 +910,10 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
           oprot.writeFieldBegin(NODE_HOST_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.node_host.size()));
-            for (Map.Entry<String, String> _iter620 : struct.node_host.entrySet())
+            for (Map.Entry<String, String> _iter640 : struct.node_host.entrySet())
             {
-              oprot.writeString(_iter620.getKey());
-              oprot.writeString(_iter620.getValue());
+              oprot.writeString(_iter640.getKey());
+              oprot.writeString(_iter640.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -925,17 +925,17 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
           oprot.writeFieldBegin(EXECUTOR_NODE_PORT_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.LIST, org.apache.thrift.protocol.TType.STRUCT, struct.executor_node_port.size()));
-            for (Map.Entry<List<Long>, NodeInfo> _iter621 : struct.executor_node_port.entrySet())
+            for (Map.Entry<List<Long>, NodeInfo> _iter641 : struct.executor_node_port.entrySet())
             {
               {
-                oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, _iter621.getKey().size()));
-                for (long _iter622 : _iter621.getKey())
+                oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, _iter641.getKey().size()));
+                for (long _iter642 : _iter641.getKey())
                 {
-                  oprot.writeI64(_iter622);
+                  oprot.writeI64(_iter642);
                 }
                 oprot.writeListEnd();
               }
-              _iter621.getValue().write(oprot);
+              _iter641.getValue().write(oprot);
             }
             oprot.writeMapEnd();
           }
@@ -947,17 +947,17 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
           oprot.writeFieldBegin(EXECUTOR_START_TIME_SECS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.LIST, org.apache.thrift.protocol.TType.I64, struct.executor_start_time_secs.size()));
-            for (Map.Entry<List<Long>, Long> _iter623 : struct.executor_start_time_secs.entrySet())
+            for (Map.Entry<List<Long>, Long> _iter643 : struct.executor_start_time_secs.entrySet())
             {
               {
-                oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, _iter623.getKey().size()));
-                for (long _iter624 : _iter623.getKey())
+                oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, _iter643.getKey().size()));
+                for (long _iter644 : _iter643.getKey())
                 {
-                  oprot.writeI64(_iter624);
+                  oprot.writeI64(_iter644);
                 }
                 oprot.writeListEnd();
               }
-              oprot.writeI64(_iter623.getValue());
+              oprot.writeI64(_iter643.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -969,10 +969,10 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
           oprot.writeFieldBegin(WORKER_RESOURCES_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRUCT, org.apache.thrift.protocol.TType.STRUCT, struct.worker_resources.size()));
-            for (Map.Entry<NodeInfo, WorkerResources> _iter625 : struct.worker_resources.entrySet())
+            for (Map.Entry<NodeInfo, WorkerResources> _iter645 : struct.worker_resources.entrySet())
             {
-              _iter625.getKey().write(oprot);
-              _iter625.getValue().write(oprot);
+              _iter645.getKey().write(oprot);
+              _iter645.getValue().write(oprot);
             }
             oprot.writeMapEnd();
           }
@@ -1014,52 +1014,52 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
       if (struct.is_set_node_host()) {
         {
           oprot.writeI32(struct.node_host.size());
-          for (Map.Entry<String, String> _iter626 : struct.node_host.entrySet())
+          for (Map.Entry<String, String> _iter646 : struct.node_host.entrySet())
           {
-            oprot.writeString(_iter626.getKey());
-            oprot.writeString(_iter626.getValue());
+            oprot.writeString(_iter646.getKey());
+            oprot.writeString(_iter646.getValue());
           }
         }
       }
       if (struct.is_set_executor_node_port()) {
         {
           oprot.writeI32(struct.executor_node_port.size());
-          for (Map.Entry<List<Long>, NodeInfo> _iter627 : struct.executor_node_port.entrySet())
+          for (Map.Entry<List<Long>, NodeInfo> _iter647 : struct.executor_node_port.entrySet())
           {
             {
-              oprot.writeI32(_iter627.getKey().size());
-              for (long _iter628 : _iter627.getKey())
+              oprot.writeI32(_iter647.getKey().size());
+              for (long _iter648 : _iter647.getKey())
               {
-                oprot.writeI64(_iter628);
+                oprot.writeI64(_iter648);
               }
             }
-            _iter627.getValue().write(oprot);
+            _iter647.getValue().write(oprot);
           }
         }
       }
       if (struct.is_set_executor_start_time_secs()) {
         {
           oprot.writeI32(struct.executor_start_time_secs.size());
-          for (Map.Entry<List<Long>, Long> _iter629 : struct.executor_start_time_secs.entrySet())
+          for (Map.Entry<List<Long>, Long> _iter649 : struct.executor_start_time_secs.entrySet())
           {
             {
-              oprot.writeI32(_iter629.getKey().size());
-              for (long _iter630 : _iter629.getKey())
+              oprot.writeI32(_iter649.getKey().size());
+              for (long _iter650 : _iter649.getKey())
               {
-                oprot.writeI64(_iter630);
+                oprot.writeI64(_iter650);
               }
             }
-            oprot.writeI64(_iter629.getValue());
+            oprot.writeI64(_iter649.getValue());
           }
         }
       }
       if (struct.is_set_worker_resources()) {
         {
           oprot.writeI32(struct.worker_resources.size());
-          for (Map.Entry<NodeInfo, WorkerResources> _iter631 : struct.worker_resources.entrySet())
+          for (Map.Entry<NodeInfo, WorkerResources> _iter651 : struct.worker_resources.entrySet())
           {
-            _iter631.getKey().write(oprot);
-            _iter631.getValue().write(oprot);
+            _iter651.getKey().write(oprot);
+            _iter651.getValue().write(oprot);
           }
         }
       }
@@ -1073,81 +1073,81 @@ public class Assignment implements org.apache.thrift.TBase<Assignment, Assignmen
       BitSet incoming = iprot.readBitSet(4);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TMap _map632 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-          struct.node_host = new HashMap<String,String>(2*_map632.size);
-          String _key633;
-          String _val634;
-          for (int _i635 = 0; _i635 < _map632.size; ++_i635)
+          org.apache.thrift.protocol.TMap _map652 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+          struct.node_host = new HashMap<String,String>(2*_map652.size);
+          String _key653;
+          String _val654;
+          for (int _i655 = 0; _i655 < _map652.size; ++_i655)
           {
-            _key633 = iprot.readString();
-            _val634 = iprot.readString();
-            struct.node_host.put(_key633, _val634);
+            _key653 = iprot.readString();
+            _val654 = iprot.readString();
+            struct.node_host.put(_key653, _val654);
           }
         }
         struct.set_node_host_isSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TMap _map636 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.LIST, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.executor_node_port = new HashMap<List<Long>,NodeInfo>(2*_map636.size);
-          List<Long> _key637;
-          NodeInfo _val638;
-          for (int _i639 = 0; _i639 < _map636.size; ++_i639)
+          org.apache.thrift.protocol.TMap _map656 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.LIST, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.executor_node_port = new HashMap<List<Long>,NodeInfo>(2*_map656.size);
+          List<Long> _key657;
+          NodeInfo _val658;
+          for (int _i659 = 0; _i659 < _map656.size; ++_i659)
           {
             {
-              org.apache.thrift.protocol.TList _list640 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-              _key637 = new ArrayList<Long>(_list640.size);
-              long _elem641;
-              for (int _i642 = 0; _i642 < _list640.size; ++_i642)
+              org.apache.thrift.protocol.TList _list660 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+              _key657 = new ArrayList<Long>(_list660.size);
+              long _elem661;
+              for (int _i662 = 0; _i662 < _list660.size; ++_i662)
               {
-                _elem641 = iprot.readI64();
-                _key637.add(_elem641);
+                _elem661 = iprot.readI64();
+                _key657.add(_elem661);
               }
             }
-            _val638 = new NodeInfo();
-            _val638.read(iprot);
-            struct.executor_node_port.put(_key637, _val638);
+            _val658 = new NodeInfo();
+            _val658.read(iprot);
+            struct.executor_node_port.put(_key657, _val658);
           }
         }
         struct.set_executor_node_port_isSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TMap _map643 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.LIST, org.apache.thrift.protocol.TType.I64, iprot.readI32());
-          struct.executor_start_time_secs = new HashMap<List<Long>,Long>(2*_map643.size);
-          List<Long> _key644;
-          long _val645;
-          for (int _i646 = 0; _i646 < _map643.size; ++_i646)
+          org.apache.thrift.protocol.TMap _map663 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.LIST, org.apache.thrift.protocol.TType.I64, iprot.readI32());
+          struct.executor_start_time_secs = new HashMap<List<Long>,Long>(2*_map663.size);
+          List<Long> _key664;
+          long _val665;
+          for (int _i666 = 0; _i666 < _map663.size; ++_i666)
           {
             {
-              org.apache.thrift.protocol.TList _list647 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-              _key644 = new ArrayList<Long>(_list647.size);
-              long _elem648;
-              for (int _i649 = 0; _i649 < _list647.size; ++_i649)
+              org.apache.thrift.protocol.TList _list667 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+              _key664 = new ArrayList<Long>(_list667.size);
+              long _elem668;
+              for (int _i669 = 0; _i669 < _list667.size; ++_i669)
               {
-                _elem648 = iprot.readI64();
-                _key644.add(_elem648);
+                _elem668 = iprot.readI64();
+                _key664.add(_elem668);
               }
             }
-            _val645 = iprot.readI64();
-            struct.executor_start_time_secs.put(_key644, _val645);
+            _val665 = iprot.readI64();
+            struct.executor_start_time_secs.put(_key664, _val665);
           }
         }
         struct.set_executor_start_time_secs_isSet(true);
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TMap _map650 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRUCT, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.worker_resources = new HashMap<NodeInfo,WorkerResources>(2*_map650.size);
-          NodeInfo _key651;
-          WorkerResources _val652;
-          for (int _i653 = 0; _i653 < _map650.size; ++_i653)
+          org.apache.thrift.protocol.TMap _map670 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRUCT, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.worker_resources = new HashMap<NodeInfo,WorkerResources>(2*_map670.size);
+          NodeInfo _key671;
+          WorkerResources _val672;
+          for (int _i673 = 0; _i673 < _map670.size; ++_i673)
           {
-            _key651 = new NodeInfo();
-            _key651.read(iprot);
-            _val652 = new WorkerResources();
-            _val652.read(iprot);
-            struct.worker_resources.put(_key651, _val652);
+            _key671 = new NodeInfo();
+            _key671.read(iprot);
+            _val672 = new WorkerResources();
+            _val672.read(iprot);
+            struct.worker_resources.put(_key671, _val672);
           }
         }
         struct.set_worker_resources_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/ClusterWorkerHeartbeat.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/ClusterWorkerHeartbeat.java
@@ -635,17 +635,17 @@ public class ClusterWorkerHeartbeat implements org.apache.thrift.TBase<ClusterWo
           case 2: // EXECUTOR_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map674 = iprot.readMapBegin();
-                struct.executor_stats = new HashMap<ExecutorInfo,ExecutorStats>(2*_map674.size);
-                ExecutorInfo _key675;
-                ExecutorStats _val676;
-                for (int _i677 = 0; _i677 < _map674.size; ++_i677)
+                org.apache.thrift.protocol.TMap _map694 = iprot.readMapBegin();
+                struct.executor_stats = new HashMap<ExecutorInfo,ExecutorStats>(2*_map694.size);
+                ExecutorInfo _key695;
+                ExecutorStats _val696;
+                for (int _i697 = 0; _i697 < _map694.size; ++_i697)
                 {
-                  _key675 = new ExecutorInfo();
-                  _key675.read(iprot);
-                  _val676 = new ExecutorStats();
-                  _val676.read(iprot);
-                  struct.executor_stats.put(_key675, _val676);
+                  _key695 = new ExecutorInfo();
+                  _key695.read(iprot);
+                  _val696 = new ExecutorStats();
+                  _val696.read(iprot);
+                  struct.executor_stats.put(_key695, _val696);
                 }
                 iprot.readMapEnd();
               }
@@ -692,10 +692,10 @@ public class ClusterWorkerHeartbeat implements org.apache.thrift.TBase<ClusterWo
         oprot.writeFieldBegin(EXECUTOR_STATS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRUCT, org.apache.thrift.protocol.TType.STRUCT, struct.executor_stats.size()));
-          for (Map.Entry<ExecutorInfo, ExecutorStats> _iter678 : struct.executor_stats.entrySet())
+          for (Map.Entry<ExecutorInfo, ExecutorStats> _iter698 : struct.executor_stats.entrySet())
           {
-            _iter678.getKey().write(oprot);
-            _iter678.getValue().write(oprot);
+            _iter698.getKey().write(oprot);
+            _iter698.getValue().write(oprot);
           }
           oprot.writeMapEnd();
         }
@@ -727,10 +727,10 @@ public class ClusterWorkerHeartbeat implements org.apache.thrift.TBase<ClusterWo
       oprot.writeString(struct.storm_id);
       {
         oprot.writeI32(struct.executor_stats.size());
-        for (Map.Entry<ExecutorInfo, ExecutorStats> _iter679 : struct.executor_stats.entrySet())
+        for (Map.Entry<ExecutorInfo, ExecutorStats> _iter699 : struct.executor_stats.entrySet())
         {
-          _iter679.getKey().write(oprot);
-          _iter679.getValue().write(oprot);
+          _iter699.getKey().write(oprot);
+          _iter699.getValue().write(oprot);
         }
       }
       oprot.writeI32(struct.time_secs);
@@ -743,17 +743,17 @@ public class ClusterWorkerHeartbeat implements org.apache.thrift.TBase<ClusterWo
       struct.storm_id = iprot.readString();
       struct.set_storm_id_isSet(true);
       {
-        org.apache.thrift.protocol.TMap _map680 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRUCT, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-        struct.executor_stats = new HashMap<ExecutorInfo,ExecutorStats>(2*_map680.size);
-        ExecutorInfo _key681;
-        ExecutorStats _val682;
-        for (int _i683 = 0; _i683 < _map680.size; ++_i683)
+        org.apache.thrift.protocol.TMap _map700 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRUCT, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+        struct.executor_stats = new HashMap<ExecutorInfo,ExecutorStats>(2*_map700.size);
+        ExecutorInfo _key701;
+        ExecutorStats _val702;
+        for (int _i703 = 0; _i703 < _map700.size; ++_i703)
         {
-          _key681 = new ExecutorInfo();
-          _key681.read(iprot);
-          _val682 = new ExecutorStats();
-          _val682.read(iprot);
-          struct.executor_stats.put(_key681, _val682);
+          _key701 = new ExecutorInfo();
+          _key701.read(iprot);
+          _val702 = new ExecutorStats();
+          _val702.read(iprot);
+          struct.executor_stats.put(_key701, _val702);
         }
       }
       struct.set_executor_stats_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/CommonAggregateStats.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/CommonAggregateStats.java
@@ -61,6 +61,7 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
   private static final org.apache.thrift.protocol.TField TRANSFERRED_FIELD_DESC = new org.apache.thrift.protocol.TField("transferred", org.apache.thrift.protocol.TType.I64, (short)4);
   private static final org.apache.thrift.protocol.TField ACKED_FIELD_DESC = new org.apache.thrift.protocol.TField("acked", org.apache.thrift.protocol.TType.I64, (short)5);
   private static final org.apache.thrift.protocol.TField FAILED_FIELD_DESC = new org.apache.thrift.protocol.TField("failed", org.apache.thrift.protocol.TType.I64, (short)6);
+  private static final org.apache.thrift.protocol.TField RESOURCES_MAP_FIELD_DESC = new org.apache.thrift.protocol.TField("resources_map", org.apache.thrift.protocol.TType.MAP, (short)7);
 
   private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
   static {
@@ -74,6 +75,7 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
   private long transferred; // optional
   private long acked; // optional
   private long failed; // optional
+  private Map<String,Double> resources_map; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -82,7 +84,8 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
     EMITTED((short)3, "emitted"),
     TRANSFERRED((short)4, "transferred"),
     ACKED((short)5, "acked"),
-    FAILED((short)6, "failed");
+    FAILED((short)6, "failed"),
+    RESOURCES_MAP((short)7, "resources_map");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -109,6 +112,8 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
           return ACKED;
         case 6: // FAILED
           return FAILED;
+        case 7: // RESOURCES_MAP
+          return RESOURCES_MAP;
         default:
           return null;
       }
@@ -156,7 +161,7 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
   private static final int __ACKED_ISSET_ID = 4;
   private static final int __FAILED_ISSET_ID = 5;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.NUM_EXECUTORS,_Fields.NUM_TASKS,_Fields.EMITTED,_Fields.TRANSFERRED,_Fields.ACKED,_Fields.FAILED};
+  private static final _Fields optionals[] = {_Fields.NUM_EXECUTORS,_Fields.NUM_TASKS,_Fields.EMITTED,_Fields.TRANSFERRED,_Fields.ACKED,_Fields.FAILED,_Fields.RESOURCES_MAP};
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -172,6 +177,10 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     tmpMap.put(_Fields.FAILED, new org.apache.thrift.meta_data.FieldMetaData("failed", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
+    tmpMap.put(_Fields.RESOURCES_MAP, new org.apache.thrift.meta_data.FieldMetaData("resources_map", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.MapMetaData(org.apache.thrift.protocol.TType.MAP, 
+            new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING), 
+            new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE))));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(CommonAggregateStats.class, metaDataMap);
   }
@@ -190,6 +199,10 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
     this.transferred = other.transferred;
     this.acked = other.acked;
     this.failed = other.failed;
+    if (other.is_set_resources_map()) {
+      Map<String,Double> __this__resources_map = new HashMap<String,Double>(other.resources_map);
+      this.resources_map = __this__resources_map;
+    }
   }
 
   public CommonAggregateStats deepCopy() {
@@ -210,6 +223,7 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
     this.acked = 0;
     set_failed_isSet(false);
     this.failed = 0;
+    this.resources_map = null;
   }
 
   public int get_num_executors() {
@@ -344,6 +358,40 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
     __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __FAILED_ISSET_ID, value);
   }
 
+  public int get_resources_map_size() {
+    return (this.resources_map == null) ? 0 : this.resources_map.size();
+  }
+
+  public void put_to_resources_map(String key, double val) {
+    if (this.resources_map == null) {
+      this.resources_map = new HashMap<String,Double>();
+    }
+    this.resources_map.put(key, val);
+  }
+
+  public Map<String,Double> get_resources_map() {
+    return this.resources_map;
+  }
+
+  public void set_resources_map(Map<String,Double> resources_map) {
+    this.resources_map = resources_map;
+  }
+
+  public void unset_resources_map() {
+    this.resources_map = null;
+  }
+
+  /** Returns true if field resources_map is set (has been assigned a value) and false otherwise */
+  public boolean is_set_resources_map() {
+    return this.resources_map != null;
+  }
+
+  public void set_resources_map_isSet(boolean value) {
+    if (!value) {
+      this.resources_map = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case NUM_EXECUTORS:
@@ -394,6 +442,14 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
       }
       break;
 
+    case RESOURCES_MAP:
+      if (value == null) {
+        unset_resources_map();
+      } else {
+        set_resources_map((Map<String,Double>)value);
+      }
+      break;
+
     }
   }
 
@@ -416,6 +472,9 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
 
     case FAILED:
       return get_failed();
+
+    case RESOURCES_MAP:
+      return get_resources_map();
 
     }
     throw new IllegalStateException();
@@ -440,6 +499,8 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
       return is_set_acked();
     case FAILED:
       return is_set_failed();
+    case RESOURCES_MAP:
+      return is_set_resources_map();
     }
     throw new IllegalStateException();
   }
@@ -511,6 +572,15 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
         return false;
     }
 
+    boolean this_present_resources_map = true && this.is_set_resources_map();
+    boolean that_present_resources_map = true && that.is_set_resources_map();
+    if (this_present_resources_map || that_present_resources_map) {
+      if (!(this_present_resources_map && that_present_resources_map))
+        return false;
+      if (!this.resources_map.equals(that.resources_map))
+        return false;
+    }
+
     return true;
   }
 
@@ -547,6 +617,11 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
     list.add(present_failed);
     if (present_failed)
       list.add(failed);
+
+    boolean present_resources_map = true && (is_set_resources_map());
+    list.add(present_resources_map);
+    if (present_resources_map)
+      list.add(resources_map);
 
     return list.hashCode();
   }
@@ -619,6 +694,16 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(is_set_resources_map()).compareTo(other.is_set_resources_map());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (is_set_resources_map()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.resources_map, other.resources_map);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -672,6 +757,16 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
       if (!first) sb.append(", ");
       sb.append("failed:");
       sb.append(this.failed);
+      first = false;
+    }
+    if (is_set_resources_map()) {
+      if (!first) sb.append(", ");
+      sb.append("resources_map:");
+      if (this.resources_map == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.resources_map);
+      }
       first = false;
     }
     sb.append(")");
@@ -767,6 +862,26 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 7: // RESOURCES_MAP
+            if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
+              {
+                org.apache.thrift.protocol.TMap _map368 = iprot.readMapBegin();
+                struct.resources_map = new HashMap<String,Double>(2*_map368.size);
+                String _key369;
+                double _val370;
+                for (int _i371 = 0; _i371 < _map368.size; ++_i371)
+                {
+                  _key369 = iprot.readString();
+                  _val370 = iprot.readDouble();
+                  struct.resources_map.put(_key369, _val370);
+                }
+                iprot.readMapEnd();
+              }
+              struct.set_resources_map_isSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -810,6 +925,21 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
         oprot.writeI64(struct.failed);
         oprot.writeFieldEnd();
       }
+      if (struct.resources_map != null) {
+        if (struct.is_set_resources_map()) {
+          oprot.writeFieldBegin(RESOURCES_MAP_FIELD_DESC);
+          {
+            oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, struct.resources_map.size()));
+            for (Map.Entry<String, Double> _iter372 : struct.resources_map.entrySet())
+            {
+              oprot.writeString(_iter372.getKey());
+              oprot.writeDouble(_iter372.getValue());
+            }
+            oprot.writeMapEnd();
+          }
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -846,7 +976,10 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
       if (struct.is_set_failed()) {
         optionals.set(5);
       }
-      oprot.writeBitSet(optionals, 6);
+      if (struct.is_set_resources_map()) {
+        optionals.set(6);
+      }
+      oprot.writeBitSet(optionals, 7);
       if (struct.is_set_num_executors()) {
         oprot.writeI32(struct.num_executors);
       }
@@ -865,12 +998,22 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
       if (struct.is_set_failed()) {
         oprot.writeI64(struct.failed);
       }
+      if (struct.is_set_resources_map()) {
+        {
+          oprot.writeI32(struct.resources_map.size());
+          for (Map.Entry<String, Double> _iter373 : struct.resources_map.entrySet())
+          {
+            oprot.writeString(_iter373.getKey());
+            oprot.writeDouble(_iter373.getValue());
+          }
+        }
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, CommonAggregateStats struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
-      BitSet incoming = iprot.readBitSet(6);
+      BitSet incoming = iprot.readBitSet(7);
       if (incoming.get(0)) {
         struct.num_executors = iprot.readI32();
         struct.set_num_executors_isSet(true);
@@ -894,6 +1037,21 @@ public class CommonAggregateStats implements org.apache.thrift.TBase<CommonAggre
       if (incoming.get(5)) {
         struct.failed = iprot.readI64();
         struct.set_failed_isSet(true);
+      }
+      if (incoming.get(6)) {
+        {
+          org.apache.thrift.protocol.TMap _map374 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, iprot.readI32());
+          struct.resources_map = new HashMap<String,Double>(2*_map374.size);
+          String _key375;
+          double _val376;
+          for (int _i377 = 0; _i377 < _map374.size; ++_i377)
+          {
+            _key375 = iprot.readString();
+            _val376 = iprot.readDouble();
+            struct.resources_map.put(_key375, _val376);
+          }
+        }
+        struct.set_resources_map_isSet(true);
       }
     }
   }

--- a/storm-core/src/jvm/org/apache/storm/generated/ComponentPageInfo.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/ComponentPageInfo.java
@@ -70,6 +70,7 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
   private static final org.apache.thrift.protocol.TField EVENTLOG_PORT_FIELD_DESC = new org.apache.thrift.protocol.TField("eventlog_port", org.apache.thrift.protocol.TType.I32, (short)13);
   private static final org.apache.thrift.protocol.TField DEBUG_OPTIONS_FIELD_DESC = new org.apache.thrift.protocol.TField("debug_options", org.apache.thrift.protocol.TType.STRUCT, (short)14);
   private static final org.apache.thrift.protocol.TField TOPOLOGY_STATUS_FIELD_DESC = new org.apache.thrift.protocol.TField("topology_status", org.apache.thrift.protocol.TType.STRING, (short)15);
+  private static final org.apache.thrift.protocol.TField RESOURCES_MAP_FIELD_DESC = new org.apache.thrift.protocol.TField("resources_map", org.apache.thrift.protocol.TType.MAP, (short)16);
 
   private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
   static {
@@ -92,6 +93,7 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
   private int eventlog_port; // optional
   private DebugOptions debug_options; // optional
   private String topology_status; // optional
+  private Map<String,Double> resources_map; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -113,7 +115,8 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
     EVENTLOG_HOST((short)12, "eventlog_host"),
     EVENTLOG_PORT((short)13, "eventlog_port"),
     DEBUG_OPTIONS((short)14, "debug_options"),
-    TOPOLOGY_STATUS((short)15, "topology_status");
+    TOPOLOGY_STATUS((short)15, "topology_status"),
+    RESOURCES_MAP((short)16, "resources_map");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -158,6 +161,8 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           return DEBUG_OPTIONS;
         case 15: // TOPOLOGY_STATUS
           return TOPOLOGY_STATUS;
+        case 16: // RESOURCES_MAP
+          return RESOURCES_MAP;
         default:
           return null;
       }
@@ -202,7 +207,7 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
   private static final int __NUM_TASKS_ISSET_ID = 1;
   private static final int __EVENTLOG_PORT_ISSET_ID = 2;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.TOPOLOGY_ID,_Fields.TOPOLOGY_NAME,_Fields.NUM_EXECUTORS,_Fields.NUM_TASKS,_Fields.WINDOW_TO_STATS,_Fields.GSID_TO_INPUT_STATS,_Fields.SID_TO_OUTPUT_STATS,_Fields.EXEC_STATS,_Fields.ERRORS,_Fields.EVENTLOG_HOST,_Fields.EVENTLOG_PORT,_Fields.DEBUG_OPTIONS,_Fields.TOPOLOGY_STATUS};
+  private static final _Fields optionals[] = {_Fields.TOPOLOGY_ID,_Fields.TOPOLOGY_NAME,_Fields.NUM_EXECUTORS,_Fields.NUM_TASKS,_Fields.WINDOW_TO_STATS,_Fields.GSID_TO_INPUT_STATS,_Fields.SID_TO_OUTPUT_STATS,_Fields.EXEC_STATS,_Fields.ERRORS,_Fields.EVENTLOG_HOST,_Fields.EVENTLOG_PORT,_Fields.DEBUG_OPTIONS,_Fields.TOPOLOGY_STATUS,_Fields.RESOURCES_MAP};
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -244,6 +249,10 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, DebugOptions.class)));
     tmpMap.put(_Fields.TOPOLOGY_STATUS, new org.apache.thrift.meta_data.FieldMetaData("topology_status", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(_Fields.RESOURCES_MAP, new org.apache.thrift.meta_data.FieldMetaData("resources_map", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.MapMetaData(org.apache.thrift.protocol.TType.MAP, 
+            new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING), 
+            new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE))));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(ComponentPageInfo.class, metaDataMap);
   }
@@ -348,6 +357,10 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
     if (other.is_set_topology_status()) {
       this.topology_status = other.topology_status;
     }
+    if (other.is_set_resources_map()) {
+      Map<String,Double> __this__resources_map = new HashMap<String,Double>(other.resources_map);
+      this.resources_map = __this__resources_map;
+    }
   }
 
   public ComponentPageInfo deepCopy() {
@@ -374,6 +387,7 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
     this.eventlog_port = 0;
     this.debug_options = null;
     this.topology_status = null;
+    this.resources_map = null;
   }
 
   public String get_component_id() {
@@ -789,6 +803,40 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
     }
   }
 
+  public int get_resources_map_size() {
+    return (this.resources_map == null) ? 0 : this.resources_map.size();
+  }
+
+  public void put_to_resources_map(String key, double val) {
+    if (this.resources_map == null) {
+      this.resources_map = new HashMap<String,Double>();
+    }
+    this.resources_map.put(key, val);
+  }
+
+  public Map<String,Double> get_resources_map() {
+    return this.resources_map;
+  }
+
+  public void set_resources_map(Map<String,Double> resources_map) {
+    this.resources_map = resources_map;
+  }
+
+  public void unset_resources_map() {
+    this.resources_map = null;
+  }
+
+  /** Returns true if field resources_map is set (has been assigned a value) and false otherwise */
+  public boolean is_set_resources_map() {
+    return this.resources_map != null;
+  }
+
+  public void set_resources_map_isSet(boolean value) {
+    if (!value) {
+      this.resources_map = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case COMPONENT_ID:
@@ -911,6 +959,14 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
       }
       break;
 
+    case RESOURCES_MAP:
+      if (value == null) {
+        unset_resources_map();
+      } else {
+        set_resources_map((Map<String,Double>)value);
+      }
+      break;
+
     }
   }
 
@@ -961,6 +1017,9 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
     case TOPOLOGY_STATUS:
       return get_topology_status();
 
+    case RESOURCES_MAP:
+      return get_resources_map();
+
     }
     throw new IllegalStateException();
   }
@@ -1002,6 +1061,8 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
       return is_set_debug_options();
     case TOPOLOGY_STATUS:
       return is_set_topology_status();
+    case RESOURCES_MAP:
+      return is_set_resources_map();
     }
     throw new IllegalStateException();
   }
@@ -1154,6 +1215,15 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
         return false;
     }
 
+    boolean this_present_resources_map = true && this.is_set_resources_map();
+    boolean that_present_resources_map = true && that.is_set_resources_map();
+    if (this_present_resources_map || that_present_resources_map) {
+      if (!(this_present_resources_map && that_present_resources_map))
+        return false;
+      if (!this.resources_map.equals(that.resources_map))
+        return false;
+    }
+
     return true;
   }
 
@@ -1235,6 +1305,11 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
     list.add(present_topology_status);
     if (present_topology_status)
       list.add(topology_status);
+
+    boolean present_resources_map = true && (is_set_resources_map());
+    list.add(present_resources_map);
+    if (present_resources_map)
+      list.add(resources_map);
 
     return list.hashCode();
   }
@@ -1397,6 +1472,16 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(is_set_resources_map()).compareTo(other.is_set_resources_map());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (is_set_resources_map()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.resources_map, other.resources_map);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -1550,6 +1635,16 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
       }
       first = false;
     }
+    if (is_set_resources_map()) {
+      if (!first) sb.append(", ");
+      sb.append("resources_map:");
+      if (this.resources_map == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.resources_map);
+      }
+      first = false;
+    }
     sb.append(")");
     return sb.toString();
   }
@@ -1657,16 +1752,16 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           case 7: // WINDOW_TO_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map472 = iprot.readMapBegin();
-                struct.window_to_stats = new HashMap<String,ComponentAggregateStats>(2*_map472.size);
-                String _key473;
-                ComponentAggregateStats _val474;
-                for (int _i475 = 0; _i475 < _map472.size; ++_i475)
+                org.apache.thrift.protocol.TMap _map482 = iprot.readMapBegin();
+                struct.window_to_stats = new HashMap<String,ComponentAggregateStats>(2*_map482.size);
+                String _key483;
+                ComponentAggregateStats _val484;
+                for (int _i485 = 0; _i485 < _map482.size; ++_i485)
                 {
-                  _key473 = iprot.readString();
-                  _val474 = new ComponentAggregateStats();
-                  _val474.read(iprot);
-                  struct.window_to_stats.put(_key473, _val474);
+                  _key483 = iprot.readString();
+                  _val484 = new ComponentAggregateStats();
+                  _val484.read(iprot);
+                  struct.window_to_stats.put(_key483, _val484);
                 }
                 iprot.readMapEnd();
               }
@@ -1678,17 +1773,17 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           case 8: // GSID_TO_INPUT_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map476 = iprot.readMapBegin();
-                struct.gsid_to_input_stats = new HashMap<GlobalStreamId,ComponentAggregateStats>(2*_map476.size);
-                GlobalStreamId _key477;
-                ComponentAggregateStats _val478;
-                for (int _i479 = 0; _i479 < _map476.size; ++_i479)
+                org.apache.thrift.protocol.TMap _map486 = iprot.readMapBegin();
+                struct.gsid_to_input_stats = new HashMap<GlobalStreamId,ComponentAggregateStats>(2*_map486.size);
+                GlobalStreamId _key487;
+                ComponentAggregateStats _val488;
+                for (int _i489 = 0; _i489 < _map486.size; ++_i489)
                 {
-                  _key477 = new GlobalStreamId();
-                  _key477.read(iprot);
-                  _val478 = new ComponentAggregateStats();
-                  _val478.read(iprot);
-                  struct.gsid_to_input_stats.put(_key477, _val478);
+                  _key487 = new GlobalStreamId();
+                  _key487.read(iprot);
+                  _val488 = new ComponentAggregateStats();
+                  _val488.read(iprot);
+                  struct.gsid_to_input_stats.put(_key487, _val488);
                 }
                 iprot.readMapEnd();
               }
@@ -1700,16 +1795,16 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           case 9: // SID_TO_OUTPUT_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map480 = iprot.readMapBegin();
-                struct.sid_to_output_stats = new HashMap<String,ComponentAggregateStats>(2*_map480.size);
-                String _key481;
-                ComponentAggregateStats _val482;
-                for (int _i483 = 0; _i483 < _map480.size; ++_i483)
+                org.apache.thrift.protocol.TMap _map490 = iprot.readMapBegin();
+                struct.sid_to_output_stats = new HashMap<String,ComponentAggregateStats>(2*_map490.size);
+                String _key491;
+                ComponentAggregateStats _val492;
+                for (int _i493 = 0; _i493 < _map490.size; ++_i493)
                 {
-                  _key481 = iprot.readString();
-                  _val482 = new ComponentAggregateStats();
-                  _val482.read(iprot);
-                  struct.sid_to_output_stats.put(_key481, _val482);
+                  _key491 = iprot.readString();
+                  _val492 = new ComponentAggregateStats();
+                  _val492.read(iprot);
+                  struct.sid_to_output_stats.put(_key491, _val492);
                 }
                 iprot.readMapEnd();
               }
@@ -1721,14 +1816,14 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           case 10: // EXEC_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list484 = iprot.readListBegin();
-                struct.exec_stats = new ArrayList<ExecutorAggregateStats>(_list484.size);
-                ExecutorAggregateStats _elem485;
-                for (int _i486 = 0; _i486 < _list484.size; ++_i486)
+                org.apache.thrift.protocol.TList _list494 = iprot.readListBegin();
+                struct.exec_stats = new ArrayList<ExecutorAggregateStats>(_list494.size);
+                ExecutorAggregateStats _elem495;
+                for (int _i496 = 0; _i496 < _list494.size; ++_i496)
                 {
-                  _elem485 = new ExecutorAggregateStats();
-                  _elem485.read(iprot);
-                  struct.exec_stats.add(_elem485);
+                  _elem495 = new ExecutorAggregateStats();
+                  _elem495.read(iprot);
+                  struct.exec_stats.add(_elem495);
                 }
                 iprot.readListEnd();
               }
@@ -1740,14 +1835,14 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           case 11: // ERRORS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list487 = iprot.readListBegin();
-                struct.errors = new ArrayList<ErrorInfo>(_list487.size);
-                ErrorInfo _elem488;
-                for (int _i489 = 0; _i489 < _list487.size; ++_i489)
+                org.apache.thrift.protocol.TList _list497 = iprot.readListBegin();
+                struct.errors = new ArrayList<ErrorInfo>(_list497.size);
+                ErrorInfo _elem498;
+                for (int _i499 = 0; _i499 < _list497.size; ++_i499)
                 {
-                  _elem488 = new ErrorInfo();
-                  _elem488.read(iprot);
-                  struct.errors.add(_elem488);
+                  _elem498 = new ErrorInfo();
+                  _elem498.read(iprot);
+                  struct.errors.add(_elem498);
                 }
                 iprot.readListEnd();
               }
@@ -1785,6 +1880,26 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
             if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
               struct.topology_status = iprot.readString();
               struct.set_topology_status_isSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
+          case 16: // RESOURCES_MAP
+            if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
+              {
+                org.apache.thrift.protocol.TMap _map500 = iprot.readMapBegin();
+                struct.resources_map = new HashMap<String,Double>(2*_map500.size);
+                String _key501;
+                double _val502;
+                for (int _i503 = 0; _i503 < _map500.size; ++_i503)
+                {
+                  _key501 = iprot.readString();
+                  _val502 = iprot.readDouble();
+                  struct.resources_map.put(_key501, _val502);
+                }
+                iprot.readMapEnd();
+              }
+              struct.set_resources_map_isSet(true);
             } else { 
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
@@ -1841,10 +1956,10 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           oprot.writeFieldBegin(WINDOW_TO_STATS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, struct.window_to_stats.size()));
-            for (Map.Entry<String, ComponentAggregateStats> _iter490 : struct.window_to_stats.entrySet())
+            for (Map.Entry<String, ComponentAggregateStats> _iter504 : struct.window_to_stats.entrySet())
             {
-              oprot.writeString(_iter490.getKey());
-              _iter490.getValue().write(oprot);
+              oprot.writeString(_iter504.getKey());
+              _iter504.getValue().write(oprot);
             }
             oprot.writeMapEnd();
           }
@@ -1856,10 +1971,10 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           oprot.writeFieldBegin(GSID_TO_INPUT_STATS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRUCT, org.apache.thrift.protocol.TType.STRUCT, struct.gsid_to_input_stats.size()));
-            for (Map.Entry<GlobalStreamId, ComponentAggregateStats> _iter491 : struct.gsid_to_input_stats.entrySet())
+            for (Map.Entry<GlobalStreamId, ComponentAggregateStats> _iter505 : struct.gsid_to_input_stats.entrySet())
             {
-              _iter491.getKey().write(oprot);
-              _iter491.getValue().write(oprot);
+              _iter505.getKey().write(oprot);
+              _iter505.getValue().write(oprot);
             }
             oprot.writeMapEnd();
           }
@@ -1871,10 +1986,10 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           oprot.writeFieldBegin(SID_TO_OUTPUT_STATS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, struct.sid_to_output_stats.size()));
-            for (Map.Entry<String, ComponentAggregateStats> _iter492 : struct.sid_to_output_stats.entrySet())
+            for (Map.Entry<String, ComponentAggregateStats> _iter506 : struct.sid_to_output_stats.entrySet())
             {
-              oprot.writeString(_iter492.getKey());
-              _iter492.getValue().write(oprot);
+              oprot.writeString(_iter506.getKey());
+              _iter506.getValue().write(oprot);
             }
             oprot.writeMapEnd();
           }
@@ -1886,9 +2001,9 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           oprot.writeFieldBegin(EXEC_STATS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.exec_stats.size()));
-            for (ExecutorAggregateStats _iter493 : struct.exec_stats)
+            for (ExecutorAggregateStats _iter507 : struct.exec_stats)
             {
-              _iter493.write(oprot);
+              _iter507.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1900,9 +2015,9 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
           oprot.writeFieldBegin(ERRORS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.errors.size()));
-            for (ErrorInfo _iter494 : struct.errors)
+            for (ErrorInfo _iter508 : struct.errors)
             {
-              _iter494.write(oprot);
+              _iter508.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -1932,6 +2047,21 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
         if (struct.is_set_topology_status()) {
           oprot.writeFieldBegin(TOPOLOGY_STATUS_FIELD_DESC);
           oprot.writeString(struct.topology_status);
+          oprot.writeFieldEnd();
+        }
+      }
+      if (struct.resources_map != null) {
+        if (struct.is_set_resources_map()) {
+          oprot.writeFieldBegin(RESOURCES_MAP_FIELD_DESC);
+          {
+            oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, struct.resources_map.size()));
+            for (Map.Entry<String, Double> _iter509 : struct.resources_map.entrySet())
+            {
+              oprot.writeString(_iter509.getKey());
+              oprot.writeDouble(_iter509.getValue());
+            }
+            oprot.writeMapEnd();
+          }
           oprot.writeFieldEnd();
         }
       }
@@ -1994,7 +2124,10 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
       if (struct.is_set_topology_status()) {
         optionals.set(12);
       }
-      oprot.writeBitSet(optionals, 13);
+      if (struct.is_set_resources_map()) {
+        optionals.set(13);
+      }
+      oprot.writeBitSet(optionals, 14);
       if (struct.is_set_topology_id()) {
         oprot.writeString(struct.topology_id);
       }
@@ -2010,48 +2143,48 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
       if (struct.is_set_window_to_stats()) {
         {
           oprot.writeI32(struct.window_to_stats.size());
-          for (Map.Entry<String, ComponentAggregateStats> _iter495 : struct.window_to_stats.entrySet())
+          for (Map.Entry<String, ComponentAggregateStats> _iter510 : struct.window_to_stats.entrySet())
           {
-            oprot.writeString(_iter495.getKey());
-            _iter495.getValue().write(oprot);
+            oprot.writeString(_iter510.getKey());
+            _iter510.getValue().write(oprot);
           }
         }
       }
       if (struct.is_set_gsid_to_input_stats()) {
         {
           oprot.writeI32(struct.gsid_to_input_stats.size());
-          for (Map.Entry<GlobalStreamId, ComponentAggregateStats> _iter496 : struct.gsid_to_input_stats.entrySet())
+          for (Map.Entry<GlobalStreamId, ComponentAggregateStats> _iter511 : struct.gsid_to_input_stats.entrySet())
           {
-            _iter496.getKey().write(oprot);
-            _iter496.getValue().write(oprot);
+            _iter511.getKey().write(oprot);
+            _iter511.getValue().write(oprot);
           }
         }
       }
       if (struct.is_set_sid_to_output_stats()) {
         {
           oprot.writeI32(struct.sid_to_output_stats.size());
-          for (Map.Entry<String, ComponentAggregateStats> _iter497 : struct.sid_to_output_stats.entrySet())
+          for (Map.Entry<String, ComponentAggregateStats> _iter512 : struct.sid_to_output_stats.entrySet())
           {
-            oprot.writeString(_iter497.getKey());
-            _iter497.getValue().write(oprot);
+            oprot.writeString(_iter512.getKey());
+            _iter512.getValue().write(oprot);
           }
         }
       }
       if (struct.is_set_exec_stats()) {
         {
           oprot.writeI32(struct.exec_stats.size());
-          for (ExecutorAggregateStats _iter498 : struct.exec_stats)
+          for (ExecutorAggregateStats _iter513 : struct.exec_stats)
           {
-            _iter498.write(oprot);
+            _iter513.write(oprot);
           }
         }
       }
       if (struct.is_set_errors()) {
         {
           oprot.writeI32(struct.errors.size());
-          for (ErrorInfo _iter499 : struct.errors)
+          for (ErrorInfo _iter514 : struct.errors)
           {
-            _iter499.write(oprot);
+            _iter514.write(oprot);
           }
         }
       }
@@ -2067,6 +2200,16 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
       if (struct.is_set_topology_status()) {
         oprot.writeString(struct.topology_status);
       }
+      if (struct.is_set_resources_map()) {
+        {
+          oprot.writeI32(struct.resources_map.size());
+          for (Map.Entry<String, Double> _iter515 : struct.resources_map.entrySet())
+          {
+            oprot.writeString(_iter515.getKey());
+            oprot.writeDouble(_iter515.getValue());
+          }
+        }
+      }
     }
 
     @Override
@@ -2076,7 +2219,7 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
       struct.set_component_id_isSet(true);
       struct.component_type = org.apache.storm.generated.ComponentType.findByValue(iprot.readI32());
       struct.set_component_type_isSet(true);
-      BitSet incoming = iprot.readBitSet(13);
+      BitSet incoming = iprot.readBitSet(14);
       if (incoming.get(0)) {
         struct.topology_id = iprot.readString();
         struct.set_topology_id_isSet(true);
@@ -2095,77 +2238,77 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TMap _map500 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.window_to_stats = new HashMap<String,ComponentAggregateStats>(2*_map500.size);
-          String _key501;
-          ComponentAggregateStats _val502;
-          for (int _i503 = 0; _i503 < _map500.size; ++_i503)
+          org.apache.thrift.protocol.TMap _map516 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.window_to_stats = new HashMap<String,ComponentAggregateStats>(2*_map516.size);
+          String _key517;
+          ComponentAggregateStats _val518;
+          for (int _i519 = 0; _i519 < _map516.size; ++_i519)
           {
-            _key501 = iprot.readString();
-            _val502 = new ComponentAggregateStats();
-            _val502.read(iprot);
-            struct.window_to_stats.put(_key501, _val502);
+            _key517 = iprot.readString();
+            _val518 = new ComponentAggregateStats();
+            _val518.read(iprot);
+            struct.window_to_stats.put(_key517, _val518);
           }
         }
         struct.set_window_to_stats_isSet(true);
       }
       if (incoming.get(5)) {
         {
-          org.apache.thrift.protocol.TMap _map504 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRUCT, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.gsid_to_input_stats = new HashMap<GlobalStreamId,ComponentAggregateStats>(2*_map504.size);
-          GlobalStreamId _key505;
-          ComponentAggregateStats _val506;
-          for (int _i507 = 0; _i507 < _map504.size; ++_i507)
+          org.apache.thrift.protocol.TMap _map520 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRUCT, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.gsid_to_input_stats = new HashMap<GlobalStreamId,ComponentAggregateStats>(2*_map520.size);
+          GlobalStreamId _key521;
+          ComponentAggregateStats _val522;
+          for (int _i523 = 0; _i523 < _map520.size; ++_i523)
           {
-            _key505 = new GlobalStreamId();
-            _key505.read(iprot);
-            _val506 = new ComponentAggregateStats();
-            _val506.read(iprot);
-            struct.gsid_to_input_stats.put(_key505, _val506);
+            _key521 = new GlobalStreamId();
+            _key521.read(iprot);
+            _val522 = new ComponentAggregateStats();
+            _val522.read(iprot);
+            struct.gsid_to_input_stats.put(_key521, _val522);
           }
         }
         struct.set_gsid_to_input_stats_isSet(true);
       }
       if (incoming.get(6)) {
         {
-          org.apache.thrift.protocol.TMap _map508 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.sid_to_output_stats = new HashMap<String,ComponentAggregateStats>(2*_map508.size);
-          String _key509;
-          ComponentAggregateStats _val510;
-          for (int _i511 = 0; _i511 < _map508.size; ++_i511)
+          org.apache.thrift.protocol.TMap _map524 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.sid_to_output_stats = new HashMap<String,ComponentAggregateStats>(2*_map524.size);
+          String _key525;
+          ComponentAggregateStats _val526;
+          for (int _i527 = 0; _i527 < _map524.size; ++_i527)
           {
-            _key509 = iprot.readString();
-            _val510 = new ComponentAggregateStats();
-            _val510.read(iprot);
-            struct.sid_to_output_stats.put(_key509, _val510);
+            _key525 = iprot.readString();
+            _val526 = new ComponentAggregateStats();
+            _val526.read(iprot);
+            struct.sid_to_output_stats.put(_key525, _val526);
           }
         }
         struct.set_sid_to_output_stats_isSet(true);
       }
       if (incoming.get(7)) {
         {
-          org.apache.thrift.protocol.TList _list512 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.exec_stats = new ArrayList<ExecutorAggregateStats>(_list512.size);
-          ExecutorAggregateStats _elem513;
-          for (int _i514 = 0; _i514 < _list512.size; ++_i514)
+          org.apache.thrift.protocol.TList _list528 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.exec_stats = new ArrayList<ExecutorAggregateStats>(_list528.size);
+          ExecutorAggregateStats _elem529;
+          for (int _i530 = 0; _i530 < _list528.size; ++_i530)
           {
-            _elem513 = new ExecutorAggregateStats();
-            _elem513.read(iprot);
-            struct.exec_stats.add(_elem513);
+            _elem529 = new ExecutorAggregateStats();
+            _elem529.read(iprot);
+            struct.exec_stats.add(_elem529);
           }
         }
         struct.set_exec_stats_isSet(true);
       }
       if (incoming.get(8)) {
         {
-          org.apache.thrift.protocol.TList _list515 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.errors = new ArrayList<ErrorInfo>(_list515.size);
-          ErrorInfo _elem516;
-          for (int _i517 = 0; _i517 < _list515.size; ++_i517)
+          org.apache.thrift.protocol.TList _list531 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.errors = new ArrayList<ErrorInfo>(_list531.size);
+          ErrorInfo _elem532;
+          for (int _i533 = 0; _i533 < _list531.size; ++_i533)
           {
-            _elem516 = new ErrorInfo();
-            _elem516.read(iprot);
-            struct.errors.add(_elem516);
+            _elem532 = new ErrorInfo();
+            _elem532.read(iprot);
+            struct.errors.add(_elem532);
           }
         }
         struct.set_errors_isSet(true);
@@ -2186,6 +2329,21 @@ public class ComponentPageInfo implements org.apache.thrift.TBase<ComponentPageI
       if (incoming.get(12)) {
         struct.topology_status = iprot.readString();
         struct.set_topology_status_isSet(true);
+      }
+      if (incoming.get(13)) {
+        {
+          org.apache.thrift.protocol.TMap _map534 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, iprot.readI32());
+          struct.resources_map = new HashMap<String,Double>(2*_map534.size);
+          String _key535;
+          double _val536;
+          for (int _i537 = 0; _i537 < _map534.size; ++_i537)
+          {
+            _key535 = iprot.readString();
+            _val536 = iprot.readDouble();
+            struct.resources_map.put(_key535, _val536);
+          }
+        }
+        struct.set_resources_map_isSet(true);
       }
     }
   }

--- a/storm-core/src/jvm/org/apache/storm/generated/Credentials.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/Credentials.java
@@ -365,15 +365,15 @@ public class Credentials implements org.apache.thrift.TBase<Credentials, Credent
           case 1: // CREDS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map528 = iprot.readMapBegin();
-                struct.creds = new HashMap<String,String>(2*_map528.size);
-                String _key529;
-                String _val530;
-                for (int _i531 = 0; _i531 < _map528.size; ++_i531)
+                org.apache.thrift.protocol.TMap _map548 = iprot.readMapBegin();
+                struct.creds = new HashMap<String,String>(2*_map548.size);
+                String _key549;
+                String _val550;
+                for (int _i551 = 0; _i551 < _map548.size; ++_i551)
                 {
-                  _key529 = iprot.readString();
-                  _val530 = iprot.readString();
-                  struct.creds.put(_key529, _val530);
+                  _key549 = iprot.readString();
+                  _val550 = iprot.readString();
+                  struct.creds.put(_key549, _val550);
                 }
                 iprot.readMapEnd();
               }
@@ -399,10 +399,10 @@ public class Credentials implements org.apache.thrift.TBase<Credentials, Credent
         oprot.writeFieldBegin(CREDS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.creds.size()));
-          for (Map.Entry<String, String> _iter532 : struct.creds.entrySet())
+          for (Map.Entry<String, String> _iter552 : struct.creds.entrySet())
           {
-            oprot.writeString(_iter532.getKey());
-            oprot.writeString(_iter532.getValue());
+            oprot.writeString(_iter552.getKey());
+            oprot.writeString(_iter552.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -427,10 +427,10 @@ public class Credentials implements org.apache.thrift.TBase<Credentials, Credent
       TTupleProtocol oprot = (TTupleProtocol) prot;
       {
         oprot.writeI32(struct.creds.size());
-        for (Map.Entry<String, String> _iter533 : struct.creds.entrySet())
+        for (Map.Entry<String, String> _iter553 : struct.creds.entrySet())
         {
-          oprot.writeString(_iter533.getKey());
-          oprot.writeString(_iter533.getValue());
+          oprot.writeString(_iter553.getKey());
+          oprot.writeString(_iter553.getValue());
         }
       }
     }
@@ -439,15 +439,15 @@ public class Credentials implements org.apache.thrift.TBase<Credentials, Credent
     public void read(org.apache.thrift.protocol.TProtocol prot, Credentials struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TMap _map534 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-        struct.creds = new HashMap<String,String>(2*_map534.size);
-        String _key535;
-        String _val536;
-        for (int _i537 = 0; _i537 < _map534.size; ++_i537)
+        org.apache.thrift.protocol.TMap _map554 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+        struct.creds = new HashMap<String,String>(2*_map554.size);
+        String _key555;
+        String _val556;
+        for (int _i557 = 0; _i557 < _map554.size; ++_i557)
         {
-          _key535 = iprot.readString();
-          _val536 = iprot.readString();
-          struct.creds.put(_key535, _val536);
+          _key555 = iprot.readString();
+          _val556 = iprot.readString();
+          struct.creds.put(_key555, _val556);
         }
       }
       struct.set_creds_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/HBNodes.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/HBNodes.java
@@ -364,13 +364,13 @@ public class HBNodes implements org.apache.thrift.TBase<HBNodes, HBNodes._Fields
           case 1: // PULSE_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list780 = iprot.readListBegin();
-                struct.pulseIds = new ArrayList<String>(_list780.size);
-                String _elem781;
-                for (int _i782 = 0; _i782 < _list780.size; ++_i782)
+                org.apache.thrift.protocol.TList _list800 = iprot.readListBegin();
+                struct.pulseIds = new ArrayList<String>(_list800.size);
+                String _elem801;
+                for (int _i802 = 0; _i802 < _list800.size; ++_i802)
                 {
-                  _elem781 = iprot.readString();
-                  struct.pulseIds.add(_elem781);
+                  _elem801 = iprot.readString();
+                  struct.pulseIds.add(_elem801);
                 }
                 iprot.readListEnd();
               }
@@ -396,9 +396,9 @@ public class HBNodes implements org.apache.thrift.TBase<HBNodes, HBNodes._Fields
         oprot.writeFieldBegin(PULSE_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.pulseIds.size()));
-          for (String _iter783 : struct.pulseIds)
+          for (String _iter803 : struct.pulseIds)
           {
-            oprot.writeString(_iter783);
+            oprot.writeString(_iter803);
           }
           oprot.writeListEnd();
         }
@@ -429,9 +429,9 @@ public class HBNodes implements org.apache.thrift.TBase<HBNodes, HBNodes._Fields
       if (struct.is_set_pulseIds()) {
         {
           oprot.writeI32(struct.pulseIds.size());
-          for (String _iter784 : struct.pulseIds)
+          for (String _iter804 : struct.pulseIds)
           {
-            oprot.writeString(_iter784);
+            oprot.writeString(_iter804);
           }
         }
       }
@@ -443,13 +443,13 @@ public class HBNodes implements org.apache.thrift.TBase<HBNodes, HBNodes._Fields
       BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list785 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-          struct.pulseIds = new ArrayList<String>(_list785.size);
-          String _elem786;
-          for (int _i787 = 0; _i787 < _list785.size; ++_i787)
+          org.apache.thrift.protocol.TList _list805 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+          struct.pulseIds = new ArrayList<String>(_list805.size);
+          String _elem806;
+          for (int _i807 = 0; _i807 < _list805.size; ++_i807)
           {
-            _elem786 = iprot.readString();
-            struct.pulseIds.add(_elem786);
+            _elem806 = iprot.readString();
+            struct.pulseIds.add(_elem806);
           }
         }
         struct.set_pulseIds_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/HBRecords.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/HBRecords.java
@@ -367,14 +367,14 @@ public class HBRecords implements org.apache.thrift.TBase<HBRecords, HBRecords._
           case 1: // PULSES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list772 = iprot.readListBegin();
-                struct.pulses = new ArrayList<HBPulse>(_list772.size);
-                HBPulse _elem773;
-                for (int _i774 = 0; _i774 < _list772.size; ++_i774)
+                org.apache.thrift.protocol.TList _list792 = iprot.readListBegin();
+                struct.pulses = new ArrayList<HBPulse>(_list792.size);
+                HBPulse _elem793;
+                for (int _i794 = 0; _i794 < _list792.size; ++_i794)
                 {
-                  _elem773 = new HBPulse();
-                  _elem773.read(iprot);
-                  struct.pulses.add(_elem773);
+                  _elem793 = new HBPulse();
+                  _elem793.read(iprot);
+                  struct.pulses.add(_elem793);
                 }
                 iprot.readListEnd();
               }
@@ -400,9 +400,9 @@ public class HBRecords implements org.apache.thrift.TBase<HBRecords, HBRecords._
         oprot.writeFieldBegin(PULSES_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.pulses.size()));
-          for (HBPulse _iter775 : struct.pulses)
+          for (HBPulse _iter795 : struct.pulses)
           {
-            _iter775.write(oprot);
+            _iter795.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -433,9 +433,9 @@ public class HBRecords implements org.apache.thrift.TBase<HBRecords, HBRecords._
       if (struct.is_set_pulses()) {
         {
           oprot.writeI32(struct.pulses.size());
-          for (HBPulse _iter776 : struct.pulses)
+          for (HBPulse _iter796 : struct.pulses)
           {
-            _iter776.write(oprot);
+            _iter796.write(oprot);
           }
         }
       }
@@ -447,14 +447,14 @@ public class HBRecords implements org.apache.thrift.TBase<HBRecords, HBRecords._
       BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list777 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.pulses = new ArrayList<HBPulse>(_list777.size);
-          HBPulse _elem778;
-          for (int _i779 = 0; _i779 < _list777.size; ++_i779)
+          org.apache.thrift.protocol.TList _list797 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.pulses = new ArrayList<HBPulse>(_list797.size);
+          HBPulse _elem798;
+          for (int _i799 = 0; _i799 < _list797.size; ++_i799)
           {
-            _elem778 = new HBPulse();
-            _elem778.read(iprot);
-            struct.pulses.add(_elem778);
+            _elem798 = new HBPulse();
+            _elem798.read(iprot);
+            struct.pulses.add(_elem798);
           }
         }
         struct.set_pulses_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/LSApprovedWorkers.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/LSApprovedWorkers.java
@@ -365,15 +365,15 @@ public class LSApprovedWorkers implements org.apache.thrift.TBase<LSApprovedWork
           case 1: // APPROVED_WORKERS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map702 = iprot.readMapBegin();
-                struct.approved_workers = new HashMap<String,Integer>(2*_map702.size);
-                String _key703;
-                int _val704;
-                for (int _i705 = 0; _i705 < _map702.size; ++_i705)
+                org.apache.thrift.protocol.TMap _map722 = iprot.readMapBegin();
+                struct.approved_workers = new HashMap<String,Integer>(2*_map722.size);
+                String _key723;
+                int _val724;
+                for (int _i725 = 0; _i725 < _map722.size; ++_i725)
                 {
-                  _key703 = iprot.readString();
-                  _val704 = iprot.readI32();
-                  struct.approved_workers.put(_key703, _val704);
+                  _key723 = iprot.readString();
+                  _val724 = iprot.readI32();
+                  struct.approved_workers.put(_key723, _val724);
                 }
                 iprot.readMapEnd();
               }
@@ -399,10 +399,10 @@ public class LSApprovedWorkers implements org.apache.thrift.TBase<LSApprovedWork
         oprot.writeFieldBegin(APPROVED_WORKERS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I32, struct.approved_workers.size()));
-          for (Map.Entry<String, Integer> _iter706 : struct.approved_workers.entrySet())
+          for (Map.Entry<String, Integer> _iter726 : struct.approved_workers.entrySet())
           {
-            oprot.writeString(_iter706.getKey());
-            oprot.writeI32(_iter706.getValue());
+            oprot.writeString(_iter726.getKey());
+            oprot.writeI32(_iter726.getValue());
           }
           oprot.writeMapEnd();
         }
@@ -427,10 +427,10 @@ public class LSApprovedWorkers implements org.apache.thrift.TBase<LSApprovedWork
       TTupleProtocol oprot = (TTupleProtocol) prot;
       {
         oprot.writeI32(struct.approved_workers.size());
-        for (Map.Entry<String, Integer> _iter707 : struct.approved_workers.entrySet())
+        for (Map.Entry<String, Integer> _iter727 : struct.approved_workers.entrySet())
         {
-          oprot.writeString(_iter707.getKey());
-          oprot.writeI32(_iter707.getValue());
+          oprot.writeString(_iter727.getKey());
+          oprot.writeI32(_iter727.getValue());
         }
       }
     }
@@ -439,15 +439,15 @@ public class LSApprovedWorkers implements org.apache.thrift.TBase<LSApprovedWork
     public void read(org.apache.thrift.protocol.TProtocol prot, LSApprovedWorkers struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TMap _map708 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I32, iprot.readI32());
-        struct.approved_workers = new HashMap<String,Integer>(2*_map708.size);
-        String _key709;
-        int _val710;
-        for (int _i711 = 0; _i711 < _map708.size; ++_i711)
+        org.apache.thrift.protocol.TMap _map728 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I32, iprot.readI32());
+        struct.approved_workers = new HashMap<String,Integer>(2*_map728.size);
+        String _key729;
+        int _val730;
+        for (int _i731 = 0; _i731 < _map728.size; ++_i731)
         {
-          _key709 = iprot.readString();
-          _val710 = iprot.readI32();
-          struct.approved_workers.put(_key709, _val710);
+          _key729 = iprot.readString();
+          _val730 = iprot.readI32();
+          struct.approved_workers.put(_key729, _val730);
         }
       }
       struct.set_approved_workers_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/LSSupervisorAssignments.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/LSSupervisorAssignments.java
@@ -376,16 +376,16 @@ public class LSSupervisorAssignments implements org.apache.thrift.TBase<LSSuperv
           case 1: // ASSIGNMENTS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map712 = iprot.readMapBegin();
-                struct.assignments = new HashMap<Integer,LocalAssignment>(2*_map712.size);
-                int _key713;
-                LocalAssignment _val714;
-                for (int _i715 = 0; _i715 < _map712.size; ++_i715)
+                org.apache.thrift.protocol.TMap _map732 = iprot.readMapBegin();
+                struct.assignments = new HashMap<Integer,LocalAssignment>(2*_map732.size);
+                int _key733;
+                LocalAssignment _val734;
+                for (int _i735 = 0; _i735 < _map732.size; ++_i735)
                 {
-                  _key713 = iprot.readI32();
-                  _val714 = new LocalAssignment();
-                  _val714.read(iprot);
-                  struct.assignments.put(_key713, _val714);
+                  _key733 = iprot.readI32();
+                  _val734 = new LocalAssignment();
+                  _val734.read(iprot);
+                  struct.assignments.put(_key733, _val734);
                 }
                 iprot.readMapEnd();
               }
@@ -411,10 +411,10 @@ public class LSSupervisorAssignments implements org.apache.thrift.TBase<LSSuperv
         oprot.writeFieldBegin(ASSIGNMENTS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRUCT, struct.assignments.size()));
-          for (Map.Entry<Integer, LocalAssignment> _iter716 : struct.assignments.entrySet())
+          for (Map.Entry<Integer, LocalAssignment> _iter736 : struct.assignments.entrySet())
           {
-            oprot.writeI32(_iter716.getKey());
-            _iter716.getValue().write(oprot);
+            oprot.writeI32(_iter736.getKey());
+            _iter736.getValue().write(oprot);
           }
           oprot.writeMapEnd();
         }
@@ -439,10 +439,10 @@ public class LSSupervisorAssignments implements org.apache.thrift.TBase<LSSuperv
       TTupleProtocol oprot = (TTupleProtocol) prot;
       {
         oprot.writeI32(struct.assignments.size());
-        for (Map.Entry<Integer, LocalAssignment> _iter717 : struct.assignments.entrySet())
+        for (Map.Entry<Integer, LocalAssignment> _iter737 : struct.assignments.entrySet())
         {
-          oprot.writeI32(_iter717.getKey());
-          _iter717.getValue().write(oprot);
+          oprot.writeI32(_iter737.getKey());
+          _iter737.getValue().write(oprot);
         }
       }
     }
@@ -451,16 +451,16 @@ public class LSSupervisorAssignments implements org.apache.thrift.TBase<LSSuperv
     public void read(org.apache.thrift.protocol.TProtocol prot, LSSupervisorAssignments struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TMap _map718 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-        struct.assignments = new HashMap<Integer,LocalAssignment>(2*_map718.size);
-        int _key719;
-        LocalAssignment _val720;
-        for (int _i721 = 0; _i721 < _map718.size; ++_i721)
+        org.apache.thrift.protocol.TMap _map738 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+        struct.assignments = new HashMap<Integer,LocalAssignment>(2*_map738.size);
+        int _key739;
+        LocalAssignment _val740;
+        for (int _i741 = 0; _i741 < _map738.size; ++_i741)
         {
-          _key719 = iprot.readI32();
-          _val720 = new LocalAssignment();
-          _val720.read(iprot);
-          struct.assignments.put(_key719, _val720);
+          _key739 = iprot.readI32();
+          _val740 = new LocalAssignment();
+          _val740.read(iprot);
+          struct.assignments.put(_key739, _val740);
         }
       }
       struct.set_assignments_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/LSTopoHistory.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/LSTopoHistory.java
@@ -656,13 +656,13 @@ public class LSTopoHistory implements org.apache.thrift.TBase<LSTopoHistory, LST
           case 3: // USERS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list730 = iprot.readListBegin();
-                struct.users = new ArrayList<String>(_list730.size);
-                String _elem731;
-                for (int _i732 = 0; _i732 < _list730.size; ++_i732)
+                org.apache.thrift.protocol.TList _list750 = iprot.readListBegin();
+                struct.users = new ArrayList<String>(_list750.size);
+                String _elem751;
+                for (int _i752 = 0; _i752 < _list750.size; ++_i752)
                 {
-                  _elem731 = iprot.readString();
-                  struct.users.add(_elem731);
+                  _elem751 = iprot.readString();
+                  struct.users.add(_elem751);
                 }
                 iprot.readListEnd();
               }
@@ -674,13 +674,13 @@ public class LSTopoHistory implements org.apache.thrift.TBase<LSTopoHistory, LST
           case 4: // GROUPS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list733 = iprot.readListBegin();
-                struct.groups = new ArrayList<String>(_list733.size);
-                String _elem734;
-                for (int _i735 = 0; _i735 < _list733.size; ++_i735)
+                org.apache.thrift.protocol.TList _list753 = iprot.readListBegin();
+                struct.groups = new ArrayList<String>(_list753.size);
+                String _elem754;
+                for (int _i755 = 0; _i755 < _list753.size; ++_i755)
                 {
-                  _elem734 = iprot.readString();
-                  struct.groups.add(_elem734);
+                  _elem754 = iprot.readString();
+                  struct.groups.add(_elem754);
                 }
                 iprot.readListEnd();
               }
@@ -714,9 +714,9 @@ public class LSTopoHistory implements org.apache.thrift.TBase<LSTopoHistory, LST
         oprot.writeFieldBegin(USERS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.users.size()));
-          for (String _iter736 : struct.users)
+          for (String _iter756 : struct.users)
           {
-            oprot.writeString(_iter736);
+            oprot.writeString(_iter756);
           }
           oprot.writeListEnd();
         }
@@ -726,9 +726,9 @@ public class LSTopoHistory implements org.apache.thrift.TBase<LSTopoHistory, LST
         oprot.writeFieldBegin(GROUPS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.groups.size()));
-          for (String _iter737 : struct.groups)
+          for (String _iter757 : struct.groups)
           {
-            oprot.writeString(_iter737);
+            oprot.writeString(_iter757);
           }
           oprot.writeListEnd();
         }
@@ -755,16 +755,16 @@ public class LSTopoHistory implements org.apache.thrift.TBase<LSTopoHistory, LST
       oprot.writeI64(struct.time_stamp);
       {
         oprot.writeI32(struct.users.size());
-        for (String _iter738 : struct.users)
+        for (String _iter758 : struct.users)
         {
-          oprot.writeString(_iter738);
+          oprot.writeString(_iter758);
         }
       }
       {
         oprot.writeI32(struct.groups.size());
-        for (String _iter739 : struct.groups)
+        for (String _iter759 : struct.groups)
         {
-          oprot.writeString(_iter739);
+          oprot.writeString(_iter759);
         }
       }
     }
@@ -777,24 +777,24 @@ public class LSTopoHistory implements org.apache.thrift.TBase<LSTopoHistory, LST
       struct.time_stamp = iprot.readI64();
       struct.set_time_stamp_isSet(true);
       {
-        org.apache.thrift.protocol.TList _list740 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-        struct.users = new ArrayList<String>(_list740.size);
-        String _elem741;
-        for (int _i742 = 0; _i742 < _list740.size; ++_i742)
+        org.apache.thrift.protocol.TList _list760 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+        struct.users = new ArrayList<String>(_list760.size);
+        String _elem761;
+        for (int _i762 = 0; _i762 < _list760.size; ++_i762)
         {
-          _elem741 = iprot.readString();
-          struct.users.add(_elem741);
+          _elem761 = iprot.readString();
+          struct.users.add(_elem761);
         }
       }
       struct.set_users_isSet(true);
       {
-        org.apache.thrift.protocol.TList _list743 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-        struct.groups = new ArrayList<String>(_list743.size);
-        String _elem744;
-        for (int _i745 = 0; _i745 < _list743.size; ++_i745)
+        org.apache.thrift.protocol.TList _list763 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+        struct.groups = new ArrayList<String>(_list763.size);
+        String _elem764;
+        for (int _i765 = 0; _i765 < _list763.size; ++_i765)
         {
-          _elem744 = iprot.readString();
-          struct.groups.add(_elem744);
+          _elem764 = iprot.readString();
+          struct.groups.add(_elem764);
         }
       }
       struct.set_groups_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/LSTopoHistoryList.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/LSTopoHistoryList.java
@@ -371,14 +371,14 @@ public class LSTopoHistoryList implements org.apache.thrift.TBase<LSTopoHistoryL
           case 1: // TOPO_HISTORY
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list746 = iprot.readListBegin();
-                struct.topo_history = new ArrayList<LSTopoHistory>(_list746.size);
-                LSTopoHistory _elem747;
-                for (int _i748 = 0; _i748 < _list746.size; ++_i748)
+                org.apache.thrift.protocol.TList _list766 = iprot.readListBegin();
+                struct.topo_history = new ArrayList<LSTopoHistory>(_list766.size);
+                LSTopoHistory _elem767;
+                for (int _i768 = 0; _i768 < _list766.size; ++_i768)
                 {
-                  _elem747 = new LSTopoHistory();
-                  _elem747.read(iprot);
-                  struct.topo_history.add(_elem747);
+                  _elem767 = new LSTopoHistory();
+                  _elem767.read(iprot);
+                  struct.topo_history.add(_elem767);
                 }
                 iprot.readListEnd();
               }
@@ -404,9 +404,9 @@ public class LSTopoHistoryList implements org.apache.thrift.TBase<LSTopoHistoryL
         oprot.writeFieldBegin(TOPO_HISTORY_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.topo_history.size()));
-          for (LSTopoHistory _iter749 : struct.topo_history)
+          for (LSTopoHistory _iter769 : struct.topo_history)
           {
-            _iter749.write(oprot);
+            _iter769.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -431,9 +431,9 @@ public class LSTopoHistoryList implements org.apache.thrift.TBase<LSTopoHistoryL
       TTupleProtocol oprot = (TTupleProtocol) prot;
       {
         oprot.writeI32(struct.topo_history.size());
-        for (LSTopoHistory _iter750 : struct.topo_history)
+        for (LSTopoHistory _iter770 : struct.topo_history)
         {
-          _iter750.write(oprot);
+          _iter770.write(oprot);
         }
       }
     }
@@ -442,14 +442,14 @@ public class LSTopoHistoryList implements org.apache.thrift.TBase<LSTopoHistoryL
     public void read(org.apache.thrift.protocol.TProtocol prot, LSTopoHistoryList struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list751 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-        struct.topo_history = new ArrayList<LSTopoHistory>(_list751.size);
-        LSTopoHistory _elem752;
-        for (int _i753 = 0; _i753 < _list751.size; ++_i753)
+        org.apache.thrift.protocol.TList _list771 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+        struct.topo_history = new ArrayList<LSTopoHistory>(_list771.size);
+        LSTopoHistory _elem772;
+        for (int _i773 = 0; _i773 < _list771.size; ++_i773)
         {
-          _elem752 = new LSTopoHistory();
-          _elem752.read(iprot);
-          struct.topo_history.add(_elem752);
+          _elem772 = new LSTopoHistory();
+          _elem772.read(iprot);
+          struct.topo_history.add(_elem772);
         }
       }
       struct.set_topo_history_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/LSWorkerHeartbeat.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/LSWorkerHeartbeat.java
@@ -638,14 +638,14 @@ public class LSWorkerHeartbeat implements org.apache.thrift.TBase<LSWorkerHeartb
           case 3: // EXECUTORS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list722 = iprot.readListBegin();
-                struct.executors = new ArrayList<ExecutorInfo>(_list722.size);
-                ExecutorInfo _elem723;
-                for (int _i724 = 0; _i724 < _list722.size; ++_i724)
+                org.apache.thrift.protocol.TList _list742 = iprot.readListBegin();
+                struct.executors = new ArrayList<ExecutorInfo>(_list742.size);
+                ExecutorInfo _elem743;
+                for (int _i744 = 0; _i744 < _list742.size; ++_i744)
                 {
-                  _elem723 = new ExecutorInfo();
-                  _elem723.read(iprot);
-                  struct.executors.add(_elem723);
+                  _elem743 = new ExecutorInfo();
+                  _elem743.read(iprot);
+                  struct.executors.add(_elem743);
                 }
                 iprot.readListEnd();
               }
@@ -687,9 +687,9 @@ public class LSWorkerHeartbeat implements org.apache.thrift.TBase<LSWorkerHeartb
         oprot.writeFieldBegin(EXECUTORS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.executors.size()));
-          for (ExecutorInfo _iter725 : struct.executors)
+          for (ExecutorInfo _iter745 : struct.executors)
           {
-            _iter725.write(oprot);
+            _iter745.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -719,9 +719,9 @@ public class LSWorkerHeartbeat implements org.apache.thrift.TBase<LSWorkerHeartb
       oprot.writeString(struct.topology_id);
       {
         oprot.writeI32(struct.executors.size());
-        for (ExecutorInfo _iter726 : struct.executors)
+        for (ExecutorInfo _iter746 : struct.executors)
         {
-          _iter726.write(oprot);
+          _iter746.write(oprot);
         }
       }
       oprot.writeI32(struct.port);
@@ -735,14 +735,14 @@ public class LSWorkerHeartbeat implements org.apache.thrift.TBase<LSWorkerHeartb
       struct.topology_id = iprot.readString();
       struct.set_topology_id_isSet(true);
       {
-        org.apache.thrift.protocol.TList _list727 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-        struct.executors = new ArrayList<ExecutorInfo>(_list727.size);
-        ExecutorInfo _elem728;
-        for (int _i729 = 0; _i729 < _list727.size; ++_i729)
+        org.apache.thrift.protocol.TList _list747 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+        struct.executors = new ArrayList<ExecutorInfo>(_list747.size);
+        ExecutorInfo _elem748;
+        for (int _i749 = 0; _i749 < _list747.size; ++_i749)
         {
-          _elem728 = new ExecutorInfo();
-          _elem728.read(iprot);
-          struct.executors.add(_elem728);
+          _elem748 = new ExecutorInfo();
+          _elem748.read(iprot);
+          struct.executors.add(_elem748);
         }
       }
       struct.set_executors_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/ListBlobsResult.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/ListBlobsResult.java
@@ -453,13 +453,13 @@ public class ListBlobsResult implements org.apache.thrift.TBase<ListBlobsResult,
           case 1: // KEYS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list546 = iprot.readListBegin();
-                struct.keys = new ArrayList<String>(_list546.size);
-                String _elem547;
-                for (int _i548 = 0; _i548 < _list546.size; ++_i548)
+                org.apache.thrift.protocol.TList _list566 = iprot.readListBegin();
+                struct.keys = new ArrayList<String>(_list566.size);
+                String _elem567;
+                for (int _i568 = 0; _i568 < _list566.size; ++_i568)
                 {
-                  _elem547 = iprot.readString();
-                  struct.keys.add(_elem547);
+                  _elem567 = iprot.readString();
+                  struct.keys.add(_elem567);
                 }
                 iprot.readListEnd();
               }
@@ -493,9 +493,9 @@ public class ListBlobsResult implements org.apache.thrift.TBase<ListBlobsResult,
         oprot.writeFieldBegin(KEYS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.keys.size()));
-          for (String _iter549 : struct.keys)
+          for (String _iter569 : struct.keys)
           {
-            oprot.writeString(_iter549);
+            oprot.writeString(_iter569);
           }
           oprot.writeListEnd();
         }
@@ -525,9 +525,9 @@ public class ListBlobsResult implements org.apache.thrift.TBase<ListBlobsResult,
       TTupleProtocol oprot = (TTupleProtocol) prot;
       {
         oprot.writeI32(struct.keys.size());
-        for (String _iter550 : struct.keys)
+        for (String _iter570 : struct.keys)
         {
-          oprot.writeString(_iter550);
+          oprot.writeString(_iter570);
         }
       }
       oprot.writeString(struct.session);
@@ -537,13 +537,13 @@ public class ListBlobsResult implements org.apache.thrift.TBase<ListBlobsResult,
     public void read(org.apache.thrift.protocol.TProtocol prot, ListBlobsResult struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list551 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-        struct.keys = new ArrayList<String>(_list551.size);
-        String _elem552;
-        for (int _i553 = 0; _i553 < _list551.size; ++_i553)
+        org.apache.thrift.protocol.TList _list571 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+        struct.keys = new ArrayList<String>(_list571.size);
+        String _elem572;
+        for (int _i573 = 0; _i573 < _list571.size; ++_i573)
         {
-          _elem552 = iprot.readString();
-          struct.keys.add(_elem552);
+          _elem572 = iprot.readString();
+          struct.keys.add(_elem572);
         }
       }
       struct.set_keys_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/LocalAssignment.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/LocalAssignment.java
@@ -549,14 +549,14 @@ public class LocalAssignment implements org.apache.thrift.TBase<LocalAssignment,
           case 2: // EXECUTORS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list694 = iprot.readListBegin();
-                struct.executors = new ArrayList<ExecutorInfo>(_list694.size);
-                ExecutorInfo _elem695;
-                for (int _i696 = 0; _i696 < _list694.size; ++_i696)
+                org.apache.thrift.protocol.TList _list714 = iprot.readListBegin();
+                struct.executors = new ArrayList<ExecutorInfo>(_list714.size);
+                ExecutorInfo _elem715;
+                for (int _i716 = 0; _i716 < _list714.size; ++_i716)
                 {
-                  _elem695 = new ExecutorInfo();
-                  _elem695.read(iprot);
-                  struct.executors.add(_elem695);
+                  _elem715 = new ExecutorInfo();
+                  _elem715.read(iprot);
+                  struct.executors.add(_elem715);
                 }
                 iprot.readListEnd();
               }
@@ -596,9 +596,9 @@ public class LocalAssignment implements org.apache.thrift.TBase<LocalAssignment,
         oprot.writeFieldBegin(EXECUTORS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.executors.size()));
-          for (ExecutorInfo _iter697 : struct.executors)
+          for (ExecutorInfo _iter717 : struct.executors)
           {
-            _iter697.write(oprot);
+            _iter717.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -631,9 +631,9 @@ public class LocalAssignment implements org.apache.thrift.TBase<LocalAssignment,
       oprot.writeString(struct.topology_id);
       {
         oprot.writeI32(struct.executors.size());
-        for (ExecutorInfo _iter698 : struct.executors)
+        for (ExecutorInfo _iter718 : struct.executors)
         {
-          _iter698.write(oprot);
+          _iter718.write(oprot);
         }
       }
       BitSet optionals = new BitSet();
@@ -652,14 +652,14 @@ public class LocalAssignment implements org.apache.thrift.TBase<LocalAssignment,
       struct.topology_id = iprot.readString();
       struct.set_topology_id_isSet(true);
       {
-        org.apache.thrift.protocol.TList _list699 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-        struct.executors = new ArrayList<ExecutorInfo>(_list699.size);
-        ExecutorInfo _elem700;
-        for (int _i701 = 0; _i701 < _list699.size; ++_i701)
+        org.apache.thrift.protocol.TList _list719 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+        struct.executors = new ArrayList<ExecutorInfo>(_list719.size);
+        ExecutorInfo _elem720;
+        for (int _i721 = 0; _i721 < _list719.size; ++_i721)
         {
-          _elem700 = new ExecutorInfo();
-          _elem700.read(iprot);
-          struct.executors.add(_elem700);
+          _elem720 = new ExecutorInfo();
+          _elem720.read(iprot);
+          struct.executors.add(_elem720);
         }
       }
       struct.set_executors_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/LocalStateData.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/LocalStateData.java
@@ -376,16 +376,16 @@ public class LocalStateData implements org.apache.thrift.TBase<LocalStateData, L
           case 1: // SERIALIZED_PARTS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map684 = iprot.readMapBegin();
-                struct.serialized_parts = new HashMap<String,ThriftSerializedObject>(2*_map684.size);
-                String _key685;
-                ThriftSerializedObject _val686;
-                for (int _i687 = 0; _i687 < _map684.size; ++_i687)
+                org.apache.thrift.protocol.TMap _map704 = iprot.readMapBegin();
+                struct.serialized_parts = new HashMap<String,ThriftSerializedObject>(2*_map704.size);
+                String _key705;
+                ThriftSerializedObject _val706;
+                for (int _i707 = 0; _i707 < _map704.size; ++_i707)
                 {
-                  _key685 = iprot.readString();
-                  _val686 = new ThriftSerializedObject();
-                  _val686.read(iprot);
-                  struct.serialized_parts.put(_key685, _val686);
+                  _key705 = iprot.readString();
+                  _val706 = new ThriftSerializedObject();
+                  _val706.read(iprot);
+                  struct.serialized_parts.put(_key705, _val706);
                 }
                 iprot.readMapEnd();
               }
@@ -411,10 +411,10 @@ public class LocalStateData implements org.apache.thrift.TBase<LocalStateData, L
         oprot.writeFieldBegin(SERIALIZED_PARTS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, struct.serialized_parts.size()));
-          for (Map.Entry<String, ThriftSerializedObject> _iter688 : struct.serialized_parts.entrySet())
+          for (Map.Entry<String, ThriftSerializedObject> _iter708 : struct.serialized_parts.entrySet())
           {
-            oprot.writeString(_iter688.getKey());
-            _iter688.getValue().write(oprot);
+            oprot.writeString(_iter708.getKey());
+            _iter708.getValue().write(oprot);
           }
           oprot.writeMapEnd();
         }
@@ -439,10 +439,10 @@ public class LocalStateData implements org.apache.thrift.TBase<LocalStateData, L
       TTupleProtocol oprot = (TTupleProtocol) prot;
       {
         oprot.writeI32(struct.serialized_parts.size());
-        for (Map.Entry<String, ThriftSerializedObject> _iter689 : struct.serialized_parts.entrySet())
+        for (Map.Entry<String, ThriftSerializedObject> _iter709 : struct.serialized_parts.entrySet())
         {
-          oprot.writeString(_iter689.getKey());
-          _iter689.getValue().write(oprot);
+          oprot.writeString(_iter709.getKey());
+          _iter709.getValue().write(oprot);
         }
       }
     }
@@ -451,16 +451,16 @@ public class LocalStateData implements org.apache.thrift.TBase<LocalStateData, L
     public void read(org.apache.thrift.protocol.TProtocol prot, LocalStateData struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TMap _map690 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-        struct.serialized_parts = new HashMap<String,ThriftSerializedObject>(2*_map690.size);
-        String _key691;
-        ThriftSerializedObject _val692;
-        for (int _i693 = 0; _i693 < _map690.size; ++_i693)
+        org.apache.thrift.protocol.TMap _map710 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+        struct.serialized_parts = new HashMap<String,ThriftSerializedObject>(2*_map710.size);
+        String _key711;
+        ThriftSerializedObject _val712;
+        for (int _i713 = 0; _i713 < _map710.size; ++_i713)
         {
-          _key691 = iprot.readString();
-          _val692 = new ThriftSerializedObject();
-          _val692.read(iprot);
-          struct.serialized_parts.put(_key691, _val692);
+          _key711 = iprot.readString();
+          _val712 = new ThriftSerializedObject();
+          _val712.read(iprot);
+          struct.serialized_parts.put(_key711, _val712);
         }
       }
       struct.set_serialized_parts_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/LogConfig.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/LogConfig.java
@@ -368,16 +368,16 @@ public class LogConfig implements org.apache.thrift.TBase<LogConfig, LogConfig._
           case 2: // NAMED_LOGGER_LEVEL
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map754 = iprot.readMapBegin();
-                struct.named_logger_level = new HashMap<String,LogLevel>(2*_map754.size);
-                String _key755;
-                LogLevel _val756;
-                for (int _i757 = 0; _i757 < _map754.size; ++_i757)
+                org.apache.thrift.protocol.TMap _map774 = iprot.readMapBegin();
+                struct.named_logger_level = new HashMap<String,LogLevel>(2*_map774.size);
+                String _key775;
+                LogLevel _val776;
+                for (int _i777 = 0; _i777 < _map774.size; ++_i777)
                 {
-                  _key755 = iprot.readString();
-                  _val756 = new LogLevel();
-                  _val756.read(iprot);
-                  struct.named_logger_level.put(_key755, _val756);
+                  _key775 = iprot.readString();
+                  _val776 = new LogLevel();
+                  _val776.read(iprot);
+                  struct.named_logger_level.put(_key775, _val776);
                 }
                 iprot.readMapEnd();
               }
@@ -404,10 +404,10 @@ public class LogConfig implements org.apache.thrift.TBase<LogConfig, LogConfig._
           oprot.writeFieldBegin(NAMED_LOGGER_LEVEL_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, struct.named_logger_level.size()));
-            for (Map.Entry<String, LogLevel> _iter758 : struct.named_logger_level.entrySet())
+            for (Map.Entry<String, LogLevel> _iter778 : struct.named_logger_level.entrySet())
             {
-              oprot.writeString(_iter758.getKey());
-              _iter758.getValue().write(oprot);
+              oprot.writeString(_iter778.getKey());
+              _iter778.getValue().write(oprot);
             }
             oprot.writeMapEnd();
           }
@@ -439,10 +439,10 @@ public class LogConfig implements org.apache.thrift.TBase<LogConfig, LogConfig._
       if (struct.is_set_named_logger_level()) {
         {
           oprot.writeI32(struct.named_logger_level.size());
-          for (Map.Entry<String, LogLevel> _iter759 : struct.named_logger_level.entrySet())
+          for (Map.Entry<String, LogLevel> _iter779 : struct.named_logger_level.entrySet())
           {
-            oprot.writeString(_iter759.getKey());
-            _iter759.getValue().write(oprot);
+            oprot.writeString(_iter779.getKey());
+            _iter779.getValue().write(oprot);
           }
         }
       }
@@ -454,16 +454,16 @@ public class LogConfig implements org.apache.thrift.TBase<LogConfig, LogConfig._
       BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TMap _map760 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.named_logger_level = new HashMap<String,LogLevel>(2*_map760.size);
-          String _key761;
-          LogLevel _val762;
-          for (int _i763 = 0; _i763 < _map760.size; ++_i763)
+          org.apache.thrift.protocol.TMap _map780 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.named_logger_level = new HashMap<String,LogLevel>(2*_map780.size);
+          String _key781;
+          LogLevel _val782;
+          for (int _i783 = 0; _i783 < _map780.size; ++_i783)
           {
-            _key761 = iprot.readString();
-            _val762 = new LogLevel();
-            _val762.read(iprot);
-            struct.named_logger_level.put(_key761, _val762);
+            _key781 = iprot.readString();
+            _val782 = new LogLevel();
+            _val782.read(iprot);
+            struct.named_logger_level.put(_key781, _val782);
           }
         }
         struct.set_named_logger_level_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/Nimbus.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/Nimbus.java
@@ -17854,14 +17854,14 @@ public class Nimbus {
             case 0: // SUCCESS
               if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
                 {
-                  org.apache.thrift.protocol.TList _list788 = iprot.readListBegin();
-                  struct.success = new ArrayList<ProfileRequest>(_list788.size);
-                  ProfileRequest _elem789;
-                  for (int _i790 = 0; _i790 < _list788.size; ++_i790)
+                  org.apache.thrift.protocol.TList _list808 = iprot.readListBegin();
+                  struct.success = new ArrayList<ProfileRequest>(_list808.size);
+                  ProfileRequest _elem809;
+                  for (int _i810 = 0; _i810 < _list808.size; ++_i810)
                   {
-                    _elem789 = new ProfileRequest();
-                    _elem789.read(iprot);
-                    struct.success.add(_elem789);
+                    _elem809 = new ProfileRequest();
+                    _elem809.read(iprot);
+                    struct.success.add(_elem809);
                   }
                   iprot.readListEnd();
                 }
@@ -17887,9 +17887,9 @@ public class Nimbus {
           oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.success.size()));
-            for (ProfileRequest _iter791 : struct.success)
+            for (ProfileRequest _iter811 : struct.success)
             {
-              _iter791.write(oprot);
+              _iter811.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -17920,9 +17920,9 @@ public class Nimbus {
         if (struct.is_set_success()) {
           {
             oprot.writeI32(struct.success.size());
-            for (ProfileRequest _iter792 : struct.success)
+            for (ProfileRequest _iter812 : struct.success)
             {
-              _iter792.write(oprot);
+              _iter812.write(oprot);
             }
           }
         }
@@ -17934,14 +17934,14 @@ public class Nimbus {
         BitSet incoming = iprot.readBitSet(1);
         if (incoming.get(0)) {
           {
-            org.apache.thrift.protocol.TList _list793 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-            struct.success = new ArrayList<ProfileRequest>(_list793.size);
-            ProfileRequest _elem794;
-            for (int _i795 = 0; _i795 < _list793.size; ++_i795)
+            org.apache.thrift.protocol.TList _list813 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+            struct.success = new ArrayList<ProfileRequest>(_list813.size);
+            ProfileRequest _elem814;
+            for (int _i815 = 0; _i815 < _list813.size; ++_i815)
             {
-              _elem794 = new ProfileRequest();
-              _elem794.read(iprot);
-              struct.success.add(_elem794);
+              _elem814 = new ProfileRequest();
+              _elem814.read(iprot);
+              struct.success.add(_elem814);
             }
           }
           struct.set_success_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/NodeInfo.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/NodeInfo.java
@@ -461,13 +461,13 @@ public class NodeInfo implements org.apache.thrift.TBase<NodeInfo, NodeInfo._Fie
           case 2: // PORT
             if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
               {
-                org.apache.thrift.protocol.TSet _set590 = iprot.readSetBegin();
-                struct.port = new HashSet<Long>(2*_set590.size);
-                long _elem591;
-                for (int _i592 = 0; _i592 < _set590.size; ++_i592)
+                org.apache.thrift.protocol.TSet _set610 = iprot.readSetBegin();
+                struct.port = new HashSet<Long>(2*_set610.size);
+                long _elem611;
+                for (int _i612 = 0; _i612 < _set610.size; ++_i612)
                 {
-                  _elem591 = iprot.readI64();
-                  struct.port.add(_elem591);
+                  _elem611 = iprot.readI64();
+                  struct.port.add(_elem611);
                 }
                 iprot.readSetEnd();
               }
@@ -498,9 +498,9 @@ public class NodeInfo implements org.apache.thrift.TBase<NodeInfo, NodeInfo._Fie
         oprot.writeFieldBegin(PORT_FIELD_DESC);
         {
           oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.port.size()));
-          for (long _iter593 : struct.port)
+          for (long _iter613 : struct.port)
           {
-            oprot.writeI64(_iter593);
+            oprot.writeI64(_iter613);
           }
           oprot.writeSetEnd();
         }
@@ -526,9 +526,9 @@ public class NodeInfo implements org.apache.thrift.TBase<NodeInfo, NodeInfo._Fie
       oprot.writeString(struct.node);
       {
         oprot.writeI32(struct.port.size());
-        for (long _iter594 : struct.port)
+        for (long _iter614 : struct.port)
         {
-          oprot.writeI64(_iter594);
+          oprot.writeI64(_iter614);
         }
       }
     }
@@ -539,13 +539,13 @@ public class NodeInfo implements org.apache.thrift.TBase<NodeInfo, NodeInfo._Fie
       struct.node = iprot.readString();
       struct.set_node_isSet(true);
       {
-        org.apache.thrift.protocol.TSet _set595 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-        struct.port = new HashSet<Long>(2*_set595.size);
-        long _elem596;
-        for (int _i597 = 0; _i597 < _set595.size; ++_i597)
+        org.apache.thrift.protocol.TSet _set615 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+        struct.port = new HashSet<Long>(2*_set615.size);
+        long _elem616;
+        for (int _i617 = 0; _i617 < _set615.size; ++_i617)
         {
-          _elem596 = iprot.readI64();
-          struct.port.add(_elem596);
+          _elem616 = iprot.readI64();
+          struct.port.add(_elem616);
         }
       }
       struct.set_port_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/RebalanceOptions.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/RebalanceOptions.java
@@ -529,15 +529,15 @@ public class RebalanceOptions implements org.apache.thrift.TBase<RebalanceOption
           case 3: // NUM_EXECUTORS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map518 = iprot.readMapBegin();
-                struct.num_executors = new HashMap<String,Integer>(2*_map518.size);
-                String _key519;
-                int _val520;
-                for (int _i521 = 0; _i521 < _map518.size; ++_i521)
+                org.apache.thrift.protocol.TMap _map538 = iprot.readMapBegin();
+                struct.num_executors = new HashMap<String,Integer>(2*_map538.size);
+                String _key539;
+                int _val540;
+                for (int _i541 = 0; _i541 < _map538.size; ++_i541)
                 {
-                  _key519 = iprot.readString();
-                  _val520 = iprot.readI32();
-                  struct.num_executors.put(_key519, _val520);
+                  _key539 = iprot.readString();
+                  _val540 = iprot.readI32();
+                  struct.num_executors.put(_key539, _val540);
                 }
                 iprot.readMapEnd();
               }
@@ -574,10 +574,10 @@ public class RebalanceOptions implements org.apache.thrift.TBase<RebalanceOption
           oprot.writeFieldBegin(NUM_EXECUTORS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I32, struct.num_executors.size()));
-            for (Map.Entry<String, Integer> _iter522 : struct.num_executors.entrySet())
+            for (Map.Entry<String, Integer> _iter542 : struct.num_executors.entrySet())
             {
-              oprot.writeString(_iter522.getKey());
-              oprot.writeI32(_iter522.getValue());
+              oprot.writeString(_iter542.getKey());
+              oprot.writeI32(_iter542.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -621,10 +621,10 @@ public class RebalanceOptions implements org.apache.thrift.TBase<RebalanceOption
       if (struct.is_set_num_executors()) {
         {
           oprot.writeI32(struct.num_executors.size());
-          for (Map.Entry<String, Integer> _iter523 : struct.num_executors.entrySet())
+          for (Map.Entry<String, Integer> _iter543 : struct.num_executors.entrySet())
           {
-            oprot.writeString(_iter523.getKey());
-            oprot.writeI32(_iter523.getValue());
+            oprot.writeString(_iter543.getKey());
+            oprot.writeI32(_iter543.getValue());
           }
         }
       }
@@ -644,15 +644,15 @@ public class RebalanceOptions implements org.apache.thrift.TBase<RebalanceOption
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TMap _map524 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I32, iprot.readI32());
-          struct.num_executors = new HashMap<String,Integer>(2*_map524.size);
-          String _key525;
-          int _val526;
-          for (int _i527 = 0; _i527 < _map524.size; ++_i527)
+          org.apache.thrift.protocol.TMap _map544 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I32, iprot.readI32());
+          struct.num_executors = new HashMap<String,Integer>(2*_map544.size);
+          String _key545;
+          int _val546;
+          for (int _i547 = 0; _i547 < _map544.size; ++_i547)
           {
-            _key525 = iprot.readString();
-            _val526 = iprot.readI32();
-            struct.num_executors.put(_key525, _val526);
+            _key545 = iprot.readString();
+            _val546 = iprot.readI32();
+            struct.num_executors.put(_key545, _val546);
           }
         }
         struct.set_num_executors_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/SettableBlobMeta.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/SettableBlobMeta.java
@@ -452,14 +452,14 @@ public class SettableBlobMeta implements org.apache.thrift.TBase<SettableBlobMet
           case 1: // ACL
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list538 = iprot.readListBegin();
-                struct.acl = new ArrayList<AccessControl>(_list538.size);
-                AccessControl _elem539;
-                for (int _i540 = 0; _i540 < _list538.size; ++_i540)
+                org.apache.thrift.protocol.TList _list558 = iprot.readListBegin();
+                struct.acl = new ArrayList<AccessControl>(_list558.size);
+                AccessControl _elem559;
+                for (int _i560 = 0; _i560 < _list558.size; ++_i560)
                 {
-                  _elem539 = new AccessControl();
-                  _elem539.read(iprot);
-                  struct.acl.add(_elem539);
+                  _elem559 = new AccessControl();
+                  _elem559.read(iprot);
+                  struct.acl.add(_elem559);
                 }
                 iprot.readListEnd();
               }
@@ -493,9 +493,9 @@ public class SettableBlobMeta implements org.apache.thrift.TBase<SettableBlobMet
         oprot.writeFieldBegin(ACL_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.acl.size()));
-          for (AccessControl _iter541 : struct.acl)
+          for (AccessControl _iter561 : struct.acl)
           {
-            _iter541.write(oprot);
+            _iter561.write(oprot);
           }
           oprot.writeListEnd();
         }
@@ -525,9 +525,9 @@ public class SettableBlobMeta implements org.apache.thrift.TBase<SettableBlobMet
       TTupleProtocol oprot = (TTupleProtocol) prot;
       {
         oprot.writeI32(struct.acl.size());
-        for (AccessControl _iter542 : struct.acl)
+        for (AccessControl _iter562 : struct.acl)
         {
-          _iter542.write(oprot);
+          _iter562.write(oprot);
         }
       }
       BitSet optionals = new BitSet();
@@ -544,14 +544,14 @@ public class SettableBlobMeta implements org.apache.thrift.TBase<SettableBlobMet
     public void read(org.apache.thrift.protocol.TProtocol prot, SettableBlobMeta struct) throws org.apache.thrift.TException {
       TTupleProtocol iprot = (TTupleProtocol) prot;
       {
-        org.apache.thrift.protocol.TList _list543 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-        struct.acl = new ArrayList<AccessControl>(_list543.size);
-        AccessControl _elem544;
-        for (int _i545 = 0; _i545 < _list543.size; ++_i545)
+        org.apache.thrift.protocol.TList _list563 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+        struct.acl = new ArrayList<AccessControl>(_list563.size);
+        AccessControl _elem564;
+        for (int _i565 = 0; _i565 < _list563.size; ++_i565)
         {
-          _elem544 = new AccessControl();
-          _elem544.read(iprot);
-          struct.acl.add(_elem544);
+          _elem564 = new AccessControl();
+          _elem564.read(iprot);
+          struct.acl.add(_elem564);
         }
       }
       struct.set_acl_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/StormBase.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/StormBase.java
@@ -1090,15 +1090,15 @@ public class StormBase implements org.apache.thrift.TBase<StormBase, StormBase._
           case 4: // COMPONENT_EXECUTORS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map654 = iprot.readMapBegin();
-                struct.component_executors = new HashMap<String,Integer>(2*_map654.size);
-                String _key655;
-                int _val656;
-                for (int _i657 = 0; _i657 < _map654.size; ++_i657)
+                org.apache.thrift.protocol.TMap _map674 = iprot.readMapBegin();
+                struct.component_executors = new HashMap<String,Integer>(2*_map674.size);
+                String _key675;
+                int _val676;
+                for (int _i677 = 0; _i677 < _map674.size; ++_i677)
                 {
-                  _key655 = iprot.readString();
-                  _val656 = iprot.readI32();
-                  struct.component_executors.put(_key655, _val656);
+                  _key675 = iprot.readString();
+                  _val676 = iprot.readI32();
+                  struct.component_executors.put(_key675, _val676);
                 }
                 iprot.readMapEnd();
               }
@@ -1143,16 +1143,16 @@ public class StormBase implements org.apache.thrift.TBase<StormBase, StormBase._
           case 9: // COMPONENT_DEBUG
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map658 = iprot.readMapBegin();
-                struct.component_debug = new HashMap<String,DebugOptions>(2*_map658.size);
-                String _key659;
-                DebugOptions _val660;
-                for (int _i661 = 0; _i661 < _map658.size; ++_i661)
+                org.apache.thrift.protocol.TMap _map678 = iprot.readMapBegin();
+                struct.component_debug = new HashMap<String,DebugOptions>(2*_map678.size);
+                String _key679;
+                DebugOptions _val680;
+                for (int _i681 = 0; _i681 < _map678.size; ++_i681)
                 {
-                  _key659 = iprot.readString();
-                  _val660 = new DebugOptions();
-                  _val660.read(iprot);
-                  struct.component_debug.put(_key659, _val660);
+                  _key679 = iprot.readString();
+                  _val680 = new DebugOptions();
+                  _val680.read(iprot);
+                  struct.component_debug.put(_key679, _val680);
                 }
                 iprot.readMapEnd();
               }
@@ -1192,10 +1192,10 @@ public class StormBase implements org.apache.thrift.TBase<StormBase, StormBase._
           oprot.writeFieldBegin(COMPONENT_EXECUTORS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I32, struct.component_executors.size()));
-            for (Map.Entry<String, Integer> _iter662 : struct.component_executors.entrySet())
+            for (Map.Entry<String, Integer> _iter682 : struct.component_executors.entrySet())
             {
-              oprot.writeString(_iter662.getKey());
-              oprot.writeI32(_iter662.getValue());
+              oprot.writeString(_iter682.getKey());
+              oprot.writeI32(_iter682.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -1233,10 +1233,10 @@ public class StormBase implements org.apache.thrift.TBase<StormBase, StormBase._
           oprot.writeFieldBegin(COMPONENT_DEBUG_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, struct.component_debug.size()));
-            for (Map.Entry<String, DebugOptions> _iter663 : struct.component_debug.entrySet())
+            for (Map.Entry<String, DebugOptions> _iter683 : struct.component_debug.entrySet())
             {
-              oprot.writeString(_iter663.getKey());
-              _iter663.getValue().write(oprot);
+              oprot.writeString(_iter683.getKey());
+              _iter683.getValue().write(oprot);
             }
             oprot.writeMapEnd();
           }
@@ -1286,10 +1286,10 @@ public class StormBase implements org.apache.thrift.TBase<StormBase, StormBase._
       if (struct.is_set_component_executors()) {
         {
           oprot.writeI32(struct.component_executors.size());
-          for (Map.Entry<String, Integer> _iter664 : struct.component_executors.entrySet())
+          for (Map.Entry<String, Integer> _iter684 : struct.component_executors.entrySet())
           {
-            oprot.writeString(_iter664.getKey());
-            oprot.writeI32(_iter664.getValue());
+            oprot.writeString(_iter684.getKey());
+            oprot.writeI32(_iter684.getValue());
           }
         }
       }
@@ -1308,10 +1308,10 @@ public class StormBase implements org.apache.thrift.TBase<StormBase, StormBase._
       if (struct.is_set_component_debug()) {
         {
           oprot.writeI32(struct.component_debug.size());
-          for (Map.Entry<String, DebugOptions> _iter665 : struct.component_debug.entrySet())
+          for (Map.Entry<String, DebugOptions> _iter685 : struct.component_debug.entrySet())
           {
-            oprot.writeString(_iter665.getKey());
-            _iter665.getValue().write(oprot);
+            oprot.writeString(_iter685.getKey());
+            _iter685.getValue().write(oprot);
           }
         }
       }
@@ -1329,15 +1329,15 @@ public class StormBase implements org.apache.thrift.TBase<StormBase, StormBase._
       BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TMap _map666 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I32, iprot.readI32());
-          struct.component_executors = new HashMap<String,Integer>(2*_map666.size);
-          String _key667;
-          int _val668;
-          for (int _i669 = 0; _i669 < _map666.size; ++_i669)
+          org.apache.thrift.protocol.TMap _map686 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I32, iprot.readI32());
+          struct.component_executors = new HashMap<String,Integer>(2*_map686.size);
+          String _key687;
+          int _val688;
+          for (int _i689 = 0; _i689 < _map686.size; ++_i689)
           {
-            _key667 = iprot.readString();
-            _val668 = iprot.readI32();
-            struct.component_executors.put(_key667, _val668);
+            _key687 = iprot.readString();
+            _val688 = iprot.readI32();
+            struct.component_executors.put(_key687, _val688);
           }
         }
         struct.set_component_executors_isSet(true);
@@ -1361,16 +1361,16 @@ public class StormBase implements org.apache.thrift.TBase<StormBase, StormBase._
       }
       if (incoming.get(5)) {
         {
-          org.apache.thrift.protocol.TMap _map670 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.component_debug = new HashMap<String,DebugOptions>(2*_map670.size);
-          String _key671;
-          DebugOptions _val672;
-          for (int _i673 = 0; _i673 < _map670.size; ++_i673)
+          org.apache.thrift.protocol.TMap _map690 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.component_debug = new HashMap<String,DebugOptions>(2*_map690.size);
+          String _key691;
+          DebugOptions _val692;
+          for (int _i693 = 0; _i693 < _map690.size; ++_i693)
           {
-            _key671 = iprot.readString();
-            _val672 = new DebugOptions();
-            _val672.read(iprot);
-            struct.component_debug.put(_key671, _val672);
+            _key691 = iprot.readString();
+            _val692 = new DebugOptions();
+            _val692.read(iprot);
+            struct.component_debug.put(_key691, _val692);
           }
         }
         struct.set_component_debug_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/SupervisorInfo.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/SupervisorInfo.java
@@ -1085,13 +1085,13 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           case 4: // USED_PORTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list554 = iprot.readListBegin();
-                struct.used_ports = new ArrayList<Long>(_list554.size);
-                long _elem555;
-                for (int _i556 = 0; _i556 < _list554.size; ++_i556)
+                org.apache.thrift.protocol.TList _list574 = iprot.readListBegin();
+                struct.used_ports = new ArrayList<Long>(_list574.size);
+                long _elem575;
+                for (int _i576 = 0; _i576 < _list574.size; ++_i576)
                 {
-                  _elem555 = iprot.readI64();
-                  struct.used_ports.add(_elem555);
+                  _elem575 = iprot.readI64();
+                  struct.used_ports.add(_elem575);
                 }
                 iprot.readListEnd();
               }
@@ -1103,13 +1103,13 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           case 5: // META
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list557 = iprot.readListBegin();
-                struct.meta = new ArrayList<Long>(_list557.size);
-                long _elem558;
-                for (int _i559 = 0; _i559 < _list557.size; ++_i559)
+                org.apache.thrift.protocol.TList _list577 = iprot.readListBegin();
+                struct.meta = new ArrayList<Long>(_list577.size);
+                long _elem578;
+                for (int _i579 = 0; _i579 < _list577.size; ++_i579)
                 {
-                  _elem558 = iprot.readI64();
-                  struct.meta.add(_elem558);
+                  _elem578 = iprot.readI64();
+                  struct.meta.add(_elem578);
                 }
                 iprot.readListEnd();
               }
@@ -1121,15 +1121,15 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           case 6: // SCHEDULER_META
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map560 = iprot.readMapBegin();
-                struct.scheduler_meta = new HashMap<String,String>(2*_map560.size);
-                String _key561;
-                String _val562;
-                for (int _i563 = 0; _i563 < _map560.size; ++_i563)
+                org.apache.thrift.protocol.TMap _map580 = iprot.readMapBegin();
+                struct.scheduler_meta = new HashMap<String,String>(2*_map580.size);
+                String _key581;
+                String _val582;
+                for (int _i583 = 0; _i583 < _map580.size; ++_i583)
                 {
-                  _key561 = iprot.readString();
-                  _val562 = iprot.readString();
-                  struct.scheduler_meta.put(_key561, _val562);
+                  _key581 = iprot.readString();
+                  _val582 = iprot.readString();
+                  struct.scheduler_meta.put(_key581, _val582);
                 }
                 iprot.readMapEnd();
               }
@@ -1157,15 +1157,15 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           case 9: // RESOURCES_MAP
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map564 = iprot.readMapBegin();
-                struct.resources_map = new HashMap<String,Double>(2*_map564.size);
-                String _key565;
-                double _val566;
-                for (int _i567 = 0; _i567 < _map564.size; ++_i567)
+                org.apache.thrift.protocol.TMap _map584 = iprot.readMapBegin();
+                struct.resources_map = new HashMap<String,Double>(2*_map584.size);
+                String _key585;
+                double _val586;
+                for (int _i587 = 0; _i587 < _map584.size; ++_i587)
                 {
-                  _key565 = iprot.readString();
-                  _val566 = iprot.readDouble();
-                  struct.resources_map.put(_key565, _val566);
+                  _key585 = iprot.readString();
+                  _val586 = iprot.readDouble();
+                  struct.resources_map.put(_key585, _val586);
                 }
                 iprot.readMapEnd();
               }
@@ -1207,9 +1207,9 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           oprot.writeFieldBegin(USED_PORTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.used_ports.size()));
-            for (long _iter568 : struct.used_ports)
+            for (long _iter588 : struct.used_ports)
             {
-              oprot.writeI64(_iter568);
+              oprot.writeI64(_iter588);
             }
             oprot.writeListEnd();
           }
@@ -1221,9 +1221,9 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           oprot.writeFieldBegin(META_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.meta.size()));
-            for (long _iter569 : struct.meta)
+            for (long _iter589 : struct.meta)
             {
-              oprot.writeI64(_iter569);
+              oprot.writeI64(_iter589);
             }
             oprot.writeListEnd();
           }
@@ -1235,10 +1235,10 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           oprot.writeFieldBegin(SCHEDULER_META_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, struct.scheduler_meta.size()));
-            for (Map.Entry<String, String> _iter570 : struct.scheduler_meta.entrySet())
+            for (Map.Entry<String, String> _iter590 : struct.scheduler_meta.entrySet())
             {
-              oprot.writeString(_iter570.getKey());
-              oprot.writeString(_iter570.getValue());
+              oprot.writeString(_iter590.getKey());
+              oprot.writeString(_iter590.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -1262,10 +1262,10 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           oprot.writeFieldBegin(RESOURCES_MAP_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, struct.resources_map.size()));
-            for (Map.Entry<String, Double> _iter571 : struct.resources_map.entrySet())
+            for (Map.Entry<String, Double> _iter591 : struct.resources_map.entrySet())
             {
-              oprot.writeString(_iter571.getKey());
-              oprot.writeDouble(_iter571.getValue());
+              oprot.writeString(_iter591.getKey());
+              oprot.writeDouble(_iter591.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -1320,28 +1320,28 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       if (struct.is_set_used_ports()) {
         {
           oprot.writeI32(struct.used_ports.size());
-          for (long _iter572 : struct.used_ports)
+          for (long _iter592 : struct.used_ports)
           {
-            oprot.writeI64(_iter572);
+            oprot.writeI64(_iter592);
           }
         }
       }
       if (struct.is_set_meta()) {
         {
           oprot.writeI32(struct.meta.size());
-          for (long _iter573 : struct.meta)
+          for (long _iter593 : struct.meta)
           {
-            oprot.writeI64(_iter573);
+            oprot.writeI64(_iter593);
           }
         }
       }
       if (struct.is_set_scheduler_meta()) {
         {
           oprot.writeI32(struct.scheduler_meta.size());
-          for (Map.Entry<String, String> _iter574 : struct.scheduler_meta.entrySet())
+          for (Map.Entry<String, String> _iter594 : struct.scheduler_meta.entrySet())
           {
-            oprot.writeString(_iter574.getKey());
-            oprot.writeString(_iter574.getValue());
+            oprot.writeString(_iter594.getKey());
+            oprot.writeString(_iter594.getValue());
           }
         }
       }
@@ -1354,10 +1354,10 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       if (struct.is_set_resources_map()) {
         {
           oprot.writeI32(struct.resources_map.size());
-          for (Map.Entry<String, Double> _iter575 : struct.resources_map.entrySet())
+          for (Map.Entry<String, Double> _iter595 : struct.resources_map.entrySet())
           {
-            oprot.writeString(_iter575.getKey());
-            oprot.writeDouble(_iter575.getValue());
+            oprot.writeString(_iter595.getKey());
+            oprot.writeDouble(_iter595.getValue());
           }
         }
       }
@@ -1377,41 +1377,41 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list576 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-          struct.used_ports = new ArrayList<Long>(_list576.size);
-          long _elem577;
-          for (int _i578 = 0; _i578 < _list576.size; ++_i578)
+          org.apache.thrift.protocol.TList _list596 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+          struct.used_ports = new ArrayList<Long>(_list596.size);
+          long _elem597;
+          for (int _i598 = 0; _i598 < _list596.size; ++_i598)
           {
-            _elem577 = iprot.readI64();
-            struct.used_ports.add(_elem577);
+            _elem597 = iprot.readI64();
+            struct.used_ports.add(_elem597);
           }
         }
         struct.set_used_ports_isSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TList _list579 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-          struct.meta = new ArrayList<Long>(_list579.size);
-          long _elem580;
-          for (int _i581 = 0; _i581 < _list579.size; ++_i581)
+          org.apache.thrift.protocol.TList _list599 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+          struct.meta = new ArrayList<Long>(_list599.size);
+          long _elem600;
+          for (int _i601 = 0; _i601 < _list599.size; ++_i601)
           {
-            _elem580 = iprot.readI64();
-            struct.meta.add(_elem580);
+            _elem600 = iprot.readI64();
+            struct.meta.add(_elem600);
           }
         }
         struct.set_meta_isSet(true);
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TMap _map582 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-          struct.scheduler_meta = new HashMap<String,String>(2*_map582.size);
-          String _key583;
-          String _val584;
-          for (int _i585 = 0; _i585 < _map582.size; ++_i585)
+          org.apache.thrift.protocol.TMap _map602 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+          struct.scheduler_meta = new HashMap<String,String>(2*_map602.size);
+          String _key603;
+          String _val604;
+          for (int _i605 = 0; _i605 < _map602.size; ++_i605)
           {
-            _key583 = iprot.readString();
-            _val584 = iprot.readString();
-            struct.scheduler_meta.put(_key583, _val584);
+            _key603 = iprot.readString();
+            _val604 = iprot.readString();
+            struct.scheduler_meta.put(_key603, _val604);
           }
         }
         struct.set_scheduler_meta_isSet(true);
@@ -1426,15 +1426,15 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       }
       if (incoming.get(6)) {
         {
-          org.apache.thrift.protocol.TMap _map586 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, iprot.readI32());
-          struct.resources_map = new HashMap<String,Double>(2*_map586.size);
-          String _key587;
-          double _val588;
-          for (int _i589 = 0; _i589 < _map586.size; ++_i589)
+          org.apache.thrift.protocol.TMap _map606 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, iprot.readI32());
+          struct.resources_map = new HashMap<String,Double>(2*_map606.size);
+          String _key607;
+          double _val608;
+          for (int _i609 = 0; _i609 < _map606.size; ++_i609)
           {
-            _key587 = iprot.readString();
-            _val588 = iprot.readDouble();
-            struct.resources_map.put(_key587, _val588);
+            _key607 = iprot.readString();
+            _val608 = iprot.readDouble();
+            struct.resources_map.put(_key607, _val608);
           }
         }
         struct.set_resources_map_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/SupervisorPageInfo.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/SupervisorPageInfo.java
@@ -464,14 +464,14 @@ public class SupervisorPageInfo implements org.apache.thrift.TBase<SupervisorPag
           case 1: // SUPERVISOR_SUMMARIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list428 = iprot.readListBegin();
-                struct.supervisor_summaries = new ArrayList<SupervisorSummary>(_list428.size);
-                SupervisorSummary _elem429;
-                for (int _i430 = 0; _i430 < _list428.size; ++_i430)
+                org.apache.thrift.protocol.TList _list438 = iprot.readListBegin();
+                struct.supervisor_summaries = new ArrayList<SupervisorSummary>(_list438.size);
+                SupervisorSummary _elem439;
+                for (int _i440 = 0; _i440 < _list438.size; ++_i440)
                 {
-                  _elem429 = new SupervisorSummary();
-                  _elem429.read(iprot);
-                  struct.supervisor_summaries.add(_elem429);
+                  _elem439 = new SupervisorSummary();
+                  _elem439.read(iprot);
+                  struct.supervisor_summaries.add(_elem439);
                 }
                 iprot.readListEnd();
               }
@@ -483,14 +483,14 @@ public class SupervisorPageInfo implements org.apache.thrift.TBase<SupervisorPag
           case 2: // WORKER_SUMMARIES
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list431 = iprot.readListBegin();
-                struct.worker_summaries = new ArrayList<WorkerSummary>(_list431.size);
-                WorkerSummary _elem432;
-                for (int _i433 = 0; _i433 < _list431.size; ++_i433)
+                org.apache.thrift.protocol.TList _list441 = iprot.readListBegin();
+                struct.worker_summaries = new ArrayList<WorkerSummary>(_list441.size);
+                WorkerSummary _elem442;
+                for (int _i443 = 0; _i443 < _list441.size; ++_i443)
                 {
-                  _elem432 = new WorkerSummary();
-                  _elem432.read(iprot);
-                  struct.worker_summaries.add(_elem432);
+                  _elem442 = new WorkerSummary();
+                  _elem442.read(iprot);
+                  struct.worker_summaries.add(_elem442);
                 }
                 iprot.readListEnd();
               }
@@ -517,9 +517,9 @@ public class SupervisorPageInfo implements org.apache.thrift.TBase<SupervisorPag
           oprot.writeFieldBegin(SUPERVISOR_SUMMARIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.supervisor_summaries.size()));
-            for (SupervisorSummary _iter434 : struct.supervisor_summaries)
+            for (SupervisorSummary _iter444 : struct.supervisor_summaries)
             {
-              _iter434.write(oprot);
+              _iter444.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -531,9 +531,9 @@ public class SupervisorPageInfo implements org.apache.thrift.TBase<SupervisorPag
           oprot.writeFieldBegin(WORKER_SUMMARIES_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.worker_summaries.size()));
-            for (WorkerSummary _iter435 : struct.worker_summaries)
+            for (WorkerSummary _iter445 : struct.worker_summaries)
             {
-              _iter435.write(oprot);
+              _iter445.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -568,18 +568,18 @@ public class SupervisorPageInfo implements org.apache.thrift.TBase<SupervisorPag
       if (struct.is_set_supervisor_summaries()) {
         {
           oprot.writeI32(struct.supervisor_summaries.size());
-          for (SupervisorSummary _iter436 : struct.supervisor_summaries)
+          for (SupervisorSummary _iter446 : struct.supervisor_summaries)
           {
-            _iter436.write(oprot);
+            _iter446.write(oprot);
           }
         }
       }
       if (struct.is_set_worker_summaries()) {
         {
           oprot.writeI32(struct.worker_summaries.size());
-          for (WorkerSummary _iter437 : struct.worker_summaries)
+          for (WorkerSummary _iter447 : struct.worker_summaries)
           {
-            _iter437.write(oprot);
+            _iter447.write(oprot);
           }
         }
       }
@@ -591,28 +591,28 @@ public class SupervisorPageInfo implements org.apache.thrift.TBase<SupervisorPag
       BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list438 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.supervisor_summaries = new ArrayList<SupervisorSummary>(_list438.size);
-          SupervisorSummary _elem439;
-          for (int _i440 = 0; _i440 < _list438.size; ++_i440)
+          org.apache.thrift.protocol.TList _list448 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.supervisor_summaries = new ArrayList<SupervisorSummary>(_list448.size);
+          SupervisorSummary _elem449;
+          for (int _i450 = 0; _i450 < _list448.size; ++_i450)
           {
-            _elem439 = new SupervisorSummary();
-            _elem439.read(iprot);
-            struct.supervisor_summaries.add(_elem439);
+            _elem449 = new SupervisorSummary();
+            _elem449.read(iprot);
+            struct.supervisor_summaries.add(_elem449);
           }
         }
         struct.set_supervisor_summaries_isSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TList _list441 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.worker_summaries = new ArrayList<WorkerSummary>(_list441.size);
-          WorkerSummary _elem442;
-          for (int _i443 = 0; _i443 < _list441.size; ++_i443)
+          org.apache.thrift.protocol.TList _list451 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.worker_summaries = new ArrayList<WorkerSummary>(_list451.size);
+          WorkerSummary _elem452;
+          for (int _i453 = 0; _i453 < _list451.size; ++_i453)
           {
-            _elem442 = new WorkerSummary();
-            _elem442.read(iprot);
-            struct.worker_summaries.add(_elem442);
+            _elem452 = new WorkerSummary();
+            _elem452.read(iprot);
+            struct.worker_summaries.add(_elem452);
           }
         }
         struct.set_worker_summaries_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/TopologyHistoryInfo.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/TopologyHistoryInfo.java
@@ -364,13 +364,13 @@ public class TopologyHistoryInfo implements org.apache.thrift.TBase<TopologyHist
           case 1: // TOPO_IDS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list764 = iprot.readListBegin();
-                struct.topo_ids = new ArrayList<String>(_list764.size);
-                String _elem765;
-                for (int _i766 = 0; _i766 < _list764.size; ++_i766)
+                org.apache.thrift.protocol.TList _list784 = iprot.readListBegin();
+                struct.topo_ids = new ArrayList<String>(_list784.size);
+                String _elem785;
+                for (int _i786 = 0; _i786 < _list784.size; ++_i786)
                 {
-                  _elem765 = iprot.readString();
-                  struct.topo_ids.add(_elem765);
+                  _elem785 = iprot.readString();
+                  struct.topo_ids.add(_elem785);
                 }
                 iprot.readListEnd();
               }
@@ -396,9 +396,9 @@ public class TopologyHistoryInfo implements org.apache.thrift.TBase<TopologyHist
         oprot.writeFieldBegin(TOPO_IDS_FIELD_DESC);
         {
           oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.topo_ids.size()));
-          for (String _iter767 : struct.topo_ids)
+          for (String _iter787 : struct.topo_ids)
           {
-            oprot.writeString(_iter767);
+            oprot.writeString(_iter787);
           }
           oprot.writeListEnd();
         }
@@ -429,9 +429,9 @@ public class TopologyHistoryInfo implements org.apache.thrift.TBase<TopologyHist
       if (struct.is_set_topo_ids()) {
         {
           oprot.writeI32(struct.topo_ids.size());
-          for (String _iter768 : struct.topo_ids)
+          for (String _iter788 : struct.topo_ids)
           {
-            oprot.writeString(_iter768);
+            oprot.writeString(_iter788);
           }
         }
       }
@@ -443,13 +443,13 @@ public class TopologyHistoryInfo implements org.apache.thrift.TBase<TopologyHist
       BitSet incoming = iprot.readBitSet(1);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TList _list769 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-          struct.topo_ids = new ArrayList<String>(_list769.size);
-          String _elem770;
-          for (int _i771 = 0; _i771 < _list769.size; ++_i771)
+          org.apache.thrift.protocol.TList _list789 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+          struct.topo_ids = new ArrayList<String>(_list789.size);
+          String _elem790;
+          for (int _i791 = 0; _i791 < _list789.size; ++_i791)
           {
-            _elem770 = iprot.readString();
-            struct.topo_ids.add(_elem770);
+            _elem790 = iprot.readString();
+            struct.topo_ids.add(_elem790);
           }
         }
         struct.set_topo_ids_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/TopologyPageInfo.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/TopologyPageInfo.java
@@ -2142,16 +2142,16 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
           case 9: // ID_TO_SPOUT_AGG_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map444 = iprot.readMapBegin();
-                struct.id_to_spout_agg_stats = new HashMap<String,ComponentAggregateStats>(2*_map444.size);
-                String _key445;
-                ComponentAggregateStats _val446;
-                for (int _i447 = 0; _i447 < _map444.size; ++_i447)
+                org.apache.thrift.protocol.TMap _map454 = iprot.readMapBegin();
+                struct.id_to_spout_agg_stats = new HashMap<String,ComponentAggregateStats>(2*_map454.size);
+                String _key455;
+                ComponentAggregateStats _val456;
+                for (int _i457 = 0; _i457 < _map454.size; ++_i457)
                 {
-                  _key445 = iprot.readString();
-                  _val446 = new ComponentAggregateStats();
-                  _val446.read(iprot);
-                  struct.id_to_spout_agg_stats.put(_key445, _val446);
+                  _key455 = iprot.readString();
+                  _val456 = new ComponentAggregateStats();
+                  _val456.read(iprot);
+                  struct.id_to_spout_agg_stats.put(_key455, _val456);
                 }
                 iprot.readMapEnd();
               }
@@ -2163,16 +2163,16 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
           case 10: // ID_TO_BOLT_AGG_STATS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map448 = iprot.readMapBegin();
-                struct.id_to_bolt_agg_stats = new HashMap<String,ComponentAggregateStats>(2*_map448.size);
-                String _key449;
-                ComponentAggregateStats _val450;
-                for (int _i451 = 0; _i451 < _map448.size; ++_i451)
+                org.apache.thrift.protocol.TMap _map458 = iprot.readMapBegin();
+                struct.id_to_bolt_agg_stats = new HashMap<String,ComponentAggregateStats>(2*_map458.size);
+                String _key459;
+                ComponentAggregateStats _val460;
+                for (int _i461 = 0; _i461 < _map458.size; ++_i461)
                 {
-                  _key449 = iprot.readString();
-                  _val450 = new ComponentAggregateStats();
-                  _val450.read(iprot);
-                  struct.id_to_bolt_agg_stats.put(_key449, _val450);
+                  _key459 = iprot.readString();
+                  _val460 = new ComponentAggregateStats();
+                  _val460.read(iprot);
+                  struct.id_to_bolt_agg_stats.put(_key459, _val460);
                 }
                 iprot.readMapEnd();
               }
@@ -2226,14 +2226,14 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
           case 16: // WORKERS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
-                org.apache.thrift.protocol.TList _list452 = iprot.readListBegin();
-                struct.workers = new ArrayList<WorkerSummary>(_list452.size);
-                WorkerSummary _elem453;
-                for (int _i454 = 0; _i454 < _list452.size; ++_i454)
+                org.apache.thrift.protocol.TList _list462 = iprot.readListBegin();
+                struct.workers = new ArrayList<WorkerSummary>(_list462.size);
+                WorkerSummary _elem463;
+                for (int _i464 = 0; _i464 < _list462.size; ++_i464)
                 {
-                  _elem453 = new WorkerSummary();
-                  _elem453.read(iprot);
-                  struct.workers.add(_elem453);
+                  _elem463 = new WorkerSummary();
+                  _elem463.read(iprot);
+                  struct.workers.add(_elem463);
                 }
                 iprot.readListEnd();
               }
@@ -2354,10 +2354,10 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
           oprot.writeFieldBegin(ID_TO_SPOUT_AGG_STATS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, struct.id_to_spout_agg_stats.size()));
-            for (Map.Entry<String, ComponentAggregateStats> _iter455 : struct.id_to_spout_agg_stats.entrySet())
+            for (Map.Entry<String, ComponentAggregateStats> _iter465 : struct.id_to_spout_agg_stats.entrySet())
             {
-              oprot.writeString(_iter455.getKey());
-              _iter455.getValue().write(oprot);
+              oprot.writeString(_iter465.getKey());
+              _iter465.getValue().write(oprot);
             }
             oprot.writeMapEnd();
           }
@@ -2369,10 +2369,10 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
           oprot.writeFieldBegin(ID_TO_BOLT_AGG_STATS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, struct.id_to_bolt_agg_stats.size()));
-            for (Map.Entry<String, ComponentAggregateStats> _iter456 : struct.id_to_bolt_agg_stats.entrySet())
+            for (Map.Entry<String, ComponentAggregateStats> _iter466 : struct.id_to_bolt_agg_stats.entrySet())
             {
-              oprot.writeString(_iter456.getKey());
-              _iter456.getValue().write(oprot);
+              oprot.writeString(_iter466.getKey());
+              _iter466.getValue().write(oprot);
             }
             oprot.writeMapEnd();
           }
@@ -2417,9 +2417,9 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
           oprot.writeFieldBegin(WORKERS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.workers.size()));
-            for (WorkerSummary _iter457 : struct.workers)
+            for (WorkerSummary _iter467 : struct.workers)
             {
-              _iter457.write(oprot);
+              _iter467.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -2563,20 +2563,20 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
       if (struct.is_set_id_to_spout_agg_stats()) {
         {
           oprot.writeI32(struct.id_to_spout_agg_stats.size());
-          for (Map.Entry<String, ComponentAggregateStats> _iter458 : struct.id_to_spout_agg_stats.entrySet())
+          for (Map.Entry<String, ComponentAggregateStats> _iter468 : struct.id_to_spout_agg_stats.entrySet())
           {
-            oprot.writeString(_iter458.getKey());
-            _iter458.getValue().write(oprot);
+            oprot.writeString(_iter468.getKey());
+            _iter468.getValue().write(oprot);
           }
         }
       }
       if (struct.is_set_id_to_bolt_agg_stats()) {
         {
           oprot.writeI32(struct.id_to_bolt_agg_stats.size());
-          for (Map.Entry<String, ComponentAggregateStats> _iter459 : struct.id_to_bolt_agg_stats.entrySet())
+          for (Map.Entry<String, ComponentAggregateStats> _iter469 : struct.id_to_bolt_agg_stats.entrySet())
           {
-            oprot.writeString(_iter459.getKey());
-            _iter459.getValue().write(oprot);
+            oprot.writeString(_iter469.getKey());
+            _iter469.getValue().write(oprot);
           }
         }
       }
@@ -2598,9 +2598,9 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
       if (struct.is_set_workers()) {
         {
           oprot.writeI32(struct.workers.size());
-          for (WorkerSummary _iter460 : struct.workers)
+          for (WorkerSummary _iter470 : struct.workers)
           {
-            _iter460.write(oprot);
+            _iter470.write(oprot);
           }
         }
       }
@@ -2660,32 +2660,32 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
       }
       if (incoming.get(7)) {
         {
-          org.apache.thrift.protocol.TMap _map461 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.id_to_spout_agg_stats = new HashMap<String,ComponentAggregateStats>(2*_map461.size);
-          String _key462;
-          ComponentAggregateStats _val463;
-          for (int _i464 = 0; _i464 < _map461.size; ++_i464)
+          org.apache.thrift.protocol.TMap _map471 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.id_to_spout_agg_stats = new HashMap<String,ComponentAggregateStats>(2*_map471.size);
+          String _key472;
+          ComponentAggregateStats _val473;
+          for (int _i474 = 0; _i474 < _map471.size; ++_i474)
           {
-            _key462 = iprot.readString();
-            _val463 = new ComponentAggregateStats();
-            _val463.read(iprot);
-            struct.id_to_spout_agg_stats.put(_key462, _val463);
+            _key472 = iprot.readString();
+            _val473 = new ComponentAggregateStats();
+            _val473.read(iprot);
+            struct.id_to_spout_agg_stats.put(_key472, _val473);
           }
         }
         struct.set_id_to_spout_agg_stats_isSet(true);
       }
       if (incoming.get(8)) {
         {
-          org.apache.thrift.protocol.TMap _map465 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.id_to_bolt_agg_stats = new HashMap<String,ComponentAggregateStats>(2*_map465.size);
-          String _key466;
-          ComponentAggregateStats _val467;
-          for (int _i468 = 0; _i468 < _map465.size; ++_i468)
+          org.apache.thrift.protocol.TMap _map475 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.id_to_bolt_agg_stats = new HashMap<String,ComponentAggregateStats>(2*_map475.size);
+          String _key476;
+          ComponentAggregateStats _val477;
+          for (int _i478 = 0; _i478 < _map475.size; ++_i478)
           {
-            _key466 = iprot.readString();
-            _val467 = new ComponentAggregateStats();
-            _val467.read(iprot);
-            struct.id_to_bolt_agg_stats.put(_key466, _val467);
+            _key476 = iprot.readString();
+            _val477 = new ComponentAggregateStats();
+            _val477.read(iprot);
+            struct.id_to_bolt_agg_stats.put(_key476, _val477);
           }
         }
         struct.set_id_to_bolt_agg_stats_isSet(true);
@@ -2714,14 +2714,14 @@ public class TopologyPageInfo implements org.apache.thrift.TBase<TopologyPageInf
       }
       if (incoming.get(14)) {
         {
-          org.apache.thrift.protocol.TList _list469 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-          struct.workers = new ArrayList<WorkerSummary>(_list469.size);
-          WorkerSummary _elem470;
-          for (int _i471 = 0; _i471 < _list469.size; ++_i471)
+          org.apache.thrift.protocol.TList _list479 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+          struct.workers = new ArrayList<WorkerSummary>(_list479.size);
+          WorkerSummary _elem480;
+          for (int _i481 = 0; _i481 < _list479.size; ++_i481)
           {
-            _elem470 = new WorkerSummary();
-            _elem470.read(iprot);
-            struct.workers.add(_elem470);
+            _elem480 = new WorkerSummary();
+            _elem480.read(iprot);
+            struct.workers.add(_elem480);
           }
         }
         struct.set_workers_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/TopologyStats.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/TopologyStats.java
@@ -737,15 +737,15 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           case 1: // WINDOW_TO_EMITTED
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map368 = iprot.readMapBegin();
-                struct.window_to_emitted = new HashMap<String,Long>(2*_map368.size);
-                String _key369;
-                long _val370;
-                for (int _i371 = 0; _i371 < _map368.size; ++_i371)
+                org.apache.thrift.protocol.TMap _map378 = iprot.readMapBegin();
+                struct.window_to_emitted = new HashMap<String,Long>(2*_map378.size);
+                String _key379;
+                long _val380;
+                for (int _i381 = 0; _i381 < _map378.size; ++_i381)
                 {
-                  _key369 = iprot.readString();
-                  _val370 = iprot.readI64();
-                  struct.window_to_emitted.put(_key369, _val370);
+                  _key379 = iprot.readString();
+                  _val380 = iprot.readI64();
+                  struct.window_to_emitted.put(_key379, _val380);
                 }
                 iprot.readMapEnd();
               }
@@ -757,15 +757,15 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           case 2: // WINDOW_TO_TRANSFERRED
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map372 = iprot.readMapBegin();
-                struct.window_to_transferred = new HashMap<String,Long>(2*_map372.size);
-                String _key373;
-                long _val374;
-                for (int _i375 = 0; _i375 < _map372.size; ++_i375)
+                org.apache.thrift.protocol.TMap _map382 = iprot.readMapBegin();
+                struct.window_to_transferred = new HashMap<String,Long>(2*_map382.size);
+                String _key383;
+                long _val384;
+                for (int _i385 = 0; _i385 < _map382.size; ++_i385)
                 {
-                  _key373 = iprot.readString();
-                  _val374 = iprot.readI64();
-                  struct.window_to_transferred.put(_key373, _val374);
+                  _key383 = iprot.readString();
+                  _val384 = iprot.readI64();
+                  struct.window_to_transferred.put(_key383, _val384);
                 }
                 iprot.readMapEnd();
               }
@@ -777,15 +777,15 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           case 3: // WINDOW_TO_COMPLETE_LATENCIES_MS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map376 = iprot.readMapBegin();
-                struct.window_to_complete_latencies_ms = new HashMap<String,Double>(2*_map376.size);
-                String _key377;
-                double _val378;
-                for (int _i379 = 0; _i379 < _map376.size; ++_i379)
+                org.apache.thrift.protocol.TMap _map386 = iprot.readMapBegin();
+                struct.window_to_complete_latencies_ms = new HashMap<String,Double>(2*_map386.size);
+                String _key387;
+                double _val388;
+                for (int _i389 = 0; _i389 < _map386.size; ++_i389)
                 {
-                  _key377 = iprot.readString();
-                  _val378 = iprot.readDouble();
-                  struct.window_to_complete_latencies_ms.put(_key377, _val378);
+                  _key387 = iprot.readString();
+                  _val388 = iprot.readDouble();
+                  struct.window_to_complete_latencies_ms.put(_key387, _val388);
                 }
                 iprot.readMapEnd();
               }
@@ -797,15 +797,15 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           case 4: // WINDOW_TO_ACKED
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map380 = iprot.readMapBegin();
-                struct.window_to_acked = new HashMap<String,Long>(2*_map380.size);
-                String _key381;
-                long _val382;
-                for (int _i383 = 0; _i383 < _map380.size; ++_i383)
+                org.apache.thrift.protocol.TMap _map390 = iprot.readMapBegin();
+                struct.window_to_acked = new HashMap<String,Long>(2*_map390.size);
+                String _key391;
+                long _val392;
+                for (int _i393 = 0; _i393 < _map390.size; ++_i393)
                 {
-                  _key381 = iprot.readString();
-                  _val382 = iprot.readI64();
-                  struct.window_to_acked.put(_key381, _val382);
+                  _key391 = iprot.readString();
+                  _val392 = iprot.readI64();
+                  struct.window_to_acked.put(_key391, _val392);
                 }
                 iprot.readMapEnd();
               }
@@ -817,15 +817,15 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           case 5: // WINDOW_TO_FAILED
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map384 = iprot.readMapBegin();
-                struct.window_to_failed = new HashMap<String,Long>(2*_map384.size);
-                String _key385;
-                long _val386;
-                for (int _i387 = 0; _i387 < _map384.size; ++_i387)
+                org.apache.thrift.protocol.TMap _map394 = iprot.readMapBegin();
+                struct.window_to_failed = new HashMap<String,Long>(2*_map394.size);
+                String _key395;
+                long _val396;
+                for (int _i397 = 0; _i397 < _map394.size; ++_i397)
                 {
-                  _key385 = iprot.readString();
-                  _val386 = iprot.readI64();
-                  struct.window_to_failed.put(_key385, _val386);
+                  _key395 = iprot.readString();
+                  _val396 = iprot.readI64();
+                  struct.window_to_failed.put(_key395, _val396);
                 }
                 iprot.readMapEnd();
               }
@@ -852,10 +852,10 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           oprot.writeFieldBegin(WINDOW_TO_EMITTED_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, struct.window_to_emitted.size()));
-            for (Map.Entry<String, Long> _iter388 : struct.window_to_emitted.entrySet())
+            for (Map.Entry<String, Long> _iter398 : struct.window_to_emitted.entrySet())
             {
-              oprot.writeString(_iter388.getKey());
-              oprot.writeI64(_iter388.getValue());
+              oprot.writeString(_iter398.getKey());
+              oprot.writeI64(_iter398.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -867,10 +867,10 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           oprot.writeFieldBegin(WINDOW_TO_TRANSFERRED_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, struct.window_to_transferred.size()));
-            for (Map.Entry<String, Long> _iter389 : struct.window_to_transferred.entrySet())
+            for (Map.Entry<String, Long> _iter399 : struct.window_to_transferred.entrySet())
             {
-              oprot.writeString(_iter389.getKey());
-              oprot.writeI64(_iter389.getValue());
+              oprot.writeString(_iter399.getKey());
+              oprot.writeI64(_iter399.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -882,10 +882,10 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           oprot.writeFieldBegin(WINDOW_TO_COMPLETE_LATENCIES_MS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, struct.window_to_complete_latencies_ms.size()));
-            for (Map.Entry<String, Double> _iter390 : struct.window_to_complete_latencies_ms.entrySet())
+            for (Map.Entry<String, Double> _iter400 : struct.window_to_complete_latencies_ms.entrySet())
             {
-              oprot.writeString(_iter390.getKey());
-              oprot.writeDouble(_iter390.getValue());
+              oprot.writeString(_iter400.getKey());
+              oprot.writeDouble(_iter400.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -897,10 +897,10 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           oprot.writeFieldBegin(WINDOW_TO_ACKED_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, struct.window_to_acked.size()));
-            for (Map.Entry<String, Long> _iter391 : struct.window_to_acked.entrySet())
+            for (Map.Entry<String, Long> _iter401 : struct.window_to_acked.entrySet())
             {
-              oprot.writeString(_iter391.getKey());
-              oprot.writeI64(_iter391.getValue());
+              oprot.writeString(_iter401.getKey());
+              oprot.writeI64(_iter401.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -912,10 +912,10 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
           oprot.writeFieldBegin(WINDOW_TO_FAILED_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, struct.window_to_failed.size()));
-            for (Map.Entry<String, Long> _iter392 : struct.window_to_failed.entrySet())
+            for (Map.Entry<String, Long> _iter402 : struct.window_to_failed.entrySet())
             {
-              oprot.writeString(_iter392.getKey());
-              oprot.writeI64(_iter392.getValue());
+              oprot.writeString(_iter402.getKey());
+              oprot.writeI64(_iter402.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -959,50 +959,50 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
       if (struct.is_set_window_to_emitted()) {
         {
           oprot.writeI32(struct.window_to_emitted.size());
-          for (Map.Entry<String, Long> _iter393 : struct.window_to_emitted.entrySet())
+          for (Map.Entry<String, Long> _iter403 : struct.window_to_emitted.entrySet())
           {
-            oprot.writeString(_iter393.getKey());
-            oprot.writeI64(_iter393.getValue());
+            oprot.writeString(_iter403.getKey());
+            oprot.writeI64(_iter403.getValue());
           }
         }
       }
       if (struct.is_set_window_to_transferred()) {
         {
           oprot.writeI32(struct.window_to_transferred.size());
-          for (Map.Entry<String, Long> _iter394 : struct.window_to_transferred.entrySet())
+          for (Map.Entry<String, Long> _iter404 : struct.window_to_transferred.entrySet())
           {
-            oprot.writeString(_iter394.getKey());
-            oprot.writeI64(_iter394.getValue());
+            oprot.writeString(_iter404.getKey());
+            oprot.writeI64(_iter404.getValue());
           }
         }
       }
       if (struct.is_set_window_to_complete_latencies_ms()) {
         {
           oprot.writeI32(struct.window_to_complete_latencies_ms.size());
-          for (Map.Entry<String, Double> _iter395 : struct.window_to_complete_latencies_ms.entrySet())
+          for (Map.Entry<String, Double> _iter405 : struct.window_to_complete_latencies_ms.entrySet())
           {
-            oprot.writeString(_iter395.getKey());
-            oprot.writeDouble(_iter395.getValue());
+            oprot.writeString(_iter405.getKey());
+            oprot.writeDouble(_iter405.getValue());
           }
         }
       }
       if (struct.is_set_window_to_acked()) {
         {
           oprot.writeI32(struct.window_to_acked.size());
-          for (Map.Entry<String, Long> _iter396 : struct.window_to_acked.entrySet())
+          for (Map.Entry<String, Long> _iter406 : struct.window_to_acked.entrySet())
           {
-            oprot.writeString(_iter396.getKey());
-            oprot.writeI64(_iter396.getValue());
+            oprot.writeString(_iter406.getKey());
+            oprot.writeI64(_iter406.getValue());
           }
         }
       }
       if (struct.is_set_window_to_failed()) {
         {
           oprot.writeI32(struct.window_to_failed.size());
-          for (Map.Entry<String, Long> _iter397 : struct.window_to_failed.entrySet())
+          for (Map.Entry<String, Long> _iter407 : struct.window_to_failed.entrySet())
           {
-            oprot.writeString(_iter397.getKey());
-            oprot.writeI64(_iter397.getValue());
+            oprot.writeString(_iter407.getKey());
+            oprot.writeI64(_iter407.getValue());
           }
         }
       }
@@ -1014,75 +1014,75 @@ public class TopologyStats implements org.apache.thrift.TBase<TopologyStats, Top
       BitSet incoming = iprot.readBitSet(5);
       if (incoming.get(0)) {
         {
-          org.apache.thrift.protocol.TMap _map398 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
-          struct.window_to_emitted = new HashMap<String,Long>(2*_map398.size);
-          String _key399;
-          long _val400;
-          for (int _i401 = 0; _i401 < _map398.size; ++_i401)
+          org.apache.thrift.protocol.TMap _map408 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
+          struct.window_to_emitted = new HashMap<String,Long>(2*_map408.size);
+          String _key409;
+          long _val410;
+          for (int _i411 = 0; _i411 < _map408.size; ++_i411)
           {
-            _key399 = iprot.readString();
-            _val400 = iprot.readI64();
-            struct.window_to_emitted.put(_key399, _val400);
+            _key409 = iprot.readString();
+            _val410 = iprot.readI64();
+            struct.window_to_emitted.put(_key409, _val410);
           }
         }
         struct.set_window_to_emitted_isSet(true);
       }
       if (incoming.get(1)) {
         {
-          org.apache.thrift.protocol.TMap _map402 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
-          struct.window_to_transferred = new HashMap<String,Long>(2*_map402.size);
-          String _key403;
-          long _val404;
-          for (int _i405 = 0; _i405 < _map402.size; ++_i405)
+          org.apache.thrift.protocol.TMap _map412 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
+          struct.window_to_transferred = new HashMap<String,Long>(2*_map412.size);
+          String _key413;
+          long _val414;
+          for (int _i415 = 0; _i415 < _map412.size; ++_i415)
           {
-            _key403 = iprot.readString();
-            _val404 = iprot.readI64();
-            struct.window_to_transferred.put(_key403, _val404);
+            _key413 = iprot.readString();
+            _val414 = iprot.readI64();
+            struct.window_to_transferred.put(_key413, _val414);
           }
         }
         struct.set_window_to_transferred_isSet(true);
       }
       if (incoming.get(2)) {
         {
-          org.apache.thrift.protocol.TMap _map406 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, iprot.readI32());
-          struct.window_to_complete_latencies_ms = new HashMap<String,Double>(2*_map406.size);
-          String _key407;
-          double _val408;
-          for (int _i409 = 0; _i409 < _map406.size; ++_i409)
+          org.apache.thrift.protocol.TMap _map416 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, iprot.readI32());
+          struct.window_to_complete_latencies_ms = new HashMap<String,Double>(2*_map416.size);
+          String _key417;
+          double _val418;
+          for (int _i419 = 0; _i419 < _map416.size; ++_i419)
           {
-            _key407 = iprot.readString();
-            _val408 = iprot.readDouble();
-            struct.window_to_complete_latencies_ms.put(_key407, _val408);
+            _key417 = iprot.readString();
+            _val418 = iprot.readDouble();
+            struct.window_to_complete_latencies_ms.put(_key417, _val418);
           }
         }
         struct.set_window_to_complete_latencies_ms_isSet(true);
       }
       if (incoming.get(3)) {
         {
-          org.apache.thrift.protocol.TMap _map410 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
-          struct.window_to_acked = new HashMap<String,Long>(2*_map410.size);
-          String _key411;
-          long _val412;
-          for (int _i413 = 0; _i413 < _map410.size; ++_i413)
+          org.apache.thrift.protocol.TMap _map420 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
+          struct.window_to_acked = new HashMap<String,Long>(2*_map420.size);
+          String _key421;
+          long _val422;
+          for (int _i423 = 0; _i423 < _map420.size; ++_i423)
           {
-            _key411 = iprot.readString();
-            _val412 = iprot.readI64();
-            struct.window_to_acked.put(_key411, _val412);
+            _key421 = iprot.readString();
+            _val422 = iprot.readI64();
+            struct.window_to_acked.put(_key421, _val422);
           }
         }
         struct.set_window_to_acked_isSet(true);
       }
       if (incoming.get(4)) {
         {
-          org.apache.thrift.protocol.TMap _map414 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
-          struct.window_to_failed = new HashMap<String,Long>(2*_map414.size);
-          String _key415;
-          long _val416;
-          for (int _i417 = 0; _i417 < _map414.size; ++_i417)
+          org.apache.thrift.protocol.TMap _map424 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
+          struct.window_to_failed = new HashMap<String,Long>(2*_map424.size);
+          String _key425;
+          long _val426;
+          for (int _i427 = 0; _i427 < _map424.size; ++_i427)
           {
-            _key415 = iprot.readString();
-            _val416 = iprot.readI64();
-            struct.window_to_failed.put(_key415, _val416);
+            _key425 = iprot.readString();
+            _val426 = iprot.readI64();
+            struct.window_to_failed.put(_key425, _val426);
           }
         }
         struct.set_window_to_failed_isSet(true);

--- a/storm-core/src/jvm/org/apache/storm/generated/WorkerSummary.java
+++ b/storm-core/src/jvm/org/apache/storm/generated/WorkerSummary.java
@@ -1493,15 +1493,15 @@ public class WorkerSummary implements org.apache.thrift.TBase<WorkerSummary, Wor
           case 7: // COMPONENT_TO_NUM_TASKS
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
-                org.apache.thrift.protocol.TMap _map418 = iprot.readMapBegin();
-                struct.component_to_num_tasks = new HashMap<String,Long>(2*_map418.size);
-                String _key419;
-                long _val420;
-                for (int _i421 = 0; _i421 < _map418.size; ++_i421)
+                org.apache.thrift.protocol.TMap _map428 = iprot.readMapBegin();
+                struct.component_to_num_tasks = new HashMap<String,Long>(2*_map428.size);
+                String _key429;
+                long _val430;
+                for (int _i431 = 0; _i431 < _map428.size; ++_i431)
                 {
-                  _key419 = iprot.readString();
-                  _val420 = iprot.readI64();
-                  struct.component_to_num_tasks.put(_key419, _val420);
+                  _key429 = iprot.readString();
+                  _val430 = iprot.readI64();
+                  struct.component_to_num_tasks.put(_key429, _val430);
                 }
                 iprot.readMapEnd();
               }
@@ -1630,10 +1630,10 @@ public class WorkerSummary implements org.apache.thrift.TBase<WorkerSummary, Wor
           oprot.writeFieldBegin(COMPONENT_TO_NUM_TASKS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, struct.component_to_num_tasks.size()));
-            for (Map.Entry<String, Long> _iter422 : struct.component_to_num_tasks.entrySet())
+            for (Map.Entry<String, Long> _iter432 : struct.component_to_num_tasks.entrySet())
             {
-              oprot.writeString(_iter422.getKey());
-              oprot.writeI64(_iter422.getValue());
+              oprot.writeString(_iter432.getKey());
+              oprot.writeI64(_iter432.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -1765,10 +1765,10 @@ public class WorkerSummary implements org.apache.thrift.TBase<WorkerSummary, Wor
       if (struct.is_set_component_to_num_tasks()) {
         {
           oprot.writeI32(struct.component_to_num_tasks.size());
-          for (Map.Entry<String, Long> _iter423 : struct.component_to_num_tasks.entrySet())
+          for (Map.Entry<String, Long> _iter433 : struct.component_to_num_tasks.entrySet())
           {
-            oprot.writeString(_iter423.getKey());
-            oprot.writeI64(_iter423.getValue());
+            oprot.writeString(_iter433.getKey());
+            oprot.writeI64(_iter433.getValue());
           }
         }
       }
@@ -1828,15 +1828,15 @@ public class WorkerSummary implements org.apache.thrift.TBase<WorkerSummary, Wor
       }
       if (incoming.get(6)) {
         {
-          org.apache.thrift.protocol.TMap _map424 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
-          struct.component_to_num_tasks = new HashMap<String,Long>(2*_map424.size);
-          String _key425;
-          long _val426;
-          for (int _i427 = 0; _i427 < _map424.size; ++_i427)
+          org.apache.thrift.protocol.TMap _map434 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.I64, iprot.readI32());
+          struct.component_to_num_tasks = new HashMap<String,Long>(2*_map434.size);
+          String _key435;
+          long _val436;
+          for (int _i437 = 0; _i437 < _map434.size; ++_i437)
           {
-            _key425 = iprot.readString();
-            _val426 = iprot.readI64();
-            struct.component_to_num_tasks.put(_key425, _val426);
+            _key435 = iprot.readString();
+            _val436 = iprot.readI64();
+            struct.component_to_num_tasks.put(_key435, _val436);
           }
         }
         struct.set_component_to_num_tasks_isSet(true);

--- a/storm-core/src/py/storm/Nimbus.py
+++ b/storm-core/src/py/storm/Nimbus.py
@@ -4797,11 +4797,11 @@ class getComponentPendingProfileActions_result:
       if fid == 0:
         if ftype == TType.LIST:
           self.success = []
-          (_etype706, _size703) = iprot.readListBegin()
-          for _i707 in xrange(_size703):
-            _elem708 = ProfileRequest()
-            _elem708.read(iprot)
-            self.success.append(_elem708)
+          (_etype724, _size721) = iprot.readListBegin()
+          for _i725 in xrange(_size721):
+            _elem726 = ProfileRequest()
+            _elem726.read(iprot)
+            self.success.append(_elem726)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -4818,8 +4818,8 @@ class getComponentPendingProfileActions_result:
     if self.success is not None:
       oprot.writeFieldBegin('success', TType.LIST, 0)
       oprot.writeListBegin(TType.STRUCT, len(self.success))
-      for iter709 in self.success:
-        iter709.write(oprot)
+      for iter727 in self.success:
+        iter727.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()

--- a/storm-core/src/py/storm/ttypes.py
+++ b/storm-core/src/py/storm/ttypes.py
@@ -5098,6 +5098,7 @@ class CommonAggregateStats:
    - transferred
    - acked
    - failed
+   - resources_map
   """
 
   thrift_spec = (
@@ -5108,15 +5109,17 @@ class CommonAggregateStats:
     (4, TType.I64, 'transferred', None, None, ), # 4
     (5, TType.I64, 'acked', None, None, ), # 5
     (6, TType.I64, 'failed', None, None, ), # 6
+    (7, TType.MAP, 'resources_map', (TType.STRING,None,TType.DOUBLE,None), None, ), # 7
   )
 
-  def __init__(self, num_executors=None, num_tasks=None, emitted=None, transferred=None, acked=None, failed=None,):
+  def __init__(self, num_executors=None, num_tasks=None, emitted=None, transferred=None, acked=None, failed=None, resources_map=None,):
     self.num_executors = num_executors
     self.num_tasks = num_tasks
     self.emitted = emitted
     self.transferred = transferred
     self.acked = acked
     self.failed = failed
+    self.resources_map = resources_map
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -5157,6 +5160,17 @@ class CommonAggregateStats:
           self.failed = iprot.readI64()
         else:
           iprot.skip(ftype)
+      elif fid == 7:
+        if ftype == TType.MAP:
+          self.resources_map = {}
+          (_ktype330, _vtype331, _size329 ) = iprot.readMapBegin()
+          for _i333 in xrange(_size329):
+            _key334 = iprot.readString().decode('utf-8')
+            _val335 = iprot.readDouble()
+            self.resources_map[_key334] = _val335
+          iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
       else:
         iprot.skip(ftype)
       iprot.readFieldEnd()
@@ -5191,6 +5205,14 @@ class CommonAggregateStats:
       oprot.writeFieldBegin('failed', TType.I64, 6)
       oprot.writeI64(self.failed)
       oprot.writeFieldEnd()
+    if self.resources_map is not None:
+      oprot.writeFieldBegin('resources_map', TType.MAP, 7)
+      oprot.writeMapBegin(TType.STRING, TType.DOUBLE, len(self.resources_map))
+      for kiter336,viter337 in self.resources_map.items():
+        oprot.writeString(kiter336.encode('utf-8'))
+        oprot.writeDouble(viter337)
+      oprot.writeMapEnd()
+      oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
 
@@ -5206,6 +5228,7 @@ class CommonAggregateStats:
     value = (value * 31) ^ hash(self.transferred)
     value = (value * 31) ^ hash(self.acked)
     value = (value * 31) ^ hash(self.failed)
+    value = (value * 31) ^ hash(self.resources_map)
     return value
 
   def __repr__(self):
@@ -5613,55 +5636,55 @@ class TopologyStats:
       if fid == 1:
         if ftype == TType.MAP:
           self.window_to_emitted = {}
-          (_ktype330, _vtype331, _size329 ) = iprot.readMapBegin()
-          for _i333 in xrange(_size329):
-            _key334 = iprot.readString().decode('utf-8')
-            _val335 = iprot.readI64()
-            self.window_to_emitted[_key334] = _val335
+          (_ktype339, _vtype340, _size338 ) = iprot.readMapBegin()
+          for _i342 in xrange(_size338):
+            _key343 = iprot.readString().decode('utf-8')
+            _val344 = iprot.readI64()
+            self.window_to_emitted[_key343] = _val344
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.MAP:
           self.window_to_transferred = {}
-          (_ktype337, _vtype338, _size336 ) = iprot.readMapBegin()
-          for _i340 in xrange(_size336):
-            _key341 = iprot.readString().decode('utf-8')
-            _val342 = iprot.readI64()
-            self.window_to_transferred[_key341] = _val342
+          (_ktype346, _vtype347, _size345 ) = iprot.readMapBegin()
+          for _i349 in xrange(_size345):
+            _key350 = iprot.readString().decode('utf-8')
+            _val351 = iprot.readI64()
+            self.window_to_transferred[_key350] = _val351
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 3:
         if ftype == TType.MAP:
           self.window_to_complete_latencies_ms = {}
-          (_ktype344, _vtype345, _size343 ) = iprot.readMapBegin()
-          for _i347 in xrange(_size343):
-            _key348 = iprot.readString().decode('utf-8')
-            _val349 = iprot.readDouble()
-            self.window_to_complete_latencies_ms[_key348] = _val349
+          (_ktype353, _vtype354, _size352 ) = iprot.readMapBegin()
+          for _i356 in xrange(_size352):
+            _key357 = iprot.readString().decode('utf-8')
+            _val358 = iprot.readDouble()
+            self.window_to_complete_latencies_ms[_key357] = _val358
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 4:
         if ftype == TType.MAP:
           self.window_to_acked = {}
-          (_ktype351, _vtype352, _size350 ) = iprot.readMapBegin()
-          for _i354 in xrange(_size350):
-            _key355 = iprot.readString().decode('utf-8')
-            _val356 = iprot.readI64()
-            self.window_to_acked[_key355] = _val356
+          (_ktype360, _vtype361, _size359 ) = iprot.readMapBegin()
+          for _i363 in xrange(_size359):
+            _key364 = iprot.readString().decode('utf-8')
+            _val365 = iprot.readI64()
+            self.window_to_acked[_key364] = _val365
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 5:
         if ftype == TType.MAP:
           self.window_to_failed = {}
-          (_ktype358, _vtype359, _size357 ) = iprot.readMapBegin()
-          for _i361 in xrange(_size357):
-            _key362 = iprot.readString().decode('utf-8')
-            _val363 = iprot.readI64()
-            self.window_to_failed[_key362] = _val363
+          (_ktype367, _vtype368, _size366 ) = iprot.readMapBegin()
+          for _i370 in xrange(_size366):
+            _key371 = iprot.readString().decode('utf-8')
+            _val372 = iprot.readI64()
+            self.window_to_failed[_key371] = _val372
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -5678,41 +5701,41 @@ class TopologyStats:
     if self.window_to_emitted is not None:
       oprot.writeFieldBegin('window_to_emitted', TType.MAP, 1)
       oprot.writeMapBegin(TType.STRING, TType.I64, len(self.window_to_emitted))
-      for kiter364,viter365 in self.window_to_emitted.items():
-        oprot.writeString(kiter364.encode('utf-8'))
-        oprot.writeI64(viter365)
+      for kiter373,viter374 in self.window_to_emitted.items():
+        oprot.writeString(kiter373.encode('utf-8'))
+        oprot.writeI64(viter374)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.window_to_transferred is not None:
       oprot.writeFieldBegin('window_to_transferred', TType.MAP, 2)
       oprot.writeMapBegin(TType.STRING, TType.I64, len(self.window_to_transferred))
-      for kiter366,viter367 in self.window_to_transferred.items():
-        oprot.writeString(kiter366.encode('utf-8'))
-        oprot.writeI64(viter367)
+      for kiter375,viter376 in self.window_to_transferred.items():
+        oprot.writeString(kiter375.encode('utf-8'))
+        oprot.writeI64(viter376)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.window_to_complete_latencies_ms is not None:
       oprot.writeFieldBegin('window_to_complete_latencies_ms', TType.MAP, 3)
       oprot.writeMapBegin(TType.STRING, TType.DOUBLE, len(self.window_to_complete_latencies_ms))
-      for kiter368,viter369 in self.window_to_complete_latencies_ms.items():
-        oprot.writeString(kiter368.encode('utf-8'))
-        oprot.writeDouble(viter369)
+      for kiter377,viter378 in self.window_to_complete_latencies_ms.items():
+        oprot.writeString(kiter377.encode('utf-8'))
+        oprot.writeDouble(viter378)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.window_to_acked is not None:
       oprot.writeFieldBegin('window_to_acked', TType.MAP, 4)
       oprot.writeMapBegin(TType.STRING, TType.I64, len(self.window_to_acked))
-      for kiter370,viter371 in self.window_to_acked.items():
-        oprot.writeString(kiter370.encode('utf-8'))
-        oprot.writeI64(viter371)
+      for kiter379,viter380 in self.window_to_acked.items():
+        oprot.writeString(kiter379.encode('utf-8'))
+        oprot.writeI64(viter380)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.window_to_failed is not None:
       oprot.writeFieldBegin('window_to_failed', TType.MAP, 5)
       oprot.writeMapBegin(TType.STRING, TType.I64, len(self.window_to_failed))
-      for kiter372,viter373 in self.window_to_failed.items():
-        oprot.writeString(kiter372.encode('utf-8'))
-        oprot.writeI64(viter373)
+      for kiter381,viter382 in self.window_to_failed.items():
+        oprot.writeString(kiter381.encode('utf-8'))
+        oprot.writeI64(viter382)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -6351,11 +6374,11 @@ class WorkerSummary:
       elif fid == 7:
         if ftype == TType.MAP:
           self.component_to_num_tasks = {}
-          (_ktype375, _vtype376, _size374 ) = iprot.readMapBegin()
-          for _i378 in xrange(_size374):
-            _key379 = iprot.readString().decode('utf-8')
-            _val380 = iprot.readI64()
-            self.component_to_num_tasks[_key379] = _val380
+          (_ktype384, _vtype385, _size383 ) = iprot.readMapBegin()
+          for _i387 in xrange(_size383):
+            _key388 = iprot.readString().decode('utf-8')
+            _val389 = iprot.readI64()
+            self.component_to_num_tasks[_key388] = _val389
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -6436,9 +6459,9 @@ class WorkerSummary:
     if self.component_to_num_tasks is not None:
       oprot.writeFieldBegin('component_to_num_tasks', TType.MAP, 7)
       oprot.writeMapBegin(TType.STRING, TType.I64, len(self.component_to_num_tasks))
-      for kiter381,viter382 in self.component_to_num_tasks.items():
-        oprot.writeString(kiter381.encode('utf-8'))
-        oprot.writeI64(viter382)
+      for kiter390,viter391 in self.component_to_num_tasks.items():
+        oprot.writeString(kiter390.encode('utf-8'))
+        oprot.writeI64(viter391)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.time_secs is not None:
@@ -6539,22 +6562,22 @@ class SupervisorPageInfo:
       if fid == 1:
         if ftype == TType.LIST:
           self.supervisor_summaries = []
-          (_etype386, _size383) = iprot.readListBegin()
-          for _i387 in xrange(_size383):
-            _elem388 = SupervisorSummary()
-            _elem388.read(iprot)
-            self.supervisor_summaries.append(_elem388)
+          (_etype395, _size392) = iprot.readListBegin()
+          for _i396 in xrange(_size392):
+            _elem397 = SupervisorSummary()
+            _elem397.read(iprot)
+            self.supervisor_summaries.append(_elem397)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.LIST:
           self.worker_summaries = []
-          (_etype392, _size389) = iprot.readListBegin()
-          for _i393 in xrange(_size389):
-            _elem394 = WorkerSummary()
-            _elem394.read(iprot)
-            self.worker_summaries.append(_elem394)
+          (_etype401, _size398) = iprot.readListBegin()
+          for _i402 in xrange(_size398):
+            _elem403 = WorkerSummary()
+            _elem403.read(iprot)
+            self.worker_summaries.append(_elem403)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -6571,15 +6594,15 @@ class SupervisorPageInfo:
     if self.supervisor_summaries is not None:
       oprot.writeFieldBegin('supervisor_summaries', TType.LIST, 1)
       oprot.writeListBegin(TType.STRUCT, len(self.supervisor_summaries))
-      for iter395 in self.supervisor_summaries:
-        iter395.write(oprot)
+      for iter404 in self.supervisor_summaries:
+        iter404.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.worker_summaries is not None:
       oprot.writeFieldBegin('worker_summaries', TType.LIST, 2)
       oprot.writeListBegin(TType.STRUCT, len(self.worker_summaries))
-      for iter396 in self.worker_summaries:
-        iter396.write(oprot)
+      for iter405 in self.worker_summaries:
+        iter405.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -7239,24 +7262,24 @@ class TopologyPageInfo:
       elif fid == 9:
         if ftype == TType.MAP:
           self.id_to_spout_agg_stats = {}
-          (_ktype398, _vtype399, _size397 ) = iprot.readMapBegin()
-          for _i401 in xrange(_size397):
-            _key402 = iprot.readString().decode('utf-8')
-            _val403 = ComponentAggregateStats()
-            _val403.read(iprot)
-            self.id_to_spout_agg_stats[_key402] = _val403
+          (_ktype407, _vtype408, _size406 ) = iprot.readMapBegin()
+          for _i410 in xrange(_size406):
+            _key411 = iprot.readString().decode('utf-8')
+            _val412 = ComponentAggregateStats()
+            _val412.read(iprot)
+            self.id_to_spout_agg_stats[_key411] = _val412
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 10:
         if ftype == TType.MAP:
           self.id_to_bolt_agg_stats = {}
-          (_ktype405, _vtype406, _size404 ) = iprot.readMapBegin()
-          for _i408 in xrange(_size404):
-            _key409 = iprot.readString().decode('utf-8')
-            _val410 = ComponentAggregateStats()
-            _val410.read(iprot)
-            self.id_to_bolt_agg_stats[_key409] = _val410
+          (_ktype414, _vtype415, _size413 ) = iprot.readMapBegin()
+          for _i417 in xrange(_size413):
+            _key418 = iprot.readString().decode('utf-8')
+            _val419 = ComponentAggregateStats()
+            _val419.read(iprot)
+            self.id_to_bolt_agg_stats[_key418] = _val419
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -7290,11 +7313,11 @@ class TopologyPageInfo:
       elif fid == 16:
         if ftype == TType.LIST:
           self.workers = []
-          (_etype414, _size411) = iprot.readListBegin()
-          for _i415 in xrange(_size411):
-            _elem416 = WorkerSummary()
-            _elem416.read(iprot)
-            self.workers.append(_elem416)
+          (_etype423, _size420) = iprot.readListBegin()
+          for _i424 in xrange(_size420):
+            _elem425 = WorkerSummary()
+            _elem425.read(iprot)
+            self.workers.append(_elem425)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -7373,17 +7396,17 @@ class TopologyPageInfo:
     if self.id_to_spout_agg_stats is not None:
       oprot.writeFieldBegin('id_to_spout_agg_stats', TType.MAP, 9)
       oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.id_to_spout_agg_stats))
-      for kiter417,viter418 in self.id_to_spout_agg_stats.items():
-        oprot.writeString(kiter417.encode('utf-8'))
-        viter418.write(oprot)
+      for kiter426,viter427 in self.id_to_spout_agg_stats.items():
+        oprot.writeString(kiter426.encode('utf-8'))
+        viter427.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.id_to_bolt_agg_stats is not None:
       oprot.writeFieldBegin('id_to_bolt_agg_stats', TType.MAP, 10)
       oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.id_to_bolt_agg_stats))
-      for kiter419,viter420 in self.id_to_bolt_agg_stats.items():
-        oprot.writeString(kiter419.encode('utf-8'))
-        viter420.write(oprot)
+      for kiter428,viter429 in self.id_to_bolt_agg_stats.items():
+        oprot.writeString(kiter428.encode('utf-8'))
+        viter429.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.sched_status is not None:
@@ -7409,8 +7432,8 @@ class TopologyPageInfo:
     if self.workers is not None:
       oprot.writeFieldBegin('workers', TType.LIST, 16)
       oprot.writeListBegin(TType.STRUCT, len(self.workers))
-      for iter421 in self.workers:
-        iter421.write(oprot)
+      for iter430 in self.workers:
+        iter430.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.requested_memonheap is not None:
@@ -7581,6 +7604,7 @@ class ComponentPageInfo:
    - eventlog_port
    - debug_options
    - topology_status
+   - resources_map
   """
 
   thrift_spec = (
@@ -7600,9 +7624,10 @@ class ComponentPageInfo:
     (13, TType.I32, 'eventlog_port', None, None, ), # 13
     (14, TType.STRUCT, 'debug_options', (DebugOptions, DebugOptions.thrift_spec), None, ), # 14
     (15, TType.STRING, 'topology_status', None, None, ), # 15
+    (16, TType.MAP, 'resources_map', (TType.STRING,None,TType.DOUBLE,None), None, ), # 16
   )
 
-  def __init__(self, component_id=None, component_type=None, topology_id=None, topology_name=None, num_executors=None, num_tasks=None, window_to_stats=None, gsid_to_input_stats=None, sid_to_output_stats=None, exec_stats=None, errors=None, eventlog_host=None, eventlog_port=None, debug_options=None, topology_status=None,):
+  def __init__(self, component_id=None, component_type=None, topology_id=None, topology_name=None, num_executors=None, num_tasks=None, window_to_stats=None, gsid_to_input_stats=None, sid_to_output_stats=None, exec_stats=None, errors=None, eventlog_host=None, eventlog_port=None, debug_options=None, topology_status=None, resources_map=None,):
     self.component_id = component_id
     self.component_type = component_type
     self.topology_id = topology_id
@@ -7618,6 +7643,7 @@ class ComponentPageInfo:
     self.eventlog_port = eventlog_port
     self.debug_options = debug_options
     self.topology_status = topology_status
+    self.resources_map = resources_map
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -7661,59 +7687,59 @@ class ComponentPageInfo:
       elif fid == 7:
         if ftype == TType.MAP:
           self.window_to_stats = {}
-          (_ktype423, _vtype424, _size422 ) = iprot.readMapBegin()
-          for _i426 in xrange(_size422):
-            _key427 = iprot.readString().decode('utf-8')
-            _val428 = ComponentAggregateStats()
-            _val428.read(iprot)
-            self.window_to_stats[_key427] = _val428
+          (_ktype432, _vtype433, _size431 ) = iprot.readMapBegin()
+          for _i435 in xrange(_size431):
+            _key436 = iprot.readString().decode('utf-8')
+            _val437 = ComponentAggregateStats()
+            _val437.read(iprot)
+            self.window_to_stats[_key436] = _val437
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 8:
         if ftype == TType.MAP:
           self.gsid_to_input_stats = {}
-          (_ktype430, _vtype431, _size429 ) = iprot.readMapBegin()
-          for _i433 in xrange(_size429):
-            _key434 = GlobalStreamId()
-            _key434.read(iprot)
-            _val435 = ComponentAggregateStats()
-            _val435.read(iprot)
-            self.gsid_to_input_stats[_key434] = _val435
+          (_ktype439, _vtype440, _size438 ) = iprot.readMapBegin()
+          for _i442 in xrange(_size438):
+            _key443 = GlobalStreamId()
+            _key443.read(iprot)
+            _val444 = ComponentAggregateStats()
+            _val444.read(iprot)
+            self.gsid_to_input_stats[_key443] = _val444
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 9:
         if ftype == TType.MAP:
           self.sid_to_output_stats = {}
-          (_ktype437, _vtype438, _size436 ) = iprot.readMapBegin()
-          for _i440 in xrange(_size436):
-            _key441 = iprot.readString().decode('utf-8')
-            _val442 = ComponentAggregateStats()
-            _val442.read(iprot)
-            self.sid_to_output_stats[_key441] = _val442
+          (_ktype446, _vtype447, _size445 ) = iprot.readMapBegin()
+          for _i449 in xrange(_size445):
+            _key450 = iprot.readString().decode('utf-8')
+            _val451 = ComponentAggregateStats()
+            _val451.read(iprot)
+            self.sid_to_output_stats[_key450] = _val451
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 10:
         if ftype == TType.LIST:
           self.exec_stats = []
-          (_etype446, _size443) = iprot.readListBegin()
-          for _i447 in xrange(_size443):
-            _elem448 = ExecutorAggregateStats()
-            _elem448.read(iprot)
-            self.exec_stats.append(_elem448)
+          (_etype455, _size452) = iprot.readListBegin()
+          for _i456 in xrange(_size452):
+            _elem457 = ExecutorAggregateStats()
+            _elem457.read(iprot)
+            self.exec_stats.append(_elem457)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
       elif fid == 11:
         if ftype == TType.LIST:
           self.errors = []
-          (_etype452, _size449) = iprot.readListBegin()
-          for _i453 in xrange(_size449):
-            _elem454 = ErrorInfo()
-            _elem454.read(iprot)
-            self.errors.append(_elem454)
+          (_etype461, _size458) = iprot.readListBegin()
+          for _i462 in xrange(_size458):
+            _elem463 = ErrorInfo()
+            _elem463.read(iprot)
+            self.errors.append(_elem463)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -7736,6 +7762,17 @@ class ComponentPageInfo:
       elif fid == 15:
         if ftype == TType.STRING:
           self.topology_status = iprot.readString().decode('utf-8')
+        else:
+          iprot.skip(ftype)
+      elif fid == 16:
+        if ftype == TType.MAP:
+          self.resources_map = {}
+          (_ktype465, _vtype466, _size464 ) = iprot.readMapBegin()
+          for _i468 in xrange(_size464):
+            _key469 = iprot.readString().decode('utf-8')
+            _val470 = iprot.readDouble()
+            self.resources_map[_key469] = _val470
+          iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       else:
@@ -7775,39 +7812,39 @@ class ComponentPageInfo:
     if self.window_to_stats is not None:
       oprot.writeFieldBegin('window_to_stats', TType.MAP, 7)
       oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.window_to_stats))
-      for kiter455,viter456 in self.window_to_stats.items():
-        oprot.writeString(kiter455.encode('utf-8'))
-        viter456.write(oprot)
+      for kiter471,viter472 in self.window_to_stats.items():
+        oprot.writeString(kiter471.encode('utf-8'))
+        viter472.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.gsid_to_input_stats is not None:
       oprot.writeFieldBegin('gsid_to_input_stats', TType.MAP, 8)
       oprot.writeMapBegin(TType.STRUCT, TType.STRUCT, len(self.gsid_to_input_stats))
-      for kiter457,viter458 in self.gsid_to_input_stats.items():
-        kiter457.write(oprot)
-        viter458.write(oprot)
+      for kiter473,viter474 in self.gsid_to_input_stats.items():
+        kiter473.write(oprot)
+        viter474.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.sid_to_output_stats is not None:
       oprot.writeFieldBegin('sid_to_output_stats', TType.MAP, 9)
       oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.sid_to_output_stats))
-      for kiter459,viter460 in self.sid_to_output_stats.items():
-        oprot.writeString(kiter459.encode('utf-8'))
-        viter460.write(oprot)
+      for kiter475,viter476 in self.sid_to_output_stats.items():
+        oprot.writeString(kiter475.encode('utf-8'))
+        viter476.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.exec_stats is not None:
       oprot.writeFieldBegin('exec_stats', TType.LIST, 10)
       oprot.writeListBegin(TType.STRUCT, len(self.exec_stats))
-      for iter461 in self.exec_stats:
-        iter461.write(oprot)
+      for iter477 in self.exec_stats:
+        iter477.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.errors is not None:
       oprot.writeFieldBegin('errors', TType.LIST, 11)
       oprot.writeListBegin(TType.STRUCT, len(self.errors))
-      for iter462 in self.errors:
-        iter462.write(oprot)
+      for iter478 in self.errors:
+        iter478.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.eventlog_host is not None:
@@ -7825,6 +7862,14 @@ class ComponentPageInfo:
     if self.topology_status is not None:
       oprot.writeFieldBegin('topology_status', TType.STRING, 15)
       oprot.writeString(self.topology_status.encode('utf-8'))
+      oprot.writeFieldEnd()
+    if self.resources_map is not None:
+      oprot.writeFieldBegin('resources_map', TType.MAP, 16)
+      oprot.writeMapBegin(TType.STRING, TType.DOUBLE, len(self.resources_map))
+      for kiter479,viter480 in self.resources_map.items():
+        oprot.writeString(kiter479.encode('utf-8'))
+        oprot.writeDouble(viter480)
+      oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
@@ -7854,6 +7899,7 @@ class ComponentPageInfo:
     value = (value * 31) ^ hash(self.eventlog_port)
     value = (value * 31) ^ hash(self.debug_options)
     value = (value * 31) ^ hash(self.topology_status)
+    value = (value * 31) ^ hash(self.resources_map)
     return value
 
   def __repr__(self):
@@ -7974,11 +8020,11 @@ class RebalanceOptions:
       elif fid == 3:
         if ftype == TType.MAP:
           self.num_executors = {}
-          (_ktype464, _vtype465, _size463 ) = iprot.readMapBegin()
-          for _i467 in xrange(_size463):
-            _key468 = iprot.readString().decode('utf-8')
-            _val469 = iprot.readI32()
-            self.num_executors[_key468] = _val469
+          (_ktype482, _vtype483, _size481 ) = iprot.readMapBegin()
+          for _i485 in xrange(_size481):
+            _key486 = iprot.readString().decode('utf-8')
+            _val487 = iprot.readI32()
+            self.num_executors[_key486] = _val487
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -8003,9 +8049,9 @@ class RebalanceOptions:
     if self.num_executors is not None:
       oprot.writeFieldBegin('num_executors', TType.MAP, 3)
       oprot.writeMapBegin(TType.STRING, TType.I32, len(self.num_executors))
-      for kiter470,viter471 in self.num_executors.items():
-        oprot.writeString(kiter470.encode('utf-8'))
-        oprot.writeI32(viter471)
+      for kiter488,viter489 in self.num_executors.items():
+        oprot.writeString(kiter488.encode('utf-8'))
+        oprot.writeI32(viter489)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -8059,11 +8105,11 @@ class Credentials:
       if fid == 1:
         if ftype == TType.MAP:
           self.creds = {}
-          (_ktype473, _vtype474, _size472 ) = iprot.readMapBegin()
-          for _i476 in xrange(_size472):
-            _key477 = iprot.readString().decode('utf-8')
-            _val478 = iprot.readString().decode('utf-8')
-            self.creds[_key477] = _val478
+          (_ktype491, _vtype492, _size490 ) = iprot.readMapBegin()
+          for _i494 in xrange(_size490):
+            _key495 = iprot.readString().decode('utf-8')
+            _val496 = iprot.readString().decode('utf-8')
+            self.creds[_key495] = _val496
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -8080,9 +8126,9 @@ class Credentials:
     if self.creds is not None:
       oprot.writeFieldBegin('creds', TType.MAP, 1)
       oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.creds))
-      for kiter479,viter480 in self.creds.items():
-        oprot.writeString(kiter479.encode('utf-8'))
-        oprot.writeString(viter480.encode('utf-8'))
+      for kiter497,viter498 in self.creds.items():
+        oprot.writeString(kiter497.encode('utf-8'))
+        oprot.writeString(viter498.encode('utf-8'))
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -8315,11 +8361,11 @@ class SettableBlobMeta:
       if fid == 1:
         if ftype == TType.LIST:
           self.acl = []
-          (_etype484, _size481) = iprot.readListBegin()
-          for _i485 in xrange(_size481):
-            _elem486 = AccessControl()
-            _elem486.read(iprot)
-            self.acl.append(_elem486)
+          (_etype502, _size499) = iprot.readListBegin()
+          for _i503 in xrange(_size499):
+            _elem504 = AccessControl()
+            _elem504.read(iprot)
+            self.acl.append(_elem504)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -8341,8 +8387,8 @@ class SettableBlobMeta:
     if self.acl is not None:
       oprot.writeFieldBegin('acl', TType.LIST, 1)
       oprot.writeListBegin(TType.STRUCT, len(self.acl))
-      for iter487 in self.acl:
-        iter487.write(oprot)
+      for iter505 in self.acl:
+        iter505.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.replication_factor is not None:
@@ -8487,10 +8533,10 @@ class ListBlobsResult:
       if fid == 1:
         if ftype == TType.LIST:
           self.keys = []
-          (_etype491, _size488) = iprot.readListBegin()
-          for _i492 in xrange(_size488):
-            _elem493 = iprot.readString().decode('utf-8')
-            self.keys.append(_elem493)
+          (_etype509, _size506) = iprot.readListBegin()
+          for _i510 in xrange(_size506):
+            _elem511 = iprot.readString().decode('utf-8')
+            self.keys.append(_elem511)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -8512,8 +8558,8 @@ class ListBlobsResult:
     if self.keys is not None:
       oprot.writeFieldBegin('keys', TType.LIST, 1)
       oprot.writeListBegin(TType.STRING, len(self.keys))
-      for iter494 in self.keys:
-        oprot.writeString(iter494.encode('utf-8'))
+      for iter512 in self.keys:
+        oprot.writeString(iter512.encode('utf-8'))
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.session is not None:
@@ -8708,31 +8754,31 @@ class SupervisorInfo:
       elif fid == 4:
         if ftype == TType.LIST:
           self.used_ports = []
-          (_etype498, _size495) = iprot.readListBegin()
-          for _i499 in xrange(_size495):
-            _elem500 = iprot.readI64()
-            self.used_ports.append(_elem500)
+          (_etype516, _size513) = iprot.readListBegin()
+          for _i517 in xrange(_size513):
+            _elem518 = iprot.readI64()
+            self.used_ports.append(_elem518)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
       elif fid == 5:
         if ftype == TType.LIST:
           self.meta = []
-          (_etype504, _size501) = iprot.readListBegin()
-          for _i505 in xrange(_size501):
-            _elem506 = iprot.readI64()
-            self.meta.append(_elem506)
+          (_etype522, _size519) = iprot.readListBegin()
+          for _i523 in xrange(_size519):
+            _elem524 = iprot.readI64()
+            self.meta.append(_elem524)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
       elif fid == 6:
         if ftype == TType.MAP:
           self.scheduler_meta = {}
-          (_ktype508, _vtype509, _size507 ) = iprot.readMapBegin()
-          for _i511 in xrange(_size507):
-            _key512 = iprot.readString().decode('utf-8')
-            _val513 = iprot.readString().decode('utf-8')
-            self.scheduler_meta[_key512] = _val513
+          (_ktype526, _vtype527, _size525 ) = iprot.readMapBegin()
+          for _i529 in xrange(_size525):
+            _key530 = iprot.readString().decode('utf-8')
+            _val531 = iprot.readString().decode('utf-8')
+            self.scheduler_meta[_key530] = _val531
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -8749,11 +8795,11 @@ class SupervisorInfo:
       elif fid == 9:
         if ftype == TType.MAP:
           self.resources_map = {}
-          (_ktype515, _vtype516, _size514 ) = iprot.readMapBegin()
-          for _i518 in xrange(_size514):
-            _key519 = iprot.readString().decode('utf-8')
-            _val520 = iprot.readDouble()
-            self.resources_map[_key519] = _val520
+          (_ktype533, _vtype534, _size532 ) = iprot.readMapBegin()
+          for _i536 in xrange(_size532):
+            _key537 = iprot.readString().decode('utf-8')
+            _val538 = iprot.readDouble()
+            self.resources_map[_key537] = _val538
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -8782,23 +8828,23 @@ class SupervisorInfo:
     if self.used_ports is not None:
       oprot.writeFieldBegin('used_ports', TType.LIST, 4)
       oprot.writeListBegin(TType.I64, len(self.used_ports))
-      for iter521 in self.used_ports:
-        oprot.writeI64(iter521)
+      for iter539 in self.used_ports:
+        oprot.writeI64(iter539)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.meta is not None:
       oprot.writeFieldBegin('meta', TType.LIST, 5)
       oprot.writeListBegin(TType.I64, len(self.meta))
-      for iter522 in self.meta:
-        oprot.writeI64(iter522)
+      for iter540 in self.meta:
+        oprot.writeI64(iter540)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.scheduler_meta is not None:
       oprot.writeFieldBegin('scheduler_meta', TType.MAP, 6)
       oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.scheduler_meta))
-      for kiter523,viter524 in self.scheduler_meta.items():
-        oprot.writeString(kiter523.encode('utf-8'))
-        oprot.writeString(viter524.encode('utf-8'))
+      for kiter541,viter542 in self.scheduler_meta.items():
+        oprot.writeString(kiter541.encode('utf-8'))
+        oprot.writeString(viter542.encode('utf-8'))
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.uptime_secs is not None:
@@ -8812,9 +8858,9 @@ class SupervisorInfo:
     if self.resources_map is not None:
       oprot.writeFieldBegin('resources_map', TType.MAP, 9)
       oprot.writeMapBegin(TType.STRING, TType.DOUBLE, len(self.resources_map))
-      for kiter525,viter526 in self.resources_map.items():
-        oprot.writeString(kiter525.encode('utf-8'))
-        oprot.writeDouble(viter526)
+      for kiter543,viter544 in self.resources_map.items():
+        oprot.writeString(kiter543.encode('utf-8'))
+        oprot.writeDouble(viter544)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -8886,10 +8932,10 @@ class NodeInfo:
       elif fid == 2:
         if ftype == TType.SET:
           self.port = set()
-          (_etype530, _size527) = iprot.readSetBegin()
-          for _i531 in xrange(_size527):
-            _elem532 = iprot.readI64()
-            self.port.add(_elem532)
+          (_etype548, _size545) = iprot.readSetBegin()
+          for _i549 in xrange(_size545):
+            _elem550 = iprot.readI64()
+            self.port.add(_elem550)
           iprot.readSetEnd()
         else:
           iprot.skip(ftype)
@@ -8910,8 +8956,8 @@ class NodeInfo:
     if self.port is not None:
       oprot.writeFieldBegin('port', TType.SET, 2)
       oprot.writeSetBegin(TType.I64, len(self.port))
-      for iter533 in self.port:
-        oprot.writeI64(iter533)
+      for iter551 in self.port:
+        oprot.writeI64(iter551)
       oprot.writeSetEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -9092,57 +9138,57 @@ class Assignment:
       elif fid == 2:
         if ftype == TType.MAP:
           self.node_host = {}
-          (_ktype535, _vtype536, _size534 ) = iprot.readMapBegin()
-          for _i538 in xrange(_size534):
-            _key539 = iprot.readString().decode('utf-8')
-            _val540 = iprot.readString().decode('utf-8')
-            self.node_host[_key539] = _val540
+          (_ktype553, _vtype554, _size552 ) = iprot.readMapBegin()
+          for _i556 in xrange(_size552):
+            _key557 = iprot.readString().decode('utf-8')
+            _val558 = iprot.readString().decode('utf-8')
+            self.node_host[_key557] = _val558
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 3:
         if ftype == TType.MAP:
           self.executor_node_port = {}
-          (_ktype542, _vtype543, _size541 ) = iprot.readMapBegin()
-          for _i545 in xrange(_size541):
-            _key546 = []
-            (_etype551, _size548) = iprot.readListBegin()
-            for _i552 in xrange(_size548):
-              _elem553 = iprot.readI64()
-              _key546.append(_elem553)
+          (_ktype560, _vtype561, _size559 ) = iprot.readMapBegin()
+          for _i563 in xrange(_size559):
+            _key564 = []
+            (_etype569, _size566) = iprot.readListBegin()
+            for _i570 in xrange(_size566):
+              _elem571 = iprot.readI64()
+              _key564.append(_elem571)
             iprot.readListEnd()
-            _val547 = NodeInfo()
-            _val547.read(iprot)
-            self.executor_node_port[_key546] = _val547
+            _val565 = NodeInfo()
+            _val565.read(iprot)
+            self.executor_node_port[_key564] = _val565
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 4:
         if ftype == TType.MAP:
           self.executor_start_time_secs = {}
-          (_ktype555, _vtype556, _size554 ) = iprot.readMapBegin()
-          for _i558 in xrange(_size554):
-            _key559 = []
-            (_etype564, _size561) = iprot.readListBegin()
-            for _i565 in xrange(_size561):
-              _elem566 = iprot.readI64()
-              _key559.append(_elem566)
+          (_ktype573, _vtype574, _size572 ) = iprot.readMapBegin()
+          for _i576 in xrange(_size572):
+            _key577 = []
+            (_etype582, _size579) = iprot.readListBegin()
+            for _i583 in xrange(_size579):
+              _elem584 = iprot.readI64()
+              _key577.append(_elem584)
             iprot.readListEnd()
-            _val560 = iprot.readI64()
-            self.executor_start_time_secs[_key559] = _val560
+            _val578 = iprot.readI64()
+            self.executor_start_time_secs[_key577] = _val578
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 5:
         if ftype == TType.MAP:
           self.worker_resources = {}
-          (_ktype568, _vtype569, _size567 ) = iprot.readMapBegin()
-          for _i571 in xrange(_size567):
-            _key572 = NodeInfo()
-            _key572.read(iprot)
-            _val573 = WorkerResources()
-            _val573.read(iprot)
-            self.worker_resources[_key572] = _val573
+          (_ktype586, _vtype587, _size585 ) = iprot.readMapBegin()
+          for _i589 in xrange(_size585):
+            _key590 = NodeInfo()
+            _key590.read(iprot)
+            _val591 = WorkerResources()
+            _val591.read(iprot)
+            self.worker_resources[_key590] = _val591
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -9163,39 +9209,39 @@ class Assignment:
     if self.node_host is not None:
       oprot.writeFieldBegin('node_host', TType.MAP, 2)
       oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.node_host))
-      for kiter574,viter575 in self.node_host.items():
-        oprot.writeString(kiter574.encode('utf-8'))
-        oprot.writeString(viter575.encode('utf-8'))
+      for kiter592,viter593 in self.node_host.items():
+        oprot.writeString(kiter592.encode('utf-8'))
+        oprot.writeString(viter593.encode('utf-8'))
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.executor_node_port is not None:
       oprot.writeFieldBegin('executor_node_port', TType.MAP, 3)
       oprot.writeMapBegin(TType.LIST, TType.STRUCT, len(self.executor_node_port))
-      for kiter576,viter577 in self.executor_node_port.items():
-        oprot.writeListBegin(TType.I64, len(kiter576))
-        for iter578 in kiter576:
-          oprot.writeI64(iter578)
+      for kiter594,viter595 in self.executor_node_port.items():
+        oprot.writeListBegin(TType.I64, len(kiter594))
+        for iter596 in kiter594:
+          oprot.writeI64(iter596)
         oprot.writeListEnd()
-        viter577.write(oprot)
+        viter595.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.executor_start_time_secs is not None:
       oprot.writeFieldBegin('executor_start_time_secs', TType.MAP, 4)
       oprot.writeMapBegin(TType.LIST, TType.I64, len(self.executor_start_time_secs))
-      for kiter579,viter580 in self.executor_start_time_secs.items():
-        oprot.writeListBegin(TType.I64, len(kiter579))
-        for iter581 in kiter579:
-          oprot.writeI64(iter581)
+      for kiter597,viter598 in self.executor_start_time_secs.items():
+        oprot.writeListBegin(TType.I64, len(kiter597))
+        for iter599 in kiter597:
+          oprot.writeI64(iter599)
         oprot.writeListEnd()
-        oprot.writeI64(viter580)
+        oprot.writeI64(viter598)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.worker_resources is not None:
       oprot.writeFieldBegin('worker_resources', TType.MAP, 5)
       oprot.writeMapBegin(TType.STRUCT, TType.STRUCT, len(self.worker_resources))
-      for kiter582,viter583 in self.worker_resources.items():
-        kiter582.write(oprot)
-        viter583.write(oprot)
+      for kiter600,viter601 in self.worker_resources.items():
+        kiter600.write(oprot)
+        viter601.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -9372,11 +9418,11 @@ class StormBase:
       elif fid == 4:
         if ftype == TType.MAP:
           self.component_executors = {}
-          (_ktype585, _vtype586, _size584 ) = iprot.readMapBegin()
-          for _i588 in xrange(_size584):
-            _key589 = iprot.readString().decode('utf-8')
-            _val590 = iprot.readI32()
-            self.component_executors[_key589] = _val590
+          (_ktype603, _vtype604, _size602 ) = iprot.readMapBegin()
+          for _i606 in xrange(_size602):
+            _key607 = iprot.readString().decode('utf-8')
+            _val608 = iprot.readI32()
+            self.component_executors[_key607] = _val608
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -9404,12 +9450,12 @@ class StormBase:
       elif fid == 9:
         if ftype == TType.MAP:
           self.component_debug = {}
-          (_ktype592, _vtype593, _size591 ) = iprot.readMapBegin()
-          for _i595 in xrange(_size591):
-            _key596 = iprot.readString().decode('utf-8')
-            _val597 = DebugOptions()
-            _val597.read(iprot)
-            self.component_debug[_key596] = _val597
+          (_ktype610, _vtype611, _size609 ) = iprot.readMapBegin()
+          for _i613 in xrange(_size609):
+            _key614 = iprot.readString().decode('utf-8')
+            _val615 = DebugOptions()
+            _val615.read(iprot)
+            self.component_debug[_key614] = _val615
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -9438,9 +9484,9 @@ class StormBase:
     if self.component_executors is not None:
       oprot.writeFieldBegin('component_executors', TType.MAP, 4)
       oprot.writeMapBegin(TType.STRING, TType.I32, len(self.component_executors))
-      for kiter598,viter599 in self.component_executors.items():
-        oprot.writeString(kiter598.encode('utf-8'))
-        oprot.writeI32(viter599)
+      for kiter616,viter617 in self.component_executors.items():
+        oprot.writeString(kiter616.encode('utf-8'))
+        oprot.writeI32(viter617)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.launch_time_secs is not None:
@@ -9462,9 +9508,9 @@ class StormBase:
     if self.component_debug is not None:
       oprot.writeFieldBegin('component_debug', TType.MAP, 9)
       oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.component_debug))
-      for kiter600,viter601 in self.component_debug.items():
-        oprot.writeString(kiter600.encode('utf-8'))
-        viter601.write(oprot)
+      for kiter618,viter619 in self.component_debug.items():
+        oprot.writeString(kiter618.encode('utf-8'))
+        viter619.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -9544,13 +9590,13 @@ class ClusterWorkerHeartbeat:
       elif fid == 2:
         if ftype == TType.MAP:
           self.executor_stats = {}
-          (_ktype603, _vtype604, _size602 ) = iprot.readMapBegin()
-          for _i606 in xrange(_size602):
-            _key607 = ExecutorInfo()
-            _key607.read(iprot)
-            _val608 = ExecutorStats()
-            _val608.read(iprot)
-            self.executor_stats[_key607] = _val608
+          (_ktype621, _vtype622, _size620 ) = iprot.readMapBegin()
+          for _i624 in xrange(_size620):
+            _key625 = ExecutorInfo()
+            _key625.read(iprot)
+            _val626 = ExecutorStats()
+            _val626.read(iprot)
+            self.executor_stats[_key625] = _val626
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -9581,9 +9627,9 @@ class ClusterWorkerHeartbeat:
     if self.executor_stats is not None:
       oprot.writeFieldBegin('executor_stats', TType.MAP, 2)
       oprot.writeMapBegin(TType.STRUCT, TType.STRUCT, len(self.executor_stats))
-      for kiter609,viter610 in self.executor_stats.items():
-        kiter609.write(oprot)
-        viter610.write(oprot)
+      for kiter627,viter628 in self.executor_stats.items():
+        kiter627.write(oprot)
+        viter628.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.time_secs is not None:
@@ -9736,12 +9782,12 @@ class LocalStateData:
       if fid == 1:
         if ftype == TType.MAP:
           self.serialized_parts = {}
-          (_ktype612, _vtype613, _size611 ) = iprot.readMapBegin()
-          for _i615 in xrange(_size611):
-            _key616 = iprot.readString().decode('utf-8')
-            _val617 = ThriftSerializedObject()
-            _val617.read(iprot)
-            self.serialized_parts[_key616] = _val617
+          (_ktype630, _vtype631, _size629 ) = iprot.readMapBegin()
+          for _i633 in xrange(_size629):
+            _key634 = iprot.readString().decode('utf-8')
+            _val635 = ThriftSerializedObject()
+            _val635.read(iprot)
+            self.serialized_parts[_key634] = _val635
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -9758,9 +9804,9 @@ class LocalStateData:
     if self.serialized_parts is not None:
       oprot.writeFieldBegin('serialized_parts', TType.MAP, 1)
       oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.serialized_parts))
-      for kiter618,viter619 in self.serialized_parts.items():
-        oprot.writeString(kiter618.encode('utf-8'))
-        viter619.write(oprot)
+      for kiter636,viter637 in self.serialized_parts.items():
+        oprot.writeString(kiter636.encode('utf-8'))
+        viter637.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -9825,11 +9871,11 @@ class LocalAssignment:
       elif fid == 2:
         if ftype == TType.LIST:
           self.executors = []
-          (_etype623, _size620) = iprot.readListBegin()
-          for _i624 in xrange(_size620):
-            _elem625 = ExecutorInfo()
-            _elem625.read(iprot)
-            self.executors.append(_elem625)
+          (_etype641, _size638) = iprot.readListBegin()
+          for _i642 in xrange(_size638):
+            _elem643 = ExecutorInfo()
+            _elem643.read(iprot)
+            self.executors.append(_elem643)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -9856,8 +9902,8 @@ class LocalAssignment:
     if self.executors is not None:
       oprot.writeFieldBegin('executors', TType.LIST, 2)
       oprot.writeListBegin(TType.STRUCT, len(self.executors))
-      for iter626 in self.executors:
-        iter626.write(oprot)
+      for iter644 in self.executors:
+        iter644.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.resources is not None:
@@ -9986,11 +10032,11 @@ class LSApprovedWorkers:
       if fid == 1:
         if ftype == TType.MAP:
           self.approved_workers = {}
-          (_ktype628, _vtype629, _size627 ) = iprot.readMapBegin()
-          for _i631 in xrange(_size627):
-            _key632 = iprot.readString().decode('utf-8')
-            _val633 = iprot.readI32()
-            self.approved_workers[_key632] = _val633
+          (_ktype646, _vtype647, _size645 ) = iprot.readMapBegin()
+          for _i649 in xrange(_size645):
+            _key650 = iprot.readString().decode('utf-8')
+            _val651 = iprot.readI32()
+            self.approved_workers[_key650] = _val651
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -10007,9 +10053,9 @@ class LSApprovedWorkers:
     if self.approved_workers is not None:
       oprot.writeFieldBegin('approved_workers', TType.MAP, 1)
       oprot.writeMapBegin(TType.STRING, TType.I32, len(self.approved_workers))
-      for kiter634,viter635 in self.approved_workers.items():
-        oprot.writeString(kiter634.encode('utf-8'))
-        oprot.writeI32(viter635)
+      for kiter652,viter653 in self.approved_workers.items():
+        oprot.writeString(kiter652.encode('utf-8'))
+        oprot.writeI32(viter653)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -10063,12 +10109,12 @@ class LSSupervisorAssignments:
       if fid == 1:
         if ftype == TType.MAP:
           self.assignments = {}
-          (_ktype637, _vtype638, _size636 ) = iprot.readMapBegin()
-          for _i640 in xrange(_size636):
-            _key641 = iprot.readI32()
-            _val642 = LocalAssignment()
-            _val642.read(iprot)
-            self.assignments[_key641] = _val642
+          (_ktype655, _vtype656, _size654 ) = iprot.readMapBegin()
+          for _i658 in xrange(_size654):
+            _key659 = iprot.readI32()
+            _val660 = LocalAssignment()
+            _val660.read(iprot)
+            self.assignments[_key659] = _val660
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -10085,9 +10131,9 @@ class LSSupervisorAssignments:
     if self.assignments is not None:
       oprot.writeFieldBegin('assignments', TType.MAP, 1)
       oprot.writeMapBegin(TType.I32, TType.STRUCT, len(self.assignments))
-      for kiter643,viter644 in self.assignments.items():
-        oprot.writeI32(kiter643)
-        viter644.write(oprot)
+      for kiter661,viter662 in self.assignments.items():
+        oprot.writeI32(kiter661)
+        viter662.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -10160,11 +10206,11 @@ class LSWorkerHeartbeat:
       elif fid == 3:
         if ftype == TType.LIST:
           self.executors = []
-          (_etype648, _size645) = iprot.readListBegin()
-          for _i649 in xrange(_size645):
-            _elem650 = ExecutorInfo()
-            _elem650.read(iprot)
-            self.executors.append(_elem650)
+          (_etype666, _size663) = iprot.readListBegin()
+          for _i667 in xrange(_size663):
+            _elem668 = ExecutorInfo()
+            _elem668.read(iprot)
+            self.executors.append(_elem668)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -10194,8 +10240,8 @@ class LSWorkerHeartbeat:
     if self.executors is not None:
       oprot.writeFieldBegin('executors', TType.LIST, 3)
       oprot.writeListBegin(TType.STRUCT, len(self.executors))
-      for iter651 in self.executors:
-        iter651.write(oprot)
+      for iter669 in self.executors:
+        iter669.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.port is not None:
@@ -10281,20 +10327,20 @@ class LSTopoHistory:
       elif fid == 3:
         if ftype == TType.LIST:
           self.users = []
-          (_etype655, _size652) = iprot.readListBegin()
-          for _i656 in xrange(_size652):
-            _elem657 = iprot.readString().decode('utf-8')
-            self.users.append(_elem657)
+          (_etype673, _size670) = iprot.readListBegin()
+          for _i674 in xrange(_size670):
+            _elem675 = iprot.readString().decode('utf-8')
+            self.users.append(_elem675)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
       elif fid == 4:
         if ftype == TType.LIST:
           self.groups = []
-          (_etype661, _size658) = iprot.readListBegin()
-          for _i662 in xrange(_size658):
-            _elem663 = iprot.readString().decode('utf-8')
-            self.groups.append(_elem663)
+          (_etype679, _size676) = iprot.readListBegin()
+          for _i680 in xrange(_size676):
+            _elem681 = iprot.readString().decode('utf-8')
+            self.groups.append(_elem681)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -10319,15 +10365,15 @@ class LSTopoHistory:
     if self.users is not None:
       oprot.writeFieldBegin('users', TType.LIST, 3)
       oprot.writeListBegin(TType.STRING, len(self.users))
-      for iter664 in self.users:
-        oprot.writeString(iter664.encode('utf-8'))
+      for iter682 in self.users:
+        oprot.writeString(iter682.encode('utf-8'))
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.groups is not None:
       oprot.writeFieldBegin('groups', TType.LIST, 4)
       oprot.writeListBegin(TType.STRING, len(self.groups))
-      for iter665 in self.groups:
-        oprot.writeString(iter665.encode('utf-8'))
+      for iter683 in self.groups:
+        oprot.writeString(iter683.encode('utf-8'))
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -10390,11 +10436,11 @@ class LSTopoHistoryList:
       if fid == 1:
         if ftype == TType.LIST:
           self.topo_history = []
-          (_etype669, _size666) = iprot.readListBegin()
-          for _i670 in xrange(_size666):
-            _elem671 = LSTopoHistory()
-            _elem671.read(iprot)
-            self.topo_history.append(_elem671)
+          (_etype687, _size684) = iprot.readListBegin()
+          for _i688 in xrange(_size684):
+            _elem689 = LSTopoHistory()
+            _elem689.read(iprot)
+            self.topo_history.append(_elem689)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -10411,8 +10457,8 @@ class LSTopoHistoryList:
     if self.topo_history is not None:
       oprot.writeFieldBegin('topo_history', TType.LIST, 1)
       oprot.writeListBegin(TType.STRUCT, len(self.topo_history))
-      for iter672 in self.topo_history:
-        iter672.write(oprot)
+      for iter690 in self.topo_history:
+        iter690.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -10747,12 +10793,12 @@ class LogConfig:
       if fid == 2:
         if ftype == TType.MAP:
           self.named_logger_level = {}
-          (_ktype674, _vtype675, _size673 ) = iprot.readMapBegin()
-          for _i677 in xrange(_size673):
-            _key678 = iprot.readString().decode('utf-8')
-            _val679 = LogLevel()
-            _val679.read(iprot)
-            self.named_logger_level[_key678] = _val679
+          (_ktype692, _vtype693, _size691 ) = iprot.readMapBegin()
+          for _i695 in xrange(_size691):
+            _key696 = iprot.readString().decode('utf-8')
+            _val697 = LogLevel()
+            _val697.read(iprot)
+            self.named_logger_level[_key696] = _val697
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -10769,9 +10815,9 @@ class LogConfig:
     if self.named_logger_level is not None:
       oprot.writeFieldBegin('named_logger_level', TType.MAP, 2)
       oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.named_logger_level))
-      for kiter680,viter681 in self.named_logger_level.items():
-        oprot.writeString(kiter680.encode('utf-8'))
-        viter681.write(oprot)
+      for kiter698,viter699 in self.named_logger_level.items():
+        oprot.writeString(kiter698.encode('utf-8'))
+        viter699.write(oprot)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -10823,10 +10869,10 @@ class TopologyHistoryInfo:
       if fid == 1:
         if ftype == TType.LIST:
           self.topo_ids = []
-          (_etype685, _size682) = iprot.readListBegin()
-          for _i686 in xrange(_size682):
-            _elem687 = iprot.readString().decode('utf-8')
-            self.topo_ids.append(_elem687)
+          (_etype703, _size700) = iprot.readListBegin()
+          for _i704 in xrange(_size700):
+            _elem705 = iprot.readString().decode('utf-8')
+            self.topo_ids.append(_elem705)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -10843,8 +10889,8 @@ class TopologyHistoryInfo:
     if self.topo_ids is not None:
       oprot.writeFieldBegin('topo_ids', TType.LIST, 1)
       oprot.writeListBegin(TType.STRING, len(self.topo_ids))
-      for iter688 in self.topo_ids:
-        oprot.writeString(iter688.encode('utf-8'))
+      for iter706 in self.topo_ids:
+        oprot.writeString(iter706.encode('utf-8'))
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -11128,11 +11174,11 @@ class HBRecords:
       if fid == 1:
         if ftype == TType.LIST:
           self.pulses = []
-          (_etype692, _size689) = iprot.readListBegin()
-          for _i693 in xrange(_size689):
-            _elem694 = HBPulse()
-            _elem694.read(iprot)
-            self.pulses.append(_elem694)
+          (_etype710, _size707) = iprot.readListBegin()
+          for _i711 in xrange(_size707):
+            _elem712 = HBPulse()
+            _elem712.read(iprot)
+            self.pulses.append(_elem712)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -11149,8 +11195,8 @@ class HBRecords:
     if self.pulses is not None:
       oprot.writeFieldBegin('pulses', TType.LIST, 1)
       oprot.writeListBegin(TType.STRUCT, len(self.pulses))
-      for iter695 in self.pulses:
-        iter695.write(oprot)
+      for iter713 in self.pulses:
+        iter713.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -11202,10 +11248,10 @@ class HBNodes:
       if fid == 1:
         if ftype == TType.LIST:
           self.pulseIds = []
-          (_etype699, _size696) = iprot.readListBegin()
-          for _i700 in xrange(_size696):
-            _elem701 = iprot.readString().decode('utf-8')
-            self.pulseIds.append(_elem701)
+          (_etype717, _size714) = iprot.readListBegin()
+          for _i718 in xrange(_size714):
+            _elem719 = iprot.readString().decode('utf-8')
+            self.pulseIds.append(_elem719)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -11222,8 +11268,8 @@ class HBNodes:
     if self.pulseIds is not None:
       oprot.writeFieldBegin('pulseIds', TType.LIST, 1)
       oprot.writeListBegin(TType.STRING, len(self.pulseIds))
-      for iter702 in self.pulseIds:
-        oprot.writeString(iter702.encode('utf-8'))
+      for iter720 in self.pulseIds:
+        oprot.writeString(iter720.encode('utf-8'))
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()

--- a/storm-core/src/storm.thrift
+++ b/storm-core/src/storm.thrift
@@ -273,6 +273,7 @@ struct CommonAggregateStats {
 4: optional i64 transferred;
 5: optional i64 acked;
 6: optional i64 failed;
+7: optional map<string, double> resources_map;
 }
 
 struct SpoutAggregateStats {
@@ -380,6 +381,7 @@ struct ComponentPageInfo {
 13: optional i32 eventlog_port;
 14: optional DebugOptions debug_options;
 15: optional string topology_status;
+16: optional map<string, double> resources_map;
 }
 
 struct KillOptions {

--- a/storm-core/src/ui/public/templates/component-page-template.html
+++ b/storm-core/src/ui/public/templates/component-page-template.html
@@ -39,6 +39,23 @@
             Tasks
           </span>
         </th>
+        {{#schedulerDisplayResource}}
+        <th>
+          <span data-toggle="tooltip" data-placement="above" title="The amount on heap memory in megabytes requested to run a single executor of this component.">
+            Requested On-heap Memory
+          </span>
+        </th>
+        <th>
+          <span data-toggle="tooltip" data-placement="above" title="The amount off heap memory in megabytes requested to run a single executor of this component.">
+            Requested Off-heap Memory
+          </span>
+        </th>
+        <th>
+          <span data-toggle="tooltip" data-placement="above" title="The amount of CPU resources requested to run a single executor of this component. Every 100 means 1 core.">
+            Requested CPU
+          </span>
+        </th>
+        {{/schedulerDisplayResource}}
         <th>
           <span data-toggle="tooltip" data-placement="top" title="Click on the link below to open the logviewer and view the events emitted by this component.">
             Debug
@@ -52,6 +69,11 @@
         <td><a href="/topology.html?id={{encodedTopologyId}}">{{name}}</a></td>
         <td>{{executors}}</td>
         <td>{{tasks}}</td>
+        {{#schedulerDisplayResource}}
+        <td>{{requestedMemOnHeap}}</td>
+        <td>{{requestedMemOffHeap}}</td>
+        <td>{{requestedCpu}}</td>
+        {{/schedulerDisplayResource}}
         <td><a href="{{eventLogLink}}">events</a></td>
     </tbody>
   </table>

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -357,66 +357,62 @@
             Id
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-original-title="Executors are threads in a Worker process." data-toggle="tooltip" data-placement="right">
             Executors
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="A Task is an instance of a Bolt or Spout. The number of Tasks is almost always equal to the number of Executors.">
             Tasks
           </span>
         </th>
         {{#schedulerDisplayResource}}
-        <th class="header">
-          <span data-toggle="tooltip" data-placement="top" title="The amount on heap memory in megabytes requested to run a single executor of this component.">
+        <th class="header table-num">
+          <span data-toggle="tooltip" data-placement="top" title="The amount of on-heap memory in megabytes requested to run a single executor of this component.">
             Req On-heap Mem (MB)
           </span>
         </th>
-        <th class="header">
-          <span data-toggle="tooltip" data-placement="top" title="The amount off heap memory in megabytes requested to run a single executor of this component.">
+        <th class="header table-num">
+          <span data-toggle="tooltip" data-placement="top" title="The amount of off-heap memory in megabytes requested to run a single executor of this component.">
             Req Off-heap Mem (MB)
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The amount of CPU resources requested to run a single executor of this component. Every 100 means 1 core.">
             Req CPU
           </span>
         </th>
         {{/schedulerDisplayResource}}
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The number of Tuples emitted.">
             Emitted
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The number of Tuples emitted that sent to one or more bolts.">
             Transferred
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The average time a Tuple &quot;tree&quot; takes to be completely processed by the Topology. A value of 0 is expected if no acking is done.">
             Complete latency (ms)
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The number of Tuple &quot;trees&quot; successfully processed. A value of 0 is expected if no acking is done.">
             Acked
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The number of Tuple &quot;trees&quot; that were explicitly failed or timed out before acking was completed. A value of 0 is expected if no acking is done.">
             Failed
           </span>
         </th>
-        <th class="header">Error Host
-        </th>
-        <th class="header">Error Port
-        </th>
-        <th class="header">Last error
-        </th>
-        <th class="header">Error Time
-        </th>
+        <th class="header">Error Host</th>
+        <th class="header">Error Port</th>
+        <th class="header">Last error</th>
+        <th class="header">Error Time</th>
       </tr>
     </thead>
     <tbody>
@@ -458,81 +454,77 @@
             Id
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-original-title="Executors are threads in a Worker process." data-toggle="tooltip" data-placement="right">
             Executors
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="A Task is an instance of a Bolt or Spout. The number of Tasks is almost always equal to the number of Executors.">
             Tasks
           </span>
         </th>
         {{#schedulerDisplayResource}}
-        <th class="header">
-          <span data-toggle="tooltip" data-placement="top" title="The amount memory in megabytes requested to run a single executor of this component.">
+        <th class="header table-num">
+          <span data-toggle="tooltip" data-placement="top" title="The amount of on-heap memory in megabytes requested to run a single executor of this component.">
             Req On-heap Mem (MB)
           </span>
         </th>
-        <th class="header">
-          <span data-toggle="tooltip" data-placement="top" title="The amount memory in megabytes requested to run a single executor of this component.">
+        <th class="header table-num">
+          <span data-toggle="tooltip" data-placement="top" title="The amount of off-heap memory in megabytes requested to run a single executor of this component.">
             Req Off-heap Mem (MB)
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The amount of CPU resources requested to run a single executor of this component. Every 100 means 1 core.">
             Req CPU
           </span>
         </th>
         {{/schedulerDisplayResource}}
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The number of Tuples emitted.">
             Emitted
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The number of Tuples emitted that sent to one or more bolts.">
             Transferred
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-original-title="If this is around 1.0, the corresponding Bolt is running as fast as it can, so you may want to increase the Bolt's parallelism. This is (number executed * average execute latency) / measurement time." data-toggle="tooltip" data-placement="top">
             Capacity (last 10m)
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The average time a Tuple spends in the execute method. The execute method may complete without sending an Ack for the tuple.">
             Execute latency (ms)
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The number of incoming Tuples processed.">
             Executed
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The average time it takes to Ack a Tuple after it is first received.  Bolts that join, aggregate or batch may not Ack a tuple until a number of other Tuples have been received.">
             Process latency (ms)
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="top" title="The number of Tuples acknowledged by this Bolt.">
             Acked
           </span>
         </th>
-        <th class="header">
+        <th class="header table-num">
           <span data-toggle="tooltip" data-placement="left" title="The number of tuples Failed by this Bolt.">
             Failed
           </span>
         </th>
-        <th class="header">Error Host
-        </th>
-        <th class="header">Error Port
-        </th>
-        <th class="header">Last error
-        </th>
-        <th class="header">Error Time
-        </th>
+        <th class="header">Error Host</th>
+        <th class="header">Error Port</th>
+        <th class="header">Last error</th>
+        <th class="header">Error Time</th>
     </tr></thead>
     <tbody>
       {{#bolts}}

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -367,6 +367,23 @@
             Tasks
           </span>
         </th>
+        {{#schedulerDisplayResource}}
+        <th class="header">
+          <span data-toggle="tooltip" data-placement="top" title="The amount on heap memory in megabytes requested to run a single executor of this component.">
+            Req On-heap Mem (MB)
+          </span>
+        </th>
+        <th class="header">
+          <span data-toggle="tooltip" data-placement="top" title="The amount off heap memory in megabytes requested to run a single executor of this component.">
+            Req Off-heap Mem (MB)
+          </span>
+        </th>
+        <th class="header">
+          <span data-toggle="tooltip" data-placement="top" title="The amount of CPU resources requested to run a single executor of this component. Every 100 means 1 core.">
+            Req CPU
+          </span>
+        </th>
+        {{/schedulerDisplayResource}}
         <th class="header">
           <span data-toggle="tooltip" data-placement="top" title="The number of Tuples emitted.">
             Emitted
@@ -408,6 +425,11 @@
         <td><a href="/component.html?id={{encodedSpoutId}}&topology_id={{encodedId}}">{{spoutId}}</a></td>
         <td>{{executors}}</td>
         <td>{{tasks}}</td>
+        {{#schedulerDisplayResource}}
+        <td>{{requestedMemOnHeap}}</td>
+        <td>{{requestedMemOffHeap}}</td>
+        <td>{{requestedCpu}}</td>
+        {{/schedulerDisplayResource}}
         <td>{{emitted}}</td>
         <td>{{transferred}}</td>
         <td>{{completeLatency}}</td>
@@ -446,6 +468,23 @@
             Tasks
           </span>
         </th>
+        {{#schedulerDisplayResource}}
+        <th class="header">
+          <span data-toggle="tooltip" data-placement="top" title="The amount memory in megabytes requested to run a single executor of this component.">
+            Req On-heap Mem (MB)
+          </span>
+        </th>
+        <th class="header">
+          <span data-toggle="tooltip" data-placement="top" title="The amount memory in megabytes requested to run a single executor of this component.">
+            Req Off-heap Mem (MB)
+          </span>
+        </th>
+        <th class="header">
+          <span data-toggle="tooltip" data-placement="top" title="The amount of CPU resources requested to run a single executor of this component. Every 100 means 1 core.">
+            Req CPU
+          </span>
+        </th>
+        {{/schedulerDisplayResource}}
         <th class="header">
           <span data-toggle="tooltip" data-placement="top" title="The number of Tuples emitted.">
             Emitted
@@ -501,6 +540,11 @@
         <td><a href="/component.html?id={{encodedBoltId}}&topology_id={{encodedId}}">{{boltId}}</a></td>
         <td>{{executors}}</td>
         <td>{{tasks}}</td>
+        {{#schedulerDisplayResource}}
+        <td>{{requestedMemOnHeap}}</td>
+        <td>{{requestedMemOffHeap}}</td>
+        <td>{{requestedCpu}}</td>
+        {{/schedulerDisplayResource}}
         <td>{{emitted}}</td>
         <td>{{transferred}}</td>
         <td>{{capacity}}</td>

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -320,18 +320,16 @@ $(document).ready(function() {
             });
 
             spoutStats.append(Mustache.render($(template).filter("#spout-stats-template").html(),response));
-            //Id,Executors,Tasks,Memory on heap requested (MB),Memory off heap requested (MB), CPU Requirement,Emitted,Transferred,Complete latency (ms),Acked,Failed,Error Host,Error Port
             dtAutoPage("#spout-stats-table", {
               columnDefs: [
-                {type: "num", targets: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+                {type: "num", targets: 'table-num'}
               ]
             });
 
             boltStats.append(Mustache.render($(template).filter("#bolt-stats-template").html(),response));
-            //Id,Executors,Tasks,Memory On heap requested (MB),Memory Off heap requested (MB),CPU Requirement,Emitted,Transferred,Capacity (last 10m),Execute latency (ms),Executed,Process latency (ms),Acked,Failed,Error Host,Error Port,Last error
             dtAutoPage("#bolt-stats-table", {
               columnDefs: [
-                {type: "num", targets: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]}
+                {type: "num", targets: 'table-num'}
               ]
             });
 

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -320,18 +320,18 @@ $(document).ready(function() {
             });
 
             spoutStats.append(Mustache.render($(template).filter("#spout-stats-template").html(),response));
-            //id, executors, tasks, emitted, transferred, complete latency, acked, failed, Last error
+            //Id,Executors,Tasks,Memory on heap requested (MB),Memory off heap requested (MB), CPU Requirement,Emitted,Transferred,Complete latency (ms),Acked,Failed,Error Host,Error Port
             dtAutoPage("#spout-stats-table", {
               columnDefs: [
-                {type: "num", targets: [1, 2, 3, 4, 5, 6, 7]}
+                {type: "num", targets: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
               ]
             });
 
             boltStats.append(Mustache.render($(template).filter("#bolt-stats-template").html(),response));
-            //id, executors, tasks, emitted, transferred, capacity, execute latency, executed, process latency, acked, failed, last error
+            //Id,Executors,Tasks,Memory On heap requested (MB),Memory Off heap requested (MB),CPU Requirement,Emitted,Transferred,Capacity (last 10m),Execute latency (ms),Executed,Process latency (ms),Acked,Failed,Error Host,Error Port,Last error
             dtAutoPage("#bolt-stats-table", {
               columnDefs: [
-                {type: "num", targets: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+                {type: "num", targets: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]}
               ]
             });
 


### PR DESCRIPTION
Work done by @jerrypeng at Yahoo. I tweaked the UI a bit. Most of the change is in the generated thrift code.

Provides extra columns per component showing requested memory and cpu.