### PR TITLE
STORM-2235 Introduce new option: 'add remote repositories' for dependency resolver

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -99,6 +99,7 @@ STORM_EXT_CLASSPATH = os.getenv('STORM_EXT_CLASSPATH', None)
 STORM_EXT_CLASSPATH_DAEMON = os.getenv('STORM_EXT_CLASSPATH_DAEMON', None)
 DEP_JARS_OPTS = []
 DEP_ARTIFACTS_OPTS = []
+DEP_ARTIFACTS_REPOSITORIES_OPTS = []
 
 def get_config_opts():
     global CONFIG_OPTS
@@ -158,11 +159,11 @@ def confvalue(name, extrapaths, daemon=True):
     return ""
 
 
-def resolve_dependencies(artifacts):
+def resolve_dependencies(artifacts, artifact_repositories):
     if len(artifacts) == 0:
         return {}
 
-    print("Resolving dependencies on demand: artifacts (%s)" % artifacts)
+    print("Resolving dependencies on demand: artifacts (%s) with repositories (%s)" % (artifacts, artifact_repositories))
     sys.stdout.flush()
 
     # TODO: should we move some external modules to outer place?
@@ -173,7 +174,7 @@ def resolve_dependencies(artifacts):
 
     command = [
         JAVA_CMD, "-client", "-cp", classpath, "org.apache.storm.submit.command.DependencyResolverMain",
-        ",".join(artifacts)
+        ",".join(artifacts), ",".join(artifact_repositories)
     ]
 
     p = sub.Popen(command, stdout=sub.PIPE)
@@ -280,14 +281,18 @@ def jar(jarfile, klass, *args):
     Please add exclusion artifacts with '^' separated string after the artifact.
     For example, --artifacts "redis.clients:jedis:2.9.0,org.apache.kafka:kafka_2.10:0.8.2.2^org.slf4j:slf4j-log4j12" will load jedis and kafka artifact and all of transitive dependencies but exclude slf4j-log4j12 from kafka.
 
-    Complete example of both options is here: `./bin/storm jar example/storm-starter/storm-starter-topologies-*.jar org.apache.storm.starter.RollingTopWords blobstore-remote2 remote --jars "./external/storm-redis/storm-redis-1.1.0.jar,./external/storm-kafka/storm-kafka-1.1.0.jar" --artifacts "redis.clients:jedis:2.9.0,org.apache.kafka:kafka_2.10:0.8.2.2^org.slf4j:slf4j-log4j12"`
+    When you need to pull the artifacts from other than Maven Central, you can pass remote repositories to --artifactRepositories option with comma-separated string.
+    Repository format is "<name>^<url>". '^' is taken as separator because URL allows various characters.
+    For example, --artifactRepositories "jboss-repository^http://repository.jboss.com/maven2,HDPRepo^http://repo.hortonworks.com/content/groups/public/" will add JBoss and HDP repositories for dependency resolver.
+
+    Complete example of options is here: `./bin/storm jar example/storm-starter/storm-starter-topologies-*.jar org.apache.storm.starter.RollingTopWords blobstore-remote2 remote --jars "./external/storm-redis/storm-redis-1.1.0.jar,./external/storm-kafka/storm-kafka-1.1.0.jar" --artifacts "redis.clients:jedis:2.9.0,org.apache.kafka:kafka_2.10:0.8.2.2^org.slf4j:slf4j-log4j12" --artifactRepositories "jboss-repository^http://repository.jboss.com/maven2,HDPRepo^http://repo.hortonworks.com/content/groups/public/"`
 
     When you pass jars and/or artifacts options, StormSubmitter will upload them when the topology is submitted, and they will be included to classpath of both the process which runs the class, and also workers for that topology.
     """
-    global DEP_JARS_OPTS, DEP_ARTIFACTS_OPTS
+    global DEP_JARS_OPTS, DEP_ARTIFACTS_OPTS, DEP_ARTIFACTS_REPOSITORIES_OPTS
 
     local_jars = DEP_JARS_OPTS
-    artifact_to_file_jars = resolve_dependencies(DEP_ARTIFACTS_OPTS)
+    artifact_to_file_jars = resolve_dependencies(DEP_ARTIFACTS_OPTS, DEP_ARTIFACTS_REPOSITORIES_OPTS)
 
     transform_class = confvalue("client.jartransformer.class", [CLUSTER_CONF_DIR])
     if (transform_class != None and transform_class != "null"):
@@ -328,14 +333,14 @@ def sql(sql_file, topology_name):
     Compiles the SQL statements into a Trident topology and submits it to Storm.
     If user activates explain mode, SQL Runner analyzes each query statement and shows query plan instead of submitting topology.
 
-    --jars and --artifacts options available for jar are also applied to sql command.
-    Please refer "help jar" to see how to use --jars and --artifacts options.
+    --jars and --artifacts, and --artifactRepositories options available for jar are also applied to sql command.
+    Please refer "help jar" to see how to use --jars and --artifacts, and --artifactRepositories options.
     You normally want to pass these options since you need to set data source to your sql which is an external storage in many cases.
     """
-    global DEP_JARS_OPTS, DEP_ARTIFACTS_OPTS
+    global DEP_JARS_OPTS, DEP_ARTIFACTS_OPTS, DEP_ARTIFACTS_REPOSITORIES_OPTS
 
     local_jars = DEP_JARS_OPTS
-    artifact_to_file_jars = resolve_dependencies(DEP_ARTIFACTS_OPTS)
+    artifact_to_file_jars = resolve_dependencies(DEP_ARTIFACTS_OPTS, DEP_ARTIFACTS_REPOSITORIES_OPTS)
 
     sql_core_jars = get_jars_full(STORM_DIR + "/external/sql/storm-sql-core")
     sql_runtime_jars = get_jars_full(STORM_DIR + "/external/sql/storm-sql-runtime")
@@ -859,6 +864,7 @@ def parse_config_opts(args):
     args_list = []
     jars_list = []
     artifacts_list = []
+    artifact_repositories_list = []
 
     while len(curr) > 0:
         token = curr.pop()
@@ -871,20 +877,23 @@ def parse_config_opts(args):
             jars_list.extend(curr.pop().split(','))
         elif token == "--artifacts":
             artifacts_list.extend(curr.pop().split(','))
+        elif token == "--artifactRepositories":
+            artifact_repositories_list.extend(curr.pop().split(','))
         else:
             args_list.append(token)
 
-    return config_list, jars_list, artifacts_list, args_list
+    return config_list, jars_list, artifacts_list, artifact_repositories_list, args_list
 
 def main():
     if len(sys.argv) <= 1:
         print_usage()
         sys.exit(-1)
-    global CONFIG_OPTS, DEP_JARS_OPTS, DEP_ARTIFACTS_OPTS
-    config_list, jars_list, artifacts_list, args = parse_config_opts(sys.argv[1:])
+    global CONFIG_OPTS, DEP_JARS_OPTS, DEP_ARTIFACTS_OPTS, DEP_ARTIFACTS_REPOSITORIES_OPTS
+    config_list, jars_list, artifacts_list, artifact_repositories_list, args = parse_config_opts(sys.argv[1:])
     parse_config(config_list)
     DEP_JARS_OPTS = jars_list
     DEP_ARTIFACTS_OPTS = artifacts_list
+    DEP_ARTIFACTS_REPOSITORIES_OPTS = artifact_repositories_list
     COMMAND = args[0]
     ARGS = args[1:]
     (COMMANDS.get(COMMAND, unknown_command))(*ARGS)

--- a/docs/Command-line-client.md
+++ b/docs/Command-line-client.md
@@ -47,7 +47,9 @@ When you want to ship other jars which is not included to application jar, you c
 For example, --jars "your-local-jar.jar,your-local-jar2.jar" will load your-local-jar.jar and your-local-jar2.jar.
 And when you want to ship maven artifacts and its transitive dependencies, you can pass them to `--artifacts` with comma-separated string. You can also exclude some dependencies like what you're doing in maven pom. Please add exclusion artifacts with '^' separated string after the artifact. For example, `--artifacts "redis.clients:jedis:2.9.0,org.apache.kafka:kafka_2.10:0.8.2.2^org.slf4j:slf4j-log4j12"` will load jedis and kafka artifact and all of transitive dependencies but exclude slf4j-log4j12 from kafka.
 
-Complete example of both options is here: `./bin/storm jar example/storm-starter/storm-starter-topologies-*.jar org.apache.storm.starter.RollingTopWords blobstore-remote2 remote --jars "./external/storm-redis/storm-redis-1.1.0.jar,./external/storm-kafka/storm-kafka-1.1.0.jar" --artifacts "redis.clients:jedis:2.9.0,org.apache.kafka:kafka_2.10:0.8.2.2^org.slf4j:slf4j-log4j12"`
+When you need to pull the artifacts from other than Maven Central, you can pass remote repositories to --artifactRepositories option with comma-separated string. Repository format is "<name>^<url>". '^' is taken as separator because URL allows various characters. For example, --artifactRepositories "jboss-repository^http://repository.jboss.com/maven2,HDPRepo^http://repo.hortonworks.com/content/groups/public/" will add JBoss and HDP repositories for dependency resolver.
+
+Complete example of both options is here: `./bin/storm jar example/storm-starter/storm-starter-topologies-*.jar org.apache.storm.starter.RollingTopWords blobstore-remote2 remote --jars "./external/storm-redis/storm-redis-1.1.0.jar,./external/storm-kafka/storm-kafka-1.1.0.jar" --artifacts "redis.clients:jedis:2.9.0,org.apache.kafka:kafka_2.10:0.8.2.2^org.slf4j:slf4j-log4j12" --artifactRepositories "jboss-repository^http://repository.jboss.com/maven2,HDPRepo^http://repo.hortonworks.com/content/groups/public/"`
 
 When you pass jars and/or artifacts options, StormSubmitter will upload them when the topology is submitted, and they will be included to classpath of both the process which runs the class, and also workers for that topology.
 
@@ -57,7 +59,7 @@ Syntax: `storm sql sql-file topology-name`
 
 Compiles the SQL statements into a Trident topology and submits it to Storm.
 
-`--jars` and `--artifacts` options are also applied to `sql` command. You normally want to pass these options since you need to set data source to your sql which is an external storage in many cases.
+`--jars` and `--artifacts`, and `--artifactRepositories` options available for jar are also applied to sql command. Please refer "help jar" to see how to use --jars and --artifacts, and --artifactRepositories options. You normally want to pass these options since you need to set data source to your sql which is an external storage in many cases.
 
 ### kill
 

--- a/external/storm-submit-tools/src/main/java/org/apache/storm/submit/command/DependencyResolverMain.java
+++ b/external/storm-submit-tools/src/main/java/org/apache/storm/submit/command/DependencyResolverMain.java
@@ -25,10 +25,12 @@ import org.apache.storm.submit.dependency.DependencyResolver;
 import org.json.simple.JSONValue;
 import org.sonatype.aether.artifact.Artifact;
 import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.repository.RemoteRepository;
 import org.sonatype.aether.resolution.ArtifactResult;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,10 +46,22 @@ public class DependencyResolverMain {
 
         // DO NOT CHANGE THIS TO SYSOUT
         System.err.println("DependencyResolver input - artifacts: " + artifactsArg);
-
         List<Dependency> dependencies = parseArtifactArgs(artifactsArg);
+
+        List<RemoteRepository> repositories;
+        if (args.length > 1) {
+            String remoteRepositoryArg = args[1];
+
+            // DO NOT CHANGE THIS TO SYSOUT
+            System.err.println("DependencyResolver input - repositories: " + remoteRepositoryArg);
+
+            repositories = parseRemoteRepositoryArgs(remoteRepositoryArg);
+        } else {
+            repositories = Collections.emptyList();
+        }
+
         try {
-            DependencyResolver resolver = new DependencyResolver("local-repo");
+            DependencyResolver resolver = new DependencyResolver("local-repo", repositories);
 
             List<ArtifactResult> artifactResults = resolver.resolve(dependencies);
 
@@ -91,6 +105,20 @@ public class DependencyResolverMain {
         }
 
         return dependencies;
+    }
+
+    private static List<RemoteRepository> parseRemoteRepositoryArgs(String remoteRepositoryArg) {
+        List<String> repositories = Arrays.asList(remoteRepositoryArg.split(","));
+        List<RemoteRepository> remoteRepositories = new ArrayList<>(repositories.size());
+        for (String repositoryOpt : repositories) {
+            if (repositoryOpt.trim().isEmpty()) {
+                continue;
+            }
+
+            remoteRepositories.add(AetherUtils.parseRemoteRepository(repositoryOpt));
+        }
+
+        return remoteRepositories;
     }
 
     private static Map<String, String> transformArtifactResultToArtifactToPaths(List<ArtifactResult> artifactResults) {

--- a/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/AetherUtils.java
+++ b/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/AetherUtils.java
@@ -20,6 +20,7 @@ package org.apache.storm.submit.dependency;
 import org.sonatype.aether.artifact.Artifact;
 import org.sonatype.aether.graph.Dependency;
 import org.sonatype.aether.graph.Exclusion;
+import org.sonatype.aether.repository.RemoteRepository;
 import org.sonatype.aether.util.artifact.DefaultArtifact;
 import org.sonatype.aether.util.artifact.JavaScopes;
 
@@ -77,5 +78,14 @@ public class AetherUtils {
         }
         buffer.append(':').append(artifact.getVersion());
         return buffer.toString();
+    }
+
+    public static RemoteRepository parseRemoteRepository(String repository) {
+        String[] parts = repository.split("\\^");
+        if (parts.length < 2) {
+            throw new IllegalArgumentException("Bad remote repository form: " + repository);
+        }
+
+        return new RemoteRepository(parts[0], "default", parts[1]);
     }
 }

--- a/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/DependencyResolver.java
+++ b/external/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/DependencyResolver.java
@@ -33,19 +33,29 @@ import org.sonatype.aether.util.filter.DependencyFilterUtils;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class DependencyResolver {
-    private RepositorySystem system = Booter.newRepositorySystem();
-    private RepositorySystemSession session;
-    private RemoteRepository mavenCentral = Booter.newCentralRepository();
-    private RemoteRepository mavenLocal = Booter.newLocalRepository();
+    private final RepositorySystem system = Booter.newRepositorySystem();
+    private final RepositorySystemSession session;
+
+    private final List<RemoteRepository> remoteRepositories;
 
     public DependencyResolver(String localRepoPath) {
+        this(localRepoPath, Collections.emptyList());
+    }
+
+    public DependencyResolver(String localRepoPath, List<RemoteRepository> repositories) {
         localRepoPath = handleRelativePath(localRepoPath);
 
         session = Booter.newRepositorySystemSession(system, localRepoPath);
+
+        remoteRepositories = new ArrayList<>();
+        remoteRepositories.add(Booter.newCentralRepository());
+        remoteRepositories.add(Booter.newLocalRepository());
+        remoteRepositories.addAll(repositories);
     }
 
     private String handleRelativePath(String localRepoPath) {
@@ -78,8 +88,9 @@ public class DependencyResolver {
             collectRequest.addDependency(dependencies.get(idx));
         }
 
-        collectRequest.addRepository(mavenCentral);
-        collectRequest.addRepository(mavenLocal);
+        for (RemoteRepository repository : remoteRepositories) {
+            collectRequest.addRepository(repository);
+        }
 
         DependencyRequest dependencyRequest = new DependencyRequest(collectRequest, classpathFilter);
         return system.resolveDependencies(session, dependencyRequest).getArtifactResults();


### PR DESCRIPTION
* add '--artifactRepositories' option to pull the artifacts from other than Maven Central

In this example, we pull specific HDP version of storm-core (only for example). If we don't add HDPRepo to `--artifactRepositories`, it fails to pull the artifacts and also dependencies.
Below is the working example:

>./bin/storm sql order_filtering_mongo.sql sql-mongo --artifacts "org.apache.storm:storm-core:1.0.1.2.5.0.0-1245" --artifactRepositories "jboss-repository^http://repository.jboss.com/maven2,cloudera^https://repository.cloudera.com/artifactory/cloudera-repos/,HDPRepo^http://repo.hortonworks.com/content/groups/public/"
