### PR TITLE
STORM-2281: Running Multiple Kafka Spouts (Trident) Throws Illegal State Exception

### DIFF
--- a/examples/storm-kafka-examples/src/main/java/org/apache/storm/kafka/trident/LocalSubmitter.java
+++ b/examples/storm-kafka-examples/src/main/java/org/apache/storm/kafka/trident/LocalSubmitter.java
@@ -47,10 +47,13 @@ public class LocalSubmitter {
     }
 
     public static Config defaultConfig() {
+        return defaultConfig(false);
+    }
+
+    public static Config defaultConfig(boolean debug) {
         final Config conf = new Config();
         conf.setMaxSpoutPending(20);
-        conf.setMaxTaskParallelism(1);
-        conf.setNumWorkers(1);
+        conf.setDebug(debug);
         return conf;
     }
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutBatchMetadata.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutBatchMetadata.java
@@ -34,8 +34,8 @@ public class KafkaTridentSpoutBatchMetadata<K,V> implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(KafkaTridentSpoutBatchMetadata.class);
 
     private TopicPartition topicPartition;  // topic partition of this batch
-    private long firstOffset;   // first offset of this batch
-    private long lastOffset;    // last offset of this batch
+    private long firstOffset;               // first offset of this batch
+    private long lastOffset;                // last offset of this batch
 
     public KafkaTridentSpoutBatchMetadata(TopicPartition topicPartition, long firstOffset, long lastOffset) {
         this.topicPartition = topicPartition;
@@ -74,8 +74,8 @@ public class KafkaTridentSpoutBatchMetadata<K,V> implements Serializable {
 
     @Override
     public String toString() {
-        return "KafkaTridentSpoutBatchMetadata{" +
-                "topicPartition=" + topicPartition +
+        return super.toString() +
+                "{topicPartition=" + topicPartition +
                 ", firstOffset=" + firstOffset +
                 ", lastOffset=" + lastOffset +
                 '}';

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaque.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaque.java
@@ -34,7 +34,7 @@ public class KafkaTridentSpoutOpaque<K,V> implements IOpaquePartitionedTridentSp
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaTridentSpoutOpaque.class);
 
-    private KafkaTridentSpoutManager<K, V> kafkaManager;
+    private final KafkaTridentSpoutManager<K, V> kafkaManager;
     private KafkaTridentSpoutEmitter<K, V> kafkaTridentSpoutEmitter;
     private KafkaTridentSpoutOpaqueCoordinator<K, V> coordinator;
 
@@ -50,19 +50,12 @@ public class KafkaTridentSpoutOpaque<K,V> implements IOpaquePartitionedTridentSp
 
     @Override
     public Emitter<List<TopicPartition>, KafkaTridentSpoutTopicPartition, KafkaTridentSpoutBatchMetadata<K,V>> getEmitter(Map conf, TopologyContext context) {
-        // Instance is created on first call rather than in constructor to avoid NotSerializableException caused by KafkaConsumer
-        if (kafkaTridentSpoutEmitter == null) {
-            kafkaTridentSpoutEmitter = new KafkaTridentSpoutEmitter<>(kafkaManager, context);
-        }
-        return kafkaTridentSpoutEmitter;
+        return new KafkaTridentSpoutEmitter<>(kafkaManager, context);
     }
 
     @Override
     public Coordinator<List<TopicPartition>> getCoordinator(Map conf, TopologyContext context) {
-        if (coordinator == null) {
-            coordinator = new KafkaTridentSpoutOpaqueCoordinator<>(kafkaManager);
-        }
-        return coordinator;
+        return new KafkaTridentSpoutOpaqueCoordinator<>(kafkaManager);
     }
 
     @Override
@@ -79,8 +72,8 @@ public class KafkaTridentSpoutOpaque<K,V> implements IOpaquePartitionedTridentSp
 
     @Override
     public String toString() {
-        return "KafkaTridentSpoutOpaque{" +
-                "kafkaManager=" + kafkaManager +
+        return super.toString() +
+                "{kafkaManager=" + kafkaManager +
                 ", kafkaTridentSpoutEmitter=" + kafkaTridentSpoutEmitter +
                 ", coordinator=" + coordinator +
                 '}';

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaqueCoordinator.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaqueCoordinator.java
@@ -57,8 +57,8 @@ public class KafkaTridentSpoutOpaqueCoordinator<K,V> implements IOpaquePartition
 
     @Override
     public String toString() {
-        return "KafkaTridentSpoutOpaqueCoordinator{" +
-                "kafkaManager=" + kafkaManager +
+        return super.toString() +
+                "{kafkaManager=" + kafkaManager +
                 '}';
     }
 }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTopicPartition.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTopicPartition.java
@@ -43,7 +43,7 @@ public class KafkaTridentSpoutTopicPartition implements ISpoutPartition, Seriali
 
     @Override
     public String getId() {
-        return topicPartition.topic() + "/" + topicPartition.partition();
+        return topicPartition.topic() + "@" + topicPartition.partition();
     }
 
     @Override

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTopicPartitionRegistry.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTopicPartitionRegistry.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public enum KafkaTridentSpoutTopicPartitionRegistry {
@@ -31,7 +31,7 @@ public enum KafkaTridentSpoutTopicPartitionRegistry {
     private Set<TopicPartition> topicPartitions;
 
     KafkaTridentSpoutTopicPartitionRegistry() {
-        this.topicPartitions = new HashSet<>();
+        this.topicPartitions = new LinkedHashSet<>();
     }
 
     public Set<TopicPartition> getTopicPartitions() {


### PR DESCRIPTION
   - Assign topic partitions to tasks running the instance of Kafka consumer that has assigned the same list of topic partitions
   - Improve logging
   - Minor code refactoring