### PR TITLE
STORM-2503: Fix lgtm.com alerts on equality and comparison operations.

### DIFF
--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/TransactionalWords.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/TransactionalWords.java
@@ -125,7 +125,7 @@ public class TransactionalWords {
             for (String key : _counts.keySet()) {
                 CountValue val = COUNT_DATABASE.get(key);
                 CountValue newVal;
-                if (val == null || !val.txid.equals(_id)) {
+                if (val == null || !val.txid.equals(_id.getTransactionId())) {
                     newVal = new CountValue();
                     newVal.txid = _id.getTransactionId();
                     if (val != null) {

--- a/storm-client/src/jvm/org/apache/storm/container/cgroup/SubSystem.java
+++ b/storm-client/src/jvm/org/apache/storm/container/cgroup/SubSystem.java
@@ -68,6 +68,15 @@ public class SubSystem {
     public void setEnable(boolean enable) {
         this.enable = enable;
     }
+    
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + hierarchyID;
+        return result;
+    }
 
     @Override
     public boolean equals(Object object) {

--- a/storm-client/src/jvm/org/apache/storm/scheduler/SchedulerAssignmentImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/scheduler/SchedulerAssignmentImpl.java
@@ -51,6 +51,15 @@ public class SchedulerAssignmentImpl implements SchedulerAssignment {
     }
     
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((topologyId == null) ? 0 : topologyId.hashCode());
+        result = prime * result + ((executorToSlot == null) ? 0 : executorToSlot.hashCode());
+        return result;
+    }
+    
+    @Override
     public boolean equals(Object other) {
         if (other == this) return true;
         if (other instanceof SchedulerAssignmentImpl) {

--- a/storm-client/src/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/DefaultResourceAwareStrategy.java
+++ b/storm-client/src/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/DefaultResourceAwareStrategy.java
@@ -541,7 +541,7 @@ public class DefaultResourceAwareStrategy implements IStrategy {
                     connections2 += (componentMap.get(childId).execs.size() * o2.execs.size());
                 }
 
-                if (connections1 > connections1) {
+                if (connections1 > connections2) {
                     return -1;
                 } else if (connections1 < connections2) {
                     return 1;
@@ -567,9 +567,9 @@ public class DefaultResourceAwareStrategy implements IStrategy {
             public int compare(Component o1, Component o2) {
                 int connections1 = o1.execs.size() * thisComp.execs.size();
                 int connections2 = o2.execs.size() * thisComp.execs.size();
-                if (connections1 > connections2) {
+                if (connections1 < connections2) {
                     return -1;
-                } else if (connections1 < connections2) {
+                } else if (connections1 > connections2) {
                     return 1;
                 } else {
                     return o1.id.compareTo(o2.id);

--- a/storm-client/src/jvm/org/apache/storm/trident/windowing/StoreBasedTridentWindowManager.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/windowing/StoreBasedTridentWindowManager.java
@@ -121,7 +121,7 @@ public class StoreBasedTridentWindowManager extends AbstractTridentWindowManager
         }
         String trimKey = key.substring(0, lastSepIndex);
         int secondLastSepIndex = trimKey.lastIndexOf(WindowsStore.KEY_SEPARATOR);
-        if (lastSepIndex < 0) {
+        if (secondLastSepIndex < 0) {
             throw new IllegalArgumentException("key "+key+" does not have second key separator '" + WindowsStore.KEY_SEPARATOR + "'");
         }
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2159,14 +2159,14 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 synchronized(lock) {
                     Credentials origCreds = state.credentials(id, null);
                     if (origCreds != null) {
-                        Map<String, String> orig = origCreds.get_creds();
-                        Map<String, String> newCreds = new HashMap<>(orig);
+                        Map<String, String> origCredsMap = origCreds.get_creds();
+                        Map<String, String> newCredsMap = new HashMap<>(origCredsMap);
                         for (ICredentialsRenewer renewer: renewers) {
                             LOG.info("Renewing Creds For {} with {}", id, renewer);
-                            renewer.renew(newCreds, topoConf);
+                            renewer.renew(newCredsMap, topoConf);
                         }
-                        if (!newCreds.equals(origCreds)) {
-                            state.setCredentials(id, new Credentials(newCreds), topoConf);
+                        if (!newCredsMap.equals(origCredsMap)) {
+                            state.setCredentials(id, new Credentials(newCredsMap), topoConf);
                         }
                     }
                 }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
@@ -195,7 +195,7 @@ public class ReadClusterState implements Runnable, AutoCloseable {
             }
             if (version == null) {
                 // ignore
-            } else if (version == recordedVersion) {
+            } else if (version.equals(recordedVersion)) {
                 updateAssignmentVersion.put(topoId, locAssignment);
             } else {
                 VersionedData<Assignment> assignmentVersion = stormClusterState.assignmentInfoWithVersion(topoId, callback);

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -26,6 +26,7 @@ import org.apache.storm.scheduler.Cluster;
 import org.apache.storm.scheduler.ExecutorDetails;
 import org.apache.storm.scheduler.INimbus;
 import org.apache.storm.scheduler.SchedulerAssignmentImpl;
+import org.apache.storm.scheduler.SchedulerAssignment;
 import org.apache.storm.scheduler.SupervisorDetails;
 import org.apache.storm.scheduler.Topologies;
 import org.apache.storm.scheduler.TopologyDetails;
@@ -48,13 +49,13 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
-
 
 public class TestDefaultResourceAwareStrategy {
 
@@ -112,55 +113,23 @@ public class TestDefaultResourceAwareStrategy {
         rs.prepare(conf);
         rs.schedule(topologies, cluster);
 
-        Map<String, List<String>> nodeToComps = new HashMap<String, List<String>>();
-        for (Map.Entry<ExecutorDetails, WorkerSlot> entry : cluster.getAssignments().get("testTopology-id").getExecutorToSlot().entrySet()) {
-            WorkerSlot ws = entry.getValue();
-            ExecutorDetails exec = entry.getKey();
-            if (!nodeToComps.containsKey(ws.getNodeId())) {
-                nodeToComps.put(ws.getNodeId(), new LinkedList<String>());
-            }
-            nodeToComps.get(ws.getNodeId()).add(topo.getExecutorToComponent().get(exec));
+        HashSet<HashSet<ExecutorDetails>> expectedScheduling = new HashSet<>();
+        expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(0, 0)))); //Spout
+        expectedScheduling.add(new HashSet<>(Arrays.asList(
+            new ExecutorDetails(2, 2), //bolt-1
+            new ExecutorDetails(4, 4), //bolt-2
+            new ExecutorDetails(6, 6)))); //bolt-3
+        expectedScheduling.add(new HashSet<>(Arrays.asList(
+            new ExecutorDetails(1, 1), //bolt-1
+            new ExecutorDetails(3, 3), //bolt-2
+            new ExecutorDetails(5, 5)))); //bolt-3
+        HashSet<HashSet<ExecutorDetails>> foundScheduling = new HashSet<>();
+        SchedulerAssignment assignment = cluster.getAssignmentById("testTopology-id");
+        for (Collection<ExecutorDetails> execs : assignment.getSlotToExecutors().values()) {
+            foundScheduling.add(new HashSet<>(execs));
         }
 
-        /**
-         * check for correct scheduling
-         * Since all the resource availabilites on nodes are the same in the beginining
-         * DefaultResourceAwareStrategy can arbitrarily pick one thus we must find if a particular scheduling
-         * exists on a node the the cluster.
-         */
-
-        //one node should have the below scheduling
-        List<String> node1 = new LinkedList<>();
-        node1.add("spout");
-        node1.add("bolt-1");
-        node1.add("bolt-2");
-        Assert.assertTrue("Check DefaultResourceAwareStrategy scheduling", checkDefaultStrategyScheduling(nodeToComps, node1));
-
-        //one node should have the below scheduling
-        List<String> node2 = new LinkedList<>();
-        node2.add("bolt-3");
-        node2.add("bolt-1");
-        node2.add("bolt-2");
-
-        Assert.assertTrue("Check DefaultResourceAwareStrategy scheduling", checkDefaultStrategyScheduling(nodeToComps, node2));
-
-        //one node should have the below scheduling
-        List<String> node3 = new LinkedList<>();
-        node3.add("bolt-3");
-
-        Assert.assertTrue("Check DefaultResourceAwareStrategy scheduling", checkDefaultStrategyScheduling(nodeToComps, node3));
-
-        //three used and one node should be empty
-        Assert.assertEquals("only three nodes should be used", 3, nodeToComps.size());
-    }
-
-    private boolean checkDefaultStrategyScheduling(Map<String, List<String>> nodeToComps, List<String> schedulingToFind) {
-        for (List<String> entry : nodeToComps.values()) {
-            if (schedulingToFind.containsAll(entry) && entry.containsAll(schedulingToFind)) {
-                return true;
-            }
-        }
-        return false;
+        Assert.assertEquals(expectedScheduling, foundScheduling);
     }
 
     /**


### PR DESCRIPTION
This PR addresses STORM-2503, by fixing a number of alerts found by lgtm.com at https://lgtm.com/projects/g/apache/storm/alerts/ that indicate genuine bugs in comparison operations in the Storm code.

These rules are:
- Equals on incomparable types (due to typos, fixed here)
- Hashed value without hashCode definition
- Inconsistent equals and hashCode (together with the previous item, this indicates some missing hashCode implementations, which have been added here)
- Comparison of identical values (indicating a comparator logic typo in `DefaultResourceAwareStrategy`, which is fixed here along with a fix to the overall comparator logic, to consider components with fewer connections as being smaller)
- Useless comparison test (indicating a variable name typo, which is fixed here)
- Suspicious reference equality test of boxed types (indicating a spurious use of `==`, replaced here by `equals`, on boxed types)

lgtm.com also provides PR integration, in case it would be useful to catch such alerts directly from incoming PRs.