### PR TITLE
[STORM-2397] modify storm-kafka.md

### DIFF
--- a/docs/storm-kafka.md
+++ b/docs/storm-kafka.md
@@ -251,7 +251,7 @@ For the bolt :
         props.put("metadata.broker.list", "localhost:9092");
         props.put("request.required.acks", "1");
         props.put("serializer.class", "kafka.serializer.StringEncoder");
-        conf.put(KafkaBolt.KAFKA_BROKER_PROPERTIES, props);
+        conf.put("kafka.broker.properties", props);
         
         StormSubmitter.submitTopology("kafkaboltTest", conf, builder.createTopology());
 ```
@@ -282,6 +282,6 @@ For Trident:
         props.put("metadata.broker.list", "localhost:9092");
         props.put("request.required.acks", "1");
         props.put("serializer.class", "kafka.serializer.StringEncoder");
-        conf.put(TridentKafkaState.KAFKA_BROKER_PROPERTIES, props);
+        conf.put("kafka.broker.properties", props);
         StormSubmitter.submitTopology("kafkaTridentTest", conf, topology.build());
 ```


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2397](url)
KafkaBolt doesn't have a static variable named "KAFKA_BROKER_PROPERTIES" in storm 1.0.2.So storm-kafka.md should be modified as the patch.
