### PR TITLE
STORM-2264 OpaqueTridentKafkaSpout failing after STORM-2216

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/trident/topology/state/TransactionalState.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/topology/state/TransactionalState.java
@@ -162,7 +162,9 @@ public class TransactionalState {
         try {
             Object data;
             if(_curator.checkExists().forPath(path)!=null) {
-                data = JSONValue.parseWithException(new String(_curator.getData().forPath(path), "UTF-8"));
+                // intentionally using parse() instead of parseWithException() to handle error cases as null
+                // this have been used from the start of Trident so we could treat it as safer way
+                data = JSONValue.parse(new String(_curator.getData().forPath(path), "UTF-8"));
             } else {
                 data = null;
             }


### PR DESCRIPTION
* use JSONValue.parse() instead of JSONValue.parseWithException() in TransactionState
  * this just rolls back to previous, doesn't provide better approach

Please note that this is just a quick and dirty fix given that the priority of STORM-2264 is critical.
Even after merging this, we should find better solution and apply soon. (#1844 is one of)