### PR TITLE
[STORM-2271] ClosedByInterruptException should be handled in few cases and removing a confusing debug statement

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/ProcessSimulator.java
+++ b/storm-core/src/jvm/org/apache/storm/ProcessSimulator.java
@@ -19,6 +19,7 @@ package org.apache.storm;
 import org.apache.storm.daemon.Shutdownable;
 import org.apache.storm.utils.Utils;
 
+import java.nio.channels.ClosedByInterruptException;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,6 +83,8 @@ public class ProcessSimulator {
             } catch (Exception e) {
                 if (Utils.exceptionCauseIsInstanceOf(InterruptedException.class, e)) {
                     LOG.warn("process {} not killed (Ignoring InterruptedException)", pid, e);
+                } else if (Utils.exceptionCauseIsInstanceOf(ClosedByInterruptException.class, e)) {
+                    LOG.warn("process {} not killed (Ignoring ClosedByInterruptException)", pid, e);
                 } else if (e instanceof RuntimeException){
                     throw e;
                 } else {

--- a/storm-core/src/jvm/org/apache/storm/StormTimer.java
+++ b/storm-core/src/jvm/org/apache/storm/StormTimer.java
@@ -23,6 +23,7 @@ import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.channels.ClosedByInterruptException;
 import java.util.Comparator;
 import java.util.Random;
 import java.util.concurrent.PriorityBlockingQueue;
@@ -100,7 +101,8 @@ public class StormTimer implements AutoCloseable {
                         Time.sleep(1000);
                     }
                 } catch (Throwable e) {
-                    if (!(Utils.exceptionCauseIsInstanceOf(InterruptedException.class, e))) {
+                    if (!(Utils.exceptionCauseIsInstanceOf(InterruptedException.class, e))
+                            && !(Utils.exceptionCauseIsInstanceOf(ClosedByInterruptException.class, e))) {
                         this.onKill.uncaughtException(this, e);
                         this.setActive(false);
                     }

--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
@@ -22,6 +22,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.channels.ClosedByInterruptException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -86,8 +87,8 @@ public class BlobSynchronizer {
             if (zkClient !=null) {
                 zkClient.close();
             }
-        } catch(InterruptedException exp) {
-            LOG.error("InterruptedException {}", exp);
+        } catch(InterruptedException | ClosedByInterruptException exp) {
+            LOG.error("Interrupt Exception {}", exp);
         } catch(Exception exp) {
             throw new RuntimeException(exp);
         }

--- a/storm-core/src/jvm/org/apache/storm/command/HealthCheck.java
+++ b/storm-core/src/jvm/org/apache/storm/command/HealthCheck.java
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +106,7 @@ public class HealthCheck {
                 return SUCCESS;
             }
             return FAILED_WITH_EXIT_CODE;
-        } catch (InterruptedException e) {
+        } catch (InterruptedException | ClosedByInterruptException e) {
             LOG.warn("Script:  {} timed out.", script);
             return TIMEOUT;
         } catch (Exception e) {

--- a/storm-core/src/jvm/org/apache/storm/container/cgroup/SystemOperation.java
+++ b/storm-core/src/jvm/org/apache/storm/container/cgroup/SystemOperation.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.channels.ClosedByInterruptException;
 
 /**
  * A class that implements system operations for using cgroups
@@ -68,7 +69,7 @@ public class SystemOperation {
                 throw new IOException(errorOutput);
             }
             return output;
-        } catch (InterruptedException ie) {
+        } catch (InterruptedException | ClosedByInterruptException ie) {
             throw new IOException(ie);
         }
     }

--- a/storm-core/src/jvm/org/apache/storm/daemon/drpc/BlockingOutstandingRequest.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/drpc/BlockingOutstandingRequest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.daemon.drpc;
 
+import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.Semaphore;
 
 import org.apache.storm.generated.DRPCExceptionType;

--- a/storm-core/src/jvm/org/apache/storm/daemon/drpc/BlockingOutstandingRequest.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/drpc/BlockingOutstandingRequest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.storm.daemon.drpc;
 
-import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.Semaphore;
 
 import org.apache.storm.generated.DRPCExceptionType;

--- a/storm-core/src/jvm/org/apache/storm/event/EventManagerImp.java
+++ b/storm-core/src/jvm/org/apache/storm/event/EventManagerImp.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InterruptedIOException;
+import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,8 +55,10 @@ public class EventManagerImp implements EventManager {
                         r.run();
                         proccessInc();
                     } catch (Throwable t) {
-                        if (Utils.exceptionCauseIsInstanceOf(InterruptedIOException.class, t)) {
+                        if (Utils.exceptionCauseIsInstanceOf(InterruptedIOException.class, t) ) {
                             LOG.info("Event manager interrupted while doing IO");
+                        } else if (Utils.exceptionCauseIsInstanceOf(ClosedByInterruptException.class, t)) {
+                            LOG.info("Event manager interrupted while doing NIO");
                         } else if (Utils.exceptionCauseIsInstanceOf(InterruptedException.class, t)) {
                             LOG.info("Event manager interrupted");
                         } else {

--- a/storm-core/src/jvm/org/apache/storm/messaging/netty/StormClientHandler.java
+++ b/storm-core/src/jvm/org/apache/storm/messaging/netty/StormClientHandler.java
@@ -60,7 +60,6 @@ public class StormClientHandler extends SimpleChannelUpstreamHandler  {
                 //This should be the metrics, and there should only be one of them
                 List<TaskMessage> list = (List<TaskMessage>)message;
                 if (list.size() < 1) throw new RuntimeException("Didn't see enough load metrics ("+client.getDstAddress()+") "+list);
-                if (list.size() != 1) LOG.debug("Messages are not being delivered fast enough, got "+list.size()+" metrics messages at once("+client.getDstAddress()+")");
                 TaskMessage tm = ((List<TaskMessage>)message).get(list.size() - 1);
                 if (tm.task() != -1) throw new RuntimeException("Metrics messages are sent to the system task ("+client.getDstAddress()+") "+tm);
                 List metrics = _des.deserialize(tm.message());


### PR DESCRIPTION
There are several places in the code where we catch and ignore an interrupted exception (because it meant the process is shutting down).  We should also include ClosedbyInterruptException which is an IOException that can also be triggered by an interruptedexception in a few cases.