### PR TITLE
STORM-2358: Update storm hdfs spout to remove specific implementation handling

### DIFF
--- a/external/storm-hdfs/README.md
+++ b/external/storm-hdfs/README.md
@@ -504,7 +504,7 @@ The following example creates an HDFS spout that reads text files from HDFS path
 
 ```java
 // Instantiate spout to read text files
-HdfsSpout textReaderSpout = new HdfsSpout().setReaderType("text")
+HdfsSpout textReaderSpout = new HDFSSpout().setReaderType(TextFileReader.class)
                                            .withOutputFields(TextFileReader.defaultFields)                                      
                                            .setHdfsUri("hdfs://localhost:54310")  // reqd
                                            .setSourceDir("/data/in")              // reqd                                      
@@ -540,7 +540,7 @@ Only methods mentioned in **bold** are required.
 
 | Method                     | Alternative config name (deprecated) | Default     | Description |
 |----------------------------|--------------------------------------|-------------|-------------|
-| **.setReaderType()**       |~~hdfsspout.reader.type~~             |             | Determines which file reader to use. Set to 'seq' for reading sequence files or 'text' for text files. Set to a fully qualified class name if using a custom file reader class (that implements interface org.apache.storm.hdfs.spout.FileReader)|
+| **.setReaderType()**       |~~hdfsspout.reader.type~~             |             | Determines which file reader to use. Set to 'org.apache.storm.hdfs.spout.SequenceFileReader' for reading sequence files or 'org.apache.storm.hdfs.spout.TextFileReader' for text files OR set to custom file reader class (that implements interface org.apache.storm.hdfs.spout.FileReader)|
 | **.withOutputFields()**    |                                      |             | Sets the names for the output fields for the spout. The number of fields depends upon the reader being used. For convenience, built-in reader types expose a static member called `defaultFields` that can be used for setting this.|
 | **.setHdfsUri()**          |~~hdfsspout.hdfs~~                    |             | HDFS URI for the hdfs Name node. Example:  hdfs://namenodehost:8020|
 | **.setSourceDir()**        |~~hdfsspout.source.dir~~              |             | HDFS directory from where to read files. E.g. /data/inputdir|

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHDFSSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHDFSSpout.java
@@ -59,7 +59,7 @@ import java.util.Map;
 import org.apache.storm.hdfs.common.HdfsUtils.Pair;
 
 
-public class TestHdfsSpout {
+public class TestHDFSSpout {
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -69,7 +69,7 @@ public class TestHdfsSpout {
   private Path badfiles;
 
 
-  public TestHdfsSpout() {
+  public TestHDFSSpout() {
   }
 
   static MiniDFSCluster.Builder builder;
@@ -117,7 +117,7 @@ public class TestHdfsSpout {
     Path file2 = new Path(source.toString() + "/file2.txt");
     createTextFile(file2, 5);
 
-    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    HDFSSpout spout = makeSpout(TextFileReader.class);
     spout.setCommitFrequencyCount(1);
     spout.setCommitFrequencySec(1);
 
@@ -139,7 +139,7 @@ public class TestHdfsSpout {
     Path file2 = new Path(source.toString() + "/file2.txt");
     createTextFile(file2, 5);
 
-    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    HDFSSpout spout = makeSpout(TextFileReader.class);
     spout.setCommitFrequencyCount(1);
     spout.setCommitFrequencySec(1);
 
@@ -165,13 +165,13 @@ public class TestHdfsSpout {
 
     final Integer lockExpirySec = 1;
 
-    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    HDFSSpout spout = makeSpout(TextFileReader.class);
     spout.setCommitFrequencyCount(1);
     spout.setCommitFrequencySec(1000);  // effectively disable commits based on time
     spout.setLockTimeoutSec(lockExpirySec);
 
 
-    HdfsSpout spout2 = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    HDFSSpout spout2 = makeSpout(TextFileReader.class);
     spout2.setCommitFrequencyCount(1);
     spout2.setCommitFrequencySec(1000);  // effectively disable commits based on time
     spout2.setLockTimeoutSec(lockExpirySec);
@@ -222,13 +222,13 @@ public class TestHdfsSpout {
 
     final Integer lockExpirySec = 1;
 
-    HdfsSpout spout = makeSpout(Configs.SEQ, SequenceFileReader.defaultFields);
+    HDFSSpout spout = makeSpout(SequenceFileReader.class);
     spout.setCommitFrequencyCount(1);
     spout.setCommitFrequencySec(1000); // effectively disable commits based on time
     spout.setLockTimeoutSec(lockExpirySec);
 
 
-    HdfsSpout spout2 = makeSpout(Configs.SEQ, SequenceFileReader.defaultFields);
+    HDFSSpout spout2 = makeSpout(SequenceFileReader.class);
     spout2.setCommitFrequencyCount(1);
     spout2.setCommitFrequencySec(1000); // effectively disable commits based on time
     spout2.setLockTimeoutSec(lockExpirySec);
@@ -278,7 +278,7 @@ public class TestHdfsSpout {
     }
 
     List<String> actual = new ArrayList<>();
-    for (Pair<HdfsSpout.MessageId, List<Object>> item : collector.items) {
+    for (Pair<HDFSSpout.MessageId, List<Object>> item : collector.items) {
       actual.add(item.getValue().get(0).toString());
     }
     Assert.assertEquals(expected, actual);
@@ -344,7 +344,7 @@ public class TestHdfsSpout {
     createTextFile(file1, 5);
 
 
-    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    HDFSSpout spout = makeSpout(TextFileReader.class);
     spout.setCommitFrequencyCount(1);
     spout.setCommitFrequencySec(1);
 
@@ -398,14 +398,14 @@ public class TestHdfsSpout {
     Assert.assertEquals(true, getBoolField(spout, "fileReadCompletely"));
   }
 
-  private static <T> T getField(HdfsSpout spout, String fieldName) throws NoSuchFieldException, IllegalAccessException {
-    Field readerFld = HdfsSpout.class.getDeclaredField(fieldName);
+  private static <T> T getField(HDFSSpout spout, String fieldName) throws NoSuchFieldException, IllegalAccessException {
+    Field readerFld = HDFSSpout.class.getDeclaredField(fieldName);
     readerFld.setAccessible(true);
     return (T) readerFld.get(spout);
   }
 
-  private static boolean getBoolField(HdfsSpout spout, String fieldName) throws NoSuchFieldException, IllegalAccessException {
-    Field readerFld = HdfsSpout.class.getDeclaredField(fieldName);
+  private static boolean getBoolField(HDFSSpout spout, String fieldName) throws NoSuchFieldException, IllegalAccessException {
+    Field readerFld = HDFSSpout.class.getDeclaredField(fieldName);
     readerFld.setAccessible(true);
     return readerFld.getBoolean(spout);
   }
@@ -426,7 +426,7 @@ public class TestHdfsSpout {
     createSeqFile(fs, file2, 5);
 
 
-    HdfsSpout spout = makeSpout(Configs.SEQ, SequenceFileReader.defaultFields);
+    HDFSSpout spout = makeSpout(SequenceFileReader.class);
     Map conf = getCommonConfigs();
     openSpout(spout, 0, conf);
 
@@ -454,7 +454,7 @@ public class TestHdfsSpout {
     Assert.assertEquals(2, listDir(source).size());
 
     // 2) run spout
-    HdfsSpout spout = makeSpout(MockTextFailingReader.class.getName(), MockTextFailingReader.defaultFields);
+    HDFSSpout spout = makeSpout(MockTextFailingReader.class);
     Map conf = getCommonConfigs();
     openSpout(spout, 0, conf);
 
@@ -476,7 +476,7 @@ public class TestHdfsSpout {
 
      // 0) config spout to log progress in lock file for each tuple
 
-     HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+     HDFSSpout spout = makeSpout(TextFileReader.class);
      spout.setCommitFrequencyCount(1);
      spout.setCommitFrequencySec(1000);  // effectively disable commits based on time
 
@@ -527,7 +527,7 @@ public class TestHdfsSpout {
 
     // 0) config spout to log progress in lock file for each tuple
 
-    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    HDFSSpout spout = makeSpout(TextFileReader.class);
     spout.setCommitFrequencyCount(2);   // 1 lock log entry every 2 tuples
     spout.setCommitFrequencySec(1000);  // Effectively disable commits based on time
 
@@ -554,7 +554,7 @@ public class TestHdfsSpout {
     createTextFile(file1, 10);
 
     // 0) config spout to log progress in lock file for each tuple
-    HdfsSpout spout = makeSpout(Configs.TEXT, TextFileReader.defaultFields);
+    HDFSSpout spout = makeSpout(TextFileReader.class);
     spout.setCommitFrequencyCount(0); // disable it
     spout.setCommitFrequencySec(2);   // log every 2 sec
 
@@ -594,9 +594,8 @@ public class TestHdfsSpout {
     return conf;
   }
 
-  private HdfsSpout makeSpout(String readerType, String[] outputFields) {
-    HdfsSpout spout = new HdfsSpout().withOutputFields(outputFields)
-                                    .setReaderType(readerType)
+  private HDFSSpout makeSpout(Class<? extends AbstractFileReader> readerType) {
+    HDFSSpout spout = new HDFSSpout().setReaderType(readerType)
                                     .setHdfsUri(hdfsCluster.getURI().toString())
                                     .setSourceDir(source.toString())
                                     .setArchiveDir(archive.toString())
@@ -605,7 +604,7 @@ public class TestHdfsSpout {
     return spout;
   }
 
-  private void openSpout(HdfsSpout spout, int spoutId, Map conf) {
+  private void openSpout(HDFSSpout spout, int spoutId, Map conf) {
     MockCollector collector = new MockCollector();
     spout.open(conf, new MockTopologyContext(spoutId), collector);
   }
@@ -620,7 +619,7 @@ public class TestHdfsSpout {
    * fN - fail, item number: N
    */
 
-  private List<String> runSpout(HdfsSpout spout, String...  cmds) {
+  private List<String> runSpout(HDFSSpout spout, String...  cmds) {
     MockCollector collector = (MockCollector) spout.getCollector();
       for(String cmd : cmds) {
         if(cmd.startsWith("r")) {
@@ -634,12 +633,12 @@ public class TestHdfsSpout {
         }
         else if(cmd.startsWith("a")) {
           int n = Integer.parseInt(cmd.substring(1));
-          Pair<HdfsSpout.MessageId, List<Object>> item = collector.items.get(n);
+          Pair<HDFSSpout.MessageId, List<Object>> item = collector.items.get(n);
           spout.ack(item.getKey());
         }
         else if(cmd.startsWith("f")) {
           int n = Integer.parseInt(cmd.substring(1));
-          Pair<HdfsSpout.MessageId, List<Object>> item = collector.items.get(n);
+          Pair<HDFSSpout.MessageId, List<Object>> item = collector.items.get(n);
           spout.fail(item.getKey());
         }
       }
@@ -684,7 +683,7 @@ public class TestHdfsSpout {
   static class MockCollector extends SpoutOutputCollector {
     //comma separated offsets
     public ArrayList<String> lines;
-    public ArrayList<Pair<HdfsSpout.MessageId, List<Object> > > items;
+    public ArrayList<Pair<HDFSSpout.MessageId, List<Object> > > items;
 
     public MockCollector() {
       super(null);


### PR DESCRIPTION
As part of this change I have removed specific handling in code for TextFileReader & SequenceFileReader also made AbstractFileReader as public