### PR TITLE
STORM-2213 ShellSpout has race condition when ShellSpout is being inactive longer than heartbeat timeout

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/spout/ShellSpout.java
+++ b/storm-core/src/jvm/org/apache/storm/spout/ShellSpout.java
@@ -288,6 +288,7 @@ public class ShellSpout implements ISpout {
     }
 
     private void markWaitingSubprocess() {
+        setHeartbeat();
         waitingOnSubprocess.compareAndSet(false, true);
     }
 


### PR DESCRIPTION
* update heartbeat time before turn on flag 'waitingOnSubprocess'

I brought additional guard logic for long idle ShellSpout ([STORM-1928](https://issues.apache.org/jira/browse/STORM-1928)), which resolved the issue, but I found race condition from new logic.

Scenario:

1. lastHeartbeat is not updated more than timeout because of inactivity
1. querySubprocess() is called
1. waitingOnSubprocess is set to true
1. HeartbeatTimerTask.run() triggers faster than updating heartbeat (getting message from subprocess)

Simplest approach is updating heartbeat before set waitingOnSubprocess to true. Last heartbeat time is no longer only from subprocess, but it doesn't harm.