### PR TITLE
Fixing a bug related to following exception

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/stats/StatsUtil.java
+++ b/storm-core/src/jvm/org/apache/storm/stats/StatsUtil.java
@@ -1516,7 +1516,7 @@ public class StatsUtil {
 
             Integer start = ((Number) key.get(0)).intValue();
             String host = (String) value.get(0);
-            Integer port = (Integer) value.get(1);
+            Integer port = (Long) value.get(1);
             String comp = (String) task2component.get(start);
             if ((compId == null || compId.equals(comp)) && (includeSys || !Utils.isSystemId(comp))) {
                 hostPorts.add(Lists.newArrayList(host, port));


### PR DESCRIPTION
java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.Integer
    at org.apache.storm.stats.StatsUtil.extractNodeInfosFromHbForComp(StatsUtil.java:1519)
    at org.apache.storm.daemon.nimbus$mk_reified_nimbus$reify__5190.getComponentPendingProfileActions(nimbus.clj:1819)
    at org.apache.storm.generated.Nimbus$Processor$getComponentPendingProfileActions.getResult(Nimbus.java:3259)
    at org.apache.storm.generated.Nimbus$Processor$getComponentPendingProfileActions.getResult(Nimbus.java:3244)
    at org.apache.storm.thrift.ProcessFunction.process(ProcessFunction.java:39)
    at org.apache.storm.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
    at org.apache.storm.security.auth.SimpleTransportPlugin$SimpleWrapProcessor.process(SimpleTransportPlugin.java:158)
    at org.apache.storm.thrift.server.AbstractNonblockingServer$FrameBuffer.invoke(AbstractNonblockingServer.java:518)
    at org.apache.storm.thrift.server.Invocation.run(Invocation.java:18)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)