### PR TITLE
STORM-2145 Leave leader nimbus's hostname to log when trying to connect leader nimbus

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/nimbus/NimbusInfo.java
+++ b/storm-core/src/jvm/org/apache/storm/nimbus/NimbusInfo.java
@@ -55,6 +55,8 @@ public class NimbusInfo implements Serializable {
             if (conf.containsKey(Config.STORM_LOCAL_HOSTNAME)) {
                 host = conf.get(Config.STORM_LOCAL_HOSTNAME).toString();
                 LOG.info("Overriding nimbus host to storm.local.hostname -> {}", host);
+            } else {
+                LOG.info("Nimbus figures out its name to {}", host);
             }
 
             int port = Integer.parseInt(conf.get(Config.NIMBUS_THRIFT_PORT).toString());

--- a/storm-core/src/jvm/org/apache/storm/utils/NimbusClient.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/NimbusClient.java
@@ -90,10 +90,12 @@ public class NimbusClient extends ThriftClient {
             if (nimbuses != null) {
                 for (NimbusSummary nimbusSummary : nimbuses) {
                     if (nimbusSummary.is_isLeader()) {
+                        String leaderNimbus = nimbusSummary.get_host() + ":" + nimbusSummary.get_port();
+                        LOG.info("Found leader nimbus : {}", leaderNimbus);
+
                         try {
                             return new NimbusClient(conf, nimbusSummary.get_host(), nimbusSummary.get_port(), null, asUser);
                         } catch (TTransportException e) {
-                            String leaderNimbus = nimbusSummary.get_host() + ":" + nimbusSummary.get_port();
                             throw new RuntimeException("Failed to create a nimbus client for the leader " + leaderNimbus, e);
                         }
                     }


### PR DESCRIPTION
* leave a log regarding leader Nimbus connection information when connecting to leader Nimbus
* also leave a log when Nimbus figures out its hostname without using storm.local.hostname

This should be also ported back to 1.x and 1.0.x.