### PR TITLE
STORM-2515: Fix most checkstyle violations in storm-kafka-client

### DIFF
--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -152,7 +152,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>15</maxAllowedViolations>
+                    <maxAllowedViolations>9</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryService.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryService.java
@@ -21,8 +21,8 @@ package org.apache.storm.kafka.spout;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
 
 /**
  * Represents the logic that manages the retrial of failed tuples.
@@ -78,6 +78,7 @@ public interface KafkaSpoutRetryService extends Serializable {
     boolean isScheduled(KafkaSpoutMessageId msgId);
 
     /**
+     * Get the number of messages ready for retry.
      * @return The number of messages that are ready for retry
      */
     int readyMessageCount();
@@ -85,7 +86,8 @@ public interface KafkaSpoutRetryService extends Serializable {
     /**
      * Gets the {@link KafkaSpoutMessageId} for the given record.
      * @param record The record to fetch the id for
-     * @return The id the record was scheduled for retry with, or a new {@link KafkaSpoutMessageId} if the record was not scheduled for retry.
+     * @return The id the record was scheduled for retry with,
+     *     or a new {@link KafkaSpoutMessageId} if the record was not scheduled for retry.
      */
     KafkaSpoutMessageId getMessageId(ConsumerRecord<?, ?> record);
 }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaque.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaque.java
@@ -46,7 +46,8 @@ public class KafkaTridentSpoutOpaque<K,V> implements IOpaquePartitionedTridentSp
     }
 
     @Override
-    public Emitter<List<TopicPartition>, KafkaTridentSpoutTopicPartition, KafkaTridentSpoutBatchMetadata<K,V>> getEmitter(Map<String, Object> conf, TopologyContext context) {
+    public Emitter<List<TopicPartition>, KafkaTridentSpoutTopicPartition, KafkaTridentSpoutBatchMetadata<K,V>> getEmitter(
+            Map<String, Object> conf, TopologyContext context) {
         return new KafkaTridentSpoutEmitter<>(kafkaManager, context);
     }
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTransactional.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutTransactional.java
@@ -25,14 +25,15 @@ import org.apache.storm.trident.spout.ISpoutPartition;
 import org.apache.storm.tuple.Fields;
 
 // TODO
-public class KafkaTridentSpoutTransactional<Ps, P extends ISpoutPartition, T> implements IPartitionedTridentSpout<Ps, P, T> {
+public class KafkaTridentSpoutTransactional<PartitionsT, P extends ISpoutPartition, T> 
+        implements IPartitionedTridentSpout<PartitionsT, P, T> {
     @Override
-    public Coordinator<Ps> getCoordinator(Map<String, Object> conf, TopologyContext context) {
+    public Coordinator<PartitionsT> getCoordinator(Map<String, Object> conf, TopologyContext context) {
         return null;
     }
 
     @Override
-    public Emitter<Ps, P, T> getEmitter(Map<String, Object> conf, TopologyContext context) {
+    public Emitter<PartitionsT, P, T> getEmitter(Map<String, Object> conf, TopologyContext context) {
         return null;
     }
 


### PR DESCRIPTION
Most of the remaining violations are a couple of methods missing javadocs in the Trident code, which I don't feel familiar enough with Trident to write. The last couple are because there's a method in KafkaSpoutConfig that contains the SSL abbreviation. The rules only allow 2 capital letters in an abbreviation. Renaming is a breaking change, but maybe this isn't an issue for 2.0?

I also added a commit making a few other changes I thought made sense. The KafkaSpoutMessageId.getMetadata method was including the TopicPartition 3 times. The found variable in OffsetManager.findNextCommitOffset can be replaced with a null check of nextCommitMsg. They are in a separate commit for now, so this is easier to review.