### PR TITLE
STORM-2188:Interrupt all executor threads before joining in executor shutdown, l…

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/ReadClusterState.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/ReadClusterState.java
@@ -294,7 +294,7 @@ public class ReadClusterState implements Runnable, AutoCloseable {
     };
     public static final UniFunc<Slot> DEFAULT_ON_WARN_TIMEOUT = (slot) -> LOG.warn("It has taken {}ms so far and {} is still not shut down.", WARN_MILLIS, slot);
     public static final UniFunc<Slot> THREAD_DUMP_ON_ERROR = (slot) -> {
-        LOG.warn("Shutdown of slot {} appreas to be stuck\n{}", slot, Utils.threadDump());
+        LOG.warn("Shutdown of slot {} appears to be stuck\n{}", slot, Utils.threadDump());
         DEFAULT_ON_ERROR_TIMEOUT.call(slot);
     };
     

--- a/storm-core/src/jvm/org/apache/storm/executor/ExecutorShutdown.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/ExecutorShutdown.java
@@ -81,6 +81,9 @@ public class ExecutorShutdown implements Shutdownable, IRunningExecutor {
             executor.getTransferWorkerQueue().haltWithInterrupt();
             for (Utils.SmartThread t : threads) {
                 t.interrupt();
+            }
+            for (Utils.SmartThread t : threads) {
+                LOG.debug("Executor " + executor.getComponentId() + ":" + executor.getExecutorId() + " joining thread " + t.getName());
                 t.join();
             }
             executor.getStats().cleanupStats();


### PR DESCRIPTION
…og when joining threads

This makes it easier to sift through the thread dump ReadClusterState outputs if a Slot fails to shut down in time.