### PR TITLE
STORM-2412: Nimbus isLeader check while waiting for max replication

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/nimbus.clj
@@ -505,8 +505,10 @@
                (or (neg? max-replication-wait-time)
                    (< @total-wait-time max-replication-wait-time)))
         (sleep-secs 1)
-        (log-debug "waiting for desired replication to be achieved.
-          min-replication-count = " min-replication-count  " max-replication-wait-time = " max-replication-wait-time
+        (log-debug "Checking if I am still the leader")
+        (is-leader nimbus)
+        (log-debug "waiting for desired replication to be achieved for storm-id = " storm-id
+          " min-replication-count = " min-replication-count  " max-replication-wait-time = " max-replication-wait-time
           (if (not (local-mode? conf))"current-replication-count for jar key = " @current-replication-count-jar)
           "current-replication-count for code key = " @current-replication-count-code
           "current-replication-count for conf key = " @current-replication-count-conf

--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobStoreUtils.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobStoreUtils.java
@@ -127,6 +127,7 @@ public class BlobStoreUtils {
             if(isSuccess) {
                 break;
             }
+            LOG.debug("Download blob key: {}, NimbusInfo {}", key, nimbusInfo);
             try(NimbusClient client = new NimbusClient(conf, nimbusInfo.getHost(), nimbusInfo.getPort(), null)) {
                 rbm = client.getClient().getBlobMeta(key);
                 remoteBlobStore = new NimbusBlobStore();

--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
@@ -81,6 +81,7 @@ public class BlobSynchronizer {
             for (String key : keySetToDownload) {
                 try {
                     Set<NimbusInfo> nimbusInfoSet = BlobStoreUtils.getNimbodesWithLatestSequenceNumberOfBlob(zkClient, key);
+                    LOG.debug("syncBlobs, key: {}, nimbusInfoSet: {}", key, nimbusInfoSet);
                     if (BlobStoreUtils.downloadMissingBlob(conf, blobStore, key, nimbusInfoSet)) {
                         BlobStoreUtils.createStateInZookeeper(conf, key, nimbusInfo);
                     }


### PR DESCRIPTION
While using local FS blob store, nimbus goes into a state where it indefinitely waits for max replication (with max replication wait time set to -1). At this time its also observed that the nimbus that received the topology submission is no longer the leader.
While waiting for max replication, nimbus can also do the `isLeader` check and fail the topology submission if its no longer the leader.

Also added some debug logs to better troubleshoot the race conditions when it happens.