### PR TITLE
[STORM-2510] update checkstyle configuration to lower violations

### DIFF
--- a/examples/storm-elasticsearch-examples/pom.xml
+++ b/examples/storm-elasticsearch-examples/pom.xml
@@ -98,7 +98,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>235</maxAllowedViolations>
+                    <maxAllowedViolations>20</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-hbase-examples/pom.xml
+++ b/examples/storm-hbase-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>57</maxAllowedViolations>
+                    <maxAllowedViolations>55</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-hbase-examples/pom.xml
+++ b/examples/storm-hbase-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>324</maxAllowedViolations>
+                    <maxAllowedViolations>57</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-hdfs-examples/pom.xml
+++ b/examples/storm-hdfs-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>230</maxAllowedViolations>
+                    <maxAllowedViolations>224</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-hdfs-examples/pom.xml
+++ b/examples/storm-hdfs-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>557</maxAllowedViolations>
+                    <maxAllowedViolations>230</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-hive-examples/pom.xml
+++ b/examples/storm-hive-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>543</maxAllowedViolations>
+                    <maxAllowedViolations>68</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-hive-examples/pom.xml
+++ b/examples/storm-hive-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>68</maxAllowedViolations>
+                    <maxAllowedViolations>67</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-jdbc-examples/pom.xml
+++ b/examples/storm-jdbc-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>40</maxAllowedViolations>
+                    <maxAllowedViolations>36</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-jdbc-examples/pom.xml
+++ b/examples/storm-jdbc-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>188</maxAllowedViolations>
+                    <maxAllowedViolations>40</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-jms-examples/pom.xml
+++ b/examples/storm-jms-examples/pom.xml
@@ -117,7 +117,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>79</maxAllowedViolations>
+                    <maxAllowedViolations>78</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-jms-examples/pom.xml
+++ b/examples/storm-jms-examples/pom.xml
@@ -117,7 +117,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>197</maxAllowedViolations>
+                    <maxAllowedViolations>79</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-kafka-client-examples/pom.xml
+++ b/examples/storm-kafka-client-examples/pom.xml
@@ -136,7 +136,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>67</maxAllowedViolations>
+                    <maxAllowedViolations>6</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-kafka-client-examples/pom.xml
+++ b/examples/storm-kafka-client-examples/pom.xml
@@ -136,7 +136,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>6</maxAllowedViolations>
+                    <maxAllowedViolations>2</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-kafka-examples/pom.xml
+++ b/examples/storm-kafka-examples/pom.xml
@@ -107,7 +107,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>29</maxAllowedViolations>
+                    <maxAllowedViolations>26</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-kafka-examples/pom.xml
+++ b/examples/storm-kafka-examples/pom.xml
@@ -107,7 +107,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>190</maxAllowedViolations>
+                    <maxAllowedViolations>29</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-mongodb-examples/pom.xml
+++ b/examples/storm-mongodb-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>349</maxAllowedViolations>
+                    <maxAllowedViolations>38</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-mqtt-examples/pom.xml
+++ b/examples/storm-mqtt-examples/pom.xml
@@ -128,7 +128,7 @@
             <artifactId>maven-checkstyle-plugin</artifactId>
             <!--Note - the version would be inherited-->
             <configuration>
-                <maxAllowedViolations>82</maxAllowedViolations>
+                <maxAllowedViolations>16</maxAllowedViolations>
             </configuration>
         </plugin>
     </plugins>

--- a/examples/storm-opentsdb-examples/pom.xml
+++ b/examples/storm-opentsdb-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>147</maxAllowedViolations>
+                    <maxAllowedViolations>22</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-opentsdb-examples/pom.xml
+++ b/examples/storm-opentsdb-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>22</maxAllowedViolations>
+                    <maxAllowedViolations>18</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-perf/pom.xml
+++ b/examples/storm-perf/pom.xml
@@ -81,7 +81,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1179</maxAllowedViolations>
+                    <maxAllowedViolations>211</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-perf/pom.xml
+++ b/examples/storm-perf/pom.xml
@@ -81,7 +81,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>211</maxAllowedViolations>
+                    <maxAllowedViolations>207</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-pmml-examples/pom.xml
+++ b/examples/storm-pmml-examples/pom.xml
@@ -79,7 +79,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>19</maxAllowedViolations>
+                    <maxAllowedViolations>17</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-pmml-examples/pom.xml
+++ b/examples/storm-pmml-examples/pom.xml
@@ -79,7 +79,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>232</maxAllowedViolations>
+                    <maxAllowedViolations>19</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-redis-examples/pom.xml
+++ b/examples/storm-redis-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>650</maxAllowedViolations>
+                    <maxAllowedViolations>54</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-rocketmq-examples/pom.xml
+++ b/examples/storm-rocketmq-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>143</maxAllowedViolations>
+                    <maxAllowedViolations>23</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-solr-examples/pom.xml
+++ b/examples/storm-solr-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>267</maxAllowedViolations>
+                    <maxAllowedViolations>48</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-solr-examples/pom.xml
+++ b/examples/storm-solr-examples/pom.xml
@@ -89,7 +89,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>48</maxAllowedViolations>
+                    <maxAllowedViolations>47</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -251,7 +251,7 @@
             <artifactId>maven-checkstyle-plugin</artifactId>
             <!--Note - the version would be inherited-->
             <configuration>
-                <maxAllowedViolations>3064</maxAllowedViolations>
+                <maxAllowedViolations>1576</maxAllowedViolations>
             </configuration>
         </plugin>
     </plugins>

--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -251,7 +251,7 @@
             <artifactId>maven-checkstyle-plugin</artifactId>
             <!--Note - the version would be inherited-->
             <configuration>
-                <maxAllowedViolations>1576</maxAllowedViolations>
+                <maxAllowedViolations>1538</maxAllowedViolations>
             </configuration>
         </plugin>
     </plugins>

--- a/external/storm-cassandra/pom.xml
+++ b/external/storm-cassandra/pom.xml
@@ -124,7 +124,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>603</maxAllowedViolations>
+                    <maxAllowedViolations>577</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-cassandra/pom.xml
+++ b/external/storm-cassandra/pom.xml
@@ -124,7 +124,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>2764</maxAllowedViolations>
+                    <maxAllowedViolations>603</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-druid/pom.xml
+++ b/external/storm-druid/pom.xml
@@ -103,7 +103,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>193</maxAllowedViolations>
+                    <maxAllowedViolations>31</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-druid/pom.xml
+++ b/external/storm-druid/pom.xml
@@ -103,7 +103,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>31</maxAllowedViolations>
+                    <maxAllowedViolations>29</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-elasticsearch/pom.xml
+++ b/external/storm-elasticsearch/pom.xml
@@ -148,7 +148,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>70</maxAllowedViolations>
+                    <maxAllowedViolations>64</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-elasticsearch/pom.xml
+++ b/external/storm-elasticsearch/pom.xml
@@ -148,7 +148,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>792</maxAllowedViolations>
+                    <maxAllowedViolations>70</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-eventhubs/pom.xml
+++ b/external/storm-eventhubs/pom.xml
@@ -53,7 +53,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1156</maxAllowedViolations>
+                    <maxAllowedViolations>1768</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-eventhubs/pom.xml
+++ b/external/storm-eventhubs/pom.xml
@@ -53,7 +53,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1768</maxAllowedViolations>
+                    <maxAllowedViolations>1764</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-hbase/pom.xml
+++ b/external/storm-hbase/pom.xml
@@ -106,7 +106,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>372</maxAllowedViolations>
+                    <maxAllowedViolations>370</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-hbase/pom.xml
+++ b/external/storm-hbase/pom.xml
@@ -106,7 +106,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1572</maxAllowedViolations>
+                    <maxAllowedViolations>372</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -256,7 +256,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>3370</maxAllowedViolations>
+                    <maxAllowedViolations>2242</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -256,7 +256,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>2242</maxAllowedViolations>
+                    <maxAllowedViolations>2220</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -188,7 +188,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <!--Note - the version would be inherited-->
         <configuration>
-          <maxAllowedViolations>1350</maxAllowedViolations>
+          <maxAllowedViolations>262</maxAllowedViolations>
         </configuration>
       </plugin>
     </plugins>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -188,7 +188,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <!--Note - the version would be inherited-->
         <configuration>
-          <maxAllowedViolations>262</maxAllowedViolations>
+          <maxAllowedViolations>259</maxAllowedViolations>
         </configuration>
       </plugin>
     </plugins>

--- a/external/storm-jdbc/pom.xml
+++ b/external/storm-jdbc/pom.xml
@@ -92,7 +92,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>862</maxAllowedViolations>
+                    <maxAllowedViolations>157</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-jdbc/pom.xml
+++ b/external/storm-jdbc/pom.xml
@@ -92,7 +92,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>157</maxAllowedViolations>
+                    <maxAllowedViolations>149</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-jms/pom.xml
+++ b/external/storm-jms/pom.xml
@@ -94,7 +94,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>941</maxAllowedViolations>
+                    <maxAllowedViolations>280</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-jms/pom.xml
+++ b/external/storm-jms/pom.xml
@@ -94,7 +94,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>280</maxAllowedViolations>
+                    <maxAllowedViolations>273</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -152,7 +152,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>400</maxAllowedViolations>
+                    <maxAllowedViolations>338</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -152,7 +152,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>2439</maxAllowedViolations>
+                    <maxAllowedViolations>400</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kafka-monitor/pom.xml
+++ b/external/storm-kafka-monitor/pom.xml
@@ -149,7 +149,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>208</maxAllowedViolations>
+                    <maxAllowedViolations>178</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kafka-monitor/pom.xml
+++ b/external/storm-kafka-monitor/pom.xml
@@ -149,7 +149,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>735</maxAllowedViolations>
+                    <maxAllowedViolations>208</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -57,7 +57,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>591</maxAllowedViolations>
+                    <maxAllowedViolations>557</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kafka/pom.xml
+++ b/external/storm-kafka/pom.xml
@@ -57,7 +57,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>2727</maxAllowedViolations>
+                    <maxAllowedViolations>591</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kinesis/pom.xml
+++ b/external/storm-kinesis/pom.xml
@@ -71,7 +71,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1118</maxAllowedViolations>
+                    <maxAllowedViolations>207</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kinesis/pom.xml
+++ b/external/storm-kinesis/pom.xml
@@ -71,7 +71,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>207</maxAllowedViolations>
+                    <maxAllowedViolations>185</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-metrics/pom.xml
+++ b/external/storm-metrics/pom.xml
@@ -106,7 +106,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <!--Note - the version would be inherited-->
         <configuration>
-          <maxAllowedViolations>87</maxAllowedViolations>
+          <maxAllowedViolations>32</maxAllowedViolations>
         </configuration>
       </plugin>
     </plugins>

--- a/external/storm-mongodb/pom.xml
+++ b/external/storm-mongodb/pom.xml
@@ -79,7 +79,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>98</maxAllowedViolations>
+                    <maxAllowedViolations>96</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-mongodb/pom.xml
+++ b/external/storm-mongodb/pom.xml
@@ -79,7 +79,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>665</maxAllowedViolations>
+                    <maxAllowedViolations>98</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-mqtt/pom.xml
+++ b/external/storm-mqtt/pom.xml
@@ -130,7 +130,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>808</maxAllowedViolations>
+                    <maxAllowedViolations>160</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-mqtt/pom.xml
+++ b/external/storm-mqtt/pom.xml
@@ -130,7 +130,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>160</maxAllowedViolations>
+                    <maxAllowedViolations>158</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-opentsdb/pom.xml
+++ b/external/storm-opentsdb/pom.xml
@@ -102,7 +102,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>103</maxAllowedViolations>
+                    <maxAllowedViolations>94</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-opentsdb/pom.xml
+++ b/external/storm-opentsdb/pom.xml
@@ -102,7 +102,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>541</maxAllowedViolations>
+                    <maxAllowedViolations>103</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-pmml/pom.xml
+++ b/external/storm-pmml/pom.xml
@@ -85,7 +85,7 @@
                 <!--Note - the version would be inherited-->
                 <configuration>
 
-                    <maxAllowedViolations>373</maxAllowedViolations>
+                    <maxAllowedViolations>73</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-pmml/pom.xml
+++ b/external/storm-pmml/pom.xml
@@ -85,7 +85,7 @@
                 <!--Note - the version would be inherited-->
                 <configuration>
 
-                    <maxAllowedViolations>73</maxAllowedViolations>
+                    <maxAllowedViolations>65</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-redis/pom.xml
+++ b/external/storm-redis/pom.xml
@@ -95,7 +95,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>2041</maxAllowedViolations>
+                    <maxAllowedViolations>616</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-redis/pom.xml
+++ b/external/storm-redis/pom.xml
@@ -95,7 +95,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>616</maxAllowedViolations>
+                    <maxAllowedViolations>598</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-rocketmq/pom.xml
+++ b/external/storm-rocketmq/pom.xml
@@ -75,7 +75,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>102</maxAllowedViolations>
+                    <maxAllowedViolations>100</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-rocketmq/pom.xml
+++ b/external/storm-rocketmq/pom.xml
@@ -75,7 +75,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>705</maxAllowedViolations>
+                    <maxAllowedViolations>102</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-solr/pom.xml
+++ b/external/storm-solr/pom.xml
@@ -109,7 +109,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>111</maxAllowedViolations>
+                    <maxAllowedViolations>108</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-solr/pom.xml
+++ b/external/storm-solr/pom.xml
@@ -109,7 +109,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>781</maxAllowedViolations>
+                    <maxAllowedViolations>111</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/flux/flux-core/pom.xml
+++ b/flux/flux-core/pom.xml
@@ -112,7 +112,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1568</maxAllowedViolations>
+                    <maxAllowedViolations>300</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/flux/flux-core/pom.xml
+++ b/flux/flux-core/pom.xml
@@ -112,7 +112,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>300</maxAllowedViolations>
+                    <maxAllowedViolations>285</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/flux/flux-wrappers/pom.xml
+++ b/flux/flux-wrappers/pom.xml
@@ -55,7 +55,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>479</maxAllowedViolations>
+                    <maxAllowedViolations>38</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1092,14 +1092,23 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>2.17</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <!-- If you change this, you should also update the storm_checkstyle.xml file to be
+                                 based on the google_checks.xml from the version of checkstyle you are choosing. -->
+                            <version>7.7</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>validate</id>
                             <phase>validate</phase>
                             <configuration>
-                                <configLocation>google_checks.xml</configLocation>
+                                <configLocation>storm-buildtools/storm_checkstyle.xml</configLocation>
                                 <encoding>UTF-8</encoding>
-                                <failOnViolation></failOnViolation>
+                                <failOnViolation>true</failOnViolation>
                                 <logViolationsToConsole>false</logViolationsToConsole>
                                 <outputFile></outputFile>
                                 <violationSeverity>warning</violationSeverity>

--- a/sql/storm-sql-core/pom.xml
+++ b/sql/storm-sql-core/pom.xml
@@ -170,7 +170,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1302</maxAllowedViolations>
+                    <maxAllowedViolations>1283</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/sql/storm-sql-core/pom.xml
+++ b/sql/storm-sql-core/pom.xml
@@ -170,7 +170,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1217</maxAllowedViolations>
+                    <maxAllowedViolations>1302</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/sql/storm-sql-external/storm-sql-hdfs/pom.xml
+++ b/sql/storm-sql-external/storm-sql-hdfs/pom.xml
@@ -106,7 +106,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>43</maxAllowedViolations>
+                    <maxAllowedViolations>55</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/sql/storm-sql-external/storm-sql-hdfs/pom.xml
+++ b/sql/storm-sql-external/storm-sql-hdfs/pom.xml
@@ -106,7 +106,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>55</maxAllowedViolations>
+                    <maxAllowedViolations>54</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/sql/storm-sql-external/storm-sql-kafka/pom.xml
+++ b/sql/storm-sql-external/storm-sql-kafka/pom.xml
@@ -95,7 +95,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>61</maxAllowedViolations>
+                    <maxAllowedViolations>96</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/sql/storm-sql-external/storm-sql-mongodb/pom.xml
+++ b/sql/storm-sql-external/storm-sql-mongodb/pom.xml
@@ -86,7 +86,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>47</maxAllowedViolations>
+                    <maxAllowedViolations>54</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/sql/storm-sql-external/storm-sql-redis/pom.xml
+++ b/sql/storm-sql-external/storm-sql-redis/pom.xml
@@ -78,7 +78,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>131</maxAllowedViolations>
+                    <maxAllowedViolations>129</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/sql/storm-sql-external/storm-sql-redis/pom.xml
+++ b/sql/storm-sql-external/storm-sql-redis/pom.xml
@@ -78,7 +78,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>92</maxAllowedViolations>
+                    <maxAllowedViolations>131</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/sql/storm-sql-runtime/pom.xml
+++ b/sql/storm-sql-runtime/pom.xml
@@ -136,7 +136,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>639</maxAllowedViolations>
+                    <maxAllowedViolations>490</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/sql/storm-sql-runtime/pom.xml
+++ b/sql/storm-sql-runtime/pom.xml
@@ -136,7 +136,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>490</maxAllowedViolations>
+                    <maxAllowedViolations>485</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/storm-buildtools/maven-shade-clojure-transformer/pom.xml
+++ b/storm-buildtools/maven-shade-clojure-transformer/pom.xml
@@ -42,7 +42,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>44</maxAllowedViolations>
+                    <maxAllowedViolations>16</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/storm-buildtools/storm-maven-plugins/pom.xml
+++ b/storm-buildtools/storm-maven-plugins/pom.xml
@@ -81,7 +81,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <!--Note - the version would be inherited-->
         <configuration>
-          <maxAllowedViolations>78</maxAllowedViolations>
+          <maxAllowedViolations>269</maxAllowedViolations>
         </configuration>
       </plugin>
     </plugins>

--- a/storm-buildtools/storm_checkstyle.xml
+++ b/storm-buildtools/storm_checkstyle.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html.
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="warning"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="FileTabCharacter">
+            <property name="eachLine" value="true"/>
+        </module>
+
+    <module name="TreeWalker">
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="100"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        </module>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="LeftCurly">
+            <property name="maxLineLength" value="100"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlySame"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAlone"/>
+            <property name="option" value="alone"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+             <message key="ws.notPreceded"
+             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="MissingSwitchDefault"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapDot"/>
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapComma"/>
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+             <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+             <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+             <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="2"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="2"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="2"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="ParenPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationMostCases"/>
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="id" value="AnnotationLocationVariables"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="SummaryJavadoc">
+            <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+    </module>
+</module>

--- a/storm-buildtools/storm_checkstyle.xml
+++ b/storm-buildtools/storm_checkstyle.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0"?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
           "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
@@ -8,7 +26,7 @@
       https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-7.7/src/main/resources/google_checks.xml
     It has been slightly modified for use in Apache Storm, as follows:
       * 4 space indents instead of 2
-      * line-length limit is 120 instead of 100
+      * line-length limit is 140 instead of 100
     Once checkstyle has the ability to override selected configuration elements from within the Maven
     pom.xml file, then we can remove this file in favor of overriding the provided google_checks.xml file.
     See this issue to track that functionality:
@@ -52,7 +70,7 @@
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
         <module name="LineLength">
-            <property name="max" value="120"/>
+            <property name="max" value="140"/>
             <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
@@ -64,7 +82,7 @@
         </module>
         <module name="NeedBraces"/>
         <module name="LeftCurly">
-            <property name="maxLineLength" value="120"/>
+            <property name="maxLineLength" value="140"/>
         </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>

--- a/storm-buildtools/storm_checkstyle.xml
+++ b/storm-buildtools/storm_checkstyle.xml
@@ -4,6 +4,18 @@
           "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!--
+    The original file came from here:
+      https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-7.7/src/main/resources/google_checks.xml
+    It has been slightly modified for use in Apache Storm, as follows:
+      * 4 space indents instead of 2
+      * line-length limit is 120 instead of 100
+    Once checkstyle has the ability to override selected configuration elements from within the Maven
+    pom.xml file, then we can remove this file in favor of overriding the provided google_checks.xml file.
+    See this issue to track that functionality:
+      https://github.com/checkstyle/checkstyle/issues/2873
+ -->
+
+<!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
     that can be found at https://google.github.io/styleguide/javaguide.html.
 
@@ -40,7 +52,7 @@
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
         <module name="LineLength">
-            <property name="max" value="100"/>
+            <property name="max" value="120"/>
             <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
@@ -52,7 +64,7 @@
         </module>
         <module name="NeedBraces"/>
         <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
+            <property name="maxLineLength" value="120"/>
         </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
@@ -155,12 +167,12 @@
              value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
         </module>
         <module name="Indentation">
-            <property name="basicOffset" value="2"/>
+            <property name="basicOffset" value="4"/>
             <property name="braceAdjustment" value="0"/>
-            <property name="caseIndent" value="2"/>
+            <property name="caseIndent" value="4"/>
             <property name="throwsIndent" value="4"/>
             <property name="lineWrappingIndentation" value="4"/>
-            <property name="arrayInitIndent" value="2"/>
+            <property name="arrayInitIndent" value="4"/>
         </module>
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>

--- a/storm-client-misc/pom.xml
+++ b/storm-client-misc/pom.xml
@@ -54,7 +54,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>42</maxAllowedViolations>
+                    <maxAllowedViolations>39</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/storm-client-misc/pom.xml
+++ b/storm-client-misc/pom.xml
@@ -54,7 +54,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>137</maxAllowedViolations>
+                    <maxAllowedViolations>42</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -252,7 +252,7 @@
                 <!--Note - the version would be inherited-->
                 <configuration>
                     <excludes>**/generated/**</excludes>
-                    <maxAllowedViolations>11352</maxAllowedViolations>
+                    <maxAllowedViolations>10785</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -251,7 +251,8 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>92181</maxAllowedViolations>
+                    <excludes>**/generated/**</excludes>
+                    <maxAllowedViolations>11352</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-clojure/pom.xml
+++ b/storm-clojure/pom.xml
@@ -112,7 +112,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>796</maxAllowedViolations>
+                    <maxAllowedViolations>173</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -468,7 +468,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>275</maxAllowedViolations>
+                    <maxAllowedViolations>254</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -468,7 +468,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1950</maxAllowedViolations>
+                    <maxAllowedViolations>275</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-rename-hack/pom.xml
+++ b/storm-rename-hack/pom.xml
@@ -123,7 +123,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <!--Note - the version would be inherited-->
         <configuration>
-          <maxAllowedViolations>409</maxAllowedViolations>
+          <maxAllowedViolations>408</maxAllowedViolations>
         </configuration>
       </plugin>
     </plugins>

--- a/storm-rename-hack/pom.xml
+++ b/storm-rename-hack/pom.xml
@@ -123,7 +123,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <!--Note - the version would be inherited-->
         <configuration>
-          <maxAllowedViolations>565</maxAllowedViolations>
+          <maxAllowedViolations>409</maxAllowedViolations>
         </configuration>
       </plugin>
     </plugins>

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -131,7 +131,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>14979</maxAllowedViolations>
+                    <maxAllowedViolations>3795</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -131,7 +131,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>3795</maxAllowedViolations>
+                    <maxAllowedViolations>3584</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-server/src/main/java/org/apache/storm/logging/filters/AccessLoggingFilter.java
+++ b/storm-server/src/main/java/org/apache/storm/logging/filters/AccessLoggingFilter.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.logging.filters;
 import java.io.IOException;
 import javax.servlet.Filter;

--- a/storm-submit-tools/pom.xml
+++ b/storm-submit-tools/pom.xml
@@ -189,7 +189,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>269</maxAllowedViolations>
+                    <maxAllowedViolations>38</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/storm-webapp/pom.xml
+++ b/storm-webapp/pom.xml
@@ -118,7 +118,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>290</maxAllowedViolations>
+                    <maxAllowedViolations>47</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-webapp/pom.xml
+++ b/storm-webapp/pom.xml
@@ -118,7 +118,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>47</maxAllowedViolations>
+                    <maxAllowedViolations>41</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
1. Update from checkstyle-6.11.2 to checkstyle-7.7.
2. Tweak google_checks.xml from checkstyle-7.7 to have the following changes that
are more inline with the way the storm code is written:
   * 4 space indents instead of 2
   * line-length limit is 120 instead of 100
3. Exclude the generated thrift code in storm-client from being checked.
4. Update all maxAllowedViolations to be in-sync with the current number of
violations, through use of the `update-all-pom-violations.bash` script that
is attached to STORM-2510.

NOTE: this also fixes STORM-2507.