### PR TITLE
STORM-2300 [Flux] support list of references

### DIFF
--- a/external/flux/README.md
+++ b/external/flux/README.md
@@ -400,6 +400,25 @@ components:
     constructorArgs:
       - ref: "stringScheme" # component with id "stringScheme" must be declared above.
 ```
+
+You can also reference existing components in list via specifying the id of the components with the `reflist` tag.
+The type of the reflist will be `List<Object>`, but Flux can automatically convert List to Array (also varargs), 
+so you can use reflist on argument which type is `List<Type>`, or `Type[]`, or `Type...`.
+
+Please note that all components in the list must be same type.
+
+```yaml
+components:
+  - id: "boundCQLStatementMapperBuilder"
+    className: "org.apache.storm.cassandra.query.builder.BoundCQLStatementMapperBuilder"
+    constructorArgs:
+    - "INSERT INTO sink_cassandra (eventKey, driverId, truckId, driverName) VALUES (?, ?, ?, ?)"
+    configMethods:
+    - name: "bind"
+      args:
+      - reflist: ["FieldSelector-1", "FieldSelector-2", "FieldSelector-3", "FieldSelector-4"]
+```
+
 **N.B.:** References can only be used after (below) the object they point to has been declared.
 
 ####Properties

--- a/external/flux/flux-core/src/main/java/org/apache/storm/flux/FluxBuilder.java
+++ b/external/flux/flux-core/src/main/java/org/apache/storm/flux/FluxBuilder.java
@@ -23,7 +23,6 @@ import org.apache.storm.grouping.CustomStreamGrouping;
 import org.apache.storm.topology.*;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
-import org.apache.storm.flux.api.TopologySource;
 import org.apache.storm.flux.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -279,6 +278,15 @@ public class FluxBuilder {
         for (Object arg : args) {
             if (arg instanceof BeanReference) {
                 cArgs.add(context.getComponent(((BeanReference) arg).getId()));
+            } else if (arg instanceof BeanListReference) {
+                List<Object> components = new ArrayList<>();
+                BeanListReference ref = (BeanListReference) arg;
+                for (String id : ref.getIds()) {
+                    components.add(context.getComponent(id));
+                }
+
+                LOG.debug("BeanListReference resolved as {}", components);
+                cArgs.add(components);
             } else {
                 cArgs.add(arg);
             }
@@ -393,7 +401,7 @@ public class FluxBuilder {
         Constructor retval = null;
         int eligibleCount = 0;
 
-        LOG.debug("Target class: {}", target.getName());
+        LOG.debug("Target class: {}, constructor args: {}", target.getName(), args);
         Constructor[] cons = target.getDeclaredConstructors();
 
         for (Constructor con : cons) {
@@ -451,7 +459,7 @@ public class FluxBuilder {
         Method retval = null;
         int eligibleCount = 0;
 
-        LOG.debug("Target class: {}", target.getName());
+        LOG.debug("Target class: {}, methodName: {}, args: {}", target.getName(), methodName, args);
         Method[] methods = target.getMethods();
 
         for (Method method : methods) {
@@ -583,6 +591,9 @@ public class FluxBuilder {
 
         for (int i = 0; i < args.size(); i++) {
             Object obj = args.get(i);
+            if (obj == null) {
+                throw new IllegalArgumentException("argument shouldn't be null - index: " + i);
+            }
             Class paramType = parameterTypes[i];
             Class objectType = obj.getClass();
             LOG.debug("Comparing parameter class {} to object class {} to see if assignment is possible.",

--- a/external/flux/flux-core/src/main/java/org/apache/storm/flux/model/BeanListReference.java
+++ b/external/flux/flux-core/src/main/java/org/apache/storm/flux/model/BeanListReference.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.flux.model;
+
+import java.util.List;
+
+/**
+ * A bean list reference is a list of bean reference.
+ */
+public class BeanListReference {
+    public List<String> ids;
+
+    public BeanListReference(){}
+
+    public BeanListReference(List<String> ids){
+        this.ids = ids;
+    }
+
+    public List<String> getIds() {
+        return ids;
+    }
+}

--- a/external/flux/flux-core/src/main/java/org/apache/storm/flux/model/ConfigMethodDef.java
+++ b/external/flux/flux-core/src/main/java/org/apache/storm/flux/model/ConfigMethodDef.java
@@ -48,6 +48,11 @@ public class ConfigMethodDef {
                 if(map.containsKey("ref") && map.size() == 1){
                     newVal.add(new BeanReference((String)map.get("ref")));
                     this.hasReferences = true;
+                } else if (map.containsKey("reflist") && map.size() == 1) {
+                    newVal.add(new BeanListReference((List<String>) map.get("reflist")));
+                    this.hasReferences = true;
+                } else {
+                    newVal.add(obj);
                 }
             } else {
                 newVal.add(obj);

--- a/external/flux/flux-core/src/main/java/org/apache/storm/flux/model/ObjectDef.java
+++ b/external/flux/flux-core/src/main/java/org/apache/storm/flux/model/ObjectDef.java
@@ -53,8 +53,11 @@ public class ObjectDef {
         for(Object obj : constructorArgs){
             if(obj instanceof LinkedHashMap){
                 Map map = (Map)obj;
-                if(map.containsKey("ref") && map.size() == 1){
-                    newVal.add(new BeanReference((String)map.get("ref")));
+                if(map.containsKey("ref") && map.size() == 1) {
+                    newVal.add(new BeanReference((String) map.get("ref")));
+                    this.hasReferences = true;
+                } else if (map.containsKey("reflist") && map.size() == 1) {
+                    newVal.add(new BeanListReference((List<String>) map.get("reflist")));
                     this.hasReferences = true;
                 } else {
                     newVal.add(obj);

--- a/external/flux/flux-core/src/test/java/org/apache/storm/flux/TCKTest.java
+++ b/external/flux/flux-core/src/test/java/org/apache/storm/flux/TCKTest.java
@@ -227,6 +227,7 @@ public class TCKTest {
         assertTrue(bolt.getFoo().equals("foo"));
         assertTrue(bolt.getBar().equals("bar"));
         assertTrue(bolt.getFooBar().equals("foobar"));
+        assertArrayEquals(new TestBolt.TestClass[] {new TestBolt.TestClass("foo"), new TestBolt.TestClass("bar"), new TestBolt.TestClass("baz")}, bolt.getClasses());
     }
 
     @Test

--- a/external/flux/flux-core/src/test/java/org/apache/storm/flux/test/TestBolt.java
+++ b/external/flux/flux-core/src/test/java/org/apache/storm/flux/test/TestBolt.java
@@ -24,6 +24,8 @@ import org.apache.storm.tuple.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
+
 
 public class TestBolt extends BaseBasicBolt {
     private static final Logger LOG = LoggerFactory.getLogger(TestBolt.class);
@@ -32,6 +34,35 @@ public class TestBolt extends BaseBasicBolt {
     private String bar;
     private String fooBar;
     private String none;
+    private TestClass[] classes;
+
+    public static class TestClass implements Serializable {
+        private String field;
+
+        public TestClass(String field) {
+            this.field = field;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof TestClass)) return false;
+
+            TestClass testClass = (TestClass) o;
+
+            return getField() != null ? getField().equals(testClass.getField()) : testClass.getField() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return getField() != null ? getField().hashCode() : 0;
+        }
+    }
+
 
     public static enum TestEnum {
         FOO,
@@ -47,6 +78,10 @@ public class TestBolt extends BaseBasicBolt {
     }
 
     public TestBolt(TestEnum te, float f, boolean b){
+
+    }
+
+    public TestBolt(TestEnum te, float f, boolean b, TestClass... str) {
 
     }
 
@@ -75,6 +110,10 @@ public class TestBolt extends BaseBasicBolt {
         this.fooBar = foo + bar;
     }
 
+    public void withClasses(TestClass...classes) {
+        this.classes = classes;
+    }
+
     public String getFoo(){
         return this.foo;
     }
@@ -84,5 +123,9 @@ public class TestBolt extends BaseBasicBolt {
 
     public String getFooBar(){
         return this.fooBar;
+    }
+
+    public TestClass[] getClasses() {
+        return classes;
     }
 }

--- a/external/flux/flux-core/src/test/resources/configs/config-methods-test.yaml
+++ b/external/flux/flux-core/src/test/resources/configs/config-methods-test.yaml
@@ -21,6 +21,20 @@ config:
   topology.workers: 1
   # ...
 
+components:
+  - id: "foo"
+    className: "org.apache.storm.flux.test.TestBolt$TestClass"
+    constructorArgs:
+      - "foo"
+  - id: "bar"
+    className: "org.apache.storm.flux.test.TestBolt$TestClass"
+    constructorArgs:
+      - "bar"
+  - id: "baz"
+    className: "org.apache.storm.flux.test.TestBolt$TestClass"
+    constructorArgs:
+      - "baz"
+
 # spout definitions
 spouts:
   - id: "spout-1"
@@ -37,6 +51,7 @@ bolts:
       - FOO # enum class
       - 1.0
       - true
+      - reflist: ["foo", "bar"]
     configMethods:
       - name: "withFoo"
         args:
@@ -49,7 +64,12 @@ bolts:
         args:
           - "foo"
           - "bar"
-
+      - name: "withClasses"
+        args:
+          - reflist:
+            - "foo"
+            - "bar"
+            - "baz"
 
 
 #stream definitions


### PR DESCRIPTION
Please refer [STORM-2300](https://issues.apache.org/jira/browse/STORM-2300) for more details.

* introduce reflist
* introduce BeanListReference which stores list of id of references
* handle BeanListReference properly
* modify unit test for testing reflist

This feature supports method which arguments contain List<Type>, Type[], Type... (varargs).