### PR TITLE
STORM-2142 ReportErrorAndDie runs suicide function only when InterruptedException or InterruptedIOException is thrown

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/executor/error/ReportErrorAndDie.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/error/ReportErrorAndDie.java
@@ -41,6 +41,7 @@ public class ReportErrorAndDie implements Thread.UncaughtExceptionHandler {
         if (Utils.exceptionCauseIsInstanceOf(InterruptedException.class, e)
                 || Utils.exceptionCauseIsInstanceOf(java.io.InterruptedIOException.class, e)) {
             LOG.info("Got interrupted exception shutting thread down...");
+        } else {
             suicideFn.run();
         }
     }


### PR DESCRIPTION
* There seems to be a small bug while porting