### PR TITLE
STORM-2325 Logviewer doesn't consider 'storm.local.hostname'

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
@@ -529,7 +529,7 @@
 
 (defn url-to-match-centered-in-log-page
   [needle fname offset port]
-  (let [host (Utils/localHostname)
+  (let [host (Utils/hostname)
         port (logviewer-port)
         fname (clojure.string/join Utils/FILE_PATH_SEPARATOR (take-last 3 (split fname (re-pattern Utils/FILE_PATH_SEPARATOR))))]
     (url (str "http://" host ":" port "/log")
@@ -542,7 +542,7 @@
 
 (defn url-to-match-centered-in-log-page-daemon-file
   [needle fname offset port]
-  (let [host (Utils/localHostname)
+  (let [host (Utils/hostname)
         port (logviewer-port)
         fname (clojure.string/join Utils/FILE_PATH_SEPARATOR (take-last 1 (split fname (re-pattern Utils/FILE_PATH_SEPARATOR))))]
     (url (str "http://" host ":" port "/daemonlog")

--- a/storm-core/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/Utils.java
@@ -1771,8 +1771,13 @@ public class Utils {
      * Gets the storm.local.hostname value, or tries to figure out the local hostname
      * if it is not set in the config.
      * @return a string representation of the hostname.
-    */
-    public static String hostname () throws UnknownHostException  {
+     */
+    public static String hostname() throws UnknownHostException {
+        return _instance.hostnameImpl();
+    }
+
+    // Non-static impl methods exist for mocking purposes.
+    protected String hostnameImpl () throws UnknownHostException  {
         if (localConf == null) {
             return memoizedLocalHostname();
         }

--- a/storm-core/test/clj/org/apache/storm/logviewer_test.clj
+++ b/storm-core/test/clj/org/apache/storm/logviewer_test.clj
@@ -380,7 +380,7 @@
 
     (stubbing [logviewer/logviewer-port expected-port]
       (with-open [_ (UtilsInstaller. (proxy [Utils] []
-                                       (localHostnameImpl [] expected-host)))]
+                                       (hostnameImpl [] expected-host)))]
         (testing "Logviewer link centers the match in the page"
           (let [expected-fname "foobar.log"]
             (is (= (str "http://"


### PR DESCRIPTION
* consider storm.local.hostname first for creating link url in Logviewer

I'll create another pull request for 1.x branch. Backporting to 1.0.x branch will be easy on that pull request.