### PR TITLE
STORM-2170 [Storm SQL] Add built-in socket datasource to runtime

### DIFF
--- a/docs/storm-sql-reference.md
+++ b/docs/storm-sql-reference.md
@@ -1268,9 +1268,18 @@ Please note that it supports only one letter for delimiter.
 
 | Data Source     | Artifact Name      | Location prefix     | Support Input data source | Support Output data source | Requires properties
 |:--------------- |:------------------ |:------------------- |:------------------------- |:-------------------------- |:-------------------
+| Socket | <built-in> | `socket://host:port` | Yes | Yes | No
 | Kafka | org.apache.storm:storm-sql-kafka | `kafka://zkhost:port/broker_path?topic=topic` | Yes | Yes | Yes
 | Redis | org.apache.storm:storm-sql-redis | `redis://:[password]@host:port/[dbIdx]` | No | Yes | Yes
 | MongoDB | org.apache.stormg:storm-sql-mongodb | `mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]` | No | Yes | Yes
+
+#### Socket
+
+Socket data source is a built-in feature so users don't need to add any artifacts to `--artifacts` options.
+
+Please note that Socket data source is only for testing: it doesn't guarantee exactly-once and at-least-once.
+
+TIP: `netcat` is a convenient tool for Socket: users can use netcat to connect Socket data source for either or both input and output purposes.
 
 #### Kafka
 

--- a/external/sql/storm-sql-runtime/pom.xml
+++ b/external/sql/storm-sql-runtime/pom.xml
@@ -97,6 +97,11 @@
     <build>
         <sourceDirectory>src/jvm</sourceDirectory>
         <testSourceDirectory>src/test</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/resources</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/SocketDataSourcesProvider.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/SocketDataSourcesProvider.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.sql.runtime.datasource.socket;
+
+import org.apache.storm.spout.Scheme;
+import org.apache.storm.sql.runtime.DataSource;
+import org.apache.storm.sql.runtime.DataSourcesProvider;
+import org.apache.storm.sql.runtime.FieldInfo;
+import org.apache.storm.sql.runtime.IOutputSerializer;
+import org.apache.storm.sql.runtime.ISqlTridentDataSource;
+import org.apache.storm.sql.runtime.SimpleSqlTridentConsumer;
+import org.apache.storm.sql.runtime.datasource.socket.trident.SocketState;
+import org.apache.storm.sql.runtime.datasource.socket.trident.SocketStateUpdater;
+import org.apache.storm.sql.runtime.datasource.socket.trident.TridentSocketSpout;
+import org.apache.storm.sql.runtime.serde.json.JsonSerializer;
+import org.apache.storm.sql.runtime.utils.FieldInfoUtils;
+import org.apache.storm.sql.runtime.utils.SerdeUtils;
+import org.apache.storm.trident.spout.ITridentDataSource;
+import org.apache.storm.trident.state.StateFactory;
+import org.apache.storm.trident.state.StateUpdater;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Create a Socket data source based on the URI and properties. The URI has the format of
+ * socket://[host]:[port]. Both of host and port are mandatory.
+ *
+ * Note that it connects to given host and port, and receive the message if it's used for input source,
+ * and send the message if it's used for output data source.
+ */
+public class SocketDataSourcesProvider implements DataSourcesProvider {
+    @Override
+    public String scheme() {
+        return "socket";
+    }
+
+    private static class SocketTridentDataSource implements ISqlTridentDataSource {
+
+        private final String host;
+        private final int port;
+        private final Scheme scheme;
+        private final IOutputSerializer serializer;
+
+        SocketTridentDataSource(Scheme scheme, IOutputSerializer serializer, String host, int port) {
+            this.scheme = scheme;
+            this.serializer = serializer;
+            this.host = host;
+            this.port = port;
+        }
+
+        @Override
+        public ITridentDataSource getProducer() {
+            return new TridentSocketSpout(scheme, host, port);
+        }
+
+        @Override
+        public SqlTridentConsumer getConsumer() {
+            StateFactory stateFactory = new SocketState.Factory(host, port);
+            StateUpdater<SocketState> stateUpdater = new SocketStateUpdater(serializer);
+            return new SimpleSqlTridentConsumer(stateFactory, stateUpdater);
+        }
+    }
+
+    @Override
+    public DataSource construct(URI uri, String inputFormatClass, String outputFormatClass, List<FieldInfo> fields) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ISqlTridentDataSource constructTrident(URI uri, String inputFormatClass, String outputFormatClass, Properties properties, List<FieldInfo> fields) {
+        String host = uri.getHost();
+        int port = uri.getPort();
+        if (port == -1) {
+            throw new RuntimeException("Port information is not available. URI: " + uri);
+        }
+
+        List<String> fieldNames = FieldInfoUtils.getFieldNames(fields);
+        Scheme scheme = SerdeUtils.getScheme(inputFormatClass, properties, fieldNames);
+        IOutputSerializer serializer = SerdeUtils.getSerializer(outputFormatClass, properties, fieldNames);
+
+        return new SocketTridentDataSource(scheme, serializer, host, port);
+    }
+}

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/trident/SocketState.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/trident/SocketState.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.sql.runtime.datasource.socket.trident;
+
+import org.apache.storm.task.IMetricsContext;
+import org.apache.storm.trident.state.State;
+import org.apache.storm.trident.state.StateFactory;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.net.Socket;
+import java.util.Map;
+
+/**
+ * Trident State implementation of Socket. It only supports writing.
+ */
+public class SocketState implements State {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void beginCommit(Long txid) {
+        // no-op
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void commit(Long txid) {
+        // no-op
+    }
+
+    public static class Factory implements StateFactory {
+        private final String host;
+        private final int port;
+
+        public Factory(String host, int port) {
+            this.host = host;
+            this.port = port;
+        }
+
+        @Override
+        public State makeState(Map conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
+            BufferedWriter out;
+            try {
+                Socket socket = new Socket(host, port);
+                out = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
+            } catch (IOException e) {
+                throw new RuntimeException("Exception while initializing socket for State. host " +
+                        host + " port " + port, e);
+            }
+
+            // State doesn't have close() and Storm actually doesn't guarantee so we can't release socket resource anyway
+            return new SocketState(out);
+        }
+    }
+
+    private BufferedWriter out;
+
+    private SocketState(BufferedWriter out) {
+        this.out = out;
+    }
+
+    public void write(String str) throws IOException {
+        out.write(str);
+    }
+
+    public void flush() throws IOException {
+        out.flush();
+    }
+}

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/trident/SocketStateUpdater.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/trident/SocketStateUpdater.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.sql.runtime.datasource.socket.trident;
+
+import org.apache.storm.sql.runtime.IOutputSerializer;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.state.BaseStateUpdater;
+import org.apache.storm.trident.tuple.TridentTuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * StateUpdater for SocketState. Serializes tuple one by one and writes to socket, and finally flushes.
+ */
+public class SocketStateUpdater extends BaseStateUpdater<SocketState> {
+    private static final Logger LOG = LoggerFactory.getLogger(SocketStateUpdater.class);
+
+    private final IOutputSerializer outputSerializer;
+
+    public SocketStateUpdater(IOutputSerializer outputSerializer) {
+        this.outputSerializer = outputSerializer;
+    }
+
+    @Override
+    public void updateState(SocketState state, List<TridentTuple> tuples, TridentCollector collector) {
+        try {
+            for (TridentTuple tuple : tuples) {
+                byte[] array = outputSerializer.write(tuple.getValues(), null).array();
+                String data = new String(array);
+                state.write(data + "\n");
+            }
+            state.flush();
+        } catch (IOException e) {
+            LOG.error("Error while updating state.", e);
+            collector.reportError(e);
+            throw new RuntimeException("Error while updating state.", e);
+        }
+
+    }
+}

--- a/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/trident/TridentSocketSpout.java
+++ b/external/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/trident/TridentSocketSpout.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.sql.runtime.datasource.socket.trident;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.storm.Config;
+import org.apache.storm.spout.Scheme;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.spout.IBatchSpout;
+import org.apache.storm.tuple.Fields;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * Trident Spout for Socket data. Only available for Storm SQL, and only use for test purposes.
+ */
+public class TridentSocketSpout implements IBatchSpout {
+    private static final Logger LOG = LoggerFactory.getLogger(TridentSocketSpout.class);
+
+    private final String host;
+    private final int port;
+    private final Scheme scheme;
+
+    private volatile boolean _running = true;
+
+    private BlockingDeque<String> queue;
+    private Socket socket;
+    private Thread readerThread;
+    private BufferedReader in;
+    private ObjectMapper objectMapper;
+
+    private Map<Long, List<List<Object>>> batches;
+
+    public TridentSocketSpout(Scheme scheme, String host, int port) {
+        this.scheme = scheme;
+        this.host = host;
+        this.port = port;
+    }
+
+    @Override
+    public void open(Map conf, TopologyContext context) {
+        this.queue = new LinkedBlockingDeque<>();
+        this.objectMapper = new ObjectMapper();
+        this.batches = new HashMap<>();
+
+        try {
+            socket = new Socket(host, port);
+            in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+        } catch (IOException e) {
+            throw new RuntimeException("Error opening socket: host " + host + " port " + port);
+        }
+
+        readerThread = new Thread(new SocketReaderRunnable());
+        readerThread.start();
+    }
+
+    @Override
+    public void emitBatch(long batchId, TridentCollector collector) {
+        // read line and parse it to json
+        List<List<Object>> batch = this.batches.get(batchId);
+        if (batch == null) {
+            batch = new ArrayList<>();
+
+            while(queue.peek() != null) {
+                String line = queue.poll();
+                List<Object> values = convertLineToTuple(line);
+                if (values == null) {
+                    continue;
+                }
+
+                batch.add(values);
+            }
+
+            this.batches.put(batchId, batch);
+        }
+
+        for (List<Object> list : batch) {
+            collector.emit(list);
+        }
+    }
+
+    private List<Object> convertLineToTuple(String line) {
+        return scheme.deserialize(ByteBuffer.wrap(line.getBytes()));
+    }
+
+    @Override
+    public void ack(long batchId) {
+        this.batches.remove(batchId);
+    }
+
+    @Override
+    public void close() {
+        _running = false;
+        readerThread.interrupt();
+        queue.clear();
+
+        closeQuietly(in);
+        closeQuietly(socket);
+    }
+
+    @Override
+    public Map<String, Object> getComponentConfiguration() {
+        Config conf = new Config();
+        conf.setMaxTaskParallelism(1);
+        return conf;
+    }
+
+    @Override
+    public Fields getOutputFields() {
+        return scheme.getOutputFields();
+    }
+
+    private class SocketReaderRunnable implements Runnable {
+        public void run() {
+            while (_running) {
+                try {
+                    String line = in.readLine();
+                    if (line == null) {
+                        throw new RuntimeException("EOF reached from the socket. We can't read the data any more.");
+                    }
+
+                    queue.push(line.trim());
+                } catch (Throwable t) {
+                    // This spout is added to test purpose, so just failing fast doesn't hurt much
+                    die(t);
+                }
+            }
+        }
+    }
+
+    private void die(Throwable t) {
+        LOG.error("Halting process: TridentSocketSpout died.", t);
+        if (_running || (t instanceof Error)) { //don't exit if not running, unless it is an Error
+            System.exit(11);
+        }
+    }
+
+    private void closeQuietly(final Closeable closeable) {
+        try {
+            if (closeable != null) {
+                closeable.close();
+            }
+        } catch (final IOException ioe) {
+            // ignore
+        }
+    }
+}

--- a/external/sql/storm-sql-runtime/src/resources/META-INF/services/org.apache.storm.sql.runtime.DataSourcesProvider
+++ b/external/sql/storm-sql-runtime/src/resources/META-INF/services/org.apache.storm.sql.runtime.DataSourcesProvider
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.storm.sql.runtime.datasource.socket.SocketDataSourcesProvider

--- a/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/runtime/datasource/socket/TestSocketDataSourceProvider.java
+++ b/external/sql/storm-sql-runtime/src/test/org/apache/storm/sql/runtime/datasource/socket/TestSocketDataSourceProvider.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.sql.runtime.datasource.socket;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.apache.storm.sql.runtime.DataSourcesRegistry;
+import org.apache.storm.sql.runtime.FieldInfo;
+import org.apache.storm.sql.runtime.ISqlTridentDataSource;
+import org.apache.storm.sql.runtime.serde.json.JsonSerializer;
+import org.apache.storm.sql.runtime.datasource.socket.trident.SocketState;
+import org.apache.storm.sql.runtime.datasource.socket.trident.SocketStateUpdater;
+import org.apache.storm.trident.state.StateUpdater;
+import org.apache.storm.trident.tuple.TridentTuple;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestSocketDataSourceProvider {
+    private static final List<FieldInfo> FIELDS = ImmutableList.of(
+            new FieldInfo("ID", int.class, true),
+            new FieldInfo("val", String.class, false));
+    private static final List<String> FIELD_NAMES = ImmutableList.of("ID", "val");
+    private static final JsonSerializer SERIALIZER = new JsonSerializer(FIELD_NAMES);
+
+    @Test
+    public void testSocketSink() throws IOException {
+        ISqlTridentDataSource ds = DataSourcesRegistry.constructTridentDataSource(
+                URI.create("socket://localhost:8888"), null, null, new Properties(), FIELDS);
+        Assert.assertNotNull(ds);
+
+        ISqlTridentDataSource.SqlTridentConsumer consumer = ds.getConsumer();
+
+        Assert.assertEquals(SocketState.Factory.class, consumer.getStateFactory().getClass());
+        Assert.assertEquals(SocketStateUpdater.class, consumer.getStateUpdater().getClass());
+
+        // makeState() fails on creating State so we just mock SocketState anyway
+        SocketState mockState = mock(SocketState.class);
+        StateUpdater stateUpdater = consumer.getStateUpdater();
+
+        List<TridentTuple> tupleList = mockTupleList();
+
+        stateUpdater.updateState(mockState, tupleList, null);
+        for (TridentTuple t : tupleList) {
+            String serializedValue = new String(SERIALIZER.write(t.getValues(), null).array());
+            verify(mockState).write(serializedValue + "\n");
+        }
+    }
+
+    private static List<TridentTuple> mockTupleList() {
+        List<TridentTuple> tupleList = new ArrayList<>();
+        TridentTuple t0 = mock(TridentTuple.class);
+        TridentTuple t1 = mock(TridentTuple.class);
+        when(t0.getValueByField("ID")).thenReturn(1);
+        when(t0.getValueByField("val")).thenReturn("2");
+        doReturn(Lists.<Object>newArrayList(1, "2")).when(t0).getValues();
+        when(t0.size()).thenReturn(2);
+
+        when(t1.getValueByField("ID")).thenReturn(2);
+        when(t1.getValueByField("val")).thenReturn("3");
+        doReturn(Lists.<Object>newArrayList(2, "3")).when(t1).getValues();
+        when(t1.size()).thenReturn(2);
+
+        tupleList.add(t0);
+        tupleList.add(t1);
+        return tupleList;
+    }
+}


### PR DESCRIPTION
- Add Socket datasource (input/output) in storm-sql-runtime module
  - only for test purpose, no guarantee
- scheme: 'socket'

Since Socket datasource is in storm-sql-runtime, it's registered to DataSourcesProvider by default.
So below SQL statements doesn't need any external artifacts at all and can be executed to below command:

```
./bin/storm sql apache_log_error_filtering_socket.sql apache_log_error_filtering_socket
```

```
CREATE EXTERNAL TABLE APACHE_LOGS (ID INT PRIMARY KEY, REMOTE_IP VARCHAR, REQUEST_URL VARCHAR, REQUEST_METHOD VARCHAR, STATUS VARCHAR, REQUEST_HEADER_USER_AGENT VARCHAR, TIME_RECEIVED_UTC_ISOFORMAT VARCHAR, TIME_US DOUBLE) LOCATION 'socket://localhost:8889'
CREATE EXTERNAL TABLE APACHE_ERROR_LOGS (ID INT PRIMARY KEY, REMOTE_IP VARCHAR, REQUEST_URL VARCHAR, REQUEST_METHOD VARCHAR, STATUS INT, REQUEST_HEADER_USER_AGENT VARCHAR, TIME_RECEIVED_UTC_ISOFORMAT VARCHAR, TIME_ELAPSED_MS INT) LOCATION 'socket://localhost:8890'
INSERT INTO APACHE_ERROR_LOGS SELECT ID, REMOTE_IP, REQUEST_URL, REQUEST_METHOD, CAST(STATUS AS INT) AS STATUS_INT, REQUEST_HEADER_USER_AGENT, TIME_RECEIVED_UTC_ISOFORMAT, (TIME_US / 1000) AS TIME_ELAPSED_MS FROM APACHE_LOGS WHERE (CAST(STATUS AS INT) / 100) >= 4
```

Manually tested via opening tcp servers via netcat.
