### PR TITLE
STORM-2423 - Join Bolt should use explicit instead of default window anchoring for emitted tuples

### DIFF
--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/JoinBoltExample.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/JoinBoltExample.java
@@ -53,7 +53,6 @@ public class JoinBoltExample {
         builder.setBolt("printer", new PrinterBolt() ).shuffleGrouping("joiner");
 
         Config conf = new Config();
-        conf.setDebug(true);
 
         LocalCluster cluster = new LocalCluster();
         cluster.submitTopology("join-example", conf, builder.createTopology());

--- a/storm-core/src/jvm/org/apache/storm/bolt/JoinBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/bolt/JoinBolt.java
@@ -191,9 +191,11 @@ public class JoinBolt extends BaseWindowedBolt {
         for (ResultRecord resultRecord : joinResult.getRecords()) {
             ArrayList<Object> outputTuple = resultRecord.getOutputFields();
             if ( outputStreamName==null )
-                collector.emit( outputTuple );
+                // explicit anchoring emits to corresponding input tuples only, as default window anchoring will anchor them to all tuples in window
+                collector.emit( resultRecord.tupleList, outputTuple );
             else
-                collector.emit( outputStreamName, outputTuple );
+                // explicitly anchor emits to corresponding input tuples only, as default window anchoring will anchor them to all tuples in window
+                collector.emit( outputStreamName, resultRecord.tupleList, outputTuple );
         }
     }
 

--- a/storm-core/test/jvm/org/apache/storm/bolt/TestJoinBolt.java
+++ b/storm-core/test/jvm/org/apache/storm/bolt/TestJoinBolt.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Collection;
 
 public class TestJoinBolt {
     String[] userFields = {"userId", "name", "city"};
@@ -328,7 +329,7 @@ public class TestJoinBolt {
         }
 
         @Override
-        public List<Integer> emit(List<Object> tuple) {
+        public List<Integer> emit(Collection<Tuple> anchors, List<Object> tuple) {
             actualResults.add(tuple);
             return null;
         }


### PR DESCRIPTION
Default anchoring will anchor each emitted tuple to every tuple in current window. This requires a very large numbers of ACKs from any downstream bolt. If topology.debug is enabled, it also worsens the load on the system significantly.
Letting the topo run in this mode (in particular with max.spout.pending disabled), could lead to the worker running out of memory and crashing.

*Fix* Join Bolt should avoid using default window anchoring, and explicitly anchor each emitted tuple with the exact matching tuples form each inputs streams. This reduces the complexity of the tuple trees and consequently the reduces burden on the ACKing & messaging subsystems.


Also added additional documentation.