### PR TITLE
STORM-2250: Kafka Spout Refactoring to Increase Modularity and Testability

### DIFF
--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -77,7 +77,13 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
@@ -90,7 +96,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>${log4j-over-slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -25,16 +25,13 @@ import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrat
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableSet;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -48,6 +45,7 @@ import org.apache.kafka.common.errors.RetriableException;
 import org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy;
 import org.apache.storm.kafka.spout.internal.KafkaConsumerFactory;
 import org.apache.storm.kafka.spout.internal.KafkaConsumerFactoryDefault;
+import org.apache.storm.kafka.spout.internal.OffsetManager;
 import org.apache.storm.kafka.spout.internal.Timer;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -58,18 +56,18 @@ import org.slf4j.LoggerFactory;
 
 public class KafkaSpout<K, V> extends BaseRichSpout {
     private static final long serialVersionUID = 4151921085047987154L;
+    //Initial delay for the commit and subscription refresh timers
+    public static final long TIMER_DELAY_MS = 500;
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSpout.class);
-    private static final Comparator<KafkaSpoutMessageId> OFFSET_COMPARATOR = new OffsetComparator();
 
     // Storm
     protected SpoutOutputCollector collector;
 
     // Kafka
     private final KafkaSpoutConfig<K, V> kafkaSpoutConfig;
-    private final KafkaConsumerFactory kafkaConsumerFactory;
+    private KafkaConsumerFactory kafkaConsumerFactory;
     private transient KafkaConsumer<K, V> kafkaConsumer;
     private transient boolean consumerAutoCommitMode;
-
 
     // Bookkeeping
     private transient FirstPollOffsetStrategy firstPollOffsetStrategy;  // Strategy to determine the fetch offset of the first realized by the spout upon activation
@@ -78,7 +76,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
     private transient boolean initialized;                              // Flag indicating that the spout is still undergoing initialization process.
     // Initialization is only complete after the first call to  KafkaSpoutConsumerRebalanceListener.onPartitionsAssigned()
 
-    transient Map<TopicPartition, OffsetEntry> acked;           // Tuples that were successfully acked. These tuples will be committed periodically when the commit timer expires, after consumer rebalance, or on close/deactivate. Not used if it's AutoCommitMode
+    private transient Map<TopicPartition, OffsetManager> acked;           // Tuples that were successfully acked. These tuples will be committed periodically when the commit timer expires, after consumer rebalance, or on close/deactivate
     private transient Set<KafkaSpoutMessageId> emitted;                 // Tuples that have been emitted but that are "on the wire", i.e. pending being acked or failed. Not used if it's AutoCommitMode
     private transient Iterator<ConsumerRecord<K, V>> waitingToEmit;         // Records that have been polled and are queued to be emitted in the nextTuple() call. One record is emitted per nextTuple()
     private transient long numUncommittedOffsets;                       // Number of offsets that have been polled and emitted but not yet been committed. Not used if it's AutoCommitMode
@@ -87,13 +85,13 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
 
 
     public KafkaSpout(KafkaSpoutConfig<K, V> kafkaSpoutConfig) {
-        this(kafkaSpoutConfig, new KafkaConsumerFactoryDefault());
+        this(kafkaSpoutConfig, new KafkaConsumerFactoryDefault<>());
     }
     
     //This constructor is here for testing
     KafkaSpout(KafkaSpoutConfig<K, V> kafkaSpoutConfig, KafkaConsumerFactory<K, V> kafkaConsumerFactory) {
-        this.kafkaSpoutConfig = kafkaSpoutConfig;                 // Pass in configuration
         this.kafkaConsumerFactory = kafkaConsumerFactory;
+        this.kafkaSpoutConfig = kafkaSpoutConfig;
     }
 
     @Override
@@ -114,9 +112,9 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         retryService = kafkaSpoutConfig.getRetryService();
 
         if (!consumerAutoCommitMode) {     // If it is auto commit, no need to commit offsets manually
-            commitTimer = new Timer(500, kafkaSpoutConfig.getOffsetsCommitPeriodMs(), TimeUnit.MILLISECONDS);
+            commitTimer = new Timer(TIMER_DELAY_MS, kafkaSpoutConfig.getOffsetsCommitPeriodMs(), TimeUnit.MILLISECONDS);
         }
-        refreshSubscriptionTimer = new Timer(500, kafkaSpoutConfig.getPartitionRefreshPeriodMs(), TimeUnit.MILLISECONDS);
+        refreshSubscriptionTimer = new Timer(TIMER_DELAY_MS, kafkaSpoutConfig.getPartitionRefreshPeriodMs(), TimeUnit.MILLISECONDS);
 
         acked = new HashMap<>();
         emitted = new HashSet<>();
@@ -198,7 +196,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
     private void setAcked(TopicPartition tp, long fetchOffset) {
         // If this partition was previously assigned to this spout, leave the acked offsets as they were to resume where it left off
         if (!consumerAutoCommitMode && !acked.containsKey(tp)) {
-            acked.put(tp, new OffsetEntry(tp, fetchOffset));
+            acked.put(tp, new OffsetManager(tp, fetchOffset));
         }
     }
 
@@ -290,7 +288,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
             if (offsetAndMeta != null) {
                 kafkaConsumer.seek(rtp, offsetAndMeta.offset() + 1);  // seek to the next offset that is ready to commit in next commit cycle
             } else {
-                kafkaConsumer.seek(rtp, acked.get(rtp).committedOffset + 1);    // Seek to last committed offset
+                kafkaConsumer.seek(rtp, acked.get(rtp).getCommittedOffset() + 1);    // Seek to last committed offset
             }
         }
     }
@@ -347,7 +345,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
     private void commitOffsetsForAckedTuples() {
         // Find offsets that are ready to be committed for every topic partition
         final Map<TopicPartition, OffsetAndMetadata> nextCommitOffsets = new HashMap<>();
-        for (Map.Entry<TopicPartition, OffsetEntry> tpOffset : acked.entrySet()) {
+        for (Map.Entry<TopicPartition, OffsetManager> tpOffset : acked.entrySet()) {
             final OffsetAndMetadata nextCommitOffset = tpOffset.getValue().findNextCommitOffset();
             if (nextCommitOffset != null) {
                 nextCommitOffsets.put(tpOffset.getKey(), nextCommitOffset);
@@ -360,9 +358,14 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
             LOG.debug("Offsets successfully committed to Kafka [{}]", nextCommitOffsets);
             // Instead of iterating again, it would be possible to commit and update the state for each TopicPartition
             // in the prior loop, but the multiple network calls should be more expensive than iterating twice over a small loop
-            for (Map.Entry<TopicPartition, OffsetEntry> tpOffset : acked.entrySet()) {
-                final OffsetEntry offsetEntry = tpOffset.getValue();
-                offsetEntry.commit(nextCommitOffsets.get(tpOffset.getKey()));
+            for (Map.Entry<TopicPartition, OffsetAndMetadata> tpOffset : nextCommitOffsets.entrySet()) {
+                //Update the OffsetManager for each committed partition, and update numUncommittedOffsets
+                final TopicPartition tp = tpOffset.getKey();
+                final OffsetManager offsetManager = acked.get(tp);
+                long numCommittedOffsets = offsetManager.commit(tpOffset.getValue());
+                numUncommittedOffsets -= numCommittedOffsets;
+                LOG.debug("[{}] uncommitted offsets across all topic partitions",
+                    numUncommittedOffsets);
             }
         } else {
             LOG.trace("No offsets to commit. {}", this);
@@ -483,127 +486,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
     private String getTopicsString() {
         return kafkaSpoutConfig.getSubscription().getTopicsString();
     }
-
-    // ======= Offsets Commit Management ==========
-
-    private static class OffsetComparator implements Comparator<KafkaSpoutMessageId> {
-        public int compare(KafkaSpoutMessageId m1, KafkaSpoutMessageId m2) {
-            return m1.offset() < m2.offset() ? -1 : m1.offset() == m2.offset() ? 0 : 1;
-        }
-    }
-
-    /**
-     * This class is not thread safe
-     */
-    class OffsetEntry {
-        private final TopicPartition tp;
-        private final long initialFetchOffset;  /* First offset to be fetched. It is either set to the beginning, end, or to the first uncommitted offset.
-                                                 * Initial value depends on offset strategy. See KafkaSpoutConsumerRebalanceListener */
-        private long committedOffset;     // last offset committed to Kafka. Initially it is set to fetchOffset - 1
-        private final NavigableSet<KafkaSpoutMessageId> ackedMsgs = new TreeSet<>(OFFSET_COMPARATOR);     // acked messages sorted by ascending order of offset
-
-        public OffsetEntry(TopicPartition tp, long initialFetchOffset) {
-            this.tp = tp;
-            this.initialFetchOffset = initialFetchOffset;
-            this.committedOffset = initialFetchOffset - 1;
-            LOG.debug("Instantiated {}", this);
-        }
-
-        public void add(KafkaSpoutMessageId msgId) {          // O(Log N)
-            ackedMsgs.add(msgId);
-        }
-
-        /**
-         * An offset is only committed when all records with lower offset have
-         * been acked. This guarantees that all offsets smaller than the
-         * committedOffset have been delivered.
-         * @return the next OffsetAndMetadata to commit, or null if no offset is ready to commit.
-         */
-        public OffsetAndMetadata findNextCommitOffset() {
-            boolean found = false;
-            long currOffset;
-            long nextCommitOffset = committedOffset;
-            KafkaSpoutMessageId nextCommitMsg = null;     // this is a convenience variable to make it faster to create OffsetAndMetadata
-
-            for (KafkaSpoutMessageId currAckedMsg : ackedMsgs) {  // complexity is that of a linear scan on a TreeMap
-                if ((currOffset = currAckedMsg.offset()) == nextCommitOffset + 1) {            // found the next offset to commit
-                    found = true;
-                    nextCommitMsg = currAckedMsg;
-                    nextCommitOffset = currOffset;
-                } else if (currAckedMsg.offset() > nextCommitOffset + 1) {    // offset found is not continuous to the offsets listed to go in the next commit, so stop search
-                    LOG.debug("topic-partition [{}] has non-continuous offset [{}]. It will be processed in a subsequent batch.", tp, currOffset);
-                    break;
-                } else {
-                    //Received a redundant ack. Ignore and continue processing.
-                    LOG.warn("topic-partition [{}] has unexpected offset [{}]. Current committed Offset [{}]",
-                            tp, currOffset,  committedOffset);
-                }
-            }
-
-            OffsetAndMetadata nextCommitOffsetAndMetadata = null;
-            if (found) {
-                nextCommitOffsetAndMetadata = new OffsetAndMetadata(nextCommitOffset, nextCommitMsg.getMetadata(Thread.currentThread()));
-                LOG.debug("topic-partition [{}] has offsets [{}-{}] ready to be committed",tp, committedOffset + 1, nextCommitOffsetAndMetadata.offset());
-            } else {
-                LOG.debug("topic-partition [{}] has NO offsets ready to be committed", tp);
-            }
-            LOG.trace("{}", this);
-            return nextCommitOffsetAndMetadata;
-        }
-
-        /**
-         * Marks an offset has committed. This method has side effects - it sets the internal state in such a way that future
-         * calls to {@link #findNextCommitOffset()} will return offsets greater than the offset specified, if any.
-         *
-         * @param committedOffset offset to be marked as committed
-         */
-        public void commit(OffsetAndMetadata committedOffset) {
-            long numCommittedOffsets = 0;
-            if (committedOffset != null) {
-                final long oldCommittedOffset = this.committedOffset;
-                numCommittedOffsets = committedOffset.offset() - this.committedOffset;
-                this.committedOffset = committedOffset.offset();
-                for (Iterator<KafkaSpoutMessageId> iterator = ackedMsgs.iterator(); iterator.hasNext(); ) {
-                    if (iterator.next().offset() <= committedOffset.offset()) {
-                        iterator.remove();
-                    } else {
-                        break;
-                    }
-                }
-                numUncommittedOffsets-= numCommittedOffsets;
-                LOG.debug("Committed offsets [{}-{} = {}] for topic-partition [{}]. [{}] uncommitted offsets across all topic partitions",
-                        oldCommittedOffset + 1, this.committedOffset, numCommittedOffsets, tp, numUncommittedOffsets);
-            } else {
-                LOG.debug("Committed [{}] offsets for topic-partition [{}]. [{}] uncommitted offsets across all topic partitions",
-                        numCommittedOffsets, tp, numUncommittedOffsets);
-            }
-            LOG.trace("{}", this);
-        }
-
-        long getCommittedOffset() {
-            return committedOffset;
-        }
-
-        public boolean isEmpty() {
-            return ackedMsgs.isEmpty();
-        }
-
-        public boolean contains(ConsumerRecord<K, V> record) {
-            return contains(new KafkaSpoutMessageId(record));
-        }
-
-        public boolean contains(KafkaSpoutMessageId msgId) {
-            return ackedMsgs.contains(msgId);
-        }
-
-        @Override
-        public String toString() {
-            return "OffsetEntry{" +
-                    "topic-partition=" + tp +
-                    ", fetchOffset=" + initialFetchOffset +
-                    ", committedOffset=" + committedOffset +
-                    ", ackedMsgs=" + ackedMsgs +
-                    '}';
-        }
-    }
 }
+
+
+

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.kafka.spout.internal;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.kafka.spout.KafkaSpoutMessageId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages acked and committed offsets for a TopicPartition. This class is not thread safe
+ */
+public class OffsetManager {
+
+    private static final Comparator<KafkaSpoutMessageId> OFFSET_COMPARATOR = new OffsetComparator();
+    private static final Logger LOG = LoggerFactory.getLogger(OffsetManager.class);
+    private final TopicPartition tp;
+    /* First offset to be fetched. It is either set to the beginning, end, or to the first uncommitted offset.
+    * Initial value depends on offset strategy. See KafkaSpoutConsumerRebalanceListener */
+    private final long initialFetchOffset;
+    // Last offset committed to Kafka. Initially it is set to fetchOffset - 1
+    private long committedOffset;
+    // Acked messages sorted by ascending order of offset
+    private final NavigableSet<KafkaSpoutMessageId> ackedMsgs = new TreeSet<>(OFFSET_COMPARATOR);
+
+    public OffsetManager(TopicPartition tp, long initialFetchOffset) {
+        this.tp = tp;
+        this.initialFetchOffset = initialFetchOffset;
+        this.committedOffset = initialFetchOffset - 1;
+        LOG.debug("Instantiated {}", this);
+    }
+
+    public void add(KafkaSpoutMessageId msgId) {          // O(Log N)
+        ackedMsgs.add(msgId);
+    }
+
+    /**
+     * An offset is only committed when all records with lower offset have been
+     * acked. This guarantees that all offsets smaller than the committedOffset
+     * have been delivered.
+     *
+     * @return the next OffsetAndMetadata to commit, or null if no offset is
+     * ready to commit.
+     */
+    public OffsetAndMetadata findNextCommitOffset() {
+        boolean found = false;
+        long currOffset;
+        long nextCommitOffset = committedOffset;
+        KafkaSpoutMessageId nextCommitMsg = null;     // this is a convenience variable to make it faster to create OffsetAndMetadata
+
+        for (KafkaSpoutMessageId currAckedMsg : ackedMsgs) {  // complexity is that of a linear scan on a TreeMap
+            if ((currOffset = currAckedMsg.offset()) == nextCommitOffset + 1) {            // found the next offset to commit
+                found = true;
+                nextCommitMsg = currAckedMsg;
+                nextCommitOffset = currOffset;
+            } else if (currAckedMsg.offset() > nextCommitOffset + 1) {    // offset found is not continuous to the offsets listed to go in the next commit, so stop search
+                LOG.debug("topic-partition [{}] has non-continuous offset [{}]. It will be processed in a subsequent batch.", tp, currOffset);
+                break;
+            } else {
+                //Received a redundant ack. Ignore and continue processing.
+                LOG.warn("topic-partition [{}] has unexpected offset [{}]. Current committed Offset [{}]",
+                    tp, currOffset, committedOffset);
+            }
+        }
+
+        OffsetAndMetadata nextCommitOffsetAndMetadata = null;
+        if (found) {
+            nextCommitOffsetAndMetadata = new OffsetAndMetadata(nextCommitOffset, nextCommitMsg.getMetadata(Thread.currentThread()));
+            LOG.debug("topic-partition [{}] has offsets [{}-{}] ready to be committed", tp, committedOffset + 1, nextCommitOffsetAndMetadata.offset());
+        } else {
+            LOG.debug("topic-partition [{}] has NO offsets ready to be committed", tp);
+        }
+        LOG.trace("{}", this);
+        return nextCommitOffsetAndMetadata;
+    }
+
+    /**
+     * Marks an offset has committed. This method has side effects - it sets the
+     * internal state in such a way that future calls to
+     * {@link #findNextCommitOffset()} will return offsets greater than the
+     * offset specified, if any.
+     *
+     * @param committedOffset offset to be marked as committed
+     * @return Number of offsets committed in this commit
+     */
+    public long commit(OffsetAndMetadata committedOffset) {
+        long preCommitCommittedOffsets = this.committedOffset;
+        long numCommittedOffsets = committedOffset.offset() - this.committedOffset;
+        this.committedOffset = committedOffset.offset();
+        for (Iterator<KafkaSpoutMessageId> iterator = ackedMsgs.iterator(); iterator.hasNext();) {
+            if (iterator.next().offset() <= committedOffset.offset()) {
+                iterator.remove();
+            } else {
+                break;
+            }
+        }
+        LOG.trace("{}", this);
+        
+        LOG.debug("Committed offsets [{}-{} = {}] for topic-partition [{}].",
+                    preCommitCommittedOffsets + 1, this.committedOffset, numCommittedOffsets, tp);
+        
+        return numCommittedOffsets;
+    }
+
+    public long getCommittedOffset() {
+        return committedOffset;
+    }
+
+    public boolean isEmpty() {
+        return ackedMsgs.isEmpty();
+    }
+
+    public boolean contains(ConsumerRecord record) {
+        return contains(new KafkaSpoutMessageId(record));
+    }
+
+    public boolean contains(KafkaSpoutMessageId msgId) {
+        return ackedMsgs.contains(msgId);
+    }
+
+    @Override
+    public String toString() {
+        return "OffsetManager{"
+            + "topic-partition=" + tp
+            + ", fetchOffset=" + initialFetchOffset
+            + ", committedOffset=" + committedOffset
+            + ", ackedMsgs=" + ackedMsgs
+            + '}';
+    }
+
+    private static class OffsetComparator implements Comparator<KafkaSpoutMessageId> {
+
+        @Override
+        public int compare(KafkaSpoutMessageId m1, KafkaSpoutMessageId m2) {
+            return m1.offset() < m2.offset() ? -1 : m1.offset() == m2.offset() ? 0 : 1;
+        }
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/Timer.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/Timer.java
@@ -18,6 +18,7 @@
 package org.apache.storm.kafka.spout.internal;
 
 import java.util.concurrent.TimeUnit;
+import org.apache.storm.utils.Time;
 
 public class Timer {
     private final long delay;
@@ -41,7 +42,7 @@ public class Timer {
         this.timeUnit = timeUnit;
 
         periodNanos = timeUnit.toNanos(period);
-        start = System.nanoTime() + timeUnit.toNanos(delay);
+        start = Time.nanoTime() + timeUnit.toNanos(delay);
     }
 
     public long period() {
@@ -65,9 +66,9 @@ public class Timer {
      * otherwise.
      */
     public boolean isExpiredResetOnTrue() {
-        final boolean expired = System.nanoTime() - start > periodNanos;
+        final boolean expired = Time.nanoTime() - start >= periodNanos;
         if (expired) {
-            start = System.nanoTime();
+            start = Time.nanoTime();
         }
         return expired;
     }

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/ByTopicRecordTranslatorTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/ByTopicRecordTranslatorTest.java
@@ -17,7 +17,7 @@
  */
 package org.apache.storm.kafka.spout;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/DefaultRecordTranslatorTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/DefaultRecordTranslatorTest.java
@@ -17,7 +17,7 @@
  */
 package org.apache.storm.kafka.spout;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutConfigTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutConfigTest.java
@@ -17,7 +17,9 @@
  */
 package org.apache.storm.kafka.spout;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/SingleTopicKafkaSpoutTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/SingleTopicKafkaSpoutTest.java
@@ -17,6 +17,8 @@
  */
 package org.apache.storm.kafka.spout;
 
+import static org.apache.storm.kafka.spout.builders.SingleTopicKafkaSpoutConfiguration.getKafkaSpoutConfig;
+
 import info.batey.kafka.unit.KafkaUnitRule;
 import kafka.producer.KeyedMessage;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -28,21 +30,39 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.junit.Assert.*;
-
 import java.util.Map;
 import java.util.stream.IntStream;
-import static org.mockito.Mockito.*;
-import static org.apache.storm.kafka.spout.builders.SingleTopicKafkaSpoutConfiguration.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.kafka.spout.internal.KafkaConsumerFactory;
+import org.apache.storm.kafka.spout.internal.KafkaConsumerFactoryDefault;
+import org.apache.storm.utils.Time;
+import org.apache.storm.utils.Time.SimulatedTime;
+import org.junit.Before;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
 
 public class SingleTopicKafkaSpoutTest {
 
     private class SpoutContext {
+
         public KafkaSpout<String, String> spout;
         public SpoutOutputCollector collector;
 
         public SpoutContext(KafkaSpout<String, String> spout,
-                            SpoutOutputCollector collector) {
+            SpoutOutputCollector collector) {
             this.spout = spout;
             this.collector = collector;
         }
@@ -51,190 +71,206 @@ public class SingleTopicKafkaSpoutTest {
     @Rule
     public KafkaUnitRule kafkaUnitRule = new KafkaUnitRule();
 
-    void populateTopicData(String topicName, int msgCount) {
+    @Captor
+    private ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> commitCapture;
+
+    private final TopologyContext topologyContext = mock(TopologyContext.class);
+    private final Map<String, Object> conf = new HashMap<>();
+    private final SpoutOutputCollector collector = mock(SpoutOutputCollector.class);
+    private final long commitOffsetPeriodMs = 2_000;
+    private KafkaConsumer<String, String> consumerSpy;
+    private KafkaConsumerFactory<String, String> consumerFactory;
+    private KafkaSpout<String, String> spout;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        KafkaSpoutConfig spoutConfig = getKafkaSpoutConfig(kafkaUnitRule.getKafkaPort(), commitOffsetPeriodMs);
+        this.consumerSpy = spy(new KafkaConsumerFactoryDefault().createConsumer(spoutConfig));
+        this.consumerFactory = (kafkaSpoutConfig) -> consumerSpy;
+        this.spout = new KafkaSpout<>(spoutConfig, consumerFactory);
+    }
+
+    private void populateTopicData(String topicName, int msgCount) {
         kafkaUnitRule.getKafkaUnit().createTopic(topicName);
 
         IntStream.range(0, msgCount).forEach(value -> {
             KeyedMessage<String, String> keyedMessage = new KeyedMessage<>(
-                    topicName, Integer.toString(value),
-                    Integer.toString(value));
+                topicName, Integer.toString(value),
+                Integer.toString(value));
 
             kafkaUnitRule.getKafkaUnit().sendMessages(keyedMessage);
         });
     }
 
-    SpoutContext initializeSpout(int msgCount) {
+    private void initializeSpout(int msgCount) {
         populateTopicData(SingleTopicKafkaSpoutConfiguration.TOPIC, msgCount);
-        int kafkaPort = kafkaUnitRule.getKafkaPort();
-
-        TopologyContext topology = mock(TopologyContext.class);
-        SpoutOutputCollector collector = mock(SpoutOutputCollector.class);
-        Map conf = mock(Map.class);
-
-        KafkaSpout<String, String> spout = new KafkaSpout<>(getKafkaSpoutConfig(kafkaPort));
-        spout.open(conf, topology, collector);
+        spout.open(conf, topologyContext, collector);
         spout.activate();
-        return new SpoutContext(spout, collector);
     }
-    /*
-     * Asserts that the next possible offset to commit or the committed offset is the provided offset.
-     * An offset that is ready to be committed is not guarenteed to be already committed.
-     */
-    private void assertOffsetCommitted(int offset, KafkaSpout.OffsetEntry entry) {
 
-        boolean currentOffsetMatch = entry.getCommittedOffset() == offset;
-        OffsetAndMetadata nextOffset = entry.findNextCommitOffset();
-        boolean nextOffsetMatch =  nextOffset != null && nextOffset.offset() == offset;
-        assertTrue("Next offset: " +
-                        entry.findNextCommitOffset() +
-                        " OR current offset: " +
-                        entry.getCommittedOffset() +
-                        " must equal desired offset: " +
-                        offset,
-                currentOffsetMatch | nextOffsetMatch);
+    /*
+     * Asserts that commitSync has been called once, 
+     * that there are only commits on one topic,
+     * and that the committed offset covers messageCount messages
+     */
+    private void verifyAllMessagesCommitted(long messageCount) {
+        verify(consumerSpy, times(1)).commitSync(commitCapture.capture());
+        Map<TopicPartition, OffsetAndMetadata> commits = commitCapture.getValue();
+        assertThat("Expected commits for only one topic partition", commits.entrySet().size(), is(1));
+        OffsetAndMetadata offset = commits.entrySet().iterator().next().getValue();
+        assertThat("Expected committed offset to cover all emitted messages", offset.offset(), is(messageCount - 1));
     }
 
     @Test
     public void shouldContinueWithSlowDoubleAcks() throws Exception {
-        int messageCount = 20;
-        SpoutContext context = initializeSpout(messageCount);
+        try (SimulatedTime simulatedTime = new SimulatedTime()) {
+            int messageCount = 20;
+            initializeSpout(messageCount);
 
-        //play 1st tuple
-        ArgumentCaptor<Object> messageIdToDoubleAck = ArgumentCaptor.forClass(Object.class);
-        context.spout.nextTuple();
-        verify(context.collector).emit(anyObject(), anyObject(), messageIdToDoubleAck.capture());
-        context.spout.ack(messageIdToDoubleAck.getValue());
+            //play 1st tuple
+            ArgumentCaptor<Object> messageIdToDoubleAck = ArgumentCaptor.forClass(Object.class);
+            spout.nextTuple();
+            verify(collector).emit(anyObject(), anyObject(), messageIdToDoubleAck.capture());
+            spout.ack(messageIdToDoubleAck.getValue());
 
-        IntStream.range(0, messageCount/2).forEach(value -> {
-            context.spout.nextTuple();
-        });
+            //Emit some more messages
+            IntStream.range(0, messageCount / 2).forEach(value -> {
+                spout.nextTuple();
+            });
 
-        context.spout.ack(messageIdToDoubleAck.getValue());
+            spout.ack(messageIdToDoubleAck.getValue());
 
-        IntStream.range(0, messageCount).forEach(value -> {
-            context.spout.nextTuple();
-        });
+            //Emit any remaining messages
+            IntStream.range(0, messageCount).forEach(value -> {
+                spout.nextTuple();
+            });
 
-        ArgumentCaptor<Object> remainingIds = ArgumentCaptor.forClass(Object.class);
-
-        verify(context.collector, times(messageCount)).emit(
-                eq(SingleTopicKafkaSpoutConfiguration.STREAM),
+            //Verify that all messages are emitted, ack all the messages
+            ArgumentCaptor<Object> messageIds = ArgumentCaptor.forClass(Object.class);
+            verify(collector, times(messageCount)).emit(eq(SingleTopicKafkaSpoutConfiguration.STREAM),
                 anyObject(),
-                remainingIds.capture());
-        remainingIds.getAllValues().iterator().forEachRemaining(context.spout::ack);
+                messageIds.capture());
+            messageIds.getAllValues().iterator().forEachRemaining(spout::ack);
 
-        context.spout.acked.values().forEach(item -> {
-            assertOffsetCommitted(messageCount - 1, (KafkaSpout.OffsetEntry) item);
-        });
+            Time.advanceTime(commitOffsetPeriodMs + KafkaSpout.TIMER_DELAY_MS);
+            //Commit offsets
+            spout.nextTuple();
+
+            verifyAllMessagesCommitted(messageCount);
+        }
     }
 
     @Test
     public void shouldEmitAllMessages() throws Exception {
-        int messageCount = 10;
-        SpoutContext context = initializeSpout(messageCount);
+        try (SimulatedTime simulatedTime = new SimulatedTime()) {
+            int messageCount = 10;
+            initializeSpout(messageCount);
 
-
-        IntStream.range(0, messageCount).forEach(value -> {
-            context.spout.nextTuple();
-            ArgumentCaptor<Object> messageId = ArgumentCaptor.forClass(Object.class);
-            verify(context.collector).emit(
+            //Emit all messages and check that they are emitted. Ack the messages too
+            IntStream.range(0, messageCount).forEach(value -> {
+                spout.nextTuple();
+                ArgumentCaptor<Object> messageId = ArgumentCaptor.forClass(Object.class);
+                verify(collector).emit(
                     eq(SingleTopicKafkaSpoutConfiguration.STREAM),
                     eq(new Values(SingleTopicKafkaSpoutConfiguration.TOPIC,
-                            Integer.toString(value),
-                            Integer.toString(value))),
-            messageId.capture());
-            context.spout.ack(messageId.getValue());
-            reset(context.collector);
-        });
+                        Integer.toString(value),
+                        Integer.toString(value))),
+                    messageId.capture());
+                spout.ack(messageId.getValue());
+                reset(collector);
+            });
 
-        context.spout.acked.values().forEach(item -> {
-            assertOffsetCommitted(messageCount - 1, (KafkaSpout.OffsetEntry) item);
-        });
+            Time.advanceTime(commitOffsetPeriodMs + KafkaSpout.TIMER_DELAY_MS);
+            //Commit offsets
+            spout.nextTuple();
+
+            verifyAllMessagesCommitted(messageCount);
+        }
     }
 
     @Test
     public void shouldReplayInOrderFailedMessages() throws Exception {
-        int messageCount = 10;
-        SpoutContext context = initializeSpout(messageCount);
+        try (SimulatedTime simulatedTime = new SimulatedTime()) {
+            int messageCount = 10;
+            initializeSpout(messageCount);
 
-        //play and ack 1 tuple
-        ArgumentCaptor<Object> messageIdAcked = ArgumentCaptor.forClass(Object.class);
-        context.spout.nextTuple();
-        verify(context.collector).emit(anyObject(), anyObject(), messageIdAcked.capture());
-        context.spout.ack(messageIdAcked.getValue());
-        reset(context.collector);
+            //play and ack 1 tuple
+            ArgumentCaptor<Object> messageIdAcked = ArgumentCaptor.forClass(Object.class);
+            spout.nextTuple();
+            verify(collector).emit(anyObject(), anyObject(), messageIdAcked.capture());
+            spout.ack(messageIdAcked.getValue());
+            reset(collector);
 
-        //play and fail 1 tuple
-        ArgumentCaptor<Object> messageIdFailed = ArgumentCaptor.forClass(Object.class);
-        context.spout.nextTuple();
-        verify(context.collector).emit(anyObject(), anyObject(), messageIdFailed.capture());
-        context.spout.fail(messageIdFailed.getValue());
-        reset(context.collector);
+            //play and fail 1 tuple
+            ArgumentCaptor<Object> messageIdFailed = ArgumentCaptor.forClass(Object.class);
+            spout.nextTuple();
+            verify(collector).emit(anyObject(), anyObject(), messageIdFailed.capture());
+            spout.fail(messageIdFailed.getValue());
+            reset(collector);
 
-        //pause so that failed tuples will be retried
-        Thread.sleep(200);
+            //Emit all remaining messages. Failed tuples retry immediately with current configuration, so no need to wait.
+            IntStream.range(0, messageCount).forEach(value -> {
+                spout.nextTuple();
+            });
 
-
-        //allow for some calls to nextTuple() to fail to emit a tuple
-        IntStream.range(0, messageCount + 5).forEach(value -> {
-            context.spout.nextTuple();
-        });
-
-        ArgumentCaptor<Object> remainingMessageIds = ArgumentCaptor.forClass(Object.class);
-
-        //1 message replayed, messageCount - 2 messages emitted for the first time
-        verify(context.collector, times(messageCount - 1)).emit(
+            ArgumentCaptor<Object> remainingMessageIds = ArgumentCaptor.forClass(Object.class);
+            //All messages except the first acked message should have been emitted
+            verify(collector, times(messageCount - 1)).emit(
                 eq(SingleTopicKafkaSpoutConfiguration.STREAM),
                 anyObject(),
                 remainingMessageIds.capture());
-        remainingMessageIds.getAllValues().iterator().forEachRemaining(context.spout::ack);
+            remainingMessageIds.getAllValues().iterator().forEachRemaining(spout::ack);
 
-        context.spout.acked.values().forEach(item -> {
-            assertOffsetCommitted(messageCount - 1, (KafkaSpout.OffsetEntry) item);
-        });
+            Time.advanceTime(commitOffsetPeriodMs + KafkaSpout.TIMER_DELAY_MS);
+            //Commit offsets
+            spout.nextTuple();
+
+            verifyAllMessagesCommitted(messageCount);
+        }
     }
 
     @Test
     public void shouldReplayFirstTupleFailedOutOfOrder() throws Exception {
-        int messageCount = 10;
-        SpoutContext context = initializeSpout(messageCount);
+        try (SimulatedTime simulatedTime = new SimulatedTime()) {
+            int messageCount = 10;
+            initializeSpout(messageCount);
 
+            //play 1st tuple
+            ArgumentCaptor<Object> messageIdToFail = ArgumentCaptor.forClass(Object.class);
+            spout.nextTuple();
+            verify(collector).emit(anyObject(), anyObject(), messageIdToFail.capture());
+            reset(collector);
 
-        //play 1st tuple
-        ArgumentCaptor<Object> messageIdToFail = ArgumentCaptor.forClass(Object.class);
-        context.spout.nextTuple();
-        verify(context.collector).emit(anyObject(), anyObject(), messageIdToFail.capture());
-        reset(context.collector);
+            //play 2nd tuple
+            ArgumentCaptor<Object> messageIdToAck = ArgumentCaptor.forClass(Object.class);
+            spout.nextTuple();
+            verify(collector).emit(anyObject(), anyObject(), messageIdToAck.capture());
+            reset(collector);
 
-        //play 2nd tuple
-        ArgumentCaptor<Object> messageIdToAck = ArgumentCaptor.forClass(Object.class);
-        context.spout.nextTuple();
-        verify(context.collector).emit(anyObject(), anyObject(), messageIdToAck.capture());
-        reset(context.collector);
+            //ack 2nd tuple
+            spout.ack(messageIdToAck.getValue());
+            //fail 1st tuple
+            spout.fail(messageIdToFail.getValue());
 
-        //ack 2nd tuple
-        context.spout.ack(messageIdToAck.getValue());
-        //fail 1st tuple
-        context.spout.fail(messageIdToFail.getValue());
+            //Emit all remaining messages. Failed tuples retry immediately with current configuration, so no need to wait.
+            IntStream.range(0, messageCount).forEach(value -> {
+                spout.nextTuple();
+            });
 
-        //pause so that failed tuples will be retried
-        Thread.sleep(200);
-
-        //allow for some calls to nextTuple() to fail to emit a tuple
-        IntStream.range(0, messageCount + 5).forEach(value -> {
-            context.spout.nextTuple();
-        });
-
-        ArgumentCaptor<Object> remainingIds = ArgumentCaptor.forClass(Object.class);
-        //1 message replayed, messageCount - 2 messages emitted for the first time
-        verify(context.collector, times(messageCount - 1)).emit(
+            ArgumentCaptor<Object> remainingIds = ArgumentCaptor.forClass(Object.class);
+            //All messages except the first acked message should have been emitted
+            verify(collector, times(messageCount - 1)).emit(
                 eq(SingleTopicKafkaSpoutConfiguration.STREAM),
                 anyObject(),
                 remainingIds.capture());
-        remainingIds.getAllValues().iterator().forEachRemaining(context.spout::ack);
+            remainingIds.getAllValues().iterator().forEachRemaining(spout::ack);
 
-        context.spout.acked.values().forEach(item -> {
-            assertOffsetCommitted(messageCount - 1, (KafkaSpout.OffsetEntry) item);
-        });
+            Time.advanceTime(commitOffsetPeriodMs + KafkaSpout.TIMER_DELAY_MS);
+            //Commit offsets
+            spout.nextTuple();
+
+            verifyAllMessagesCommitted(messageCount);
+        }
     }
 }

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainNamedTopics.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainNamedTopics.java
@@ -50,9 +50,9 @@ public class KafkaSpoutTopologyMainNamedTopics {
 
     protected void runMain(String[] args) throws Exception {
         if (args.length == 0) {
-            submitTopologyLocalCluster(getTopolgyKafkaSpout(), getConfig());
+            submitTopologyLocalCluster(getTopologyKafkaSpout(), getConfig());
         } else {
-            submitTopologyRemoteCluster(args[0], getTopolgyKafkaSpout(), getConfig());
+            submitTopologyRemoteCluster(args[0], getTopologyKafkaSpout(), getConfig());
         }
     }
 
@@ -82,7 +82,7 @@ public class KafkaSpoutTopologyMainNamedTopics {
         return config;
     }
 
-    protected StormTopology getTopolgyKafkaSpout() {
+    protected StormTopology getTopologyKafkaSpout() {
         final TopologyBuilder tp = new TopologyBuilder();
         tp.setSpout("kafka_spout", new KafkaSpout<>(getKafkaSpoutConfig()), 1);
         tp.setBolt("kafka_bolt", new KafkaSpoutTestBolt())

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainWildcardTopics.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainWildcardTopics.java
@@ -37,7 +37,7 @@ public class KafkaSpoutTopologyMainWildcardTopics extends KafkaSpoutTopologyMain
         new KafkaSpoutTopologyMainWildcardTopics().runMain(args);
     }
 
-    protected StormTopology getTopolgyKafkaSpout() {
+    protected StormTopology getTopologyKafkaSpout() {
         final TopologyBuilder tp = new TopologyBuilder();
         tp.setSpout("kafka_spout", new KafkaSpout<>(getKafkaSpoutConfig()), 1);
         tp.setBolt("kafka_bolt", new KafkaSpoutTestBolt()).shuffleGrouping("kafka_spout", STREAM);

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/storm-core/src/jvm/org/apache/storm/utils/Time.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/Time.java
@@ -24,14 +24,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+/**
+ * This class implements time simulation support. When time simulation is enabled, methods on this class will use fixed time.
+ * When time simulation is disabled, methods will pass through to relevant java.lang.System/java.lang.Thread calls.
+ * Methods using units higher than nanoseconds will pass through to System.currentTimeMillis(). Methods supporting nanoseconds will pass through to System.nanoTime().
+ */
 public class Time {
     private static final Logger LOG = LoggerFactory.getLogger(Time.class);
     private static AtomicBoolean simulating = new AtomicBoolean(false);
-    private static AtomicLong autoAdvanceOnSleep = new AtomicLong(0);
-    private static volatile Map<Thread, AtomicLong> threadSleepTimes;
+    private static AtomicLong autoAdvanceNanosOnSleep = new AtomicLong(0);
+    private static volatile Map<Thread, AtomicLong> threadSleepTimesNanos;
     private static final Object sleepTimesLock = new Object();
-    private static AtomicLong simulatedCurrTimeMs;
+    private static AtomicLong simulatedCurrTimeNanos;
     
     public static class SimulatedTime implements AutoCloseable {
 
@@ -39,13 +43,13 @@ public class Time {
             this(null);
         }
         
-        public SimulatedTime(Number ms) {
+        public SimulatedTime(Number advanceTimeMs) {
             synchronized(Time.sleepTimesLock) {
                 Time.simulating.set(true);
-                Time.simulatedCurrTimeMs = new AtomicLong(0);
-                Time.threadSleepTimes = new ConcurrentHashMap<>();
-                if (ms != null) {
-                    Time.autoAdvanceOnSleep.set(ms.longValue());
+                Time.simulatedCurrTimeNanos = new AtomicLong(0);
+                Time.threadSleepTimesNanos = new ConcurrentHashMap<>();
+                if (advanceTimeMs != null) {
+                    Time.autoAdvanceNanosOnSleep.set(millisToNanos(advanceTimeMs.longValue()));
                 }
                 LOG.warn("AutoCloseable Simulated Time Starting...");
             }
@@ -55,8 +59,8 @@ public class Time {
         public void close() {
             synchronized(Time.sleepTimesLock) {
                 Time.simulating.set(false);    
-                Time.autoAdvanceOnSleep.set(0);
-                Time.threadSleepTimes = null;
+                Time.autoAdvanceNanosOnSleep.set(0);
+                Time.threadSleepTimesNanos = null;
                 LOG.warn("AutoCloseable Simulated Time Ending...");
             }
         }
@@ -66,8 +70,8 @@ public class Time {
     public static void startSimulating() {
         synchronized(Time.sleepTimesLock) {
             Time.simulating.set(true);
-            Time.simulatedCurrTimeMs = new AtomicLong(0);
-            Time.threadSleepTimes = new ConcurrentHashMap<>();
+            Time.simulatedCurrTimeNanos = new AtomicLong(0);
+            Time.threadSleepTimesNanos = new ConcurrentHashMap<>();
             LOG.warn("Simulated Time Starting...");
         }
     }
@@ -76,8 +80,8 @@ public class Time {
     public static void stopSimulating() {
         synchronized(Time.sleepTimesLock) {
             Time.simulating.set(false);    
-            Time.autoAdvanceOnSleep.set(0);
-            Time.threadSleepTimes = null;
+            Time.autoAdvanceNanosOnSleep.set(0);
+            Time.threadSleepTimesNanos = null;
             LOG.warn("Simulated Time Ending...");
         }
     }
@@ -88,43 +92,65 @@ public class Time {
     
     public static void sleepUntil(long targetTimeMs) throws InterruptedException {
         if(simulating.get()) {
-            try {
-                synchronized(sleepTimesLock) {
-                    if (threadSleepTimes == null) {
+            simulatedSleepUntilNanos(millisToNanos(targetTimeMs));
+        } else {
+            long sleepTimeMs = targetTimeMs - currentTimeMillis();
+            if(sleepTimeMs>0) {
+                Thread.sleep(sleepTimeMs);
+            }
+        }
+    }
+    
+    public static void sleepUntilNanos(long targetTimeNanos) throws InterruptedException {
+        if(simulating.get()) {
+            simulatedSleepUntilNanos(targetTimeNanos);
+        } else {
+            long sleepTimeNanos = targetTimeNanos-nanoTime();
+            long sleepTimeMs = nanosToMillis(sleepTimeNanos);
+            int sleepTimeNanosSansMs = (int)(sleepTimeNanos%1_000_000);
+            if(sleepTimeNanos>0) {
+                Thread.sleep(sleepTimeMs, sleepTimeNanosSansMs);
+            } 
+        }
+    }
+    
+    private static void simulatedSleepUntilNanos(long targetTimeNanos) throws InterruptedException {
+        try {
+            synchronized (sleepTimesLock) {
+                if (threadSleepTimesNanos == null) {
+                    LOG.debug("{} is still sleeping after simulated time disabled.", Thread.currentThread(), new RuntimeException("STACK TRACE"));
+                    throw new InterruptedException();
+                }
+                threadSleepTimesNanos.put(Thread.currentThread(), new AtomicLong(targetTimeNanos));
+            }
+            while (simulatedCurrTimeNanos.get() < targetTimeNanos) {
+                synchronized (sleepTimesLock) {
+                    if (threadSleepTimesNanos == null) {
                         LOG.debug("{} is still sleeping after simulated time disabled.", Thread.currentThread(), new RuntimeException("STACK TRACE"));
                         throw new InterruptedException();
                     }
-                    threadSleepTimes.put(Thread.currentThread(), new AtomicLong(targetTimeMs));
                 }
-                while(simulatedCurrTimeMs.get() < targetTimeMs) {
-                    synchronized(sleepTimesLock) {
-                        if (threadSleepTimes == null) {
-                            LOG.debug("{} is still sleeping after simulated time disabled.", Thread.currentThread(), new RuntimeException("STACK TRACE"));
-                            throw new InterruptedException();
-                        }
-                    }
-                    long autoAdvance = autoAdvanceOnSleep.get();
-                    if (autoAdvance > 0) {
-                        advanceTime(autoAdvance);
-                    }
-                    Thread.sleep(10);
+                long autoAdvance = autoAdvanceNanosOnSleep.get();
+                if (autoAdvance > 0) {
+                    advanceTimeNanos(autoAdvance);
                 }
-            } finally {
-                synchronized(sleepTimesLock) {
-                    if (simulating.get() && threadSleepTimes != null) {
-                        threadSleepTimes.remove(Thread.currentThread());
-                    }
+                Thread.sleep(10);
+            }
+        } finally {
+            synchronized (sleepTimesLock) {
+                if (simulating.get() && threadSleepTimesNanos != null) {
+                    threadSleepTimesNanos.remove(Thread.currentThread());
                 }
             }
-        } else {
-            long sleepTime = targetTimeMs-currentTimeMillis();
-            if(sleepTime>0) 
-                Thread.sleep(sleepTime);
         }
     }
 
     public static void sleep(long ms) throws InterruptedException {
         sleepUntil(currentTimeMillis()+ms);
+    }
+    
+    public static void sleepNanos(long nanos) throws InterruptedException {
+        sleepUntilNanos(nanoTime() + nanos);
     }
 
     public static void sleepSecs (long secs) throws InterruptedException {
@@ -133,14 +159,30 @@ public class Time {
         }
     }
     
+    public static long nanoTime() {
+        if (simulating.get()) {
+            return simulatedCurrTimeNanos.get();
+        } else {
+            return System.nanoTime();
+        }
+    }
+    
     public static long currentTimeMillis() {
         if(simulating.get()) {
-            return simulatedCurrTimeMs.get();
+            return nanosToMillis(simulatedCurrTimeNanos.get());
         } else {
             return System.currentTimeMillis();
         }
     }
 
+    public static long nanosToMillis(long nanos) {
+        return nanos/1_000_000;
+    }
+    
+    public static long millisToNanos(long millis) {
+        return millis*1_000_000;
+    }
+    
     public static long secsToMillis (int secs) {
         return 1000*(long) secs;
     }
@@ -162,9 +204,17 @@ public class Time {
     }
     
     public static void advanceTime(long ms) {
-        if (!simulating.get()) throw new IllegalStateException("Cannot simulate time unless in simulation mode");
-        if (ms < 0) throw new IllegalArgumentException("advanceTime only accepts positive time as an argument");
-        long newTime = simulatedCurrTimeMs.addAndGet(ms);
+        advanceTimeNanos(millisToNanos(ms));
+    }
+    
+    public static void advanceTimeNanos(long nanos) {
+        if (!simulating.get()) {
+            throw new IllegalStateException("Cannot simulate time unless in simulation mode");
+        }
+        if (nanos < 0) {
+            throw new IllegalArgumentException("advanceTime only accepts positive time as an argument");
+        }
+        long newTime = simulatedCurrTimeNanos.addAndGet(nanos);
         LOG.debug("Advanced simulated time to {}", newTime);
     }
     
@@ -173,11 +223,13 @@ public class Time {
     }
     
     public static boolean isThreadWaiting(Thread t) {
-        if(!simulating.get()) throw new IllegalStateException("Must be in simulation mode");
+        if(!simulating.get()) {
+            throw new IllegalStateException("Must be in simulation mode");
+        }
         AtomicLong time;
         synchronized(sleepTimesLock) {
-            time = threadSleepTimes.get(t);
+            time = threadSleepTimesNanos.get(t);
         }
-        return !t.isAlive() || time!=null && currentTimeMillis() < time.longValue();
+        return !t.isAlive() || time!=null && nanoTime() < time.longValue();
     }
 }


### PR DESCRIPTION
Making these changes based on a discussion here https://github.com/apache/storm/pull/1826 and https://github.com/apache/storm/pull/1825 about the spout getting a bit large.

This PR makes the following changes:
* OffsetEntry was moved into a new class and renamed OffsetManager
* OffsetManager.commit now returns numCommittedOffsets, so it doesn't have to refer to a KafkaSpout internal variable.
* KafkaSpout.commitOffsetsForAckedTuples no longer iterates over acked twice. The second iteration was used to commit offsets to OffsetEntries, but we may as well use nextCommitOffsets for that iteration, since those were the offsets committed to Kafka. This also saves us a null check in OffsetManager.commit.
* OffsetManager.commit no longer checks if the parameter is null. It should no longer be possible that it is null, unless there's a bug, in which case we want to throw an NPE so we can fix it.
* Timer supports Storm's time simulation. This also means that it only supports time units down to milliseconds. If we need nanosecond precision, we need to update Storm's Utils.Time. 
* Cleaned up a few redundant version declarations in the pom. Also switched out hamcrest-all for hamcrest-core + hamcrest-library, since tests were throwing NoSuchMethodError when an assertThat failed.
* Updated the tests to use time simulation, and to check if the spout calls KafkaConsumer.commitSync instead of reading the spout's internal state

I think it would be nice if RetryService also supported time simulation, let me know what you think @hmcl