### PR TITLE
STORM-2212: Remove Redundant Declarations in Maven POM Files

### DIFF
--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -237,6 +237,7 @@
           <includeProjectDependencies>true</includeProjectDependencies>
           <includePluginDependencies>false</includePluginDependencies>
           <classpathScope>compile</classpathScope>
+          <!-- allows you to specify which topology class to run by specifying -Dstorm.topology= on the command line -->
           <mainClass>${storm.topology}</mainClass>
         </configuration>
       </plugin>

--- a/external/flux/pom.xml
+++ b/external/flux/pom.xml
@@ -81,11 +81,5 @@
             <artifactId>${storm.kafka.artifact.id}</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/external/storm-cassandra/pom.xml
+++ b/external/storm-cassandra/pom.xml
@@ -95,13 +95,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>

--- a/external/storm-eventhubs/pom.xml
+++ b/external/storm-eventhubs/pom.xml
@@ -114,11 +114,5 @@
             <artifactId>qpid-amqp-1-0-common</artifactId>
             <version>${qpid.version}</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -182,12 +182,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
             <version>${hadoop.version}</version>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -136,12 +136,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.9.0</version>

--- a/external/storm-jdbc/pom.xml
+++ b/external/storm-jdbc/pom.xml
@@ -63,12 +63,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <version>2.3.1</version>

--- a/external/storm-jms/examples/pom.xml
+++ b/external/storm-jms/examples/pom.xml
@@ -98,7 +98,6 @@
                     </descriptorRefs>
                     <archive>
                         <manifest>
-                            <mainClass></mainClass>
                         </manifest>
                     </archive>
                 </configuration>

--- a/external/storm-jms/pom.xml
+++ b/external/storm-jms/pom.xml
@@ -43,18 +43,6 @@
         <module>examples</module>
     </modules>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>storm-core</artifactId>
-            <version>${project.version}</version>
-            <!-- keep storm out of the jar-with-dependencies -->
-            <scope>provided</scope>
-        </dependency>
-
-    </dependencies>
-
-
     <build>
         <plugins>
             <plugin>

--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -75,12 +75,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>info.batey.kafka</groupId>
             <artifactId>kafka-unit</artifactId>
             <version>0.6</version>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -69,12 +69,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
             <version>${curator.version}</version>

--- a/external/storm-metrics/pom.xml
+++ b/external/storm-metrics/pom.xml
@@ -24,7 +24,6 @@
       <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.storm</groupId>
   <artifactId>storm-metrics</artifactId>
   <packaging>jar</packaging>
 

--- a/external/storm-solr/pom.xml
+++ b/external/storm-solr/pom.xml
@@ -85,12 +85,6 @@
         </dependency>
         <!--test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.3.1</version>

--- a/storm-buildtools/maven-shade-clojure-transformer/pom.xml
+++ b/storm-buildtools/maven-shade-clojure-transformer/pom.xml
@@ -25,7 +25,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <groupId>org.apache.storm</groupId>
     <artifactId>maven-shade-clojure-transformer</artifactId>
 
     <dependencies>

--- a/storm-buildtools/storm-maven-plugins/pom.xml
+++ b/storm-buildtools/storm-maven-plugins/pom.xml
@@ -25,7 +25,7 @@
         <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
   </parent>
-  <groupId>org.apache.storm</groupId>
+
   <artifactId>storm-maven-plugins</artifactId>
   <packaging>maven-plugin</packaging>
   <name>storm-maven-plugins</name>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -23,7 +23,7 @@
         <version>2.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
-    <groupId>org.apache.storm</groupId>
+
     <artifactId>storm-core</artifactId>
     <packaging>jar</packaging>
     <name>Storm Core</name>

--- a/storm-dist/binary/pom.xml
+++ b/storm-dist/binary/pom.xml
@@ -24,7 +24,7 @@
         <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-    <groupId>org.apache.storm</groupId>
+
     <artifactId>apache-storm-bin</artifactId>
     <packaging>pom</packaging>
     <name>Storm Binary Distribution</name>

--- a/storm-dist/source/pom.xml
+++ b/storm-dist/source/pom.xml
@@ -24,7 +24,7 @@
         <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-    <groupId>org.apache.storm</groupId>
+
     <artifactId>apache-storm-source</artifactId>
     <packaging>pom</packaging>
     <name>Storm Source Distribution</name>

--- a/storm-multilang/javascript/pom.xml
+++ b/storm-multilang/javascript/pom.xml
@@ -25,7 +25,7 @@
         <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-    <groupId>org.apache.storm</groupId>
+
     <artifactId>multilang-javascript</artifactId>
     <packaging>jar</packaging>
     <name>multilang-javascript</name>

--- a/storm-multilang/python/pom.xml
+++ b/storm-multilang/python/pom.xml
@@ -24,7 +24,7 @@
         <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-    <groupId>org.apache.storm</groupId>
+
     <artifactId>multilang-python</artifactId>
     <packaging>jar</packaging>
     <name>multilang-python</name>

--- a/storm-multilang/ruby/pom.xml
+++ b/storm-multilang/ruby/pom.xml
@@ -24,7 +24,7 @@
         <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-    <groupId>org.apache.storm</groupId>
+
     <artifactId>multilang-ruby</artifactId>
     <packaging>jar</packaging>
     <name>multilang-ruby</name>

--- a/storm-rename-hack/pom.xml
+++ b/storm-rename-hack/pom.xml
@@ -24,10 +24,9 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.storm</groupId>
+
   <artifactId>storm-rename-hack</artifactId>
   <packaging>jar</packaging>
-
   <name>storm-rename-hack</name>
 
   <properties>


### PR DESCRIPTION
  - Remove redundant declarations cause warnings and make the build files harder to extend and maintain