### PR TITLE
STORM-2279: Unable to open bolt page of storm ui

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3600,7 +3600,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 List<Integer> tasks = compToTasks.get(StormCommon.EVENTLOGGER_COMPONENT_ID);
                 tasks.sort(null);
                 // Find the task the events from this component route to.
-                int taskIndex = TupleUtils.listHashCode(Arrays.asList(componentId)) %
+                int taskIndex = (TupleUtils.listHashCode(Arrays.asList(componentId)) % tasks.size() + tasks.size()) %
                         tasks.size();
                 int taskId = tasks.get(taskIndex);
                 String host = null;


### PR DESCRIPTION
I have added logic to wrap the negative indexes around effectively giving it a python like behaviour.