### PR TITLE
the default blobstore.dir is storm.local.dir/blobs which is different from distcache-blobstore.md

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/blobstore/BlobStore.java
+++ b/storm-core/src/jvm/org/apache/storm/blobstore/BlobStore.java
@@ -65,7 +65,7 @@ import org.apache.storm.generated.StormTopology;
 public abstract class BlobStore implements Shutdownable {
     private static final Logger LOG = LoggerFactory.getLogger(BlobStore.class);
     private static final Pattern KEY_PATTERN = Pattern.compile("^[\\w \\t\\.:_-]+$");
-    protected static final String BASE_BLOBS_DIR_NAME = "blobs";
+    protected static final String BASE_BLOBS_DIR_NAME = "nimbus/blobs";
 
     /**
      * Allows us to initialize the blob store


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2431](url)
The default blobstore.dir is storm.local.dir/blobs which is different from distcache-blobstore.md.You can see the pictures below.The default blobstore.dir is set to storm.local.dir/blobs.And I think it is reasonable to be set to storm.local.dir/nimbus/blobs.