### PR TITLE
STORM-2386 Fail-back Blob deletion also fails in BlobSynchronizer.syncBlobs (1.x)

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
@@ -85,9 +85,7 @@ public class BlobSynchronizer {
                         BlobStoreUtils.createStateInZookeeper(conf, key, nimbusInfo);
                     }
                 } catch (KeyNotFoundException e) {
-                    LOG.debug("Detected deletion for the key {} - deleting the blob instead", key);
-                    // race condition with a delete, delete the blob in key instead
-                    blobStore.deleteBlob(key, BlobStoreUtils.getNimbusSubject());
+                    LOG.debug("Detected deletion for the key {} while downloading - skipping download", key);
                 }
             }
             if (zkClient !=null) {


### PR DESCRIPTION
Please refer [STORM-2386](https://issues.apache.org/jira/browse/STORM-2386) for more details.

I'll submit patches for master soon. If we need to port back to 1.0.x as well, it should be easy to cherry-pick.