### PR TITLE
STORM-2508:storm-solr enhancement: update solrj to 5.5, support custom SolrClientFactory and commit operation

### DIFF
--- a/external/storm-solr/pom.xml
+++ b/external/storm-solr/pom.xml
@@ -32,7 +32,7 @@
         <id>hmcl</id>
         <name>Hugo Louro</name>
         <email>hmclouro@gmail.com</email>
-    </developer>
+        </developer>
     </developers>
 
     <dependencies>
@@ -46,13 +46,13 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>5.2.1</version>
+            <version>5.5.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.3</version>
+            <version>1.4</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>
@@ -67,13 +67,13 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
-            <version>5.2.1</version>
+            <version>5.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-test-framework</artifactId>
-            <version>5.2.1</version>
+            <version>5.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/external/storm-solr/src/main/java/org/apache/storm/solr/client/DefaultSolrClientFactory.java
+++ b/external/storm-solr/src/main/java/org/apache/storm/solr/client/DefaultSolrClientFactory.java
@@ -1,0 +1,30 @@
+/*
+ * DefaultCloudSolrClientFactory.java
+ * Copyright 2017 Qunhe Tech, all rights reserved.
+ * Qunhe PROPRIETARY/CONFIDENTIAL, any form of usage is subject to approval.
+ */
+
+package org.apache.storm.solr.client;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+
+/**
+ * default implementation of {@link SolrClientFactory}, which takes a zookeeper host
+ * and produce {@link org.apache.solr.client.solrj.impl.CloudSolrClient} with the host.
+ *
+ * @author alei
+ */
+public class DefaultSolrClientFactory implements SolrClientFactory {
+
+    private String zkHostString;
+
+    public DefaultSolrClientFactory(String zkHostString) {
+        this.zkHostString = zkHostString;
+    }
+
+    @Override
+    public SolrClient getSolrClient() {
+        return new CloudSolrClient(zkHostString);
+    }
+}

--- a/external/storm-solr/src/main/java/org/apache/storm/solr/client/SolrClientFactory.java
+++ b/external/storm-solr/src/main/java/org/apache/storm/solr/client/SolrClientFactory.java
@@ -1,0 +1,21 @@
+/*
+ * SerializableSolrClientFactory.java
+ * Copyright 2017 Qunhe Tech, all rights reserved.
+ * Qunhe PROPRIETARY/CONFIDENTIAL, any form of usage is subject to approval.
+ */
+
+package org.apache.storm.solr.client;
+
+import org.apache.solr.client.solrj.SolrClient;
+
+import java.io.Serializable;
+
+/**
+ * this interface provide SolrClient for {@link org.apache.storm.solr.mapper.SolrMapper}
+ *
+ * @author alei
+ */
+public interface SolrClientFactory extends Serializable {
+
+    SolrClient getSolrClient();
+}

--- a/external/storm-solr/src/main/java/org/apache/storm/solr/config/CommitCallback.java
+++ b/external/storm-solr/src/main/java/org/apache/storm/solr/config/CommitCallback.java
@@ -1,0 +1,23 @@
+/*
+ * OnCommit.java
+ * Copyright 2017 Qunhe Tech, all rights reserved.
+ * Qunhe PROPRIETARY/CONFIDENTIAL, any form of usage is subject to approval.
+ */
+
+package org.apache.storm.solr.config;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * This callback interface is invoked on {@link SolrCommitStrategy} triggers or tick. Typically fire
+ * a "commit" request to solr, you can customize commit details by implementing this interface.
+ * @author alei
+ */
+public interface CommitCallback extends Serializable {
+
+    void process(SolrClient solrClient, String collection) throws SolrServerException, IOException;
+}

--- a/external/storm-solr/src/main/java/org/apache/storm/solr/config/DefaultCommitCallback.java
+++ b/external/storm-solr/src/main/java/org/apache/storm/solr/config/DefaultCommitCallback.java
@@ -1,0 +1,23 @@
+/*
+ * DefaultCommitOperation.java
+ * Copyright 2017 Qunhe Tech, all rights reserved.
+ * Qunhe PROPRIETARY/CONFIDENTIAL, any form of usage is subject to approval.
+ */
+
+package org.apache.storm.solr.config;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+
+import java.io.IOException;
+
+/**
+ * @author alei
+ */
+public class DefaultCommitCallback implements CommitCallback {
+
+    @Override
+    public void process(final SolrClient solrClient, final String collection) throws SolrServerException, IOException {
+        solrClient.commit(collection);
+    }
+}

--- a/external/storm-solr/src/main/java/org/apache/storm/solr/config/SolrConfig.java
+++ b/external/storm-solr/src/main/java/org/apache/storm/solr/config/SolrConfig.java
@@ -19,6 +19,8 @@
 package org.apache.storm.solr.config;
 
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.storm.solr.client.DefaultSolrClientFactory;
+import org.apache.storm.solr.client.SolrClientFactory;
 
 import java.io.Serializable;
 
@@ -27,8 +29,13 @@ import java.io.Serializable;
  * the bolts should be put in this class.
  */
 public class SolrConfig implements Serializable {
-    private final String zkHostString;
+
     private final int tickTupleInterval;
+
+    private final SolrClientFactory solrClientFactory;
+
+    private final CommitCallback commitCallback;
+
 
     /**
      * @param zkHostString Zookeeper host string as defined in the {@link CloudSolrClient} constructor
@@ -42,16 +49,35 @@ public class SolrConfig implements Serializable {
      * @param tickTupleInterval interval for tick tuples
      * */
     public SolrConfig(String zkHostString, int tickTupleInterval) {
-        this.zkHostString = zkHostString;
-        this.tickTupleInterval = tickTupleInterval;
+        this(new DefaultSolrClientFactory(zkHostString), tickTupleInterval);
     }
 
-    public String getZkHostString() {
-        return zkHostString;
+    /**
+     * @param solrClientFactory factory that provide solrClient
+     * @param tickTupleInterval interval for tick tuples
+     * */
+    public SolrConfig(SolrClientFactory solrClientFactory, int tickTupleInterval) {
+        this(solrClientFactory, tickTupleInterval, new DefaultCommitCallback());
+    }
+
+    public SolrConfig(SolrClientFactory solrClientFactory,
+                      int tickTupleInterval,
+                      CommitCallback commitCallback) {
+        this.solrClientFactory = solrClientFactory;
+        this.tickTupleInterval = tickTupleInterval;
+        this.commitCallback = commitCallback;
+    }
+
+    public SolrClientFactory getSolrClientFactory() {
+        return solrClientFactory;
     }
 
     public int getTickTupleInterval() {
         return tickTupleInterval;
+    }
+
+    public CommitCallback getCommitCallback() {
+        return commitCallback;
     }
 
 }

--- a/external/storm-solr/src/main/java/org/apache/storm/solr/schema/builder/SolrClientSchemaBuilder.java
+++ b/external/storm-solr/src/main/java/org/apache/storm/solr/schema/builder/SolrClientSchemaBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * SolrClientSchemaBuilder.java
+ * Copyright 2017 Qunhe Tech, all rights reserved.
+ * Qunhe PROPRIETARY/CONFIDENTIAL, any form of usage is subject to approval.
+ */
+
+package org.apache.storm.solr.schema.builder;
+
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.schema.FieldTypeDefinition;
+import org.apache.solr.client.solrj.request.schema.SchemaRequest;
+import org.apache.solr.client.solrj.response.schema.SchemaRepresentation;
+import org.apache.solr.client.solrj.response.schema.SchemaResponse;
+import org.apache.storm.solr.client.SolrClientFactory;
+import org.apache.storm.solr.schema.CopyField;
+import org.apache.storm.solr.schema.FieldType;
+import org.apache.storm.solr.schema.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>this Class build the {@link Schema} by Solr Schema API.</p>
+ *
+ * @see <a href="https://cwiki.apache.org/confluence/display/solr/Schema+API">Solr Schema API</a>
+ * @author alei
+ */
+public class SolrClientSchemaBuilder implements SchemaBuilder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SolrClientSchemaBuilder.class);
+
+    private Schema schema;
+
+    public SolrClientSchemaBuilder(String collection, SolrClientFactory factory) throws IOException, SolrServerException {
+        SchemaRequest request = new SchemaRequest();
+        SchemaResponse response = request.process(factory.getSolrClient(), collection);
+        SchemaRepresentation representation = response.getSchemaRepresentation();
+        schema = convert(representation);
+    }
+
+    @Override
+    public Schema getSchema() {
+        return schema;
+    }
+
+    private Schema convert(final SchemaRepresentation representation) {
+        Schema converted = new Schema();
+        converted.setUniqueKey(representation.getUniqueKey());
+        converted.setName(representation.getName());
+        converted.setVersion(String.valueOf(representation.getVersion()));
+        List<FieldType> fieldTypeList = new ArrayList<>(representation.getFieldTypes().size());
+        for (FieldTypeDefinition type : representation.getFieldTypes()) {
+            FieldType fieldType = new FieldType();
+            fieldType.setClazz(type.getAttributes().get("class").toString());
+            if (type.getAttributes().get("multiValued") != null) {
+                fieldType.setMultiValued(Boolean.valueOf(type.getAttributes().get("multiValued").toString()));
+            }
+            fieldType.setName(type.getAttributes().get("name").toString());
+            fieldTypeList.add(fieldType);
+        }
+        converted.setFieldTypes(fieldTypeList);
+        List<org.apache.storm.solr.schema.Field> fieldList =
+                new ArrayList<>(representation.getFields().size());
+        for (Map<String, Object> field : representation.getFields()) {
+            org.apache.storm.solr.schema.Field schemaField = new org.apache.storm.solr.schema.Field();
+            schemaField.setName(field.get("name").toString());
+            schemaField.setType(field.get("type").toString());
+            fieldList.add(schemaField);
+        }
+        converted.setFields(fieldList);
+        List<org.apache.storm.solr.schema.Field> dynamicFieldList =
+                new ArrayList<>(representation.getDynamicFields().size());
+        for (Map<String, Object> field : representation.getDynamicFields()) {
+            org.apache.storm.solr.schema.Field schemaField = new org.apache.storm.solr.schema.Field();
+            schemaField.setName(field.get("name").toString());
+            schemaField.setType(field.get("type").toString());
+            dynamicFieldList.add(schemaField);
+        }
+        converted.setDynamicFields(dynamicFieldList);
+        List<CopyField> copyFieldList = new ArrayList<>(representation.getCopyFields().size());
+        for (Map<String, Object> field : representation.getDynamicFields()) {
+            CopyField copyField = new CopyField();
+            copyField.setDest(field.get("dest").toString());
+            copyField.setSource(field.get("source").toString());
+            copyFieldList.add(copyField);
+        }
+        converted.setCopyFields(copyFieldList);
+        return converted;
+    }
+    
+}

--- a/external/storm-solr/src/main/java/org/apache/storm/solr/trident/SolrState.java
+++ b/external/storm-solr/src/main/java/org/apache/storm/solr/trident/SolrState.java
@@ -18,16 +18,15 @@
 
 package org.apache.storm.solr.trident;
 
-import org.apache.storm.topology.FailedException;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
-import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.storm.solr.config.SolrConfig;
 import org.apache.storm.solr.mapper.SolrMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.storm.topology.FailedException;
 import org.apache.storm.trident.state.State;
 import org.apache.storm.trident.tuple.TridentTuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -44,7 +43,7 @@ public class SolrState implements State {
     }
 
     protected void prepare() {
-        solrClient = new CloudSolrClient(solrConfig.getZkHostString());
+        solrClient = solrConfig.getSolrClientFactory().getSolrClient();
     }
 
     @Override


### PR DESCRIPTION
I have a case that the SolrCloud in my organization is protected by SSL + Basic Auth, so I need to provide customized SolrClient instance to SolrUpdateBolt. Likewise, the RestJsonSchemaBuilder cannot access Schema API without auth.
In addition, for "near real-time search", soft commit is preferred, so it is better to expose an interface for user to customize commit operation.
I think those features will also be useful for other people who needs to use custom SolrClient implementation and control the detail of commit operation. So, finally, I plan an enhancement for storm-solr:
1. update solrj and related dependencies to 5.5;
2. improve SolrConfig to support custom SolrClientFactory and CommitCallBack;
3. provide a SchemaBuilder implementation which use custom SolrClient to request Schema API;
4. elder SolrUpdateBolts intend to commit when recieve a tick, but by default BaseTickTupleAwareRichBolt will ignore tick, this PR also fix it.   