### PR TITLE
STORM-2297 [storm-opentsdb] Support Flux for OpenTSDBBolt

### DIFF
--- a/external/storm-opentsdb/src/main/java/org/apache/storm/opentsdb/bolt/OpenTsdbBolt.java
+++ b/external/storm-opentsdb/src/main/java/org/apache/storm/opentsdb/bolt/OpenTsdbBolt.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -58,7 +59,7 @@ public class OpenTsdbBolt extends BaseRichBolt {
     private static final Logger LOG = LoggerFactory.getLogger(OpenTsdbBolt.class);
 
     private final OpenTsdbClient.Builder openTsdbClientBuilder;
-    private final List<TupleOpenTsdbDatapointMapper> tupleOpenTsdbDatapointMappers;
+    private final List<ITupleOpenTsdbDatapointMapper> tupleOpenTsdbDatapointMappers;
     private int batchSize;
     private int flushIntervalInSeconds;
     private boolean failTupleForFailedMetrics;
@@ -68,7 +69,12 @@ public class OpenTsdbBolt extends BaseRichBolt {
     private Map<OpenTsdbMetricDatapoint, Tuple> metricPointsWithTuple = new HashMap<>();
     private OutputCollector collector;
 
-    public OpenTsdbBolt(OpenTsdbClient.Builder openTsdbClientBuilder, List<TupleOpenTsdbDatapointMapper> tupleOpenTsdbDatapointMappers) {
+    public OpenTsdbBolt(OpenTsdbClient.Builder openTsdbClientBuilder, ITupleOpenTsdbDatapointMapper tupleOpenTsdbDatapointMapper) {
+        this.openTsdbClientBuilder = openTsdbClientBuilder;
+        this.tupleOpenTsdbDatapointMappers = Collections.singletonList(tupleOpenTsdbDatapointMapper);
+    }
+
+    public OpenTsdbBolt(OpenTsdbClient.Builder openTsdbClientBuilder, List<ITupleOpenTsdbDatapointMapper> tupleOpenTsdbDatapointMappers) {
         this.openTsdbClientBuilder = openTsdbClientBuilder;
         this.tupleOpenTsdbDatapointMappers = tupleOpenTsdbDatapointMappers;
     }
@@ -155,7 +161,7 @@ public class OpenTsdbBolt extends BaseRichBolt {
 
     private List<OpenTsdbMetricDatapoint> getMetricPoints(Tuple tuple) {
         List<OpenTsdbMetricDatapoint> metricDataPoints = new ArrayList<>();
-        for (TupleOpenTsdbDatapointMapper tupleOpenTsdbDatapointMapper : tupleOpenTsdbDatapointMappers) {
+        for (ITupleOpenTsdbDatapointMapper tupleOpenTsdbDatapointMapper : tupleOpenTsdbDatapointMappers) {
             metricDataPoints.add(tupleOpenTsdbDatapointMapper.getMetricPoint(tuple));
         }
 

--- a/external/storm-opentsdb/src/main/java/org/apache/storm/opentsdb/client/OpenTsdbClient.java
+++ b/external/storm-opentsdb/src/main/java/org/apache/storm/opentsdb/client/OpenTsdbClient.java
@@ -120,7 +120,7 @@ public class OpenTsdbClient {
         private boolean enableChunkedEncoding;
         private ResponseType responseType = ResponseType.None;
 
-        protected Builder(String url) {
+        public Builder(String url) {
             this.url = url;
         }
 


### PR DESCRIPTION
* Expose OpenTsdbClient.Builder's constructor to public
  * This allows Flux to initialize Builder instance which is needed for OpenTSDBBolt
* Add constructor for having single mapper instance to OpenTsdbBolt
  * Flux doesn't support array of reference for now
* Also fix a bug on OpenTsdbBolt: it should refer the mapper interface for flexibility, not implemented one

Ideally it would be better for Flux to support these features, but given that it's easy fix and no harm, I decided to make this work first.

@satishd I saw you reviewed previous pull request. Could you review this again? Thanks in advance!