### PR TITLE
STORM-2298 Don't kill Nimbus when ClusterMetricsConsumer is failed to initialize

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/metric/ClusterMetricsConsumerExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/ClusterMetricsConsumerExecutor.java
@@ -17,7 +17,6 @@
  */
 package org.apache.storm.metric;
 
-import org.apache.storm.Config;
 import org.apache.storm.metric.api.DataPoint;
 import org.apache.storm.metric.api.IClusterMetricsConsumer;
 import org.slf4j.Logger;
@@ -27,6 +26,10 @@ import java.util.Collection;
 
 public class ClusterMetricsConsumerExecutor {
     public static final Logger LOG = LoggerFactory.getLogger(ClusterMetricsConsumerExecutor.class);
+    private static final String ERROR_MESSAGE_PREPARATION_CLUSTER_METRICS_CONSUMER_FAILED =
+            "Preparation of Cluster Metrics Consumer failed. " +
+            "Please check your configuration and/or corresponding systems and relaunch Nimbus. " +
+            "Skipping handle metrics.";
 
     private IClusterMetricsConsumer metricsConsumer;
     private String consumerClassName;
@@ -40,15 +43,24 @@ public class ClusterMetricsConsumerExecutor {
     public void prepare() {
         try {
             metricsConsumer = (IClusterMetricsConsumer)Class.forName(consumerClassName).newInstance();
+            metricsConsumer.prepare(registrationArgument);
         } catch (Exception e) {
-            throw new RuntimeException("Could not instantiate a class listed in config under section " +
-                    Config.STORM_CLUSTER_METRICS_CONSUMER_REGISTER + " with fully qualified name " + consumerClassName, e);
-        }
+            LOG.error("Could not instantiate or prepare Cluster Metrics Consumer with fully qualified name " +
+                    consumerClassName, e);
 
-        metricsConsumer.prepare(registrationArgument);
+            if (metricsConsumer != null) {
+                metricsConsumer.cleanup();
+            }
+            metricsConsumer = null;
+        }
     }
 
     public void handleDataPoints(final IClusterMetricsConsumer.ClusterInfo clusterInfo, final Collection<DataPoint> dataPoints) {
+        if (metricsConsumer == null) {
+            LOG.error(ERROR_MESSAGE_PREPARATION_CLUSTER_METRICS_CONSUMER_FAILED);
+            return;
+        }
+
         try {
             metricsConsumer.handleDataPoints(clusterInfo, dataPoints);
         } catch (Throwable e) {
@@ -57,6 +69,11 @@ public class ClusterMetricsConsumerExecutor {
     }
 
     public void handleDataPoints(final IClusterMetricsConsumer.SupervisorInfo supervisorInfo, final Collection<DataPoint> dataPoints) {
+        if (metricsConsumer == null) {
+            LOG.error(ERROR_MESSAGE_PREPARATION_CLUSTER_METRICS_CONSUMER_FAILED);
+            return;
+        }
+
         try {
             metricsConsumer.handleDataPoints(supervisorInfo, dataPoints);
         } catch (Throwable e) {
@@ -65,6 +82,8 @@ public class ClusterMetricsConsumerExecutor {
     }
 
     public void cleanup() {
-        metricsConsumer.cleanup();
+        if (metricsConsumer != null) {
+            metricsConsumer.cleanup();
+        }
     }
 }

--- a/storm-core/test/jvm/org/apache/storm/metric/ClusterMetricsConsumerExecutorTest.java
+++ b/storm-core/test/jvm/org/apache/storm/metric/ClusterMetricsConsumerExecutorTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.metric;
+
+import org.apache.storm.metric.api.DataPoint;
+import org.apache.storm.metric.api.IClusterMetricsConsumer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+
+public class ClusterMetricsConsumerExecutorTest {
+
+    @Before
+    public void setUp() {
+        MockFailingClusterMetricsConsumer.resetAllCounts();
+    }
+
+    @Test
+    public void testPrepareDoesNotThrowExceptionWhenInitializingClusterMetricsConsumerIsFailing() throws Exception {
+        ClusterMetricsConsumerExecutor sut = new ClusterMetricsConsumerExecutor(
+                MockFailingClusterMetricsConsumer.class.getName(), 2);
+
+        // it shouldn't propagate any exceptions
+        sut.prepare();
+        sut.prepare();
+
+        Assert.assertEquals(2, MockFailingClusterMetricsConsumer.getPrepareCallCount());
+    }
+
+    @Test
+    public void testHandleDataPointsWithClusterMetricsShouldSkipHandlingMetricsIfFailedBefore() throws Exception {
+        ClusterMetricsConsumerExecutor sut = new ClusterMetricsConsumerExecutor(
+                MockFailingClusterMetricsConsumer.class.getName(), 2);
+
+        // below calls shouldn't propagate any exceptions
+        sut.prepare();
+
+        // no specific reason to mock... this is one of easiest ways to make dummy instance
+        sut.handleDataPoints(mock(IClusterMetricsConsumer.ClusterInfo.class), Collections.emptyList());
+
+        Assert.assertEquals(1, MockFailingClusterMetricsConsumer.getPrepareCallCount());
+        Assert.assertEquals(0, MockFailingClusterMetricsConsumer.getHandleDataPointsWithClusterInfoCallCount());
+    }
+
+    @Test
+    public void testHandleDataPointsWithSupervisorMetricsShouldRetryInitializingClusterMetricsConsumerIfFailedBefore() throws Exception {
+        ClusterMetricsConsumerExecutor sut = new ClusterMetricsConsumerExecutor(
+                MockFailingClusterMetricsConsumer.class.getName(), 2);
+
+        // below calls shouldn't propagate any exceptions
+        sut.prepare();
+
+        // no specific reason to mock... this is one of easiest ways to make dummy instance
+        sut.handleDataPoints(mock(IClusterMetricsConsumer.SupervisorInfo.class), Collections.emptyList());
+
+        Assert.assertEquals(1, MockFailingClusterMetricsConsumer.getPrepareCallCount());
+        Assert.assertEquals(0, MockFailingClusterMetricsConsumer.getHandleDataPointsWithSupervisorInfoCallCount());
+    }
+
+    public static class MockFailingClusterMetricsConsumer implements IClusterMetricsConsumer {
+        private static int prepareCallCount = 0;
+        private static int handleDataPointsWithClusterInfoCallCount = 0;
+        private static int handleDataPointsWithSupervisorInfoCallCount = 0;
+        private static int cleanupCallCount = 0;
+
+        @Override
+        public void prepare(Object registrationArgument) {
+            prepareCallCount++;
+
+            throw new RuntimeException("prepare failing...");
+        }
+
+        @Override
+        public void handleDataPoints(ClusterInfo clusterInfo, Collection<DataPoint> dataPoints) {
+            handleDataPointsWithClusterInfoCallCount++;
+        }
+
+        @Override
+        public void handleDataPoints(SupervisorInfo supervisorInfo, Collection<DataPoint> dataPoints) {
+            handleDataPointsWithSupervisorInfoCallCount++;
+        }
+
+        @Override
+        public void cleanup() {
+            cleanupCallCount++;
+        }
+
+        public static int getPrepareCallCount() {
+            return prepareCallCount;
+        }
+
+        public static int getHandleDataPointsWithClusterInfoCallCount() {
+            return handleDataPointsWithClusterInfoCallCount;
+        }
+
+        public static int getHandleDataPointsWithSupervisorInfoCallCount() {
+            return handleDataPointsWithSupervisorInfoCallCount;
+        }
+
+        public static int getCleanupCallCount() {
+            return cleanupCallCount;
+        }
+
+        public static void resetAllCounts() {
+            prepareCallCount = 0;
+            handleDataPointsWithClusterInfoCallCount = 0;
+            handleDataPointsWithSupervisorInfoCallCount = 0;
+            cleanupCallCount = 0;
+        }
+    }
+
+}


### PR DESCRIPTION
Please refer [STORM-2298](https://issues.apache.org/jira/browse/STORM-2298) for more details.