### PR TITLE
STORM-2336 Close Localizer and AsyncLocalizer when supervisor is shutting down

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -77,7 +77,7 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
     private final StormTimer eventTimer;
     private final StormTimer blobUpdateTimer;
     private final Localizer localizer;
-    private final ILocalizer asyncLocalizer;
+    private final AsyncLocalizer asyncLocalizer;
     private EventManager eventManager;
     private ReadClusterState readState;
     
@@ -274,6 +274,8 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
             if (readState != null) {
                 readState.close();
             }
+            asyncLocalizer.shutdown();
+            localizer.shutdown();
             getStormClusterState().disconnect();
         } catch (Exception e) {
             LOG.error("Error Shutting down", e);


### PR DESCRIPTION
* this patch gets rid of alive non-daemon threads which prevent JVM process shutdown

This patch can be ported back to 1.x and 1.0.x branch via cherry-picking.