### PR TITLE
STORM-2402: KafkaSpout sub-classes should be able to customize tuple processing

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -304,6 +304,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
             boolean isScheduled = retryService.isScheduled(msgId);
             if (!isScheduled || retryService.isReady(msgId)) {   // not scheduled <=> never failed (i.e. never emitted) or ready to be retried
                 final List<Object> tuple = tuplesBuilder.buildTuple(record);
+                emittingTuple(msgId, tuple, record);
                 kafkaSpoutStreams.emit(collector, tuple, msgId);
                 emitted.add(msgId);
                 numUncommittedOffsets++;
@@ -313,6 +314,11 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                 LOG.trace("Emitted tuple [{}] for record [{}]", tuple, record);
             }
         }
+    }
+
+    // Allows for custom processing in sub-classes
+    protected void emittingTuple(KafkaSpoutMessageId msgId, List<Object> tuple, ConsumerRecord<K, V> record) {
+        // Yet empty
     }
 
     private void commitOffsetsForAckedTuples() {


### PR DESCRIPTION
We need a `KafkaSpout` that writes unprocessable records to a "dead-letter-topic". For this to function we sub-classed `KafkaSpout` and added the corresponding code. Without this patch sub-classses can not have access to the actual tuples/records but just the `KafkaSpoutMessageId` in `ack()` and `fail()`.