### PR TITLE
STORM-2469: fix integration-test dependencies issue

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -27,7 +27,6 @@
     </parent>
 
     <name>Storm Integration Test</name>
-    <groupId>org.apache.storm</groupId>
     <artifactId>storm-integration-test</artifactId>
     <packaging>jar</packaging>
 
@@ -65,37 +64,26 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-firefox-driver</artifactId>
-            <version>2.45.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-support</artifactId>
-            <version>2.45.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-client</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
+            <scope>${provided.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>
-            <artifactId>storm-solr</artifactId>
+            <artifactId>storm-server</artifactId>
             <version>${project.version}</version>
+            <scope>${provided.scope}</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>storm-starter</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>storm-hdfs</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
         </dependency>
     </dependencies>
 
@@ -151,7 +139,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
-                    <forkCount>1C</forkCount>
                     <argLine>-Xmx1024m</argLine>
                     <properties>
                         <property>
@@ -166,12 +153,6 @@
                         <!-- Hack to get the dir in CP through CLI and idea -->
                         <additionalClasspathElement>${storm.conf.dir}</additionalClasspathElement>
                         <additionalClasspathElement>${hadoop.conf.dir}</additionalClasspathElement>
-                        <additionalClasspathElement>${extra.classpath.1}</additionalClasspathElement>
-                        <additionalClasspathElement>${extra.classpath.2}</additionalClasspathElement>
-                        <additionalClasspathElement>${extra.classpath.3}</additionalClasspathElement>
-                        <additionalClasspathElement>${extra.classpath.4}</additionalClasspathElement>
-                        <additionalClasspathElement>${extra.classpath.5}</additionalClasspathElement>
-                        <additionalClasspathElement>${extra.classpath.6}</additionalClasspathElement>
                     </additionalClasspathElements>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This is the hot fix for integration-test dependencies issue

* add storm-server. since __the ExclamationTopology depends on LocalCluster__
* remove unused dependencies: selenium-firefox-driver, selenium-support, storm-solr, storm-starter, storm-hdfs