### PR TITLE
STORM-2335 Fix broken Topology visualization with empty ':transferred' in executor stats

### DIFF
--- a/storm-core/src/ui/public/js/visualization.js
+++ b/storm-core/src/ui/public/js/visualization.js
@@ -309,7 +309,7 @@ function gather_stream_count(stats, stream, time) {
     var transferred = 0;
     if(stats)
         for(var i = 0; i < stats.length; i++) {
-            if(stats[i][":transferred"] != null)
+            if(stats[i][":transferred"] != null && stats[i][":transferred"][time] != undefined)
             {
                 var stream_trans = stats[i][":transferred"][time][stream];
                 if(stream_trans != null)
@@ -391,12 +391,14 @@ function show_visualization(sys) {
         getStatic("/templates/topology-page-template.html", function(template) {
             jsError(function() {
                 var topologyVisualization = $("#visualization-container");
-                topologyVisualization.append(
-                    Mustache.render($(template)
-                        .filter("#topology-visualization-container-template")
-                        .html(),
-                        response));
-                });
+                if (topologyVisualization.find("canvas").length == 0) {
+                    topologyVisualization.append(
+                        Mustache.render($(template)
+                            .filter("#topology-visualization-container-template")
+                            .html(),
+                            response));
+                }
+            });
 
             if(sys == null)
             {


### PR DESCRIPTION
Also fix another bug: stream table and graph box were created for each 'Show Visualization' click.

Please refer description of [STORM-2335](https://issues.apache.org/jira/browse/STORM-2335) for more details.

This can be ported back to 1.x and 1.0.x branches via cherry-picking.