### PR TITLE
STORM-2403 Fix KafkaBolt test failure: tick tuple should not be acked

### DIFF
--- a/external/storm-kafka/src/test/org/apache/storm/kafka/bolt/KafkaBoltTest.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/bolt/KafkaBoltTest.java
@@ -97,7 +97,7 @@ public class KafkaBoltTest {
     }
 
     @Test
-    public void shouldAcknowledgeTickTuples() throws Exception {
+    public void shouldNotAcknowledgeTickTuples() throws Exception {
         // Given
         Tuple tickTuple = mockTickTuple();
 
@@ -105,7 +105,7 @@ public class KafkaBoltTest {
         bolt.execute(tickTuple);
 
         // Then
-        verify(collector).ack(tickTuple);
+        verify(collector, never()).ack(tickTuple);
     }
 
     @Test


### PR DESCRIPTION
* More detail: [STORM-2403](http://issues.apache.org/jira/browse/STORM-2403)
* This bug is introduced from [STORM-2387](http://issues.apache.org/jira/browse/STORM-2387)

**NOTE: It should be easy to cheery-pick to 1.x / 1.0.x branches, and we must cherry-pick to those branches since STORM-2387 is merged to those branches.**