### PR TITLE
[STORM-2466] The example of jaas.conf in jaas_kerberos.conf should give more details

### DIFF
--- a/conf/jaas_kerberos.conf
+++ b/conf/jaas_kerberos.conf
@@ -16,17 +16,37 @@
  * limitations under the License.
  */
 StormServer {
-       com.sun.security.auth.module.Krb5LoginModule required
-       useKeyTab=true
-       keyTab="/etc/nimbus_server.keytab"
-       storeKey=true
-       useTicketCache=false
-       principal="nimbus_server/carcloth.corp.yahoo.com@STORM.CORP.YAHOO.COM";
+   com.sun.security.auth.module.Krb5LoginModule required
+   useKeyTab=true
+   keyTab="$keytab"
+   storeKey=true
+   useTicketCache=false
+   principal="$principal";
 };
 StormClient {
-       com.sun.security.auth.module.Krb5LoginModule required
-       doNotPrompt=true
-       useTicketCache=true
-       serviceName="nimbus_server";
+   com.sun.security.auth.module.Krb5LoginModule required
+   useKeyTab=true
+   keyTab="$keytab"
+   storeKey=true
+   useTicketCache=false
+   serviceName="$nimbus_user"
+   principal="$principal";
+};
+Client {
+   com.sun.security.auth.module.Krb5LoginModule required
+   useKeyTab=true
+   keyTab="$keytab"
+   storeKey=true
+   useTicketCache=false
+   serviceName="zookeeper"
+   principal="$principal";
+};
+Server {
+   com.sun.security.auth.module.Krb5LoginModule required
+   useKeyTab=true
+   keyTab="$keytab"
+   storeKey=true
+   useTicketCache=false
+   principal="$principal";
 };
 

--- a/conf/storm_jaas.conf
+++ b/conf/storm_jaas.conf
@@ -42,5 +42,3 @@ Client {
    principal="$principal";
 };
 
-
-

--- a/conf/storm_jaas.conf
+++ b/conf/storm_jaas.conf
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 StormServer {
-       com.sun.security.auth.module.Krb5LoginModule required
-       useKeyTab=true
-       keyTab="/etc/nimbus_server.keytab"
-       storeKey=true
-       useTicketCache=false
-       principal="nimbus_server/carcloth.corp.yahoo.com@STORM.CORP.YAHOO.COM";
+   com.sun.security.auth.module.Krb5LoginModule required
+   useKeyTab=true
+   keyTab="$keytab"
+   storeKey=true
+   useTicketCache=false
+   principal="$principal";
 };
 StormClient {
    com.sun.security.auth.module.Krb5LoginModule required
@@ -41,4 +41,5 @@ Client {
    serviceName="zookeeper"
    principal="$principal";
 };
+
 

--- a/conf/storm_jaas.conf
+++ b/conf/storm_jaas.conf
@@ -41,12 +41,5 @@ Client {
    serviceName="zookeeper"
    principal="$principal";
 };
-Server {
-   com.sun.security.auth.module.Krb5LoginModule required
-   useKeyTab=true
-   keyTab="$keytab"
-   storeKey=true
-   useTicketCache=false
-   principal="$principal";
-};
+
 

--- a/conf/storm_jaas.conf
+++ b/conf/storm_jaas.conf
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 StormServer {
-   com.sun.security.auth.module.Krb5LoginModule required
-   useKeyTab=true
-   keyTab="$keytab"
-   storeKey=true
-   useTicketCache=false
-   principal="$principal";
+       com.sun.security.auth.module.Krb5LoginModule required
+       useKeyTab=true
+       keyTab="/etc/nimbus_server.keytab"
+       storeKey=true
+       useTicketCache=false
+       principal="nimbus_server/carcloth.corp.yahoo.com@STORM.CORP.YAHOO.COM";
 };
 StormClient {
    com.sun.security.auth.module.Krb5LoginModule required
@@ -41,5 +41,6 @@ Client {
    serviceName="zookeeper"
    principal="$principal";
 };
+
 
 

--- a/conf/zookeeeper_jaas.conf
+++ b/conf/zookeeeper_jaas.conf
@@ -1,0 +1,35 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+Server {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab=true
+  keyTab="$keytab"
+  storeKey=true
+  useTicketCache=false
+  principal="$principal";
+};
+Client {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab=true
+  keyTab="$keytab"
+  storeKey=true
+  useTicketCache=false
+  serviceName="zookeeper"
+  principal="$principal";
+};
+

--- a/conf/zookeeper_jaas.conf
+++ b/conf/zookeeper_jaas.conf
@@ -1,0 +1,35 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+Server {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab=true
+  keyTab="$keytab"
+  storeKey=true
+  useTicketCache=false
+  principal="$principal";
+};
+Client {
+  com.sun.security.auth.module.Krb5LoginModule required
+  useKeyTab=true
+  keyTab="$keytab"
+  storeKey=true
+  useTicketCache=false
+  serviceName="zookeeper"
+  principal="$principal";
+};
+


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2466](url)
This documentation lacks several section such as "Client" and "Server".The Client section is used by processes wanting to talk to ZooKeeper and really only needs to be included with nimbus and the supervisors.The Server section is used by the ZooKeeper servers. "jaas_kerberos.conf" should give users a good lead,so it should should give more details as SECURITY.md .Also,Having unused sections in the jaas is not a problem.So I think The example of jaas.conf in jaas_kerberos.conf should be the same as the PR.