### PR TITLE
STORM-2121: Overriding StringKeyValueScheme.getOutputFields to contain both key and value

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/StringKeyValueScheme.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/StringKeyValueScheme.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import static org.apache.storm.kafka.StringScheme.deserializeString;
+
 public class StringKeyValueScheme extends StringScheme implements KeyValueScheme {
 
     @Override
@@ -30,9 +32,7 @@ public class StringKeyValueScheme extends StringScheme implements KeyValueScheme
         if ( key == null ) {
             return deserialize(value);
         }
-        String keyString = StringScheme.deserializeString(key);
-        String valueString = StringScheme.deserializeString(value);
-        return new Values(ImmutableMap.of(keyString, valueString));
+        return new Values(ImmutableMap.of(deserializeString(key), deserializeString(value)));
     }
 
 }

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/StringKeyValueScheme.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/StringKeyValueScheme.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.kafka;
 
+import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Values;
 import com.google.common.collect.ImmutableMap;
 
@@ -24,6 +25,8 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import static org.apache.storm.kafka.StringScheme.deserializeString;
+import static org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper.BOLT_KEY;
+import static org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper.BOLT_MESSAGE;
 
 public class StringKeyValueScheme extends StringScheme implements KeyValueScheme {
 
@@ -33,6 +36,11 @@ public class StringKeyValueScheme extends StringScheme implements KeyValueScheme
             return deserialize(value);
         }
         return new Values(ImmutableMap.of(deserializeString(key), deserializeString(value)));
+    }
+
+    @Override
+    public Fields getOutputFields() {
+        return new Fields(BOLT_KEY, BOLT_MESSAGE);
     }
 
 }

--- a/external/storm-kafka/src/test/org/apache/storm/kafka/StringKeyValueSchemeTest.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/StringKeyValueSchemeTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.storm.kafka;
 
-import org.apache.storm.tuple.Fields;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
@@ -25,8 +24,10 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Collections;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper.BOLT_KEY;
+import static org.apache.storm.kafka.bolt.mapper.FieldNameBasedTupleToKafkaMapper.BOLT_MESSAGE;
 
 public class StringKeyValueSchemeTest {
 
@@ -39,9 +40,7 @@ public class StringKeyValueSchemeTest {
 
     @Test
     public void testGetOutputFields() throws Exception {
-        Fields outputFields = scheme.getOutputFields();
-        assertTrue(outputFields.contains(StringScheme.STRING_SCHEME_KEY));
-        assertEquals(1, outputFields.size());
+        assertEquals(asList(BOLT_KEY, BOLT_MESSAGE), scheme.getOutputFields().toList());
     }
 
     @Test


### PR DESCRIPTION
Added proper fields to getOutputFields method of StringKeyValueScheme as described in https://issues.apache.org/jira/browse/STORM-2121.
Minor refactoring of deserializeKeyAndValue method: inlined deserialization and added static import for StringScheme.deserializeString.