### PR TITLE
STORM-1114: Handle race condition in Storm/Trident transactional stat…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/trident/topology/state/TransactionalState.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/topology/state/TransactionalState.java
@@ -126,16 +126,19 @@ public class TransactionalState {
                 TransactionalState.createNode(_curator, path, ser, _zkAcls,
                         CreateMode.PERSISTENT);
             }
-            LOG.debug("Set [path = {}] => [data = {}]", path, asString(ser));
+        } catch (KeeperException.NodeExistsException nne){
+            LOG.warn("Node {} already created.", path);
         } catch(Exception e) {
             throw new RuntimeException(e);
-        }        
+        }
     }
     
     public void delete(String path) {
         path = "/" + path;
         try {
             _curator.delete().forPath(path);
+        } catch (KeeperException.NoNodeException nne){
+           LOG.warn("Path {} already deleted.");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Handle race condition in Storm/Trident transactional state when ZK nodes have already been created/deleted. This impacts certain Trident topologies, causing the worker to crash due to the propagation of runtime exceptions.

This change should be back ported to all branches we intend to release from. 