### PR TITLE
STORM-2280 Upgrade Calcite version to 1.11.0

### DIFF
--- a/external/sql/storm-sql-core/pom.xml
+++ b/external/sql/storm-sql-core/pom.xml
@@ -214,7 +214,7 @@
                     <dependency>
                         <groupId>org.freemarker</groupId>
                         <artifactId>freemarker</artifactId>
-                        <version>2.3.19</version>
+                        <version>2.3.25-incubating</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/external/sql/storm-sql-core/src/codegen/data/Parser.tdd
+++ b/external/sql/storm-sql-core/src/codegen/data/Parser.tdd
@@ -55,6 +55,15 @@
   nonReservedKeywords: [
   ]
 
+  createStatementParserMethods: [
+  ]
+
+  alterStatementParserMethods: [
+  ]
+
+  dropStatementParserMethods: [
+  ]
+
   # List of files in @includes directory that have parser method
   # implementations for custom SQL statements, literals or types
   # given as part of "statementParserMethods", "literalParserMethods" or

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
         <metrics-clojure.version>2.5.1</metrics-clojure.version>
         <hdrhistogram.version>2.1.7</hdrhistogram.version>
 
-        <calcite.version>1.10.0</calcite.version>
+        <calcite.version>1.11.0</calcite.version>
 
         <jackson.version>2.6.3</jackson.version>
         <maven-surefire.version>2.18.1</maven-surefire.version>


### PR DESCRIPTION
* also update freemarker version since Calcite parser file requires that
* apply the change of Calcite parser file

Announcement will be held on tomorrow or so, but artifacts are already available in Maven.