### PR TITLE
STORM-2388 JoinBolt breaks compilation against JDK 7

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/bolt/JoinBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/bolt/JoinBolt.java
@@ -18,6 +18,7 @@
 package org.apache.storm.bolt;
 
 
+import com.google.common.base.Joiner;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
@@ -476,7 +477,7 @@ public class JoinBolt extends BaseWindowedBolt {
         }
 
         public FieldSelector(String stream, String[] field)  {
-            this( stream, String.join(".", field) );
+            this( stream, Joiner.on(".").join(field) );
         }
 
 


### PR DESCRIPTION
* replace String.join with Guava Joiner to keep compatible against JDK 7

I'm just fixing it from 1.x branch since storm-core on master branch and 1.x branch are already diverged.