### PR TITLE
STORM-2270 Kafka spout should consume from latest when ZK partition commit offset bigger than the latest offset

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
@@ -202,7 +202,7 @@ public class PartitionManager {
             long partitionLatestOffset = KafkaUtils.getOffset(_consumer, _partition.topic, _partition.partition, kafka.api.OffsetRequest.LatestTime());
             if (partitionLatestOffset < offset) {
                 offset = partitionLatestOffset;
-            }else{
+            } else {
                 offset = KafkaUtils.getOffset(_consumer, _partition.topic, _partition.partition, kafka.api.OffsetRequest.EarliestTime());
             }
             // fetch failed, so don't update the fetch metrics

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
@@ -199,7 +199,12 @@ public class PartitionManager {
         try {
             msgs = KafkaUtils.fetchMessages(_spoutConfig, _consumer, _partition, offset);
         } catch (TopicOffsetOutOfRangeException e) {
-            offset = KafkaUtils.getOffset(_consumer, _partition.topic, _partition.partition, kafka.api.OffsetRequest.EarliestTime());
+            long partitionLatestOffset = KafkaUtils.getOffset(_consumer, _partition.topic, _partition.partition, kafka.api.OffsetRequest.LatestTime());
+            if (partitionLatestOffset < offset) {
+                offset = partitionLatestOffset;
+            }else{
+                offset = KafkaUtils.getOffset(_consumer, _partition.topic, _partition.partition, kafka.api.OffsetRequest.EarliestTime());
+            }
             // fetch failed, so don't update the fetch metrics
             
             //fix bug [STORM-643] : remove outdated failed offsets


### PR DESCRIPTION
Kafka spout should consume from latest when ZK offset bigger than partition's latest offset[ an TopicOffsetOutOfRangeException thrown out ], especially when Kafka topic change it's leader and some data lost, if we consume from earliest offset, much meaningless duplicate records will be re-consumed. So, we should consume from latest offset instead.
This is the jira task: [STORM-2270](https://issues.apache.org/jira/browse/STORM-2270)