### PR TITLE
STORM-2463: fix DRPCTest.testDequeueAfterTimeout test failure

### DIFF
--- a/storm-server/src/test/java/org/apache/storm/daemon/drpc/DRPCTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/drpc/DRPCTest.java
@@ -117,7 +117,7 @@ public class DRPCTest {
     
     @Test
     public void testDequeueAfterTimeout() throws Exception {
-        long timeout = 2000;
+        long timeout = 1000;
         try (DRPC server = new DRPC(null, timeout)) {
             long start = Time.currentTimeMillis();
             try {

--- a/storm-server/src/test/java/org/apache/storm/daemon/drpc/DRPCTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/drpc/DRPCTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeUnit;
 import javax.security.auth.Subject;
 
 import org.apache.storm.Config;
-import org.apache.storm.daemon.drpc.DRPC;
 import org.apache.storm.generated.AuthorizationException;
 import org.apache.storm.generated.DRPCExceptionType;
 import org.apache.storm.generated.DRPCExecutionException;
@@ -118,7 +117,7 @@ public class DRPCTest {
     
     @Test
     public void testDequeueAfterTimeout() throws Exception {
-        long timeout = 2;
+        long timeout = 2000;
         try (DRPC server = new DRPC(null, timeout)) {
             long start = Time.currentTimeMillis();
             try {


### PR DESCRIPTION
This is the hot fix for travis-ci build failure.

error info:
```
classname: org.apache.storm.daemon.drpc.DRPCTest / testname: testDequeueAfterTimeout

java.lang.AssertionError: null
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertTrue(Assert.java:52)
	at org.apache.storm.daemon.drpc.DRPCTest.testDequeueAfterTimeout(DRPCTest.java:129)
```