### PR TITLE
STORM-2184: Don't wakeup KafkaConsumer on shutdown, spout methods are…

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -386,7 +386,6 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
 
     private void shutdown() {
         try {
-            kafkaConsumer.wakeup();
             if (!consumerAutoCommitMode) {
                 commitOffsetsForAckedTuples();
             }


### PR DESCRIPTION
... not called by multiple threads at a time

See https://issues.apache.org/jira/browse/STORM-2184

