### PR TITLE
STORM-2058: Fix Maven warnings about missing reporting.plugins.plugin.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1215,10 +1215,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>2.19.1</version>
                 <configuration>
                     <reportsDirectories>
                         <file>${project.build.directory}/test-reports</file>


### PR DESCRIPTION
Add versions for maven-javadoc-plugin and maven-surefire-report-plugin to the parent pom.xml.