### PR TITLE
STORM-2477: Add generics to Config types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - rvm use 2.1.5 --install
   - nvm install 0.12.2
   - nvm use 0.12.2
+  - ./transform.sh
 install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
 script:
   - /bin/bash ./dev-tools/travis/travis-script.sh `pwd` $MODULES

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/ReachTopology.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/ReachTopology.java
@@ -109,7 +109,7 @@ public class ReachTopology {
         }
     }
 
-    public static class PartialUniquer extends BaseBatchBolt {
+    public static class PartialUniquer extends BaseBatchBolt<Object> {
         BatchOutputCollector _collector;
         Object _id;
         Set<String> _followers = new HashSet<String>();
@@ -136,7 +136,7 @@ public class ReachTopology {
         }
     }
 
-    public static class CountAggregator extends BaseBatchBolt {
+    public static class CountAggregator extends BaseBatchBolt<Object> {
         BatchOutputCollector _collector;
         Object _id;
         int _count = 0;

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/TransactionalGlobalCount.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/TransactionalGlobalCount.java
@@ -83,7 +83,7 @@ public class TransactionalGlobalCount {
     public static Map<String, Value> DATABASE = new HashMap<String, Value>();
     public static final String GLOBAL_COUNT_KEY = "GLOBAL-COUNT";
 
-    public static class BatchCount extends BaseBatchBolt {
+    public static class BatchCount extends BaseBatchBolt<Object> {
         Object _id;
         BatchOutputCollector _collector;
 

--- a/external/storm-eventhubs/pom.xml
+++ b/external/storm-eventhubs/pom.xml
@@ -53,7 +53,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1764</maxAllowedViolations>
+                    <maxAllowedViolations>1765</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-hbase/pom.xml
+++ b/external/storm-hbase/pom.xml
@@ -106,7 +106,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>370</maxAllowedViolations>
+                    <maxAllowedViolations>371</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/AbstractHBaseBolt.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/bolt/AbstractHBaseBolt.java
@@ -51,11 +51,11 @@ public abstract class AbstractHBaseBolt extends BaseRichBolt {
     }
 
     @Override
-    public void prepare(Map map, TopologyContext topologyContext, OutputCollector collector) {
+    public void prepare(Map topoConf, TopologyContext topologyContext, OutputCollector collector) {
         this.collector = collector;
         final Configuration hbConfig = HBaseConfiguration.create();
 
-        Map<String, Object> conf = (Map<String, Object>)map.get(this.configKey);
+        Map<String, Object> conf = (Map<String, Object>)topoConf.get(this.configKey);
         if(conf == null) {
             throw new IllegalArgumentException("HBase configuration not found using key '" + this.configKey + "'");
         }
@@ -70,7 +70,7 @@ public abstract class AbstractHBaseBolt extends BaseRichBolt {
         //heck for backward compatibility, we need to pass TOPOLOGY_AUTO_CREDENTIALS to hbase conf
         //the conf instance is instance of persistentMap so making a copy.
         Map<String, Object> hbaseConfMap = new HashMap<String, Object>(conf);
-        hbaseConfMap.put(Config.TOPOLOGY_AUTO_CREDENTIALS, map.get(Config.TOPOLOGY_AUTO_CREDENTIALS));
+        hbaseConfMap.put(Config.TOPOLOGY_AUTO_CREDENTIALS, topoConf.get(Config.TOPOLOGY_AUTO_CREDENTIALS));
         this.hBaseClient = new HBaseClient(hbaseConfMap, hbConfig, tableName);
     }
 

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -256,7 +256,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>2220</maxAllowedViolations>
+                    <maxAllowedViolations>2221</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-jms/src/test/java/org/apache/storm/jms/spout/JmsSpoutTest.java
+++ b/external/storm-jms/src/test/java/org/apache/storm/jms/spout/JmsSpoutTest.java
@@ -51,7 +51,7 @@ public class JmsSpoutTest {
         spout.setJmsTupleProducer(new MockTupleProducer());
         spout.setJmsAcknowledgeMode(Session.CLIENT_ACKNOWLEDGE);
         spout.setRecoveryPeriod(10); // Rapid recovery for testing.
-        spout.open(new HashMap<String,String>(), null, collector);
+        spout.open(new HashMap<>(), null, collector);
         Message msg = this.sendMessage(mockProvider.connectionFactory(), mockProvider.destination());
         Thread.sleep(100);
         spout.nextTuple(); // Pretend to be storm.

--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -152,7 +152,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>341</maxAllowedViolations>
+                    <maxAllowedViolations>342</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTransactional.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTransactional.java
@@ -20,19 +20,20 @@ package org.apache.storm.kafka.spout.trident;
 
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.trident.spout.IPartitionedTridentSpout;
+import org.apache.storm.trident.spout.ISpoutPartition;
 import org.apache.storm.tuple.Fields;
 
 import java.util.Map;
 
 // TODO
-public class KafkaTridentSpoutTransactional implements IPartitionedTridentSpout {
+public class KafkaTridentSpoutTransactional<Ps, P extends ISpoutPartition, T> implements IPartitionedTridentSpout<Ps, P, T> {
     @Override
-    public Coordinator getCoordinator(Map conf, TopologyContext context) {
+    public Coordinator<Ps> getCoordinator(Map conf, TopologyContext context) {
         return null;
     }
 
     @Override
-    public Emitter getEmitter(Map conf, TopologyContext context) {
+    public Emitter<Ps, P, T> getEmitter(Map conf, TopologyContext context) {
         return null;
     }
 

--- a/external/storm-redis/pom.xml
+++ b/external/storm-redis/pom.xml
@@ -95,7 +95,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>598</maxAllowedViolations>
+                    <maxAllowedViolations>602</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/KerberosSaslTransportPlugin.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/KerberosSaslTransportPlugin.java
@@ -61,11 +61,11 @@ public class KerberosSaslTransportPlugin extends SaslTransportPlugin {
             if (conf == null) {
                 throw new IllegalArgumentException("Configuration should not be null");
             }
-            SortedMap<String, ?> configsMap = AuthUtils.pullConfig(conf, login_context);
-            if (configsMap!=null) {
+            SortedMap<String, ?> authConf = AuthUtils.pullConfig(conf, login_context);
+            if (authConf!=null) {
                 StringBuilder stringBuilder = new StringBuilder();
-                for (String configKey: configsMap.keySet()) {
-                    String configValue = (String) configsMap.get(configKey);
+                for (String configKey: authConf.keySet()) {
+                    String configValue = (String) authConf.get(configKey);
                     stringBuilder.append(configKey);
                     stringBuilder.append(configValue);
                 }

--- a/storm-client/src/jvm/org/apache/storm/stats/StatsUtil.java
+++ b/storm-client/src/jvm/org/apache/storm/stats/StatsUtil.java
@@ -2377,11 +2377,11 @@ public class StatsUtil {
         return map.get(key);
     }
 
-    public static Map getMapByKey(Map map, String key) {
+    public static <K, V> Map<K,V> getMapByKey(Map map, String key) {
         if (map == null) {
             return null;
         }
-        return (Map) map.get(key);
+        return (Map<K,V>) map.get(key);
     }
 
     private static <K, V extends Number> long sumValues(Map<K, V> m) {

--- a/storm-client/src/jvm/org/apache/storm/testing/BatchNumberList.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/BatchNumberList.java
@@ -29,7 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class BatchNumberList extends BaseBatchBolt {
+public class BatchNumberList extends BaseBatchBolt<Object> {
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {

--- a/storm-client/src/jvm/org/apache/storm/testing/CountingBatchBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/CountingBatchBolt.java
@@ -26,7 +26,7 @@ import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
 import java.util.Map;
 
-public class CountingBatchBolt extends BaseBatchBolt {
+public class CountingBatchBolt extends BaseBatchBolt<Object> {
     BatchOutputCollector _collector;
     Object _id;
     int _count = 0;

--- a/storm-client/src/jvm/org/apache/storm/testing/KeyedCountingBatchBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/KeyedCountingBatchBolt.java
@@ -29,7 +29,7 @@ import org.apache.storm.utils.Utils;
 import java.util.HashMap;
 import java.util.Map;
 
-public class KeyedCountingBatchBolt extends BaseBatchBolt {
+public class KeyedCountingBatchBolt extends BaseBatchBolt<Object> {
     BatchOutputCollector _collector;
     Object _id;
     Map<Object, Integer> _counts = new HashMap<Object, Integer>();

--- a/storm-client/src/jvm/org/apache/storm/testing/KeyedSummingBatchBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/KeyedSummingBatchBolt.java
@@ -28,7 +28,7 @@ import org.apache.storm.utils.Utils;
 import java.util.HashMap;
 import java.util.Map;
 
-public class KeyedSummingBatchBolt extends BaseBatchBolt {
+public class KeyedSummingBatchBolt extends BaseBatchBolt<Object> {
     BatchOutputCollector _collector;
     Object _id;
     Map<Object, Number> _sums = new HashMap<Object, Number>();

--- a/storm-client/src/jvm/org/apache/storm/trident/operation/impl/IdentityMultiReducer.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/operation/impl/IdentityMultiReducer.java
@@ -24,24 +24,24 @@ import org.apache.storm.trident.operation.TridentMultiReducerContext;
 import org.apache.storm.trident.tuple.TridentTuple;
 
 
-public class IdentityMultiReducer implements MultiReducer {
+public class IdentityMultiReducer<T> implements MultiReducer<T> {
 
     @Override
     public void prepare(Map conf, TridentMultiReducerContext context) {
     }
 
     @Override
-    public Object init(TridentCollector collector) {
+    public T init(TridentCollector collector) {
         return null;
     }
 
     @Override
-    public void execute(Object state, int streamIndex, TridentTuple input, TridentCollector collector) {
+    public void execute(T state, int streamIndex, TridentTuple input, TridentCollector collector) {
         collector.emit(input);
     }
 
     @Override
-    public void complete(Object state, TridentCollector collector) {
+    public void complete(T state, TridentCollector collector) {
     }
 
     @Override

--- a/storm-client/src/jvm/org/apache/storm/trident/spout/BatchSpoutExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/spout/BatchSpoutExecutor.java
@@ -23,8 +23,8 @@ import org.apache.storm.tuple.Fields;
 import java.util.Map;
 import org.apache.storm.trident.operation.TridentCollector;
 
-public class BatchSpoutExecutor implements ITridentSpout {
-    public static class EmptyCoordinator implements BatchCoordinator {
+public class BatchSpoutExecutor implements ITridentSpout<Object> {
+    public static class EmptyCoordinator implements BatchCoordinator<Object> {
         @Override
         public Object initializeTransaction(long txid, Object prevMetadata, Object currMetadata) {
             return null;
@@ -44,7 +44,7 @@ public class BatchSpoutExecutor implements ITridentSpout {
         }
     }
     
-    public class BatchSpoutEmitter implements Emitter {
+    public class BatchSpoutEmitter implements Emitter<Object> {
 
         @Override
         public void emitBatch(TransactionAttempt tx, Object coordinatorMeta, TridentCollector collector) {
@@ -69,12 +69,12 @@ public class BatchSpoutExecutor implements ITridentSpout {
     }
     
     @Override
-    public BatchCoordinator getCoordinator(String txStateId, Map conf, TopologyContext context) {
+    public BatchCoordinator<Object> getCoordinator(String txStateId, Map conf, TopologyContext context) {
         return new EmptyCoordinator();
     }
 
     @Override
-    public Emitter getEmitter(String txStateId, Map conf, TopologyContext context) {
+    public Emitter<Object> getEmitter(String txStateId, Map conf, TopologyContext context) {
         _spout.open(conf, context);
         return new BatchSpoutEmitter();
     }

--- a/storm-client/src/jvm/org/apache/storm/trident/spout/RichSpoutBatchExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/spout/RichSpoutBatchExecutor.java
@@ -31,7 +31,7 @@ import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.topology.TransactionAttempt;
 import org.apache.storm.trident.util.TridentUtils;
 
-public class RichSpoutBatchExecutor implements ITridentSpout {
+public class RichSpoutBatchExecutor implements ITridentSpout<Object> {
     public static final String MAX_BATCH_SIZE_CONF = "topology.spout.max.batch.size";
 
     IRichSpout _spout;
@@ -52,12 +52,12 @@ public class RichSpoutBatchExecutor implements ITridentSpout {
     }
 
     @Override
-    public BatchCoordinator getCoordinator(String txStateId, Map conf, TopologyContext context) {
+    public BatchCoordinator<Object> getCoordinator(String txStateId, Map conf, TopologyContext context) {
         return new RichSpoutCoordinator();
     }
 
     @Override
-    public Emitter getEmitter(String txStateId, Map conf, TopologyContext context) {
+    public Emitter<Object> getEmitter(String txStateId, Map conf, TopologyContext context) {
         return new RichSpoutEmitter(conf, context);
     }
     
@@ -146,7 +146,7 @@ public class RichSpoutBatchExecutor implements ITridentSpout {
         
     }
     
-    private static class RichSpoutCoordinator implements ITridentSpout.BatchCoordinator {
+    private static class RichSpoutCoordinator implements ITridentSpout.BatchCoordinator<Object> {
         @Override
         public Object initializeTransaction(long txid, Object prevMetadata, Object currMetadata) {
             return null;

--- a/storm-client/src/jvm/org/apache/storm/trident/testing/FeederBatchSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/testing/FeederBatchSpout.java
@@ -32,7 +32,7 @@ import org.apache.storm.trident.spout.ITridentSpout;
 import org.apache.storm.trident.topology.TransactionAttempt;
 import org.apache.storm.trident.topology.TridentTopologyBuilder;
 
-public class FeederBatchSpout implements ITridentSpout, IFeeder {
+public class FeederBatchSpout implements ITridentSpout<Map<Integer, List<List<Object>>>>, IFeeder {
 
     String _id;
     String _semaphoreId;
@@ -167,7 +167,7 @@ public class FeederBatchSpout implements ITridentSpout, IFeeder {
     }
 
     @Override
-    public BatchCoordinator getCoordinator(String txStateId, Map conf, TopologyContext context) {
+    public BatchCoordinator<Map<Integer, List<List<Object>>>> getCoordinator(String txStateId, Map conf, TopologyContext context) {
         int numTasks = context.getComponentTasks(
                             TridentTopologyBuilder.spoutIdFromCoordinatorId(
                                 context.getThisComponentId()))
@@ -176,7 +176,7 @@ public class FeederBatchSpout implements ITridentSpout, IFeeder {
     }
 
     @Override
-    public Emitter getEmitter(String txStateId, Map conf, TopologyContext context) {
+    public Emitter<Map<Integer, List<List<Object>>>> getEmitter(String txStateId, Map conf, TopologyContext context) {
         return new FeederEmitter(context.getThisTaskIndex());
     }
     

--- a/storm-client/src/jvm/org/apache/storm/trident/testing/FeederCommitterBatchSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/testing/FeederCommitterBatchSpout.java
@@ -27,7 +27,7 @@ import org.apache.storm.trident.spout.ITridentSpout;
 import org.apache.storm.trident.topology.TransactionAttempt;
 
 
-public class FeederCommitterBatchSpout implements ICommitterTridentSpout, IFeeder {
+public class FeederCommitterBatchSpout implements ICommitterTridentSpout<Map<Integer, List<List<Object>>>>, IFeeder {
 
     FeederBatchSpout _spout;
     
@@ -74,7 +74,7 @@ public class FeederCommitterBatchSpout implements ICommitterTridentSpout, IFeede
     }
 
     @Override
-    public BatchCoordinator getCoordinator(String txStateId, Map conf, TopologyContext context) {
+    public BatchCoordinator<Map<Integer, List<List<Object>>>> getCoordinator(String txStateId, Map conf, TopologyContext context) {
         return _spout.getCoordinator(txStateId, conf, context);
     }
 

--- a/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
+++ b/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
@@ -86,7 +86,7 @@ public class TestConfigValidate {
 
     @Test(expected = InvalidTopologyException.class)
     public void testValidateTopologyBlobStoreMap() throws InvalidTopologyException {
-        Map<String,Map> stormConf = new HashMap<>();
+        Map<String, Object> stormConf = new HashMap<>();
         Map<String,Map> topologyMap = new HashMap<>();
         topologyMap.put("key1", new HashMap<String,String>());
         topologyMap.put("key2", new HashMap<String,String>());

--- a/storm-client/test/jvm/org/apache/storm/security/auth/AuthUtilsTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/AuthUtilsTest.java
@@ -23,6 +23,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -93,40 +94,36 @@ public class AuthUtilsTest {
         Assert.assertNull(AuthUtils.pullConfig(null, "foo"));
         Assert.assertNull(AuthUtils.get(null, "foo", "bar"));
 
-        Map emptyMap = new HashMap<String, String>();
-        Assert.assertNull(AuthUtils.GetConfiguration(emptyMap));
+        Assert.assertNull(AuthUtils.GetConfiguration(Collections.emptyMap()));
     }
 
     @Test
     public void getAutoCredentialsTest() {
-        Map emptyMap = new HashMap<String, String>();
-        Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
+        Map<String, Object> map = new HashMap<>();
         map.put(Config.TOPOLOGY_AUTO_CREDENTIALS, 
                 Arrays.asList(new String[]{"org.apache.storm.security.auth.AuthUtilsTestMock"}));
 
-        Assert.assertTrue(AuthUtils.GetAutoCredentials(emptyMap).isEmpty());
+        Assert.assertTrue(AuthUtils.GetAutoCredentials(Collections.emptyMap()).isEmpty());
         Assert.assertEquals(AuthUtils.GetAutoCredentials(map).size(), 1);
     }
 
     @Test
     public void getNimbusAutoCredPluginTest() {
-        Map emptyMap = new HashMap<String, String>();
-        Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
+        Map<String, Object> map = new HashMap<>();
         map.put(Config.NIMBUS_AUTO_CRED_PLUGINS, 
                 Arrays.asList(new String[]{"org.apache.storm.security.auth.AuthUtilsTestMock"}));
 
-        Assert.assertTrue(AuthUtils.getNimbusAutoCredPlugins(emptyMap).isEmpty());
+        Assert.assertTrue(AuthUtils.getNimbusAutoCredPlugins(Collections.emptyMap()).isEmpty());
         Assert.assertEquals(AuthUtils.getNimbusAutoCredPlugins(map).size(), 1);
     }
 
     @Test
     public void GetCredentialRenewersTest() {
-        Map emptyMap = new HashMap<String, String>();
-        Map<String, Collection<String>> map = new HashMap<String, Collection<String>>();
+        Map<String, Object> map = new HashMap<>();
         map.put(Config.NIMBUS_CREDENTIAL_RENEWERS, 
                 Arrays.asList(new String[]{"org.apache.storm.security.auth.AuthUtilsTestMock"}));
 
-        Assert.assertTrue(AuthUtils.GetCredentialRenewers(emptyMap).isEmpty());
+        Assert.assertTrue(AuthUtils.GetCredentialRenewers(Collections.emptyMap()).isEmpty());
         Assert.assertEquals(AuthUtils.GetCredentialRenewers(map).size(), 1);
     }
 
@@ -175,7 +172,7 @@ public class AuthUtilsTest {
 
     @Test(expected = RuntimeException.class)
     public void invalidConfigResultsInIOException() throws RuntimeException {
-        HashMap<String, String> conf = new HashMap<String, String>();
+        HashMap<String, Object> conf = new HashMap<>();
         conf.put("java.security.auth.login.config", "__FAKE_FILE__");
         Assert.assertNotNull(AuthUtils.GetConfiguration(conf));
     }
@@ -188,14 +185,14 @@ public class AuthUtilsTest {
     @Test
     public void validConfigResultsInNotNullConfigurationTest() throws IOException {
         File file1 = folder.newFile("mockfile.txt");
-        HashMap<String, String> conf = new HashMap<String, String>();
+        HashMap<String, Object> conf = new HashMap<>();
         conf.put("java.security.auth.login.config", file1.getAbsolutePath());
         Assert.assertNotNull(AuthUtils.GetConfiguration(conf));
     }
 
     @Test
     public void uiHttpCredentialsPluginTest(){
-        Map conf = new HashMap<String, String>();
+        Map<String, Object> conf = new HashMap<>();
         conf.put(
             Config.UI_HTTP_CREDS_PLUGIN, 
             "org.apache.storm.security.auth.AuthUtilsTestMock");

--- a/storm-client/test/jvm/org/apache/storm/security/auth/AuthUtilsTestMock.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/AuthUtilsTestMock.java
@@ -40,43 +40,54 @@ public class AuthUtilsTestMock implements IAutoCredentials,
     // INimbusCredentialPlugin 
     // IPrincipalToLocal 
     // IGroupMappingServiceProvider 
+    @Override
     public void prepare(Map conf) {}
 
     // IHttpCredentialsPlugin
+    @Override
     public ReqContext populateContext(ReqContext ctx, HttpServletRequest req) {
         return null;
     }
 
     // IHttpCredentialsPlugin
+    @Override
     public String getUserName(HttpServletRequest req){
         return null;
     }
 
     // IPrincipalToLocal 
+    @Override
     public String toLocal(Principal principal) {
         return null;
     }
 
     // IGroupMappingServiceProvider 
+    @Override
     public Set<String> getGroups(String user) throws IOException {
         return null;
     }
 
     // ICredentialsRenewer
+    @Override
     public void renew(Map<String, String> credentials, Map topologyConf) {}
 
     // IAutoCredentials
-    public void updateSubject(Subject subject, Map<String,String> conf) {}
+    @Override
+    public void updateSubject(Subject subject, Map<String,String> creds) {}
 
     // IAutoCredentials
-    public void populateSubject(Subject subject, Map<String,String> conf) {}
+    @Override
+    public void populateSubject(Subject subject, Map<String,String> creds) {}
 
     // IAutoCredentials
-    public void populateCredentials(Map<String,String> conf) {}
+    @Override
+    public void populateCredentials(Map<String,String> creds) {}
 
     // INimbusCredentialPlugin
+    @Override
     public void populateCredentials(Map<String,String> credentials, Map conf) {}
 
     // Shutdownable via INimbusCredentailPlugin
+    @Override
     public void shutdown() {}
 }

--- a/storm-server/src/main/java/org/apache/storm/daemon/drpc/DRPC.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/drpc/DRPC.java
@@ -76,7 +76,7 @@ public class DRPC implements AutoCloseable {
             ThriftAccessLogger.logAccessFunction(reqContext.requestID(), reqContext.remoteAddress(), reqContext.principal(), operation, function);
         }
         if (auth != null) {
-            Map<String, String> map = new HashMap<>();
+            Map<String, Object> map = new HashMap<>();
             map.put(DRPCAuthorizerBase.FUNCTION_NAME, function);
             if (!auth.permit(reqContext, operation, map)) {
                 Principal principal = reqContext.principal();

--- a/transform.sh
+++ b/transform.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+find . -iname \*.java | xargs sed -i .back \
+  -e 's/stormConf/topoConf/g' \
+  -e 's/storm_conf/topoConf/g' \
+  -e 's/topology_conf/topoConf/g' \
+  -e 's/Map topoConf/Map<String, Object> topoConf/g' \
+  -e 's/Map topologyConf/Map<String, Object> topologyConf/g' \
+  -e 's/Map conf/Map<String, Object> conf/g' \
+  -e 's/Map<String, *String> topoConf/Map<String, Object> topoConf/g' \
+  -e 's/Map<String, *String> conf/Map<String, Object> conf/g' \
+  -e 's/Map<String, *?> topoConf/Map<String, Object> topoConf/g' \
+  -e 's/Map<String, *?> conf/Map<String, Object> conf/g' \
+  -e 's/Map<Object, *Object> conf/Map<String, Object> conf/g' \
+  -e 's/conf = new HashMap<String, *String>/conf = new HashMap<>/g'
+find . -iname \*.java.back | xargs rm -f


### PR DESCRIPTION
Because this touches so much of the code to avoid having to constantly upmerge I have a script that will transform most of the code automatically. transform.sh . I don't plan on checking it in.  If everyone is OK with the change I will run the script and just check those changes in.  The other changes and small updates to make the result of running the script not produce compile errors.  Overall this drops more than 800 warnings from the code base (according to eclipse).