### PR TITLE
STORM-2239: Handle InterruptException in new Kafka spout

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -233,7 +233,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         } catch (InterruptException e) {
             //Kafka throws their own type of exception when interrupted.
             //Throw a new Java InterruptedException to ensure Storm can recognize the exception as a reaction to an interrupt.
-            throw new RuntimeException(new InterruptedException());
+            throw new RuntimeException(new InterruptedException("Kafka consumer was interrupted"));
         }
     }
 
@@ -396,7 +396,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         } catch (InterruptException e) {
             //Kafka throws their own type of exception when interrupted.
             //Throw a new Java InterruptedException to ensure Storm can recognize the exception as a reaction to an interrupt.
-            throw new RuntimeException(new InterruptedException());
+            throw new RuntimeException(new InterruptedException("Kafka consumer was interrupted"));
         }
     }
 
@@ -424,7 +424,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         } catch (InterruptException e) {
             //Kafka throws their own type of exception when interrupted.
             //Throw a new Java InterruptedException to ensure Storm can recognize the exception as a reaction to an interrupt.
-            throw new RuntimeException(new InterruptedException());
+            throw new RuntimeException(new InterruptedException("Kafka consumer was interrupted"));
         }
     }
 
@@ -435,7 +435,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         } catch (InterruptException e) {
             //Kafka throws their own type of exception when interrupted.
             //Throw a new Java InterruptedException to ensure Storm can recognize the exception as a reaction to an interrupt.
-            throw new RuntimeException(new InterruptedException());
+            throw new RuntimeException(new InterruptedException("Kafka consumer was interrupted"));
         }
     }
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -231,10 +231,14 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                 LOG.debug("Spout not initialized. Not sending tuples until initialization completes");
             }
         } catch (InterruptException e) {
-            //Kafka throws their own type of exception when interrupted.
-            //Throw a new Java InterruptedException to ensure Storm can recognize the exception as a reaction to an interrupt.
-            throw new RuntimeException(new InterruptedException("Kafka consumer was interrupted"));
+            throwKafkaConsumerInterruptedException();
         }
+    }
+    
+    private void throwKafkaConsumerInterruptedException() {
+        //Kafka throws their own type of exception when interrupted.
+        //Throw a new Java InterruptedException to ensure Storm can recognize the exception as a reaction to an interrupt.
+        throw new RuntimeException(new InterruptedException("Kafka consumer was interrupted"));
     }
 
     private boolean commit() {
@@ -394,9 +398,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         try {
             subscribeKafkaConsumer();
         } catch (InterruptException e) {
-            //Kafka throws their own type of exception when interrupted.
-            //Throw a new Java InterruptedException to ensure Storm can recognize the exception as a reaction to an interrupt.
-            throw new RuntimeException(new InterruptedException("Kafka consumer was interrupted"));
+            throwKafkaConsumerInterruptedException();
         }
     }
 
@@ -422,9 +424,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         try {
             shutdown();
         } catch (InterruptException e) {
-            //Kafka throws their own type of exception when interrupted.
-            //Throw a new Java InterruptedException to ensure Storm can recognize the exception as a reaction to an interrupt.
-            throw new RuntimeException(new InterruptedException("Kafka consumer was interrupted"));
+            throwKafkaConsumerInterruptedException();
         }
     }
 
@@ -433,9 +433,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         try {
             shutdown();
         } catch (InterruptException e) {
-            //Kafka throws their own type of exception when interrupted.
-            //Throw a new Java InterruptedException to ensure Storm can recognize the exception as a reaction to an interrupt.
-            throw new RuntimeException(new InterruptedException("Kafka consumer was interrupted"));
+            throwKafkaConsumerInterruptedException();
         }
     }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/STORM-2239.

This basically just ensures that if the Kafka consumer throws InterruptException, we catch it and interrupt the current thread before returning to Storm.

I realize that this won't be an issue until the next Kafka release, but it doesn't hurt to get it fixed now.