### PR TITLE
[STORM-2363] Provide configuration to set the number of RollingWindow

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -313,3 +313,5 @@ worker.metrics:
     "CGroupMemoryLimit": "org.apache.storm.metric.cgroup.CGroupMemoryLimit"
     "CGroupCpu": "org.apache.storm.metric.cgroup.CGroupCpu"
     "CGroupCpuGuarantee": "org.apache.storm.metric.cgroup.CGroupCpuGuarantee"
+
+num.stat.buckets: 20

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -2356,7 +2356,7 @@ public class Config extends HashMap<String, Object> {
      */
     @isInteger
     @isPositiveNumber
-    public static final String NUM_STAT_BUCKETS = "num.stat.buckets";
+    public static final String numStatBuckets = "num.stat.buckets";
 
     public static void setClasspath(Map conf, String cp) {
         conf.put(Config.TOPOLOGY_CLASSPATH, cp);

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -2351,6 +2351,13 @@ public class Config extends HashMap<String, Object> {
     @isPositiveNumber
     public static String STORM_CGROUP_MEMORY_LIMIT_TOLERANCE_MARGIN_MB = "storm.cgroup.memory.limit.tolerance.margin.mb";
 
+    /**
+     * The number of Buckets
+     */
+    @isInteger
+    @isPositiveNumber
+    public static final String NUM_STAT_BUCKETS = "num.stat.buckets";
+
     public static void setClasspath(Map conf, String cp) {
         conf.put(Config.TOPOLOGY_CLASSPATH, cp);
     }

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -2356,7 +2356,7 @@ public class Config extends HashMap<String, Object> {
      */
     @isInteger
     @isPositiveNumber
-    public static final String numStatBuckets = "num.stat.buckets";
+    public static final String NUM_STAT_BUCKETS = "num.stat.buckets";
 
     public static void setClasspath(Map conf, String cp) {
         conf.put(Config.TOPOLOGY_CLASSPATH, cp);

--- a/storm-core/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/Executor.java
@@ -146,10 +146,10 @@ public abstract class Executor implements Callable, EventHandler<Object> {
         Map<String, Bolt> bolts = topology.get_bolts();
         if (spouts.containsKey(componentId)) {
             this.type = StatsUtil.SPOUT;
-            this.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(stormConf));
+            this.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.NUM_STAT_BUCKETS)));
         } else if (bolts.containsKey(componentId)) {
             this.type = StatsUtil.BOLT;
-            this.stats = new BoltExecutorStats(ConfigUtils.samplingRate(stormConf));
+            this.stats = new BoltExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.NUM_STAT_BUCKETS)));
         } else {
             throw new RuntimeException("Could not find " + componentId + " in " + topology);
         }
@@ -183,10 +183,10 @@ public abstract class Executor implements Callable, EventHandler<Object> {
         String type = getExecutorType(workerTopologyContext, componentId);
         if (StatsUtil.SPOUT.equals(type)) {
             executor = new SpoutExecutor(workerState, executorId, credentials);
-            executor.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()));
+            executor.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.NUM_STAT_BUCKETS)));
         } else {
             executor = new BoltExecutor(workerState, executorId, credentials);
-            executor.stats = new BoltExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()));
+            executor.stats = new BoltExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.NUM_STAT_BUCKETS)));
         }
 
         Map<Integer, Task> idToTask = new HashMap<>();

--- a/storm-core/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/Executor.java
@@ -146,10 +146,10 @@ public abstract class Executor implements Callable, EventHandler<Object> {
         Map<String, Bolt> bolts = topology.get_bolts();
         if (spouts.containsKey(componentId)) {
             this.type = StatsUtil.SPOUT;
-            this.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.NUM_STAT_BUCKETS)));
+            this.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.numStatBuckets)));
         } else if (bolts.containsKey(componentId)) {
             this.type = StatsUtil.BOLT;
-            this.stats = new BoltExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.NUM_STAT_BUCKETS)));
+            this.stats = new BoltExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.numStatBuckets)));
         } else {
             throw new RuntimeException("Could not find " + componentId + " in " + topology);
         }
@@ -183,10 +183,10 @@ public abstract class Executor implements Callable, EventHandler<Object> {
         String type = getExecutorType(workerTopologyContext, componentId);
         if (StatsUtil.SPOUT.equals(type)) {
             executor = new SpoutExecutor(workerState, executorId, credentials);
-            executor.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.NUM_STAT_BUCKETS)));
+            executor.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.numStatBuckets)));
         } else {
             executor = new BoltExecutor(workerState, executorId, credentials);
-            executor.stats = new BoltExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.NUM_STAT_BUCKETS)));
+            executor.stats = new BoltExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.numStatBuckets)));
         }
 
         Map<Integer, Task> idToTask = new HashMap<>();

--- a/storm-core/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-core/src/jvm/org/apache/storm/executor/Executor.java
@@ -146,10 +146,10 @@ public abstract class Executor implements Callable, EventHandler<Object> {
         Map<String, Bolt> bolts = topology.get_bolts();
         if (spouts.containsKey(componentId)) {
             this.type = StatsUtil.SPOUT;
-            this.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.numStatBuckets)));
+            this.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.NUM_STAT_BUCKETS)));
         } else if (bolts.containsKey(componentId)) {
             this.type = StatsUtil.BOLT;
-            this.stats = new BoltExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.numStatBuckets)));
+            this.stats = new BoltExecutorStats(ConfigUtils.samplingRate(stormConf),Utils.getInt(stormConf.get(Config.NUM_STAT_BUCKETS)));
         } else {
             throw new RuntimeException("Could not find " + componentId + " in " + topology);
         }
@@ -183,10 +183,10 @@ public abstract class Executor implements Callable, EventHandler<Object> {
         String type = getExecutorType(workerTopologyContext, componentId);
         if (StatsUtil.SPOUT.equals(type)) {
             executor = new SpoutExecutor(workerState, executorId, credentials);
-            executor.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.numStatBuckets)));
+            executor.stats = new SpoutExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.NUM_STAT_BUCKETS)));
         } else {
             executor = new BoltExecutor(workerState, executorId, credentials);
-            executor.stats = new BoltExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.numStatBuckets)));
+            executor.stats = new BoltExecutorStats(ConfigUtils.samplingRate(executor.getStormConf()),Utils.getInt(executor.getStormConf().get(Config.NUM_STAT_BUCKETS)));
         }
 
         Map<Integer, Task> idToTask = new HashMap<>();

--- a/storm-core/src/jvm/org/apache/storm/stats/BoltExecutorStats.java
+++ b/storm-core/src/jvm/org/apache/storm/stats/BoltExecutorStats.java
@@ -36,14 +36,14 @@ public class BoltExecutorStats extends CommonStats {
     public static final String PROCESS_LATENCIES = "process-latencies";
     public static final String EXECUTE_LATENCIES = "execute-latencies";
 
-    public BoltExecutorStats(int rate,int NUM_STAT_BUCKETS) {
-        super(rate,NUM_STAT_BUCKETS);
+    public BoltExecutorStats(int rate,int numStatBuckets) {
+        super(rate,numStatBuckets);
 
-        this.put(ACKED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
-        this.put(FAILED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
-        this.put(EXECUTED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
-        this.put(PROCESS_LATENCIES, new MultiLatencyStatAndMetric(NUM_STAT_BUCKETS));
-        this.put(EXECUTE_LATENCIES, new MultiLatencyStatAndMetric(NUM_STAT_BUCKETS));
+        this.put(ACKED, new MultiCountStatAndMetric(numStatBuckets));
+        this.put(FAILED, new MultiCountStatAndMetric(numStatBuckets));
+        this.put(EXECUTED, new MultiCountStatAndMetric(numStatBuckets));
+        this.put(PROCESS_LATENCIES, new MultiLatencyStatAndMetric(numStatBuckets));
+        this.put(EXECUTE_LATENCIES, new MultiLatencyStatAndMetric(numStatBuckets));
     }
 
     public MultiCountStatAndMetric getAcked() {

--- a/storm-core/src/jvm/org/apache/storm/stats/BoltExecutorStats.java
+++ b/storm-core/src/jvm/org/apache/storm/stats/BoltExecutorStats.java
@@ -36,8 +36,8 @@ public class BoltExecutorStats extends CommonStats {
     public static final String PROCESS_LATENCIES = "process-latencies";
     public static final String EXECUTE_LATENCIES = "execute-latencies";
 
-    public BoltExecutorStats(int rate) {
-        super(rate);
+    public BoltExecutorStats(int rate,int NUM_STAT_BUCKETS) {
+        super(rate,NUM_STAT_BUCKETS);
 
         this.put(ACKED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
         this.put(FAILED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));

--- a/storm-core/src/jvm/org/apache/storm/stats/CommonStats.java
+++ b/storm-core/src/jvm/org/apache/storm/stats/CommonStats.java
@@ -26,7 +26,6 @@ import org.apache.storm.metric.internal.MultiLatencyStatAndMetric;
 
 @SuppressWarnings("unchecked")
 public abstract class CommonStats {
-    public static final int NUM_STAT_BUCKETS = 20;
 
     public static final String RATE = "rate";
 
@@ -37,7 +36,7 @@ public abstract class CommonStats {
     protected final int rate;
     protected final Map<String, IMetric> metricMap = new HashMap<>();
 
-    public CommonStats(int rate) {
+    public CommonStats(int rate,int NUM_STAT_BUCKETS) {
         this.rate = rate;
         this.put(EMITTED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
         this.put(TRANSFERRED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));

--- a/storm-core/src/jvm/org/apache/storm/stats/CommonStats.java
+++ b/storm-core/src/jvm/org/apache/storm/stats/CommonStats.java
@@ -36,10 +36,10 @@ public abstract class CommonStats {
     protected final int rate;
     protected final Map<String, IMetric> metricMap = new HashMap<>();
 
-    public CommonStats(int rate,int NUM_STAT_BUCKETS) {
+    public CommonStats(int rate,int numStatBuckets) {
         this.rate = rate;
-        this.put(EMITTED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
-        this.put(TRANSFERRED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
+        this.put(EMITTED, new MultiCountStatAndMetric(numStatBuckets));
+        this.put(TRANSFERRED, new MultiCountStatAndMetric(numStatBuckets));
     }
 
     public int getRate() {

--- a/storm-core/src/jvm/org/apache/storm/stats/SpoutExecutorStats.java
+++ b/storm-core/src/jvm/org/apache/storm/stats/SpoutExecutorStats.java
@@ -30,11 +30,11 @@ public class SpoutExecutorStats extends CommonStats {
     public static final String FAILED = "failed";
     public static final String COMPLETE_LATENCIES = "complete-latencies";
 
-    public SpoutExecutorStats(int rate,int NUM_STAT_BUCKETS) {
-        super(rate,NUM_STAT_BUCKETS);
-        this.put(ACKED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
-        this.put(FAILED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
-        this.put(COMPLETE_LATENCIES, new MultiLatencyStatAndMetric(NUM_STAT_BUCKETS));
+    public SpoutExecutorStats(int rate,int numStatBuckets) {
+        super(rate,numStatBuckets);
+        this.put(ACKED, new MultiCountStatAndMetric(numStatBuckets));
+        this.put(FAILED, new MultiCountStatAndMetric(numStatBuckets));
+        this.put(COMPLETE_LATENCIES, new MultiLatencyStatAndMetric(numStatBuckets));
     }
 
     public MultiCountStatAndMetric getAcked() {

--- a/storm-core/src/jvm/org/apache/storm/stats/SpoutExecutorStats.java
+++ b/storm-core/src/jvm/org/apache/storm/stats/SpoutExecutorStats.java
@@ -30,8 +30,8 @@ public class SpoutExecutorStats extends CommonStats {
     public static final String FAILED = "failed";
     public static final String COMPLETE_LATENCIES = "complete-latencies";
 
-    public SpoutExecutorStats(int rate) {
-        super(rate);
+    public SpoutExecutorStats(int rate,int NUM_STAT_BUCKETS) {
+        super(rate,NUM_STAT_BUCKETS);
         this.put(ACKED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
         this.put(FAILED, new MultiCountStatAndMetric(NUM_STAT_BUCKETS));
         this.put(COMPLETE_LATENCIES, new MultiLatencyStatAndMetric(NUM_STAT_BUCKETS));


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2363?filter=-2](url)
Users can set the number of RollingWindow which applied to storm's metric conveniently and dynamically by modifying default.yaml or storm.yaml.So they can adjust the accuracy of statistics.By passing that value from caller of CommonStats, we avoid reading storm config file again and again which looks redundant, and even doing it for constant doesn't look good.