### PR TITLE
STORM-2394 KafkaSpout: Has no leader of partitions for a short time

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaSpout.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaSpout.java
@@ -142,7 +142,17 @@ public class KafkaSpout extends BaseRichSpout {
                 }
             } catch (FailedFetchException e) {
                 LOG.warn("Fetch failed", e);
-                _coordinator.refresh();
+                for (int tryCnt = 1; tryCnt <= 3; tryCnt++) {
+                    try {
+                        _coordinator.refresh();
+                        break;
+                    } catch (Exception e) {
+                        if (tryCnt == 3) {
+                            throw e;
+                        }
+                    }
+                    sleep(10000);
+                }
             }
         }
 

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaSpout.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaSpout.java
@@ -146,14 +146,14 @@ public class KafkaSpout extends BaseRichSpout {
                     try {
                         _coordinator.refresh();
                         break;
-                    } catch (Exception e) {
+                    } catch (Exception ex) {
                         if (tryCnt == 3) {
-                            throw e;
+                            throw ex;
                         }
                     }
                     try {
                         Thread.sleep(10000);
-                    } catch (InterruptedException e) {
+                    } catch (InterruptedException ex2) {
                     }
                 }
             }

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaSpout.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaSpout.java
@@ -151,7 +151,10 @@ public class KafkaSpout extends BaseRichSpout {
                             throw e;
                         }
                     }
-                    sleep(10000);
+                    try {
+                        Thread.sleep(10000);
+                    } catch (InterruptedException e) {
+                    }
                 }
             }
         }


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/STORM-2394
In our case, there is something wrong with network for a short time. So some partitions of Kafka have no leaders.
The nextTuple of KafkaSpout throw an exception of "No leader found for partition 0" at the position of "_coordinator.refresh();". The exception is from the function getLeaderFor in DynamicBrokersReader.java. So the spout is hanged.
The partitions of Kafka have recover for a short time. But the spout can not deal with this problem. This problem appears several times on our server. Such as:
Feb 25 06:31:19 CST 2017, KafkaSpout threw the exception.
Feb 25 06:31:21 CST 2017, Kafka partitions recoverd.
To be stronger, I think that the "_coordinator.refresh();" can try times. At the last time, throw the exception. Anyway, it will die, why not try one more time?