### PR TITLE
[STORM-2454] the default returned value of this method which named "isConsumerAutoCommitMode" in KafkaSpoutConfig.java should be false

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
@@ -497,7 +497,7 @@ public class KafkaSpoutConfig<K, V> implements Serializable {
     }
 
     public boolean isConsumerAutoCommitMode() {
-        return kafkaProps.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG) == null     // default is true
+        return kafkaProps.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG) == null     // default is false
                 || Boolean.valueOf((String)kafkaProps.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG));
     }
 


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2454](url)
The configuration which named "enable.auto.commit" has been set to false when we create a instance of KafkaSpoutConfig via the method of "setDefaultsAndGetKafkaProps". And the logic of "isConsumerAutoCommitMode" makes the returned value is "false",but the annotation is "true".