### PR TITLE
STORM-2478: Fix BlobStoreTest.testDeleteAfterFailedCreate on Windows

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/blobstore/FileBlobStoreImpl.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/FileBlobStoreImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.blobstore;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -182,7 +183,8 @@ public class FileBlobStoreImpl {
         delete(keyDir);
     }
 
-    private File getKeyDir(String key) {
+    @VisibleForTesting
+    File getKeyDir(String key) {
         String hash = String.valueOf(Math.abs((long)key.hashCode()) % BUCKETS);
         File ret = new File(new File(fullPath, hash), key);
         LOG.debug("{} Looking for {} in {}", new Object[]{fullPath, key, hash});
@@ -240,7 +242,7 @@ public class FileBlobStoreImpl {
     }
 
     protected void delete(File path) throws IOException {
-        if (Files.exists(path.toPath())){
+        if (Files.exists(path.toPath())) {
 
             Files.walkFileTree(path.toPath(), new SimpleFileVisitor<Path>() {
 

--- a/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStore.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStore.java
@@ -47,6 +47,8 @@ import static org.apache.storm.blobstore.BlobStoreAclHandler.ADMIN;
 import static org.apache.storm.blobstore.BlobStoreAclHandler.READ;
 import static org.apache.storm.blobstore.BlobStoreAclHandler.WRITE;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * Provides a local file system backed blob store implementation for Nimbus.
  *
@@ -346,5 +348,10 @@ public class LocalFsBlobStore extends BlobStore {
 
     public void fullCleanup(long age) throws IOException {
         fbs.fullCleanup(age);
+    }
+    
+    @VisibleForTesting
+    File getKeyDataDir(String key) {
+        return fbs.getKeyDir(DATA_PREFIX + key);
     }
 }

--- a/storm-server/src/test/java/org/apache/storm/blobstore/BlobStoreTest.java
+++ b/storm-server/src/test/java/org/apache/storm/blobstore/BlobStoreTest.java
@@ -53,6 +53,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 
+import java.nio.file.Files;
+
 public class BlobStoreTest {
   private static final Logger LOG = LoggerFactory.getLogger(BlobStoreTest.class);
   URI base;
@@ -170,14 +172,18 @@ public class BlobStoreTest {
 
   @Test
   public void testDeleteAfterFailedCreate() throws Exception{
+    //Check that a blob can be deleted when a temporary file exists in the blob directory
     LocalFsBlobStore store = initLocalFs();
 
+    String key = "test";
     SettableBlobMeta metadata = new SettableBlobMeta(BlobStoreAclHandler
             .WORLD_EVERYTHING);
-    AtomicOutputStream out = store.createBlob("test", metadata, null);
-      out.write(1);
-
-
+    try(AtomicOutputStream out = store.createBlob(key, metadata, null)) {
+        out.write(1);
+        File blobDir = store.getKeyDataDir(key);
+        Files.createFile(blobDir.toPath().resolve("tempFile.tmp"));
+    }
+    
     store.deleteBlob("test",null);
 
   }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/STORM-2478

I couldn't think of a way to fix this test without exposing the getKeyDir method. When the AtomicOutputStream in BlobStoreTest L181 is closed, the temporary file is renamed to `data`, which is deleted explicitly when the blob store is deleted. This makes the test meaningless since it's checking that the blob store directory can be deleted when there are temporary files in it.