### PR TITLE
[STORM-2470] kafkaspout should support kerberos

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -315,3 +315,6 @@ worker.metrics:
     "CGroupCpuGuarantee": "org.apache.storm.metric.cgroup.CGroupCpuGuarantee"
 
 num.stat.buckets: 20
+
+# Config for storm-kafka-client
+kafkaspout.jaasconf.path: null

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -51,6 +51,7 @@ import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseRichSpout;
+import org.apache.storm.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,6 +120,10 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         acked = new HashMap<>();
         emitted = new HashSet<>();
         waitingToEmit = Collections.emptyListIterator();
+
+        //prepare for kerberos
+        String pathToJaas = (String)conf.get(Config.KAFKASPOUT_JAASCONF_PATH);
+        KafkaSpoutSecurity.PrepareKerberos(pathToJaas);
 
         LOG.info("Kafka Spout opened with the following configuration: {}", kafkaSpoutConfig);
     }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutSecurity.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutSecurity.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.apache.storm.kafka.spout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.security.auth.login.Configuration;
+
+public class KafkaSpoutSecurity {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSpoutSecurity.class);
+    private static final String KERBEROS_AUTH_JASSCONF = "java.security.auth.login.config";
+
+    public synchronized static void PrepareKerberos(String pathToJaas) {
+        if(pathToJaas == null || pathToJaas.isEmpty()){
+            LOG.info("No jaas.conf found.");
+        }else{
+            Configuration login_conf = Configuration.getConfiguration();
+            System.setProperty(KERBEROS_AUTH_JASSCONF, pathToJaas);
+            login_conf.refresh();
+            LOG.info("Use storm-kakfa-client in Security mode.");
+    }
+    }
+}
+

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -1481,6 +1481,12 @@ public class Config extends HashMap<String, Object> {
     @isPositiveNumber
     public static final String NUM_STAT_BUCKETS = "num.stat.buckets";
 
+    /**
+     * The path to KafkaClient's jaas.conf when use storm-kakfa-client in Security mode.
+     */
+    @isString
+    public static final String KAFKASPOUT_JAASCONF_PATH = "kafkaspout.jaasconf.path";
+
     public static void setClasspath(Map conf, String cp) {
         conf.put(Config.TOPOLOGY_CLASSPATH, cp);
     }


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2470](url)
kafkaspout should work normally when the cluster(storm and kafka) is in kerberos mode.
