### PR TITLE
Add the option to set client.id to storm-kafka, STORM-2524

### DIFF
--- a/docs/storm-kafka.md
+++ b/docs/storm-kafka.md
@@ -57,11 +57,14 @@ The optional ClientId is used as a part of the ZooKeeper path where the spout's 
 
 There are 2 extensions of KafkaConfig currently in use.
 
-Spoutconfig is an extension of KafkaConfig that supports additional fields with ZooKeeper connection info and for controlling
-behavior specific to KafkaSpout. The Zkroot will be used as root to store your consumer's offset. The id should uniquely
-identify your spout.
+SpoutConfig is an extension of KafkaConfig that supports additional fields with ZooKeeper connection info and for controlling
+behavior specific to KafkaSpout.
+The clientId will be used to identify requests which are made using the Kafka Protocol.
+The zkRoot will be used as root to store your consumer's offset.
+The id should uniquely identify your spout.
 
 ```java
+public SpoutConfig(BrokerHosts hosts, String topic, String clientId, String zkRoot, String id);
 public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id);
 ```
 

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/SpoutConfig.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/SpoutConfig.java
@@ -42,8 +42,20 @@ public class SpoutConfig extends KafkaConfig implements Serializable {
     public long retryDelayMaxMs = 60 * 1000;
     public int retryLimit = -1;
 
+    /**
+     * Create a SpoutConfig without setting client.id, which can make the source application ambiguous when tracing Kafka calls.
+     */
     public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id) {
         super(hosts, topic);
+        this.zkRoot = zkRoot;
+        this.id = id;
+    }
+
+    /**
+     * Create a SpoutConfig with a client.id value.
+     */
+    public SpoutConfig(BrokerHosts hosts, String topic, String clientId, String zkRoot, String id) {
+        super(hosts, topic, clientId);
         this.zkRoot = zkRoot;
         this.id = id;
     }


### PR DESCRIPTION
Add the ability to set the Kafka client.id property to storm-kafka and storm-kafka-client (https://issues.apache.org/jira/browse/STORM-2524).

storm-kafka example:
```
	SpoutConfig spoutConfig = new SpoutConfig(
		brokers,
		topicConfs.topic,
+		"client_id-" + confs.consumerGroupId + "-" + topicConfs.topic,
		"/consumers",
		confs.consumerGroupId + "-" + topicConfs.topic
	);
```

storm-kafka-client example:
```
	KafkaSpoutConfig<String,String> kafkaSpoutConfig = KafkaSpoutConfig.builder(KAFKA_LOCAL_BROKER, TOPIC)
		.setGroupId(confs.consumerGroupId + "-" + topicConfs.topic)
+		.setClientId("client_id-" + confs.consumerGroupId + "-" + topicConfs.topic)
		.build();
```