### PR TITLE
STORM-2408: build failed if storm.kafka.client.version = 0.10.2.0

### DIFF
--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/KafkaUnit.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/KafkaUnit.java
@@ -21,7 +21,10 @@ import kafka.admin.AdminUtils;
 import kafka.admin.RackAwareMode;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
-import kafka.utils.*;
+import kafka.utils.MockTime;
+import kafka.utils.TestUtils;
+import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
 import kafka.zk.EmbeddedZookeeper;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -65,7 +68,7 @@ public class KafkaUnit {
         brokerProps.setProperty("log.dirs", Files.createTempDirectory("kafka-").toAbsolutePath().toString());
         brokerProps.setProperty("listeners", String.format("PLAINTEXT://%s:%d", KAFKA_HOST, KAFKA_PORT));
         KafkaConfig config = new KafkaConfig(brokerProps);
-        Time mock = new MockTime();
+        MockTime mock = new MockTime();
         kafkaServer = TestUtils.createServer(config, mock);
 
         // setup default Producer


### PR DESCRIPTION
The build will fail if mvn clean install -Dstorm.kafka.client.version=0.10.2.0 because of https://issues.apache.org/jira/browse/KAFKA-2247.

1. remove wildcard imports
2. use kafka.utils.MockTime instead of kafka.utils.Time

tested:
mvn clean install -Dstorm.kafka.client.version=0.10.0.0
mvn clean install -Dstorm.kafka.client.version=0.10.1.0
mvn clean install -Dstorm.kafka.client.version=0.10.1.1
mvn clean install -Dstorm.kafka.client.version=0.10.2.0
