### PR TITLE
STORM 2197: NimbusClient connections leak due to ThriftClient connection's leakage in case of errors.

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/security/auth/ThriftClient.java
+++ b/storm-core/src/jvm/org/apache/storm/security/auth/ThriftClient.java
@@ -74,9 +74,10 @@ public class ThriftClient implements AutoCloseable {
     }
     
     public synchronized void reconnect() {
-        close();    
+        close();
+        TSocket socket = null;
         try {
-            TSocket socket = new TSocket(_host, _port);
+            socket = new TSocket(_host, _port);
             if(_timeout!=null) {
                 socket.setTimeout(_timeout);
             }
@@ -97,7 +98,13 @@ public class ThriftClient implements AutoCloseable {
                                       Utils.getInt(_conf.get(Config.STORM_NIMBUS_RETRY_INTERVAL_CEILING)),
                                       _retryForever);
             _transport = connectionRetry.doConnectWithRetry(transportPlugin, socket, _host, _asUser);
-        } catch (IOException ex) {
+        } catch (Exception ex) {
+            // close the socket, which releases connection if it has created any.
+            if(socket != null) {
+                try {
+                    socket.close();
+                } catch (Exception e) {}
+            }
             throw new RuntimeException(ex);
         }
         _protocol = null;


### PR DESCRIPTION
- NimbusClient connections leak due to ThriftClient connection's leakage in case of errors.