### PR TITLE
STORM-2194: Report error and die, not report error or die

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/executor/error/ReportErrorAndDie.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/error/ReportErrorAndDie.java
@@ -41,8 +41,7 @@ public class ReportErrorAndDie implements Thread.UncaughtExceptionHandler {
         if (Utils.exceptionCauseIsInstanceOf(InterruptedException.class, e)
                 || Utils.exceptionCauseIsInstanceOf(java.io.InterruptedIOException.class, e)) {
             LOG.info("Got interrupted exception shutting thread down...");
-        } else {
-            suicideFn.run();
         }
+        suicideFn.run();
     }
 }


### PR DESCRIPTION
This appears to have just ported an existing bug from executor.clj -- this is what I believe the expected behaviour is/was.