### PR TITLE
STORM 2324 - Fix toplogy deployment failure if resources directory is missing in topology jar

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Container.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Container.java
@@ -410,12 +410,19 @@ public abstract class Container implements Killable {
                 blobFileNames.add(ret);
             }
         }
+        File targetResourcesDir = new File(stormRoot, ConfigUtils.RESOURCES_SUBDIR);
         List<String> resourceFileNames = new ArrayList<>();
-        resourceFileNames.add(ConfigUtils.RESOURCES_SUBDIR);
+        if (targetResourcesDir.exists()) {
+            resourceFileNames.add(ConfigUtils.RESOURCES_SUBDIR);
+        }
         resourceFileNames.addAll(blobFileNames);
+
         LOG.info("Creating symlinks for worker-id: {} storm-id: {} for files({}): {}", _workerId, _topologyId, resourceFileNames.size(), resourceFileNames);
-        _ops.createSymlink(new File(workerRoot, ConfigUtils.RESOURCES_SUBDIR), 
-                new File(stormRoot, ConfigUtils.RESOURCES_SUBDIR));
+        if(targetResourcesDir.exists()) {
+            _ops.createSymlink(new File(workerRoot, ConfigUtils.RESOURCES_SUBDIR),  targetResourcesDir );
+        } else {
+            LOG.info("Topology jar for worker-id: {} storm-id: {} does not contain re sources directory {}." , _workerId, _topologyId, targetResourcesDir.toString() );
+        }
         for (String fileName : blobFileNames) {
             _ops.createSymlink(new File(workerRoot, fileName),
                     new File(stormRoot, fileName));

--- a/storm-core/test/jvm/org/apache/storm/daemon/supervisor/ContainerTest.java
+++ b/storm-core/test/jvm/org/apache/storm/daemon/supervisor/ContainerTest.java
@@ -213,9 +213,9 @@ public class ContainerTest {
         
         //Create links to artifacts dir
         verify(ops).createSymlink(new File(workerRoot, "artifacts"), workerArtifacts);
-        
-        //Create links to blobs 
-        verify(ops).createSymlink(new File(workerRoot, "resources"), new File(distRoot, "resources"));
+
+        //Create links to blobs
+        verify(ops, never()).createSymlink(new File(workerRoot, "resources"), new File(distRoot, "resources"));
     }
     
     @Test


### PR DESCRIPTION
Skips creating symlink to the resources directory if there is no target resources directory. 
This avoids failure in setup_permissions() function in worker_launcher.c 