### PR TITLE
Move new integration test to another build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
 env:
   - MODULES=storm-core
   - MODULES='!storm-core'
+  - MODULES='INTEGRATION-TEST'
 
 language: java
 jdk:
@@ -26,7 +27,7 @@ before_install:
   - nvm use 0.12.2
 install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
 script:
-  - /bin/bash ./dev-tools/travis/travis-script.sh `pwd` $MODULES && /bin/bash ./integration-test/run-it.sh
+  - /bin/bash ./dev-tools/travis/travis-script.sh `pwd` $MODULES
 sudo: true
 cache:
   directories:

--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -21,19 +21,25 @@ STORM_SRC_ROOT_DIR=$1
 TRAVIS_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 cd ${STORM_SRC_ROOT_DIR}
+  
+if [ "$2" == "INTEGRATION-TEST" ]
+then
+  /bin/bash ./integration-test/run-it.sh
+else
+  # We should be concerned that Travis CI could be very slow because it uses VM
+  export STORM_TEST_TIMEOUT_MS=150000
+  # Travis only has 3GB of memory, lets use 1GB for build, and 1.5GB for forked JVMs
+  export MAVEN_OPTS="-Xmx1024m"
+  
+  mvn --batch-mode test -fae -Pnative,all-tests -Prat -pl "$2"
+  BUILD_RET_VAL=$?
+  
+  for dir in `find . -type d -and -wholename \*/target/\*-reports`;
+  do
+    echo "Looking for errors in ${dir}"
+    python ${TRAVIS_SCRIPT_DIR}/print-errors-from-test-reports.py "${dir}"
+  done
+  
+  exit ${BUILD_RET_VAL}
+fi
 
-# We should be concerned that Travis CI could be very slow because it uses VM
-export STORM_TEST_TIMEOUT_MS=150000
-# Travis only has 3GB of memory, lets use 1GB for build, and 1.5GB for forked JVMs
-export MAVEN_OPTS="-Xmx1024m"
-
-mvn --batch-mode test -fae -Pnative,all-tests -Prat -pl "$2"
-BUILD_RET_VAL=$?
-
-for dir in `find . -type d -and -wholename \*/target/\*-reports`;
-do
-  echo "Looking for errors in ${dir}"
-  python ${TRAVIS_SCRIPT_DIR}/print-errors-from-test-reports.py "${dir}"
-done
-
-exit ${BUILD_RET_VAL}


### PR DESCRIPTION
* newly added integration test adds more and 20 mins in each build and sometimes makes build failing due to long running
* making it to separate build helps reducing build time

I and Bobby saw some builds failing due to long running. This fix should help that situation.