### PR TITLE
STORM-1443 [Storm SQL] Support customizing parallelism in StormSQL

### DIFF
--- a/docs/storm-sql.md
+++ b/docs/storm-sql.md
@@ -46,11 +46,19 @@ CREATE EXTERNAL TABLE table_name field_list
       OUTPUTFORMAT output_format_classname
     ]
     LOCATION location
+    [ PARALLELISM parallelism ]
     [ TBLPROPERTIES tbl_properties ]
     [ AS select_stmt ]
 ```
 
-You can find detailed explanations of the properties in [Hive Data Definition Language](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL). For example, the following statement specifies a Kafka spout and sink:
+You can find detailed explanations of the properties in [Hive Data Definition Language](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL). 
+
+`PARALLELISM` is StormSQL's own keyword which describes parallelism hint for input data source. This is same as providing parallelism hint to Trident Spout.
+As same as Trident, downstream operators are executed with same parallelism before repartition (Aggregation triggers repartition).
+
+Default value is 1, and this option is no effect on output data source. (We might change if needed. Normally repartition is the thing to avoid.)
+
+For example, the following statement specifies a Kafka spout and sink:
 
 ```
 CREATE EXTERNAL TABLE FOO (ID INT PRIMARY KEY) LOCATION 'kafka://localhost:2181/brokers?topic=test' TBLPROPERTIES '{"producer":{"bootstrap.servers":"localhost:9092","acks":"1","key.serializer":"org.apache.org.apache.storm.kafka.IntSerializer","value.serializer":"org.apache.org.apache.storm.kafka.ByteBufferSerializer"}}'
@@ -159,5 +167,3 @@ LogicalTableModify(table=[[LARGE_ORDERS]], operation=[INSERT], updateColumnList=
 
 - Windowing is yet to be implemented.
 - Aggregation and join are not supported (waiting for `Streaming SQL` to be matured)
-- Specifying parallelism hints in the topology is not yet supported. 
-  - All processors have a parallelism hint of 1.

--- a/external/sql/README.md
+++ b/external/sql/README.md
@@ -38,6 +38,11 @@ CREATE EXTERNAL TABLE FOO (ID INT PRIMARY KEY) LOCATION 'kafka://localhost:2181/
 The syntax of `CREATE EXTERNAL TABLE` closely follows the one defined in
 [Hive Data Definition Language](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL).
 
+`PARALLELISM` is StormSQL's own keyword which describes parallelism hint for input data source. This is same as providing parallelism hint to Trident Spout.
+Downstream operators are executed with same parallelism before repartition (Aggregation triggers repartition).
+
+Default value is 1, and this option is no effect on output data source. (We might change if needed. Normally repartition is the thing to avoid.)
+
 ## Plugging in External Data Sources
 
 Users plug in external data sources through implementing the `ISqlTridentDataSource` interface and registers them using
@@ -177,8 +182,6 @@ LogicalTableModify(table=[[LARGE_ORDERS]], operation=[INSERT], updateColumnList=
   - Not across batches.
   - Limitation came from `join` feature of Trident.
   - Please refer this doc: `Trident API Overview` for details.
-- Specifying parallelism hints in the topology is not yet supported. 
-  - All processors have a parallelism hint of 1.
 
 ## License
 

--- a/external/sql/storm-sql-core/src/codegen/data/Parser.tdd
+++ b/external/sql/storm-sql-core/src/codegen/data/Parser.tdd
@@ -32,6 +32,7 @@
     "LOCATION",
     "INPUTFORMAT",
     "OUTPUTFORMAT",
+    "PARALLELISM",
     "STORED",
     "TBLPROPERTIES",
     "JAR"

--- a/external/sql/storm-sql-core/src/codegen/includes/parserImpls.ftl
+++ b/external/sql/storm-sql-core/src/codegen/includes/parserImpls.ftl
@@ -61,6 +61,7 @@ SqlNode SqlCreateTable() :
     SqlIdentifier tblName;
     SqlNodeList fieldList;
     SqlNode location;
+    SqlNode parallelism = null;
     SqlNode input_format_class_name = null, output_format_class_name = null;
     SqlNode tbl_properties = null;
     SqlNode select = null;
@@ -77,11 +78,12 @@ SqlNode SqlCreateTable() :
     ]
     <LOCATION>
     location = StringLiteral()
+    [ <PARALLELISM> parallelism = UnsignedNumericLiteral() ]
     [ <TBLPROPERTIES> tbl_properties = StringLiteral() ]
     [ <AS> select = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY) ] {
         return new SqlCreateTable(pos, tblName, fieldList,
         input_format_class_name, output_format_class_name, location,
-        tbl_properties, select);
+        parallelism, tbl_properties, select);
     }
 }
 

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSqlImpl.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/StormSqlImpl.java
@@ -253,6 +253,9 @@ class StormSqlImpl extends StormSql {
       fields.add(new FieldInfo(col.name(), javaType, isPrimary));
     }
 
+    if (n.parallelism() != null) {
+      builder.parallelismHint(n.parallelism());
+    }
     Table table = builder.build();
     schema.add(n.tableName(), table);
     return fields;

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/calcite/ParallelStreamableTable.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/calcite/ParallelStreamableTable.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.sql.calcite;
+
+import org.apache.calcite.rel.stream.Delta;
+import org.apache.calcite.schema.StreamableTable;
+
+/**
+ * Table that can be converted to a stream. This table also has its parallelism information.
+ *
+ * @see Delta
+ */
+public interface ParallelStreamableTable extends StreamableTable {
+
+    /**
+     * Returns parallelism hint of this table. Returns null if don't know.
+     */
+    Integer parallelismHint();
+}

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/CompilerUtil.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/CompilerUtil.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlMonotonicity;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Util;
+import org.apache.storm.sql.calcite.ParallelStreamableTable;
 import org.apache.storm.sql.parser.ColumnConstraint;
 
 import java.util.ArrayList;
@@ -75,6 +76,7 @@ public class CompilerUtil {
     private final ArrayList<FieldType> fields = new ArrayList<>();
     private final ArrayList<Object[]> rows = new ArrayList<>();
     private int primaryKey = -1;
+    private Integer parallelismHint;
     private SqlMonotonicity primaryKeyMonotonicity;
     private Statistic stats;
 
@@ -110,6 +112,11 @@ public class CompilerUtil {
       return this;
     }
 
+    public TableBuilderInfo parallelismHint(int parallelismHint) {
+      this.parallelismHint = parallelismHint;
+      return this;
+    }
+
     public StreamableTable build() {
       final Statistic stat = buildStatistic();
       final Table tbl = new Table() {
@@ -135,7 +142,12 @@ public class CompilerUtil {
         }
       };
 
-      return new StreamableTable() {
+      return new ParallelStreamableTable() {
+        @Override
+        public Integer parallelismHint() {
+          return parallelismHint;
+        }
+
         @Override
         public Table stream() {
           return tbl;

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/parser/SqlCreateTable.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/parser/SqlCreateTable.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Properties;
 
 public class SqlCreateTable extends SqlCall {
+  private static final int DEFAULT_PARALLELISM = 1;
+
   public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator(
       "CREATE_TABLE", SqlKind.OTHER) {
     @Override
@@ -44,7 +46,7 @@ public class SqlCreateTable extends SqlCall {
         SqlLiteral functionQualifier, SqlParserPos pos, SqlNode... o) {
       assert functionQualifier == null;
       return new SqlCreateTable(pos, (SqlIdentifier) o[0], (SqlNodeList) o[1],
-                                o[2], o[3], o[4], o[5], o[6]);
+                                o[2], o[3], o[4], o[5], o[6], o[7]);
     }
 
     @Override
@@ -60,6 +62,9 @@ public class SqlCreateTable extends SqlCall {
             t.outputFormatClass);
       }
       u.keyword("LOCATION").node(t.location);
+      if (t.parallelism != null) {
+        u.keyword("PARALLELISM").node(t.parallelism);
+      }
       if (t.properties != null) {
         u.keyword("TBLPROPERTIES").node(t.properties);
       }
@@ -74,19 +79,21 @@ public class SqlCreateTable extends SqlCall {
   private final SqlNode inputFormatClass;
   private final SqlNode outputFormatClass;
   private final SqlNode location;
+  private final SqlNode parallelism;
   private final SqlNode properties;
   private final SqlNode query;
 
   public SqlCreateTable(
-      SqlParserPos pos, SqlIdentifier tblName, SqlNodeList fieldList,
-      SqlNode inputFormatClass, SqlNode outputFormatClass, SqlNode location,
-      SqlNode properties, SqlNode query) {
+          SqlParserPos pos, SqlIdentifier tblName, SqlNodeList fieldList,
+          SqlNode inputFormatClass, SqlNode outputFormatClass, SqlNode location,
+          SqlNode parallelism, SqlNode properties, SqlNode query) {
     super(pos);
     this.tblName = tblName;
     this.fieldList = fieldList;
     this.inputFormatClass = inputFormatClass;
     this.outputFormatClass = outputFormatClass;
     this.location = location;
+    this.parallelism = parallelism;
     this.properties = properties;
     this.query = query;
   }
@@ -114,6 +121,15 @@ public class SqlCreateTable extends SqlCall {
 
   public URI location() {
     return URI.create(getString(location));
+  }
+
+  public Integer parallelism() {
+    String parallelismStr = getString(parallelism);
+    if (parallelismStr != null) {
+      return Integer.parseInt(parallelismStr);
+    } else {
+      return DEFAULT_PARALLELISM;
+    }
   }
 
   public String inputFormatClass() {

--- a/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/planner/trident/rel/TridentStreamScanRel.java
+++ b/external/sql/storm-sql-core/src/jvm/org/apache/storm/sql/planner/trident/rel/TridentStreamScanRel.java
@@ -30,8 +30,11 @@ import org.apache.storm.trident.fluent.IAggregatableStream;
 import java.util.Map;
 
 public class TridentStreamScanRel extends StormStreamScanRelBase implements TridentRel {
-    public TridentStreamScanRel(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table) {
+    private final int parallelismHint;
+
+    public TridentStreamScanRel(RelOptCluster cluster, RelTraitSet traitSet, RelOptTable table, int parallelismHint) {
         super(cluster, traitSet, table);
+        this.parallelismHint = parallelismHint;
     }
 
     @Override
@@ -45,7 +48,8 @@ public class TridentStreamScanRel extends StormStreamScanRelBase implements Trid
         }
 
         String stageName = StormRelUtils.getStageName(this);
-        IAggregatableStream finalStream = planCreator.getTopology().newStream(stageName, sources.get(sourceName).getProducer());
+        IAggregatableStream finalStream = planCreator.getTopology().newStream(stageName, sources.get(sourceName).getProducer())
+                .parallelismHint(parallelismHint);
         planCreator.addStream(finalStream);
     }
 }


### PR DESCRIPTION
NOTE: This is on top of STORM-1446 (#1736). I can make a patch without STORM-1446 but it makes me putting same effort twice so didn't do it. Please let me know if we want to have this patch based on current master.
- Add 'PARALLELISM' to table definition
  - default value is 1
- Set parallelism to new stream while creating stream with scan
  - downstream operators will also have same parallelism unless repartitioned
  - not apply parallelism to output table since it can trigger repartition

Below is the screenshot which runs SQL statement:

<img width="1305" alt="storm-1443-screenshot" src="https://cloud.githubusercontent.com/assets/1317309/19513856/72a944c2-962c-11e6-91d0-2f6f08b7aefd.png">

```
CREATE EXTERNAL TABLE APACHE_LOGS (id INT PRIMARY KEY, remote_ip VARCHAR, request_url VARCHAR, request_method VARCHAR, status VARCHAR, request_header_user_agent VARCHAR, time_received_utc_isoformat VARCHAR, time_us DOUBLE) LOCATION 'kafka://localhost:2181/brokers?topic=apachelogs-v2' PARALLELISM 5
CREATE EXTERNAL TABLE APACHE_SLOW_LOGS (dummy_id INT PRIMARY KEY, request_url VARCHAR, request_method VARCHAR, cnt INT, time_elapsed_ms_min INT, time_elapsed_ms_max INT, time_elapsed_ms_avg INT) LOCATION 'kafka://localhost:2181/brokers?topic=apacheslowlogs-v2' TBLPROPERTIES '{"producer":{"bootstrap.servers":"localhost:9092","acks":"1","key.serializer":"org.apache.storm.kafka.IntSerializer","value.serializer":"org.apache.storm.kafka.ByteBufferSerializer"}}'
INSERT INTO APACHE_SLOW_LOGS SELECT MIN(ID), REQUEST_URL, REQUEST_METHOD, COUNT(*) AS CNT, MIN(TIME_US) / 1000 AS TIME_ELAPSED_MS_MIN, MAX(TIME_US) / 1000 AS TIME_ELAPSED_MS_MAX, AVG(TIME_US) / 1000 AS TIME_ELAPSED_MS_AVG FROM APACHE_LOGS GROUP BY REQUEST_URL, REQUEST_METHOD HAVING AVG(TIME_US) / 1000 >= 300
```

Please refer task count of each component. Task count of each component is 5 unless it's repartitioned due to aggregation.

You can narrow the change to only last commit. It's 120 lines of change.
