### PR TITLE
STORM-2315 Storm kafka client does not commit offsets when ack is disabled.

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -336,18 +336,17 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                             collector.emit(tuple);
                         }
                     } else {
-                        if (tuple instanceof KafkaTuple) {
-                            collector.emit(((KafkaTuple) tuple).getStream(), tuple, msgId);
-                        } else {
-                            collector.emit(tuple, msgId);
-                        }
-
                         emitted.add(msgId);
-
                         if (isScheduled) {  // Was scheduled for retry and re-emitted, so remove from schedule.
                             retryService.remove(msgId);
                         } else {            //New tuple, hence increment the uncommitted offset counter
                             numUncommittedOffsets++;
+                        }
+
+                        if (tuple instanceof KafkaTuple) {
+                            collector.emit(((KafkaTuple) tuple).getStream(), tuple, msgId);
+                        } else {
+                            collector.emit(tuple, msgId);
                         }
                     }
                     LOG.trace("Emitted tuple [{}] for record [{}] with msgId [{}]", tuple, record, msgId);


### PR DESCRIPTION
Here is why this bug happens: when ack is disabled, the ack method of spout will be called in the emit method, and that's why emitted message ids can not be found and moved to acked tuples.