### PR TITLE
STORM-2389 Avoid instantiating Event Logger when topology.eventlogger…

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/StormCommon.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/StormCommon.java
@@ -466,7 +466,9 @@ public class StormCommon {
 
         StormTopology ret = topology.deepCopy();
         addAcker(stormConf, ret);
-        addEventLogger(stormConf, ret);
+        if (hasEventLoggers(stormConf)) {
+            addEventLogger(stormConf, ret);
+        }
         addMetricComponents(stormConf, ret);
         addSystemComponents(stormConf, ret);
         addMetricStreams(ret);


### PR DESCRIPTION
….executors=0
