### PR TITLE
[STORM-2192] Add a new IAutoCredentials plugin to support SSL files

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/security/auth/AutoSSL.java
+++ b/storm-core/src/jvm/org/apache/storm/security/auth/AutoSSL.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.security.auth;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+import javax.xml.bind.DatatypeConverter;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * This plugin is intended to be used for user topologies to send SSL keystore/truststore files
+ * to the remote workers.
+ * On the client side, this takes the files specified in ssl.credential.files, reads the
+ * file contents, base64's it, converts it to a String, and adds it to the credentials map.
+ * The key in the credentials map is the name of the file. On the worker side it uses the
+ * filenames from the ssl.credential.files config to lookup the keys in the credentials map and
+ * decodes it and writes it back out as a file.
+ *
+ * User is responsible for referencing them from the topology code as ./<filename>.
+ */
+public class AutoSSL implements IAutoCredentials {
+    private static final Logger LOG = LoggerFactory.getLogger(AutoSSL.class);
+    private Map conf;
+    private String writeDir = "./";
+
+    public static final String SSL_FILES_CONF = "ssl.credential.files";
+
+    public void prepare(Map conf) {
+        this.conf = conf;
+        writeDir = getSSLWriteDirFromConf(this.conf);
+    }
+
+    @VisibleForTesting
+    protected String getSSLWriteDirFromConf(Map conf) {
+      return "./";
+    }
+
+    @VisibleForTesting
+    Collection<String> getSSLFilesFromConf(Map conf) {
+        Object sslConf = conf.get(SSL_FILES_CONF);
+        if (sslConf == null) {
+            LOG.info("No ssl files requested, if you want to use SSL please set {} to the " +
+                    "list of files", SSL_FILES_CONF);
+            return null;
+        }
+        Collection<String> sslFiles = null;
+        if (sslConf instanceof Collection) {
+            sslFiles = (Collection<String>) sslConf;
+        } else if (sslConf instanceof String) {
+            sslFiles = Arrays.asList(((String) sslConf).split(","));
+        } else {
+            throw new RuntimeException(
+                SSL_FILES_CONF + " is not set to something that I know how to use " + sslConf);
+        }
+        return sslFiles;
+    }
+
+    @Override
+    public void populateCredentials(Map<String, String> credentials) {
+        try {
+            Collection<String> sslFiles = getSSLFilesFromConf(conf);
+            if (sslFiles == null) {
+                return;
+            }
+            LOG.info("AutoSSL files: {}", sslFiles);
+            for (String inputFile : sslFiles) {
+                serializeSSLFile(inputFile, credentials);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Adds the serialized and base64 file to the credentials map as a string with the filename as
+    // the key.
+    public static void serializeSSLFile(String readFile, Map<String, String> credentials) {
+        try {
+            FileInputStream in = new FileInputStream(readFile);
+            LOG.debug("serializing ssl file: {}", readFile);
+            ByteArrayOutputStream result = new ByteArrayOutputStream();
+            byte[] buffer = new byte[4096];
+            int length;
+            while ((length = in.read(buffer)) != -1) {
+                result.write(buffer, 0, length);
+            }
+            String resultStr = DatatypeConverter.printBase64Binary(result.toByteArray());
+
+            File f = new File(readFile);
+            LOG.debug("ssl read files is name: {}", f.getName());
+            credentials.put(f.getName(), resultStr);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void deserializeSSLFile(String credsKey, String directory, 
+        Map<String, String> credentials) {
+        try {
+            LOG.debug("deserializing ssl file with key: {}", credsKey);
+            String resultStr = null;
+
+            if (credentials != null &&
+                credentials.containsKey(credsKey) &&
+                credentials.get(credsKey) != null)
+            {
+                resultStr = credentials.get(credsKey);
+            }
+            if (resultStr != null) {
+                byte[] decodedData = DatatypeConverter.parseBase64Binary(resultStr);
+                File f = new File(directory, credsKey);
+                FileOutputStream fout = new FileOutputStream(f);
+                fout.write(decodedData);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void updateSubject(Subject subject, Map<String, String> credentials) {
+        populateSubject(subject, credentials);
+    }
+
+    @Override
+    public void populateSubject(Subject subject, Map<String, String> credentials) {
+        LOG.info("AutoSSL populating credentials");
+        Collection<String> sslFiles = getSSLFilesFromConf(conf);
+        if (sslFiles == null) {
+            LOG.debug("ssl files is null");
+            return;
+        }
+        for (String outputFile : sslFiles) {
+            deserializeSSLFile(new File(outputFile).getName(), writeDir,  credentials);
+        }
+    }
+}

--- a/storm-core/test/jvm/org/apache/storm/security/auth/AutoSSLTest.java
+++ b/storm-core/test/jvm/org/apache/storm/security/auth/AutoSSLTest.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.storm.security.auth;
 
 import java.io.File;

--- a/storm-core/test/jvm/org/apache/storm/security/auth/AutoSSLTest.java
+++ b/storm-core/test/jvm/org/apache/storm/security/auth/AutoSSLTest.java
@@ -1,0 +1,119 @@
+package org.apache.storm.security.auth;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.UUID;
+import javax.security.auth.Subject;
+
+import static org.junit.Assert.*;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AutoSSLTest {
+    final static Logger LOG = LoggerFactory.getLogger(AutoSSLTest.class);
+
+    // Test class to override the write directory
+    public class TestAutoSSL extends AutoSSL {
+
+        String baseDir = null;
+
+        TestAutoSSL(String newDir) {
+            baseDir = newDir;
+        }
+
+        @Override
+        protected String getSSLWriteDirFromConf(Map conf) {
+            return baseDir;
+        }
+    }
+
+    @Test
+    public void testgetSSLFilesFromConf() throws Exception {
+        AutoSSL assl = new AutoSSL();
+        Map conf = new HashMap();
+        assertNull(assl.getSSLFilesFromConf(conf));
+        conf.put(AutoSSL.SSL_FILES_CONF, "sslfile1.txt");
+        assl.prepare(conf);
+        Collection<String> sslFiles = assl.getSSLFilesFromConf(conf);
+        assertNotNull(sslFiles);
+        assertEquals(1, sslFiles.size());
+        for(String file: sslFiles) {
+            assertEquals("sslfile1.txt", file);
+        }
+    }
+
+    @Test
+    public void testgetSSLFilesFromConfMultipleComma() throws Exception {
+        AutoSSL assl = new AutoSSL();
+        Map conf = new HashMap();
+        assertNull(assl.getSSLFilesFromConf(conf));
+        conf.put(AutoSSL.SSL_FILES_CONF, "sslfile1.txt,sslfile2.txt,sslfile3.txt");
+        assl.prepare(conf);
+        Collection<String> sslFiles = assl.getSSLFilesFromConf(conf);
+        assertNotNull(sslFiles);
+        assertEquals(3, sslFiles.size());
+        ArrayList valid = new ArrayList<String>();
+        Collections.addAll(valid, "sslfile1.txt", "sslfile2.txt", "sslfile3.txt");
+        for(String file: sslFiles) {
+            assertTrue("removing: " + file, valid.remove(file));
+        }
+        assertEquals(0, valid.size());
+    }
+
+    @Test
+    public void testpopulateCredentials() throws Exception {
+        File temp = File.createTempFile("tmp-autossl-test", ".txt");
+        temp.deleteOnExit();
+        List<String> lines = Arrays.asList("The first line", "The second line");
+        Files.write(temp.toPath(), lines, Charset.forName("UTF-8"));
+        File baseDir = null;
+        try {
+            baseDir = new File("/tmp/autossl-test-"+ UUID.randomUUID());
+            if (!baseDir.mkdir()) {
+                throw new IOException("failed to create base directory");
+            }
+            AutoSSL assl = new TestAutoSSL(baseDir.getPath());
+
+            LOG.debug("base dir is; " + baseDir);
+            Map sslconf = new HashMap();
+
+            sslconf.put(AutoSSL.SSL_FILES_CONF, temp.getPath());
+            assl.prepare(sslconf);
+            Collection<String> sslFiles = assl.getSSLFilesFromConf(sslconf);
+ 
+            Map<String, String> creds = new HashMap();
+            assl.populateCredentials(creds);
+            assertTrue(creds.containsKey(temp.getName()));
+
+            Subject unusedSubject = new Subject();
+            assl.populateSubject(unusedSubject, creds);
+            String[] outputFiles = baseDir.list();  
+            assertEquals(1, outputFiles.length); 
+ 
+            // compare contents of files
+            if (outputFiles.length > 0) { 
+                List<String> linesWritten = FileUtils.readLines(new File(baseDir, outputFiles[0]),
+                    Charset.forName("UTF-8"));
+                for (String l: linesWritten) {
+                    assertTrue(lines.contains(l));
+                }
+            }
+        } finally {
+            if (baseDir != null) {
+                FileUtils.deleteDirectory(baseDir);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allows you to send your SSL files with your topology and update them in a secure fashion such that they aren't stored in an intermediate on disk location. You enable it using the topology.auto-credentials config and specify org.apache.storm.security.auth.AutoSSL. The user can specify the keystore/truststore files when submitting the topology with  -c "ssl.credential.files=directory/YourFiles". The files will be serialized along with your credentials and written out into the storm workers current directory as the base filename specified (directory part is not included). You should reference them as ./filename in your topology config. 

For example:
storm jar myjar hadooptest.topologies.KafkaSpoutTopology testtopo -c "ssl.credential.files=/home/user1/kafka.server.keystore.jks,/home/user1/kafka.server.truststore.jks"
You can also update the files if they are going to expire using the storm upload-credentials command
For example:
storm upload-credentials testtopo -c "ssl.credential.files=/home/user1/kafka.server.keystore.jks,/home/user1/kafka.server.truststore.jks"

