### PR TITLE
STORM-2236 storm kafka client support manual partition management.

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaUtils.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaUtils.java
@@ -1,0 +1,23 @@
+package org.apache.storm.kafka.spout;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Created by liurenjie on 12/7/16.
+ */
+public final class KafkaUtils {
+    public static List<PartitionInfo> readPartitions(KafkaConsumer<?, ?> consumer, Iterable<String> topics) {
+        List<PartitionInfo> partitionInfos = new ArrayList<>();
+        for (String topic : topics) {
+            partitionInfos.addAll(consumer.partitionsFor(topic));
+        }
+
+        return partitionInfos;
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/TopicPartitionComparator.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/TopicPartitionComparator.java
@@ -1,0 +1,21 @@
+package org.apache.storm.kafka.spout;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Comparator;
+
+/**
+ * Created by liurenjie on 12/7/16.
+ */
+public enum TopicPartitionComparator implements Comparator<TopicPartition> {
+    INSTANCE;
+
+    @Override
+    public int compare(TopicPartition o1, TopicPartition o2) {
+        if (!o1.topic().equals(o2.topic())) {
+            return o1.topic().compareTo(o2.topic());
+        } else {
+            return o1.partition() - o2.partition();
+        }
+    }
+}


### PR DESCRIPTION
1. Support manual partition assignment, since kafka managed partition assignment may cause unnecessary rebalance if you don't keep polling.
2. A little change to fix STOMR-2077 which may lose failed messages.