### PR TITLE
[STORM-2472] kafkaspout should work normally in kerberos mode with kafka 0.9.x API

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -123,6 +123,10 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         emitted = new HashSet<>();
         waitingToEmit = Collections.emptyListIterator();
 
+        //prepare for kerberos
+        String pathToJaas = (String) kafkaSpoutConfig.getKafkaProps().get(KafkaSpoutConfig.Consumer.KAFKASPOUT_JAASCONF_PATH);
+        KafkaSpoutSecurity.PrepareKerberos(pathToJaas);
+
         LOG.info("Kafka Spout opened with the following configuration: {}", kafkaSpoutConfig);
     }
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
@@ -45,6 +45,7 @@ public class KafkaSpoutConfig<K, V> implements Serializable {
         String AUTO_COMMIT_INTERVAL_MS = "auto.commit.interval.ms";
         String KEY_DESERIALIZER = "key.deserializer";
         String VALUE_DESERIALIZER = "value.deserializer";
+        String KAFKASPOUT_JAASCONF_PATH = "kafkaspout.jaasconf.path";
     }
 
     /**

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutSecurity.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutSecurity.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.apache.storm.kafka.spout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.security.auth.login.Configuration;
+
+public class KafkaSpoutSecurity {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSpoutSecurity.class);
+    private static final String KERBEROS_AUTH_JAASCONF = "java.security.auth.login.config";
+
+    public synchronized static void PrepareKerberos(String pathToJaas) {
+        if(pathToJaas == null || pathToJaas.isEmpty()){
+            LOG.info("No jaas.conf found.Can't use storm-kakfa-client in kerberos mode.");
+        }else{
+            Configuration login_conf = Configuration.getConfiguration();
+            System.setProperty(KERBEROS_AUTH_JAASCONF, pathToJaas);
+            login_conf.refresh();
+            LOG.info("Use storm-kakfa-client in kerberos mode.");
+    }
+    }
+}
+


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2472](url)
storm 1.0.x-branch didn't support kafkaspout to consume from kafka in kerberos mode with we can't  set kafka's parameter ,'java.security.auth.login.config', in storm's process .So I solve it via preparing a kafkaspout.