### PR TITLE
Strom Rebalance command should support arbitrary component parallelism

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -303,13 +303,13 @@
         code-key (master-stormcode-key storm-id)
         nimbus-host-port-info (:nimbus-host-port-info nimbus)]
     (doseq [[comp num-tasks] component->executors
-            :let [component (comp old-components)
+            :let [component (get old-components comp)
                   component-common (.get_common component)]]
       (.set_parallelism_hint component-common num-tasks)
       (.set_json_conf component-common
-        (->> {TOPOLOGY-TASKS num-tasks}
-          (merge (component-conf component))
-          to-json)))
+                      (->> {TOPOLOGY-TASKS num-tasks}
+                           (merge (component-conf component))
+                           to-json)))
     (.deleteBlob blob-store code-key subject)
     (.createBlob blob-store code-key (Utils/serialize topology) (SettableBlobMeta. BlobStoreAclHandler/DEFAULT) subject)
     (if (instance? LocalFsBlobStore blob-store)
@@ -318,10 +318,10 @@
 (defn do-rebalance [nimbus storm-id status storm-base]
   (let [rebalance-options (:topology-action-options storm-base)]
     (.update-storm! (:storm-cluster-state nimbus)
-      storm-id
-        (-> {:topology-action-options nil}
-          (assoc-non-nil :component->executors (:component->executors rebalance-options))
-          (assoc-non-nil :num-workers (:num-workers rebalance-options))))
+                    storm-id
+                    (-> {:topology-action-options nil}
+                        (assoc-non-nil :component->executors (:component->executors rebalance-options))
+                        (assoc-non-nil :num-workers (:num-workers rebalance-options))))
     (update-storm-code-parallelism nimbus storm-id (:component->executors rebalance-options)))
   (mk-assignments nimbus :scratch-topology-id storm-id))
 


### PR DESCRIPTION
    For legacy reasons,  config TOPOLOGY-TASKS is considered first when schedule a topology, for a component, if user don’t specify TOPOLOGY-TASKS, storm just override it to be equal of component parallelism hint, and schedule based on TOPOLOGY-TASKS later on. 
    This works for the most cases, but not Rebalance command, now, when do Rebalance, the StormBase :component->executors attribute will be overridden in Zookeeper is used to partition tasks into executors for components, as we said above, the TOPOLOGY-TASKS is considered here as the real tasks number for components, something goes weird here:
    If we override a bigger executor numbers for a component when do rebalance, it just don’t work because smaller TOPOLOGY-TASKS [ not changed since first submitted at all ]is partitioned to bigger number of executors which read from ZooKeeper overridden by Rebalance command, but for smaller task, it works fine.
    I see that storm support a command like this now: [storm rebalance topology-name [-w wait-time-secs] [-n new-num-workers] [-e component=parallelism]*] which indicate that user can override a component parallelism freely, i think it’s more sensible to support this and it's meaningless to have a restriction like this.