### PR TITLE
STORM-2409: Storm-Kafka-Client KafkaSpout Support for Failed and NullTuples

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutMessageId.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutMessageId.java
@@ -25,14 +25,25 @@ public class KafkaSpoutMessageId {
     private transient TopicPartition topicPart;
     private transient long offset;
     private transient int numFails = 0;
+    private boolean emitted;   // true if the record was emitted using a form of collector.emit(...).
+                               // false when skipping null tuples as configured by the user in KafkaSpoutConfig
 
     public KafkaSpoutMessageId(ConsumerRecord<?, ?> consumerRecord) {
-        this(new TopicPartition(consumerRecord.topic(), consumerRecord.partition()), consumerRecord.offset());
+        this(consumerRecord, true);
+    }
+
+    public KafkaSpoutMessageId(ConsumerRecord<?, ?> consumerRecord, boolean emitted) {
+        this(new TopicPartition(consumerRecord.topic(), consumerRecord.partition()), consumerRecord.offset(), emitted);
     }
 
     public KafkaSpoutMessageId(TopicPartition topicPart, long offset) {
+        this(topicPart, offset, true);
+    }
+
+    public KafkaSpoutMessageId(TopicPartition topicPart, long offset, boolean emitted) {
         this.topicPart = topicPart;
         this.offset = offset;
+        this.emitted = emitted;
     }
 
     public int partition() {
@@ -57,6 +68,14 @@ public class KafkaSpoutMessageId {
 
     public TopicPartition getTopicPartition() {
         return topicPart;
+    }
+
+    public boolean isEmitted() {
+        return emitted;
+    }
+
+    public void setEmitted(boolean emitted) {
+        this.emitted = emitted;
     }
 
     public String getMetadata(Thread currThread) {

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/RecordTranslator.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/RecordTranslator.java
@@ -17,12 +17,14 @@
  */
 package org.apache.storm.kafka.spout;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.storm.tuple.Fields;
+
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.storm.tuple.Fields;
+import static org.apache.storm.kafka.spout.KafkaSpoutConfig.Builder;
 
 /**
  * Translate a {@link org.apache.kafka.clients.consumer.ConsumerRecord} to a tuple.
@@ -34,7 +36,8 @@ public interface RecordTranslator<K, V> extends Serializable, Func<ConsumerRecor
      * Translate the ConsumerRecord into a list of objects that can be emitted
      * @param record the record to translate
      * @return the objects in the tuple.  Return a {@link KafkaTuple}
-     * if you want to route the tuple to a non-default stream
+     * if you want to route the tuple to a non-default stream.
+     * Return null to discard an invalid {@link ConsumerRecord} if {@link Builder#setEmitNullTuples(boolean)} is set to true
      */
     List<Object> apply(ConsumerRecord<K,V> record);
     

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutConfigTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutConfigTest.java
@@ -17,14 +17,14 @@
  */
 package org.apache.storm.kafka.spout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy;
+import org.junit.Test;
 
 import java.util.HashMap;
 
-import org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class KafkaSpoutConfigTest {
 
@@ -38,5 +38,14 @@ public class KafkaSpoutConfigTest {
         expected.put("bootstrap.servers", "localhost:1234");
         expected.put("enable.auto.commit", "false");
         assertEquals(expected, conf.getKafkaProps());
+    }
+
+    @Test
+    public void test_setEmitNullTuples_true_true() {
+        final KafkaSpoutConfig<String, String> conf = KafkaSpoutConfig.builder("localhost:1234", "topic")
+                .setEmitNullTuples(true)
+                .build();
+
+        assertTrue("Failed to set emit null tuples to true", conf.isEmitNullTuples());
     }
 }


### PR DESCRIPTION
  - Created config property to make emit null tuples configurable
  - Ack directly null tuples that are not emitted