### PR TITLE
Fix storm.py which breaks when client.jartransformer.class is not set

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -294,7 +294,7 @@ def jar(jarfile, klass, *args):
     artifact_to_file_jars = resolve_dependencies(DEP_ARTIFACTS_OPTS, DEP_ARTIFACTS_REPOSITORIES_OPTS)
 
     transform_class = confvalue("client.jartransformer.class", [CLUSTER_CONF_DIR])
-    if (transform_class != None and transform_class != "null"):
+    if (transform_class != None and transform_class != "nil"):
         tmpjar = os.path.join(tempfile.gettempdir(), uuid.uuid1().hex+".jar")
         exec_storm_class("org.apache.storm.daemon.ClientJarTransformerRunner", args=[transform_class, jarfile, tmpjar], fork=True, daemon=False)
         extra_jars = [tmpjar, USER_CONF_DIR, STORM_BIN_DIR]


### PR DESCRIPTION
When such configuration is not set, `confvalue` returns `nil` in 1.x branch, and `null` in master branch.

Such difference is based on whether language storm script runs: 
- for 1.x, it runs `org.apache.storm.command.config_value` which is Clojure file
- for master, it runs `org.apache.storm.command.ConfigValue` which is Java file

I accidentally changed that value from `nil` to `null` without recognized the difference between master and 1.x. 
Since it breaks all deployments on 1.x branch when client.jartransformer.class is not set, so it must be fixed before releasing. 