### PR TITLE
STORM-2496 Dependency artifacts should be uploaded to blobstore with …

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/dependency/DependencyUploader.java
+++ b/storm-client/src/jvm/org/apache/storm/dependency/DependencyUploader.java
@@ -19,8 +19,10 @@ package org.apache.storm.dependency;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.storm.blobstore.AtomicOutputStream;
+import org.apache.storm.blobstore.BlobStoreAclHandler;
 import org.apache.storm.blobstore.ClientBlobStore;
 import org.apache.storm.generated.AccessControl;
+import org.apache.storm.generated.AccessControlType;
 import org.apache.storm.generated.AuthorizationException;
 import org.apache.storm.generated.KeyAlreadyExistsException;
 import org.apache.storm.generated.KeyNotFoundException;
@@ -145,9 +147,14 @@ public class DependencyUploader {
             // as a workaround, we call getBlobMeta() for all keys
             getBlobStore().getBlobMeta(key);
         } catch (KeyNotFoundException e) {
-            // TODO: do we want to add ACL here?
-            AtomicOutputStream blob = getBlobStore()
-                    .createBlob(key, new SettableBlobMeta(new ArrayList<AccessControl>()));
+            // set acl to below so that it can be shared by other users as well, but allows only read
+            List<AccessControl> acls = new ArrayList<>();
+            acls.add(new AccessControl(AccessControlType.USER,
+                    BlobStoreAclHandler.READ | BlobStoreAclHandler.WRITE | BlobStoreAclHandler.ADMIN));
+            acls.add(new AccessControl(AccessControlType.OTHER,
+                    BlobStoreAclHandler.READ));
+
+            AtomicOutputStream blob = getBlobStore().createBlob(key, new SettableBlobMeta(acls));
             Files.copy(dependency.toPath(), blob);
             blob.close();
 

--- a/storm-client/test/jvm/org/apache/storm/dependency/DependencyUploaderTest.java
+++ b/storm-client/test/jvm/org/apache/storm/dependency/DependencyUploaderTest.java
@@ -20,13 +20,17 @@ package org.apache.storm.dependency;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.apache.storm.blobstore.AtomicOutputStream;
+import org.apache.storm.blobstore.BlobStoreAclHandler;
 import org.apache.storm.blobstore.ClientBlobStore;
+import org.apache.storm.generated.AccessControl;
+import org.apache.storm.generated.AccessControlType;
 import org.apache.storm.generated.KeyNotFoundException;
 import org.apache.storm.generated.ReadableBlobMeta;
 import org.apache.storm.generated.SettableBlobMeta;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -170,6 +174,16 @@ public class DependencyUploaderTest {
 
         assertTrue(counter.get() > 0);
         verify(mockOutputStream).close();
+
+        ArgumentCaptor<SettableBlobMeta> blobMetaArgumentCaptor = ArgumentCaptor.forClass(SettableBlobMeta.class);
+        verify(mockBlobStore).createBlob(anyString(), blobMetaArgumentCaptor.capture());
+
+        SettableBlobMeta actualBlobMeta = blobMetaArgumentCaptor.getValue();
+        List<AccessControl> actualAcls = actualBlobMeta.get_acl();
+        assertTrue(actualAcls.contains(new AccessControl(AccessControlType.USER,
+                BlobStoreAclHandler.READ | BlobStoreAclHandler.WRITE | BlobStoreAclHandler.ADMIN)));
+        assertTrue(actualAcls.contains(new AccessControl(AccessControlType.OTHER,
+                BlobStoreAclHandler.READ)));
     }
 
     @Test(expected = FileNotAvailableException.class)


### PR DESCRIPTION
…READ permission for all

* When uploading dependencies, set ACL properly so that it can be shared to other users as well
  * but allows only READ so that it can't be deleted from others

This is needed for Supervisor with secured cluster, since dependency artifacts are uploaded once and shared for all topologies.