### PR TITLE
STORM-2412: Nimbus isLeader check while waiting for max replication

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobStoreUtils.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobStoreUtils.java
@@ -128,6 +128,7 @@ public class BlobStoreUtils {
             if(isSuccess) {
                 break;
             }
+            LOG.debug("Download blob key: {}, NimbusInfo {}", key, nimbusInfo);
             try(NimbusClient client = new NimbusClient(conf, nimbusInfo.getHost(), nimbusInfo.getPort(), null)) {
                 rbm = client.getClient().getBlobMeta(key);
                 remoteBlobStore = new NimbusBlobStore();

--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobSynchronizer.java
@@ -82,6 +82,7 @@ public class BlobSynchronizer {
             for (String key : keySetToDownload) {
                 try {
                     Set<NimbusInfo> nimbusInfoSet = BlobStoreUtils.getNimbodesWithLatestSequenceNumberOfBlob(zkClient, key);
+                    LOG.debug("syncBlobs, key: {}, nimbusInfoSet: {}", key, nimbusInfoSet);
                     if (BlobStoreUtils.downloadMissingBlob(conf, blobStore, key, nimbusInfoSet)) {
                         BlobStoreUtils.createStateInZookeeper(conf, key, nimbusInfo);
                     }

--- a/storm-core/src/jvm/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1296,7 +1296,9 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                             minReplicationCount, maxWaitTime, confCount, codeCount, jarCount);
                     return;
                 }
-                LOG.info("WAITING... {} <? {} {} {}", minReplicationCount, jarCount, codeCount, confCount);
+                LOG.debug("Checking if I am still the leader");
+                assertIsLeader();
+                LOG.info("WAITING... storm-id {}, {} <? {} {} {}", topoId, minReplicationCount, jarCount, codeCount, confCount);
                 LOG.info("WAITING... {} <? {}", totalWaitTime, maxWaitTime);
                 Time.sleepSecs(1);
                 totalWaitTime++;


### PR DESCRIPTION
While using local FS blob store, nimbus goes into a state where it indefinitely waits for max replication (with max replication wait time set to -1). At this time its also observed that the nimbus that received the topology submission is no longer the leader.
While waiting for max replication, nimbus can also do the `isLeader` check and fail the topology submission if its no longer the leader.

Also added some debug logs to better troubleshoot the race conditions when it happens.

This is https://github.com/apache/storm/pull/2003 applied to master branch.