### PR TITLE
STORM-2038:  No symlinks for local cluster

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/LocalContainer.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/LocalContainer.java
@@ -39,7 +39,17 @@ public class LocalContainer extends Container {
         _sharedContext = sharedContext;
         _workerId = Utils.uuid();
     }
-    
+
+    @Override
+    protected void createArtifactsLink() {
+        //NOOP no need to create links in local mode
+    }
+
+    @Override
+    protected void createBlobstoreLinks() {
+        // NOOP no need to create links in local mode
+    }
+
     @Override
     public void launch() throws IOException {
         Worker worker = new Worker(_conf, _sharedContext, _topologyId, _supervisorId, _port, _workerId);


### PR DESCRIPTION
This is a clean cherry-pick back to 1.x and 1.0.x too.