### PR TITLE
STORM-2354: Upgrade to datastax driver 3.1.3

### DIFF
--- a/external/storm-cassandra/pom.xml
+++ b/external/storm-cassandra/pom.xml
@@ -37,7 +37,7 @@
         <junit.version>4.11</junit.version>
         <guava.version>16.0.1</guava.version>
         <commons-lang3.version>3.3</commons-lang3.version>
-        <cassandra.driver.core.version>2.1.7.1</cassandra.driver.core.version>
+        <cassandra.driver.core.version>3.1.3</cassandra.driver.core.version>
     </properties>
 
     <developers>

--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/query/impl/BoundCQLStatementTupleMapper.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/query/impl/BoundCQLStatementTupleMapper.java
@@ -75,7 +75,7 @@ public class BoundCQLStatementTupleMapper implements CQLStatementTupleMapper {
 
         PreparedStatement statement = getPreparedStatement(session, query);
         if(hasRoutingKeys()) {
-            List<ByteBuffer> keys = rkGenerator.getRoutingKeys(tuple);
+            List<ByteBuffer> keys = rkGenerator.getRoutingKeys(tuple, session.getCluster().getConfiguration().getProtocolOptions().getProtocolVersion());
             if( keys.size() == 1)
                 statement.setRoutingKey(keys.get(0));
             else

--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/query/impl/PreparedStatementBinder.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/query/impl/PreparedStatementBinder.java
@@ -112,7 +112,7 @@ public interface PreparedStatementBinder extends Serializable {
                 statement.setInet(name, (InetAddress)value);
 
             if (value instanceof Date)
-                statement.setDate(name, (Date)value);
+                statement.setTimestamp(name, (Date)value);
 
             if (value instanceof UUID)
                 statement.setUUID(name, (UUID)value);

--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/query/impl/SimpleCQLStatementMapper.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/query/impl/SimpleCQLStatementMapper.java
@@ -72,7 +72,7 @@ public class SimpleCQLStatementMapper implements CQLStatementTupleMapper {
         SimpleStatement statement = new SimpleStatement(queryString, Column.getVals(columns));
 
         if(hasRoutingKeys()) {
-            List<ByteBuffer> keys = rkGenerator.getRoutingKeys(tuple);
+            List<ByteBuffer> keys = rkGenerator.getRoutingKeys(tuple, session.getCluster().getConfiguration().getProtocolOptions().getProtocolVersion());
             if( keys.size() == 1)
                 statement.setRoutingKey(keys.get(0));
             else


### PR DESCRIPTION
implemented some fixes to allow using driver 3.1.3. 
This TODO is also commented in the code as a possible new fix:

// TODO: codecFor(Object) return first codec that accepts value.
// perhaps we could provide a way to the programmer give more info
// to allow other forms of codedFor more suitable to the case we
// known the the correct CSQL types involved. Anyway, does not
// impact when Token-aware Load Balancing Policy is not used.