### PR TITLE
[STORM-2093] Fix permissions in multi-tenant, secure mode

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
@@ -1115,9 +1115,9 @@
   (GET "/download" [:as {:keys [servlet-request servlet-response log-root]} & m]
     (try
       (.mark logviewer:num-download-log-file-http-requests)
-      (set-log-file-permissions file log-root) 
       (let [user (.getUserName http-creds-handler servlet-request)
             file (URLDecoder/decode (:file m))]
+        (set-log-file-permissions file log-root) 
         (download-log-file file servlet-request servlet-response user log-root))
       (catch InvalidRequestException ex
         (log-error ex)


### PR DESCRIPTION
Heap dumps created on OOM, when served through the logviewer in secure multi-tenant configurations have permissions set such that the logviewer cannot read them.

This change checks permissions in this case before serving and then runs the worker-launcher to enable the logviewer to serve them.