### PR TITLE
STORM-2395: storm.cmd supervisor calls the wrong class name

### DIFF
--- a/bin/storm.cmd
+++ b/bin/storm.cmd
@@ -214,7 +214,7 @@
   goto :eof
   
 :supervisor
-  set CLASS=org.apache.storm.daemon.supervisor
+  set CLASS=org.apache.storm.daemon.supervisor.Supervisor
   "%JAVA%" -client -Dstorm.options= -Dstorm.conf.file= -cp "%CLASSPATH%" org.apache.storm.command.config_value supervisor.childopts > %CMD_TEMP_FILE%
   FOR /F "delims=" %%i in (%CMD_TEMP_FILE%) do (
      FOR /F "tokens=1,* delims= " %%a in ("%%i") do (


### PR DESCRIPTION
use org.apache.storm.daemon.supervisor.Supervisor instead

Signed-off-by: alexlehm <alexlehm@gmail.com>