### PR TITLE
STORM-2295:KafkaSpoutStreamsNamedTopics changing the sequence of fields name while emitting data

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsNamedTopics.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsNamedTopics.java
@@ -18,6 +18,13 @@
 
 package org.apache.storm.kafka.spout;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.OutputFieldsGetter;
@@ -25,13 +32,6 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Represents the {@link KafkaSpoutStream} associated with each topic, and provides a public API to
@@ -62,7 +62,7 @@ public class KafkaSpoutStreamsNamedTopics implements KafkaSpoutStreams {
 
     @Override
     public Fields getOutputFields() {
-        final Set<String> allFields = new HashSet<>();
+        final Set<String> allFields = new LinkedHashSet<>();
         for (KafkaSpoutStream kafkaSpoutStream : topicToStream.values()) {
             allFields.addAll(kafkaSpoutStream.getOutputFields().toList());
         }

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsNamedTopicsTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutStreamsNamedTopicsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.kafka.spout;
+
+import org.apache.storm.tuple.Fields;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KafkaSpoutStreamsNamedTopicsTest {
+
+	@Test
+	public void testGetOutputFields() {
+		Fields outputFields = new Fields("b","a");
+		String[] topics = new String[]{"testTopic"};
+		String streamId = "test";
+		KafkaSpoutStreamsNamedTopics build = new KafkaSpoutStreamsNamedTopics.Builder(outputFields, streamId, topics)
+        .addStream(outputFields, streamId, topics)
+        .build();
+		Fields actualFields = build.getOutputFields();
+		Assert.assertEquals(outputFields.get(0), actualFields.get(0));
+		Assert.assertEquals(outputFields.get(1), actualFields.get(1));
+
+	}
+
+}


### PR DESCRIPTION
STORM-2295: I have just updated code to make sure sequence Fields should remains same even its added in set. In old implementation because of HashSet it was changing. Also added testcase for the same