### PR TITLE
STORM-2372: Pacemaker client doesn't clean up heartbeats properly. (1.x)

### DIFF
--- a/storm-core/src/clj/org/apache/storm/pacemaker/pacemaker.clj
+++ b/storm-core/src/clj/org/apache/storm/pacemaker/pacemaker.clj
@@ -160,7 +160,7 @@
 (defn delete-path [^String path heartbeats]
   (let [prefix (if (= \/ (last path)) path (str path "/"))]
     (doseq [k (.keySet heartbeats)
-            :when (= (.indexOf k prefix) 0)]
+            :when (= (.indexOf (str k "/") prefix) 0)]
       (delete-pulse-id k heartbeats)))
   (HBMessage. HBServerMessageType/DELETE_PATH_RESPONSE nil))
 

--- a/storm-core/src/clj/org/apache/storm/pacemaker/pacemaker_state_factory.clj
+++ b/storm-core/src/clj/org/apache/storm/pacemaker/pacemaker_state_factory.clj
@@ -200,9 +200,18 @@
         (pacemaker-retry-on-exception
           max-retries
           "delete-worker-hb"
-          #(delete-worker-hb path (get-pacemaker-write-client conf servers pacemaker-client-pool))
-          (fn delete_worker_hb_error [err]
-            (shutdown-rotate servers pacemaker-client-pool))))
+          #(let [pacemaker-client-pool (makeClientPool conf pacemaker-client-pool servers)
+                 results (map (fn [[host client]]
+                                (try
+                                  (if (is-connection-ready client)
+                                    (delete-worker-hb path client)
+                                    :error)
+                                  (catch Exception e
+                                    :error)))
+                              @pacemaker-client-pool)]
+             (when (every? (fn [result] (= :error result)) results)
+               (throw (HBExecutionException. "Cannot connect to any pacemaker servers"))))
+          nil))
 
       ;; aggregating worker heartbeat details
       (get_worker_hb [this path watch?]


### PR DESCRIPTION


Paths are not deleted correctly. Pacemaker's delete-path operates by matching a prefix against all the keys in the map.

The issue here is that the prefix is given a '/' on the end, but keys don't have a trailing '/' if there is no 'subkey'.

i.e. delete path `/foo/bar/baz/` doesn't match the key `/foo/bar/baz`
The path has to have the trailing '/' so that delete path `/foo/bar/baz` doesn't also delete `/foo/bar/bazoo`

The solution here is to tack on a '/' to every key when checking against the prefix.

We also want to send the delete command to every pacemaker server rather than just the normal write client.
