### PR TITLE
[STORM-2194]  Stop ignoring socket timeout error from executor

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/executor/error/ReportErrorAndDie.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/error/ReportErrorAndDie.java
@@ -39,7 +39,8 @@ public class ReportErrorAndDie implements Thread.UncaughtExceptionHandler {
             LOG.error("Error while reporting error to cluster, proceeding with shutdown", ex);
         }
         if (Utils.exceptionCauseIsInstanceOf(InterruptedException.class, e)
-                || Utils.exceptionCauseIsInstanceOf(java.io.InterruptedIOException.class, e)) {
+                || (Utils.exceptionCauseIsInstanceOf(java.io.InterruptedIOException.class, e)
+                    && !Utils.exceptionCauseIsInstanceOf(java.net.SocketTimeoutException.class, e))) {
             LOG.info("Got interrupted exception shutting thread down...");
         } else {
             suicideFn.run();


### PR DESCRIPTION
This is a translation of the fix recommended by @revans2 here:

https://github.com/apache/storm/pull/1767