### PR TITLE
[STORM-2467] Use explicit charset when decoding from array backed buffer

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/StringScheme.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/StringScheme.java
@@ -38,7 +38,7 @@ public class StringScheme implements Scheme {
     public static String deserializeString(ByteBuffer string) {
         if (string.hasArray()) {
             int base = string.arrayOffset();
-            return new String(string.array(), base + string.position(), string.remaining());
+            return new String(string.array(), base + string.position(), string.remaining(), UTF8_CHARSET);
         } else {
             return new String(Utils.toByteArray(string), UTF8_CHARSET);
         }


### PR DESCRIPTION
We had the case that this broke encoding for us because it used the default
system locale. Given the fact that this code uses an explicit encoding for the
other case and that it evolved from something that always used an explicit
encoding I believe this is more correct.