### PR TITLE
STORM-2387 Handle tick tuples properly for Bolts in external modules (1.x)

### DIFF
--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/bolt/BaseCassandraBolt.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/bolt/BaseCassandraBolt.java
@@ -36,6 +36,7 @@ import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.TupleUtils;
@@ -49,9 +50,9 @@ import java.util.Map;
 /**
  * A base cassandra bolt.
  *
- * Default {@link org.apache.storm.topology.base.BaseRichBolt}
+ * Default {@link org.apache.storm.topology.base.BaseTickTupleAwareRichBolt}
  */
-public abstract class BaseCassandraBolt<T> extends BaseRichBolt {
+public abstract class BaseCassandraBolt<T> extends BaseTickTupleAwareRichBolt {
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseCassandraBolt.class);
 
@@ -171,25 +172,8 @@ public abstract class BaseCassandraBolt<T> extends BaseRichBolt {
     @Override
     public final void execute(Tuple input) {
         getAsyncHandler().flush(outputCollector);
-        if (TupleUtils.isTick(input)) {
-            onTickTuple();
-            outputCollector.ack(input);
-        } else {
-            process(input);
-        }
+        super.execute(input);
     }
-
-    /**
-     * Process a single tuple of input.
-     *
-     * @param input The input tuple to be processed.
-     */
-    abstract protected void process(Tuple input);
-
-    /**
-     * Calls by an input tick tuple.
-     */
-    abstract protected void onTickTuple();
 
     /**
      * {@inheritDoc}

--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/bolt/BatchCassandraWriterBolt.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/bolt/BatchCassandraWriterBolt.java
@@ -106,7 +106,7 @@ public class BatchCassandraWriterBolt extends BaseCassandraBolt<List<Tuple>> {
      * {@inheritDoc}
      */
     @Override
-    protected void onTickTuple() {
+    protected void onTickTuple(Tuple tuple) {
         prepareAndExecuteStatement();
     }
 

--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/bolt/CassandraWriterBolt.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/bolt/CassandraWriterBolt.java
@@ -59,13 +59,6 @@ public class CassandraWriterBolt extends BaseCassandraBolt<Tuple> {
         if (statements.size() == 1) getAsyncExecutor().execAsync(statements.get(0), input);
         else getAsyncExecutor().execAsync(statements, input);
     }
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void onTickTuple() {
-        /** do nothing **/
-    }
 }
 
 

--- a/external/storm-elasticsearch/src/main/java/org/apache/storm/elasticsearch/bolt/AbstractEsBolt.java
+++ b/external/storm-elasticsearch/src/main/java/org/apache/storm/elasticsearch/bolt/AbstractEsBolt.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 import org.apache.storm.elasticsearch.common.EsConfig;
 import org.apache.storm.elasticsearch.common.StormElasticSearchClient;
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
+import org.apache.storm.utils.TupleUtils;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -34,7 +36,7 @@ import org.apache.storm.tuple.Tuple;
 
 import static org.elasticsearch.common.base.Preconditions.checkNotNull;
 
-public abstract class AbstractEsBolt extends BaseRichBolt {
+public abstract class AbstractEsBolt extends BaseTickTupleAwareRichBolt {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractEsBolt.class);
 
@@ -61,9 +63,6 @@ public abstract class AbstractEsBolt extends BaseRichBolt {
             LOG.warn("unable to initialize EsBolt ", e);
         }
     }
-
-    @Override
-    public abstract void execute(Tuple tuple);
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer outputFieldsDeclarer) {

--- a/external/storm-elasticsearch/src/main/java/org/apache/storm/elasticsearch/bolt/EsIndexBolt.java
+++ b/external/storm-elasticsearch/src/main/java/org/apache/storm/elasticsearch/bolt/EsIndexBolt.java
@@ -23,6 +23,7 @@ import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.elasticsearch.common.EsConfig;
 import org.apache.storm.elasticsearch.common.EsTupleMapper;
+import org.apache.storm.utils.TupleUtils;
 
 import java.util.Map;
 
@@ -54,7 +55,7 @@ public class EsIndexBolt extends AbstractEsBolt {
      * Tuple should have relevant fields (source, index, type, id) for tupleMapper to extract ES document.
      */
     @Override
-    public void execute(Tuple tuple) {
+    public void process(Tuple tuple) {
         try {
             String source = tupleMapper.getSource(tuple);
             String index = tupleMapper.getIndex(tuple);

--- a/external/storm-elasticsearch/src/main/java/org/apache/storm/elasticsearch/bolt/EsLookupBolt.java
+++ b/external/storm-elasticsearch/src/main/java/org/apache/storm/elasticsearch/bolt/EsLookupBolt.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import org.apache.storm.elasticsearch.ElasticsearchGetRequest;
 import org.apache.storm.elasticsearch.EsLookupResultOutput;
 import org.apache.storm.elasticsearch.common.EsConfig;
+import org.apache.storm.utils.TupleUtils;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 
@@ -51,7 +52,7 @@ public class EsLookupBolt extends AbstractEsBolt {
     }
 
     @Override
-    public void execute(Tuple tuple) {
+    public void process(Tuple tuple) {
         try {
             Collection<Values> values = lookupValuesInEs(tuple);
             tryEmitAndAck(values, tuple);

--- a/external/storm-elasticsearch/src/main/java/org/apache/storm/elasticsearch/bolt/EsPercolateBolt.java
+++ b/external/storm-elasticsearch/src/main/java/org/apache/storm/elasticsearch/bolt/EsPercolateBolt.java
@@ -25,6 +25,7 @@ import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import org.apache.storm.elasticsearch.common.EsConfig;
 import org.apache.storm.elasticsearch.common.EsTupleMapper;
+import org.apache.storm.utils.TupleUtils;
 import org.elasticsearch.action.percolate.PercolateResponse;
 import org.elasticsearch.action.percolate.PercolateSourceBuilder;
 
@@ -61,7 +62,7 @@ public class EsPercolateBolt extends AbstractEsBolt {
      * and Percolate.Match for each Percolate.Match in PercolateResponse.
      */
     @Override
-    public void execute(Tuple tuple) {
+    public void process(Tuple tuple) {
         try {
             String source = tupleMapper.getSource(tuple);
             String index = tupleMapper.getIndex(tuple);

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/bolt/EventHubBolt.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/bolt/EventHubBolt.java
@@ -19,6 +19,7 @@ package org.apache.storm.eventhubs.bolt;
 
 import java.util.Map;
 
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,16 +30,15 @@ import com.microsoft.eventhubs.client.EventHubSender;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Tuple;
 
 /**
  * A bolt that writes event message to EventHub.
  */
-public class EventHubBolt extends BaseRichBolt {
-  private static final long serialVersionUID = 1L;
-  private static final Logger logger = LoggerFactory
-      .getLogger(EventHubBolt.class);
+public class EventHubBolt extends BaseTickTupleAwareRichBolt {
+	private static final long serialVersionUID = 1L;
+	private static final Logger logger = LoggerFactory
+			.getLogger(EventHubBolt.class);
 
   protected OutputCollector collector;
   protected EventHubSender sender;
@@ -82,7 +82,7 @@ public class EventHubBolt extends BaseRichBolt {
   }
 
   @Override
-  public void execute(Tuple tuple) {
+  protected void process(Tuple tuple) {
     try {
       sender.send(boltConfig.getEventDataFormat().serialize(tuple));
       collector.ack(tuple);

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/samples/bolt/GlobalCountBolt.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/samples/bolt/GlobalCountBolt.java
@@ -20,6 +20,7 @@ package org.apache.storm.eventhubs.samples.bolt;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.storm.utils.TupleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +67,10 @@ public class GlobalCountBolt extends BaseBasicBolt {
 
   @Override
   public void execute(Tuple tuple, BasicOutputCollector collector) {
+    if (TupleUtils.isTick(tuple)) {
+      return;
+    }
+
     int partial = (Integer)tuple.getValueByField("partial_count");
     globalCount += partial;
     globalCountDiff += partial;

--- a/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/samples/bolt/PartialCountBolt.java
+++ b/external/storm-eventhubs/src/main/java/org/apache/storm/eventhubs/samples/bolt/PartialCountBolt.java
@@ -19,6 +19,7 @@ package org.apache.storm.eventhubs.samples.bolt;
 
 import java.util.Map;
 
+import org.apache.storm.utils.TupleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,10 @@ public class PartialCountBolt extends BaseBasicBolt {
   
   @Override
   public void execute(Tuple tuple, BasicOutputCollector collector) {
+    if (TupleUtils.isTick(tuple)) {
+      return;
+    }
+
     partialCount++;
     if(partialCount == PartialCountBatchSize) {
       collector.emit(new Values(PartialCountBatchSize));

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/AbstractJdbcBolt.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/AbstractJdbcBolt.java
@@ -24,12 +24,15 @@ import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.commons.lang.Validate;
 import org.apache.storm.jdbc.common.ConnectionProvider;
 import org.apache.storm.jdbc.common.JdbcClient;
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.TupleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-public abstract class AbstractJdbcBolt extends BaseRichBolt {
+public abstract class AbstractJdbcBolt extends BaseTickTupleAwareRichBolt {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractJdbcBolt.class);
 
     protected OutputCollector collector;

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/JdbcInsertBolt.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/JdbcInsertBolt.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.storm.jdbc.common.Column;
 import org.apache.storm.jdbc.common.ConnectionProvider;
 import org.apache.storm.jdbc.mapper.JdbcMapper;
+import org.apache.storm.utils.TupleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +82,7 @@ public class JdbcInsertBolt extends AbstractJdbcBolt {
     }
 
     @Override
-    public void execute(Tuple tuple) {
+    protected void process(Tuple tuple) {
         try {
             List<Column> columns = jdbcMapper.getColumns(tuple);
             List<List<Column>> columnLists = new ArrayList<List<Column>>();

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/JdbcLookupBolt.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/JdbcLookupBolt.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.Validate;
 import org.apache.storm.jdbc.common.Column;
 import org.apache.storm.jdbc.common.ConnectionProvider;
 import org.apache.storm.jdbc.mapper.JdbcLookupMapper;
+import org.apache.storm.utils.TupleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public class JdbcLookupBolt extends AbstractJdbcBolt {
     }
 
     @Override
-    public void execute(Tuple tuple) {
+    protected void process(Tuple tuple) {
         try {
             List<Column> columns = jdbcLookupMapper.getColumns(tuple);
             List<List<Column>> result = jdbcClient.select(this.selectQuery, columns);

--- a/external/storm-jms/core/src/main/java/org/apache/storm/jms/bolt/JmsBolt.java
+++ b/external/storm-jms/core/src/main/java/org/apache/storm/jms/bolt/JmsBolt.java
@@ -30,6 +30,8 @@ import javax.jms.Session;
 import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.jms.JmsMessageProducer;
 import org.apache.storm.jms.JmsProvider;
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
+import org.apache.storm.utils.TupleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +62,7 @@ import org.apache.storm.tuple.Tuple;
  * The JmsBolt is typically an endpoint in a topology -- in other words
  * it does not emit any tuples.
  */
-public class JmsBolt extends BaseRichBolt {
+public class JmsBolt extends BaseTickTupleAwareRichBolt {
     private static Logger LOG = LoggerFactory.getLogger(JmsBolt.class);
 
     private boolean autoAck = true;
@@ -147,7 +149,7 @@ public class JmsBolt extends BaseRichBolt {
      * If JMS sending fails, the tuple will be failed.
      */
     @Override
-    public void execute(Tuple input) {
+    protected void process(Tuple input) {
         // write the tuple to a JMS destination...
         LOG.debug("Tuple received. Sending JMS message.");
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/bolt/KafkaBolt.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/bolt/KafkaBolt.java
@@ -21,6 +21,7 @@ import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.TupleUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -51,7 +52,7 @@ import java.util.Properties;
  * <p/>
  * respectively.
  */
-public class KafkaBolt<K, V> extends BaseRichBolt {
+public class KafkaBolt<K, V> extends BaseTickTupleAwareRichBolt {
     private static final long serialVersionUID = -5205886631877033478L;
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBolt.class);
@@ -130,11 +131,7 @@ public class KafkaBolt<K, V> extends BaseRichBolt {
     }
 
     @Override
-    public void execute(final Tuple input) {
-        if (TupleUtils.isTick(input)) {
-          collector.ack(input);
-          return; // Do not try to send ticks to Kafka
-        }
+    protected void process(final Tuple input) {
         K key = null;
         V message = null;
         String topic = null;

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/bolt/KafkaBolt.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/bolt/KafkaBolt.java
@@ -21,6 +21,7 @@ import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.TupleUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -54,7 +55,7 @@ import java.util.Properties;
  * @deprecated Please use the KafkaBolt in storm-kafka-client
  */
 @Deprecated
-public class KafkaBolt<K, V> extends BaseRichBolt {
+public class KafkaBolt<K, V> extends BaseTickTupleAwareRichBolt {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaBolt.class);
 
@@ -112,11 +113,7 @@ public class KafkaBolt<K, V> extends BaseRichBolt {
     }
 
     @Override
-    public void execute(final Tuple input) {
-        if (TupleUtils.isTick(input)) {
-          collector.ack(input);
-          return; // Do not try to send ticks to Kafka
-        }
+    protected void process(final Tuple input) {
         K key = null;
         V message = null;
         String topic = null;

--- a/external/storm-mongodb/src/main/java/org/apache/storm/mongodb/bolt/MongoUpdateBolt.java
+++ b/external/storm-mongodb/src/main/java/org/apache/storm/mongodb/bolt/MongoUpdateBolt.java
@@ -22,6 +22,7 @@ import org.apache.storm.mongodb.common.QueryFilterCreator;
 import org.apache.storm.mongodb.common.mapper.MongoMapper;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.TupleUtils;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
@@ -50,6 +51,10 @@ public class MongoUpdateBolt extends AbstractMongoBolt {
 
     @Override
     public void execute(Tuple tuple) {
+        if (TupleUtils.isTick(tuple)) {
+            return;
+        }
+
         try{
             //get document
             Document doc = mapper.toDocument(tuple);

--- a/external/storm-pmml/src/main/java/org/apache/storm/pmml/PMMLPredictorBolt.java
+++ b/external/storm-pmml/src/main/java/org/apache/storm/pmml/PMMLPredictorBolt.java
@@ -25,15 +25,17 @@ import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.TupleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
 
-public class PMMLPredictorBolt extends BaseRichBolt {
+public class PMMLPredictorBolt extends BaseTickTupleAwareRichBolt {
     protected static final Logger LOG = LoggerFactory.getLogger(PMMLPredictorBolt.class);
 
     private final ModelOutputs outputs;
@@ -65,7 +67,7 @@ public class PMMLPredictorBolt extends BaseRichBolt {
     }
 
     @Override
-    public void execute(Tuple input) {
+    protected void process(Tuple input) {
         try {
             final Map<String, List<Object>> scoresPerStream = runner.scoredTuplePerStream(input);
             LOG.debug("Input tuple [{}] generated predicted scores [{}]", input, scoresPerStream);

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
@@ -24,6 +24,9 @@ import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.apache.storm.redis.common.config.JedisPoolConfig;
 import org.apache.storm.redis.common.container.JedisCommandsContainerBuilder;
 import org.apache.storm.redis.common.container.JedisCommandsInstanceContainer;
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.TupleUtils;
 import redis.clients.jedis.JedisCommands;
 
 import java.util.Map;
@@ -48,7 +51,7 @@ import java.util.Map;
  *
  */
 // TODO: Separate Jedis / JedisCluster to provide full operations for each environment to users
-public abstract class AbstractRedisBolt extends BaseRichBolt {
+public abstract class AbstractRedisBolt extends BaseTickTupleAwareRichBolt {
     protected OutputCollector collector;
 
     private transient JedisCommandsInstanceContainer container;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisFilterBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisFilterBolt.java
@@ -87,7 +87,7 @@ public class RedisFilterBolt extends AbstractRedisBolt {
      * {@inheritDoc}
      */
     @Override
-    public void execute(Tuple input) {
+    public void process(Tuple input) {
         String key = filterMapper.getKeyFromTuple(input);
 
         boolean found;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisLookupBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisLookupBolt.java
@@ -72,7 +72,7 @@ public class RedisLookupBolt extends AbstractRedisBolt {
      * {@inheritDoc}
      */
     @Override
-    public void execute(Tuple input) {
+    public void process(Tuple input) {
         String key = lookupMapper.getKeyFromTuple(input);
         Object lookupValue;
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisStoreBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisStoreBolt.java
@@ -67,7 +67,7 @@ public class RedisStoreBolt extends AbstractRedisBolt {
      * {@inheritDoc}
      */
     @Override
-    public void execute(Tuple input) {
+    public void process(Tuple input) {
         String key = storeMapper.getKeyFromTuple(input);
         String value = storeMapper.getValueFromTuple(input);
 

--- a/external/storm-solr/src/main/java/org/apache/storm/solr/bolt/SolrUpdateBolt.java
+++ b/external/storm-solr/src/main/java/org/apache/storm/solr/bolt/SolrUpdateBolt.java
@@ -22,6 +22,7 @@ import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.TupleUtils;
 import org.apache.solr.client.solrj.SolrClient;
@@ -40,7 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class SolrUpdateBolt extends BaseRichBolt {
+public class SolrUpdateBolt extends BaseTickTupleAwareRichBolt {
     private static final Logger LOG = LoggerFactory.getLogger(SolrUpdateBolt.class);
 
     /**
@@ -85,12 +86,10 @@ public class SolrUpdateBolt extends BaseRichBolt {
     }
 
     @Override
-    public void execute(Tuple tuple) {
+    protected void process(Tuple tuple) {
         try {
-            if (!TupleUtils.isTick(tuple)) {    // Don't add tick tuples to the SolrRequest
-                SolrRequest request = solrMapper.toSolrRequest(tuple);
-                solrClient.request(request, solrMapper.getCollection());
-            }
+            SolrRequest request = solrMapper.toSolrRequest(tuple);
+            solrClient.request(request, solrMapper.getCollection());
             ack(tuple);
         } catch (Exception e) {
             fail(tuple, e);

--- a/storm-core/src/jvm/org/apache/storm/topology/base/BaseTickTupleAwareRichBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/base/BaseTickTupleAwareRichBolt.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.topology.base;
+
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.TupleUtils;
+
+/**
+ * This class is based on BaseRichBolt, but is aware of tick tuple.
+ */
+public abstract class BaseTickTupleAwareRichBolt extends BaseRichBolt {
+    /**
+     * {@inheritDoc}
+     *
+     * @param tuple the tuple to process.
+     */
+    @Override
+    public void execute(final Tuple tuple) {
+        if (TupleUtils.isTick(tuple)) {
+            onTickTuple(tuple);
+        } else {
+            process(tuple);
+        }
+    }
+
+    /**
+     * Process a single tick tuple of input. Tick tuple doesn't need to be acked.
+     * It provides default "DO NOTHING" implementation for convenient. Override this method if needed.
+     *
+     * More details on {@link org.apache.storm.task.IBolt#execute(Tuple)}.
+     *
+     * @param tuple The input tuple to be processed.
+     */
+    protected void onTickTuple(final Tuple tuple) {
+    }
+
+    /**
+     * Process a single non-tick tuple of input. Implementation needs to handle ack manually.
+     * More details on {@link org.apache.storm.task.IBolt#execute(Tuple)}.
+     *
+     * @param tuple The input tuple to be processed.
+     */
+    protected abstract void process(final Tuple tuple);
+}


### PR DESCRIPTION
* also remove ack for tick tuples since it's not necessary

I also fixed some mixing indentations. We should introduce code style soon.

For master branch: #1978 