### PR TITLE
STORM-2396: setting interrupted status back before throwing a RuntimeException

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/Utils.java
@@ -356,6 +356,7 @@ public class Utils {
         try {
             Time.sleep(millis);
         } catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
As described in [JIRA](https://issues.apache.org/jira/browse/STORM-2396) the interrupted flag is not set back after catching InterruptedException and wrapping it into a RuntimeException so any code dependent on checking the interrupted status will not work properly in case the RuntimeException doesn't make it up the stack.