### PR TITLE
Leave checkstyle violation to each module's target directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1110,7 +1110,7 @@
                                 <encoding>UTF-8</encoding>
                                 <failOnViolation>true</failOnViolation>
                                 <logViolationsToConsole>false</logViolationsToConsole>
-                                <outputFile></outputFile>
+                                <outputFile>target/checkstyle-violation.xml</outputFile>
                                 <violationSeverity>warning</violationSeverity>
                             </configuration>
                             <goals>


### PR DESCRIPTION
Because of output log size policy for Travis CI, we can't print violation report to the console. Instead of that, we can just leave violation to the file. 

This would help to track and fix checkstyle violations.