### PR TITLE
STORM-2386 Fail-back Blob deletion also fails in BlobSynchronizer.syncBlobs

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
@@ -86,9 +86,7 @@ public class BlobSynchronizer {
                         BlobStoreUtils.createStateInZookeeper(conf, key, nimbusInfo);
                     }
                 } catch (KeyNotFoundException e) {
-                    LOG.debug("Detected deletion for the key {} - deleting the blob instead", key);
-                    // race condition with a delete, delete the blob in key instead
-                    blobStore.deleteBlob(key, BlobStoreUtils.getNimbusSubject());
+                    LOG.debug("Detected deletion for the key {} while downloading - skipping download", key);
                 }
             }
             if (zkClient !=null) {


### PR DESCRIPTION
Please refer [STORM-2386](https://issues.apache.org/jira/browse/STORM-2386) for more details.

This is against master branch, 

* 1.x-branch: #1975