### PR TITLE
Convert NoNodeException to KeyNotFoundException in getNimbodesWithLatestSequenceNumberOfBlob

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobStoreUtils.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobStoreUtils.java
@@ -30,6 +30,7 @@ import org.apache.storm.utils.Utils;
 import org.apache.storm.utils.ZookeeperAuthInfo;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.thrift.transport.TTransportException;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +77,15 @@ public class BlobStoreUtils {
 
     // Check for latest sequence number of a key inside zookeeper and return nimbodes containing the latest sequence number
     public static Set<NimbusInfo> getNimbodesWithLatestSequenceNumberOfBlob(CuratorFramework zkClient, String key) throws Exception {
-        List<String> stateInfoList = zkClient.getChildren().forPath("/blobstore/" + key);
+        List<String> stateInfoList;
+        try {
+            stateInfoList = zkClient.getChildren().forPath("/blobstore/" + key);
+        } catch (KeeperException.NoNodeException e) {
+            // there's a race condition with a delete: blobstore
+            // this should be thrown to the caller to indicate that the key is invalid now
+            throw new KeyNotFoundException(key);
+        }
+
         Set<NimbusInfo> nimbusInfoSet = new HashSet<NimbusInfo>();
         int latestSeqNumber = getLatestSequenceNumber(stateInfoList);
         LOG.debug("getNimbodesWithLatestSequenceNumberOfBlob stateInfo {} version {}", stateInfoList, latestSeqNumber);


### PR DESCRIPTION
* since callers are able to handle KeyNotFoundException but not NoNodeException

This patch is addressing missed spot on [STORM-2321](https://issues.apache.org/jira/browse/STORM-2321).

It doesn't mean patch for STORM-2321 is broken (just found a missing case), so it doesn't hurt the release vote for 1.0.3 RC2.