### PR TITLE
STORM-2462 Adding regex mapper to KerberosPrincipalToLocal class

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/RegexKerberosPrincipalToLocal.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/RegexKerberosPrincipalToLocal.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.security.auth;
+
+import java.util.Map;
+import java.security.Principal;
+
+/**
+ * Map a kerberos principal to a local user
+ */
+public class RegexKerberosPrincipalToLocal extends KerberosPrincipalToLocal {
+
+    private String inputRegex;
+	private String replacementString;
+
+	/**
+     * Invoked once immediately after construction
+     * @param storm_conf Storm configuration
+     */
+    public void prepare(@SuppressWarnings("rawtypes") Map storm_conf) {
+        Object object = storm_conf.get("storm.principal.mapper.regex");
+        if (object != null) {
+            inputRegex = object.toString();
+        }
+        object = storm_conf.get("storm.principal.mapper.replacement");
+        if (object != null) {
+            replacementString = object.toString();
+        }
+    }
+    
+    /**
+     * Convert a Principal to a local user name.
+     * @param principal the principal to convert
+     * @return The local user name.
+     */
+    public String toLocal(Principal principal) {
+        String local = super.toLocal(principal);
+        return local.replaceAll(inputRegex, replacementString);
+    }
+}

--- a/storm-client/test/jvm/org/apache/storm/security/auth/AuthUtilsTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/AuthUtilsTest.java
@@ -18,9 +18,13 @@
 package org.apache.storm.security.auth;
 
 import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -236,5 +240,22 @@ public class AuthUtilsTest {
         Subject s = new Subject();
         AuthUtils.updateSubject(s, autos, null);
         Mockito.verify(mock, Mockito.times(1)).updateSubject(s, null);
+    }
+    
+    @Test
+    public void testRegexKerberosPrincipalToLocal() {
+    	RegexKerberosPrincipalToLocal mapper = new RegexKerberosPrincipalToLocal();
+    	Map storm_conf = new HashMap<>();
+    	storm_conf.put("storm.principal.mapper.regex", "^");
+    	storm_conf.put("storm.principal.mapper.replacement", "A");
+		mapper.prepare(storm_conf);
+		String output = mapper.toLocal(new Principal() {
+			
+			@Override
+			public String getName() {
+				return "0001@storm.apache.org";
+			}
+		});
+		assertEquals("A0001", output);
     }
 }


### PR DESCRIPTION
In some environments it may be the case that the local unix usernames are different than the ones in Kerberos account. This feature lets you override the username and map it to the one locally available.

Added settings:
storm.principal.mapper.regex = what to replace in the existing principal
storm.principal.mapper.replacement = what to replace in the existing principal with

e.g.

Kerberos principal is 0001@storm.apache.org 
storm.principal.mapper.regex=^
storm.principal.mapper.replacement=A

Would result in local principal=A0001

https://issues.apache.org/jira/browse/STORM-2462