### PR TITLE
[STORM-2486] Prevent cd from printing target directory to avoid breaking classpath

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# STORM-2486: Prevent `cd` from printing the target directory.
+unset CDPATH
+
 # Resolve links - $0 may be a softlink
 PRG="${0}"
 


### PR DESCRIPTION
@harshach &/or @hmcl &/or @revans2 &/or @HeartSaVioR : can you please review this when you get a chance?  I spoke to Hugo and Harsha about this last week.  I put a bunch of details into [STORM-2486](https://issues.apache.org/jira/browse/STORM-2486).  This should also be backported into every active branch.