### PR TITLE
Expose OpenTsdbClient.Builder's constructor to public

### DIFF
--- a/external/storm-opentsdb/src/main/java/org/apache/storm/opentsdb/client/OpenTsdbClient.java
+++ b/external/storm-opentsdb/src/main/java/org/apache/storm/opentsdb/client/OpenTsdbClient.java
@@ -120,7 +120,7 @@ public class OpenTsdbClient {
         private boolean enableChunkedEncoding;
         private ResponseType responseType = ResponseType.None;
 
-        protected Builder(String url) {
+        public Builder(String url) {
             this.url = url;
         }
 


### PR DESCRIPTION
* This allows Flux to initialize Builder instance which is needed for OpenTSDBBolt