### PR TITLE
STORM-2325 Logviewer doesn't consider 'storm.local.hostname' (1.x)

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
@@ -518,7 +518,7 @@
 
 (defn url-to-match-centered-in-log-page
   [needle fname offset port]
-  (let [host (local-hostname)
+  (let [host (hostname)
         port (logviewer-port)
         fname (clojure.string/join file-path-separator (take-last 3 (split fname (re-pattern file-path-separator))))]
     (url (str "http://" host ":" port "/log")
@@ -531,7 +531,7 @@
 
 (defn url-to-match-centered-in-log-page-daemon-file
   [needle fname offset port]
-  (let [host (local-hostname)
+  (let [host (hostname)
         port (logviewer-port)
         fname (clojure.string/join file-path-separator (take-last 1 (split fname (re-pattern file-path-separator))))]
     (url (str "http://" host ":" port "/daemonlog")

--- a/storm-core/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/Utils.java
@@ -1746,8 +1746,13 @@ public class Utils {
      * Gets the storm.local.hostname value, or tries to figure out the local hostname
      * if it is not set in the config.
      * @return a string representation of the hostname.
-    */
-    public static String hostname () throws UnknownHostException  {
+     */
+    public static String hostname() throws UnknownHostException {
+        return _instance.hostnameImpl();
+    }
+
+    // Non-static impl methods exist for mocking purposes.
+    protected String hostnameImpl () throws UnknownHostException  {
         if (localConf == null) {
             return memoizedLocalHostname();
         }

--- a/storm-core/test/clj/org/apache/storm/logviewer_test.clj
+++ b/storm-core/test/clj/org/apache/storm/logviewer_test.clj
@@ -371,7 +371,7 @@
         ;; match.
         exp-offset-fn #(- (/ logviewer/default-bytes-per-page 2) %)]
 
-    (stubbing [local-hostname expected-host
+    (stubbing [hostname expected-host
                logviewer/logviewer-port expected-port]
 
       (testing "Logviewer link centers the match in the page"


### PR DESCRIPTION
* consider storm.local.hostname first for creating link url in Logviewer

This should be easy to port back to 1.0.x branch.