### PR TITLE
fix typo in storm-client pom file: kyro -> kryo

### DIFF
--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -141,7 +141,7 @@
             <artifactId>netty</artifactId>
         </dependency>
 
-        <!-- kyro -->
+        <!-- kryo -->
         <dependency>
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo</artifactId>


### PR DESCRIPTION
@revans2 : typo I found while poking around and trying to understand the shaded kryo jar, as per [our discussion in STORM-2191](https://issues.apache.org/jira/browse/STORM-2191?focusedCommentId=15984124&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15984124).