### PR TITLE
STORM-2176 Workers do not shutdown cleanly and worker hooks don't run when a topology is killed

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -150,7 +150,7 @@ supervisor.worker.start.timeout.secs: 120
 #how long between heartbeats until supervisor considers that worker dead and tries to restart it
 supervisor.worker.timeout.secs: 30
 #how many seconds to sleep for before shutting down threads on worker
-supervisor.worker.shutdown.sleep.secs: 1
+supervisor.worker.shutdown.sleep.secs: 3
 #how frequently the supervisor checks on the status of the processes it's monitoring and restarts if necessary
 supervisor.monitor.frequency.secs: 3
 #how frequently the supervisor heartbeats to the cluster state (for nimbus)

--- a/log4j2/cluster.xml
+++ b/log4j2/cluster.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 -->
 
-<configuration monitorInterval="60">
+<configuration monitorInterval="60" shutdownHook="disable">
 <properties>
     <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %t %c{1.} [%p] %msg%n</property>
 </properties>

--- a/log4j2/worker.xml
+++ b/log4j2/worker.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 -->
 
-<configuration monitorInterval="60">
+<configuration monitorInterval="60" shutdownHook="disable">
 <properties>
     <property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} %c{1.} %t [%p] %msg%n</property>
     <property name="patternNoTime">%msg%n</property>


### PR DESCRIPTION
* increase supervisor.worker.shutdown.sleep.secs to let workers kill themselves first even stuck
* disable shutdown hook for log4j2 to make sure logs are written after shutdown is started

Please note that I didn't touch JVM's shutdown hook (leaving it to sleep 1 sec and halt) given that 1 sec looks enough if there's no issue on the worker. In fact shutdown hook shouldn't take too much time.

Given that this is blocker for releasing 1.0.3 and 1.1.0, please review soon so that we can go ahead.