### PR TITLE
STORM-2205: Racecondition in getting nimbus summaries while ZK connections are reconnected.

### DIFF
--- a/storm-core/src/clj/org/apache/storm/cluster.clj
+++ b/storm-core/src/clj/org/apache/storm/cluster.clj
@@ -320,8 +320,11 @@
 
       (nimbuses
         [this]
-        (map #(maybe-deserialize (.get_data cluster-state (nimbus-path %1) false) NimbusSummary)
-          (.get_children cluster-state NIMBUSES-SUBTREE false)))
+        ;; remove any null instances which can exist because of a race condition in which
+        ;;  - nimbus nodes in zk may have been removed when connections are reconnected after getting children in
+        ;; /nimbuses node in zk.
+        (remove nil?  (map #(maybe-deserialize (.get_data cluster-state (nimbus-path %1) false) NimbusSummary)
+                           (.get_children cluster-state NIMBUSES-SUBTREE false))))
 
       (add-nimbus-host!
         [this nimbus-id nimbus-summary]


### PR DESCRIPTION
Below Exception is thrown because of race condition explained in the suggested fix.

```
java.lang.NullPointerException
	at clojure.lang.Reflector.invokeNoArgInstanceMember(Reflector.java:301)
	at org.apache.storm.daemon.nimbus$get_cluster_info$fn__11160.invoke(nimbus.clj:1397)
	at org.apache.storm.daemon.nimbus$get_cluster_info.invoke(nimbus.clj:1396)
	at org.apache.storm.daemon.nimbus$send_cluster_metrics_to_executors.invoke(nimbus.clj:1457)
	at org.apache.storm.daemon.nimbus$fn__11415$exec_fn__3529__auto____11416$fn__11442.invoke(nimbus.clj:2257)
	at org.apache.storm.timer$schedule_recurring$this__2156.invoke(timer.clj:105)
	at org.apache.storm.timer$mk_timer$fn__2139$fn__2140.invoke(timer.clj:50)
	at org.apache.storm.timer$mk_timer$fn__2139.invoke(timer.clj:42)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.lang.Thread.run(Thread.java:745)
2016-08-12 16:41:30.862 o.a.s.util [ERROR] Halting process: ("Error when processing an event")
java.lang.RuntimeException: ("Error when processing an event")
	at org.apache.storm.util$exit_process_BANG_.doInvoke(util.clj:341)
	at clojure.lang.RestFn.invoke(RestFn.java:423)
	at org.apache.storm.daemon.nimbus$nimbus_data$fn__10352.invoke(nimbus.clj:205)
	at org.apache.storm.timer$mk_timer$fn__2139$fn__2140.invoke(timer.clj:71)
	at org.apache.storm.timer$mk_timer$fn__2139.invoke(timer.clj:42)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.lang.Thread.run(Thread.java:745)
```