### PR TITLE
STORM-2532: Remove uses of Utils.getAvailablePort where possible

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/messaging/IConnection.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/IConnection.java
@@ -55,6 +55,12 @@ public interface IConnection {
      * @return a Load for each of the tasks it knows about.
      */
     public Map<Integer, Load> getLoad(Collection<Integer> tasks);
+    
+    /**
+     * Get the port for this connection
+     * @return The port this connection is using
+     */
+    public int getPort();
 
     /**
      * close this connection

--- a/storm-client/src/jvm/org/apache/storm/messaging/IContext.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/IContext.java
@@ -36,7 +36,7 @@ public interface IContext {
     public void prepare(Map<String, Object> topoConf);
     
     /**
-     * This method is invoked when a worker is unload a messaging plugin
+     * This method is invoked when a worker is unloading a messaging plugin
      */
     public void term();
 

--- a/storm-client/src/jvm/org/apache/storm/messaging/local/Context.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/local/Context.java
@@ -45,6 +45,11 @@ public class Context implements IContext {
     private static class LocalServer implements IConnection {
         volatile IConnectionCallback _cb;
         final ConcurrentHashMap<Integer, Double> _load = new ConcurrentHashMap<>();
+        final int port;
+        
+        public LocalServer(int port) {
+            this.port = port;
+        }
 
         @Override
         public void registerRecv(IConnectionCallback cb) {
@@ -76,6 +81,11 @@ public class Context implements IContext {
         @Override
         public void sendLoadMetrics(Map<Integer, Double> taskToLoad) {
             _load.putAll(taskToLoad);
+        }
+
+        @Override
+        public int getPort() {
+            return port;
         }
  
         @Override
@@ -168,6 +178,11 @@ public class Context implements IContext {
         public void sendLoadMetrics(Map<Integer, Double> taskToLoad) {
             _server.sendLoadMetrics(taskToLoad);
         }
+
+        @Override
+        public int getPort() {
+            return _server.getPort();
+        }
  
         @Override
         public void close() {
@@ -185,7 +200,7 @@ public class Context implements IContext {
         String key = nodeId + "-" + port;
         LocalServer ret = _registry.get(key);
         if (ret == null) {
-            ret = new LocalServer();
+            ret = new LocalServer(port);
             LocalServer tmp = _registry.putIfAbsent(key, ret);
             if (tmp != null) {
                 ret = tmp;

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/Client.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/Client.java
@@ -414,6 +414,11 @@ public class Client extends ConnectionWithStatus implements IStatefulObject, ISa
         return false;
     }
 
+    @Override
+    public int getPort() {
+        return dstAddress.getPort();
+    }
+    
     /**
      * Gracefully close this client.
      */

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/Context.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/Context.java
@@ -65,7 +65,7 @@ public class Context implements IContext {
      */
     public synchronized IConnection bind(String storm_id, int port) {
         IConnection server = new Server(topoConf, port);
-        connections.put(key(storm_id, port), server);
+        connections.put(key(storm_id, server.getPort()), server);
         return server;
     }
 
@@ -80,7 +80,7 @@ public class Context implements IContext {
         }
         IConnection client =  new Client(topoConf, clientChannelFactory, 
                 clientScheduleService, host, port, this);
-        connections.put(key(host, port), client);
+        connections.put(key(host, client.getPort()), client);
         return client;
     }
 

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/Server.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/Server.java
@@ -64,6 +64,7 @@ class Server extends ConnectionWithStatus implements IStatefulObject, ISaslServe
     List<TaskMessage> closeMessage = Arrays.asList(new TaskMessage(-1, null));
     private KryoValuesSerializer _ser;
     private IConnectionCallback _cb = null; 
+    private final int boundPort;
     
     @SuppressWarnings("rawtypes")
     Server(Map<String, Object> topoConf, int port) {
@@ -100,6 +101,7 @@ class Server extends ConnectionWithStatus implements IStatefulObject, ISaslServe
 
         // Bind and start to accept incoming connections.
         Channel channel = bootstrap.bind(new InetSocketAddress(port));
+        boundPort = ((InetSocketAddress)channel.getLocalAddress()).getPort();
         allChannels.add(channel);
     }
     
@@ -156,6 +158,11 @@ class Server extends ConnectionWithStatus implements IStatefulObject, ISaslServe
         allChannels.remove(channel);
     }
 
+    @Override
+    public int getPort() {
+        return boundPort;
+    }
+    
     /**
      * close all channels, and release resources
      */

--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -1166,18 +1166,30 @@ public class Utils {
         return null;
     }
 
-    public static int getAvailablePort(int prefferedPort) {
+    /**
+     * Gets an available port. Consider if it is possible to pass port 0 to the
+     * server instead of using this method, since there is no guarantee that the
+     * port returned by this method will remain free.
+     *
+     * @param preferredPort
+     * @return The preferred port if available, or a random available port
+     */
+    public static int getAvailablePort(int preferredPort) {
         int localPort = -1;
-        try(ServerSocket socket = new ServerSocket(prefferedPort)) {
+        try(ServerSocket socket = new ServerSocket(preferredPort)) {
             localPort = socket.getLocalPort();
         } catch(IOException exp) {
-            if (prefferedPort > 0) {
+            if (preferredPort > 0) {
                 return getAvailablePort(0);
             }
         }
         return localPort;
     }
 
+    /**
+     * Shortcut to calling {@link #getAvailablePort(int) } with 0 as the preferred port
+     * @return A random available port
+     */
     public static int getAvailablePort() {
         return getAvailablePort(0);
     }

--- a/storm-core/test/clj/org/apache/storm/messaging/netty_unit_test.clj
+++ b/storm-core/test/clj/org/apache/storm/messaging/netty_unit_test.clj
@@ -22,7 +22,6 @@
   (:import [java.util ArrayList]
            (org.apache.storm.daemon.worker WorkerState)))
 
-(def port (Utils/getAvailablePort))
 (def task 1)
 
 ;; In a "real" cluster (or an integration test), Storm itself would ensure that a topology's workers would only be
@@ -69,11 +68,10 @@
   (log-message "1. Should send and receive a basic message")
   (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
         context (TransportFactory/makeContext storm-conf)
-        port (Utils/getAvailablePort (int 6700))
         resp (atom nil)
-        server (.bind context nil port)
+        server (.bind context nil 0)
         _ (register-callback (fn [message] (reset! resp message)) server)
-        client (.connect context nil "localhost" port)
+        client (.connect context nil "localhost" (.getPort server))
         _ (wait-until-ready [server client])
         _ (.send client task (.getBytes req_msg))]
     (wait-for-not-nil resp)
@@ -107,11 +105,10 @@
   (log-message "2 test load")
   (let [req_msg (String. "0123456789abcdefghijklmnopqrstuvwxyz")
         context (TransportFactory/makeContext storm-conf)
-        port (Utils/getAvailablePort (int 6700))
         resp (atom nil)
-        server (.bind context nil port)
+        server (.bind context nil 0)
         _ (register-callback (fn [message] (reset! resp message)) server)
-        client (.connect context nil "localhost" port)
+        client (.connect context nil "localhost" (.getPort server))
         _ (wait-until-ready [server client])
         _ (.send client task (.getBytes req_msg))
         _ (.sendLoadMetrics server {(int 1) 0.0 (int 2) 1.0})
@@ -150,11 +147,10 @@
   (log-message "3 Should send and receive a large message")
   (let [req_msg (apply str (repeat 2048000 'c'))
         context (TransportFactory/makeContext storm-conf)
-        port (Utils/getAvailablePort (int 6700))
         resp (atom nil)
-        server (.bind context nil port)
+        server (.bind context nil 0)
         _ (register-callback (fn [message] (reset! resp message)) server)
-        client (.connect context nil "localhost" port)
+        client (.connect context nil "localhost" (.getPort server))
         _ (wait-until-ready [server client])
         _ (.send client task (.getBytes req_msg))]
     (wait-for-not-nil resp)
@@ -238,10 +234,9 @@
         resp (ArrayList.)
         received (atom 0)
         context (TransportFactory/makeContext storm-conf)
-        port (Utils/getAvailablePort (int 6700))
-        server (.bind context nil port)
+        server (.bind context nil 0)
         _ (register-callback (fn [message] (.add resp message) (swap! received inc)) server)
-        client (.connect context nil "localhost" port)
+        client (.connect context nil "localhost" (.getPort server))
         _ (wait-until-ready [server client])]
     (doseq [num (range 1 num-messages)]
       (let [req_msg (str num)]

--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -629,6 +629,10 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
         return getNimbus().getTopologyInfo(id);
     }
 
+    public int getThriftServerPort() {
+        return thriftServer.getPort();
+    }
+
     @Override
     public synchronized void close() throws Exception {
         if (nimbus != null) {


### PR DESCRIPTION
Followup for https://github.com/apache/storm/pull/2075

The only remaining uses of Utils.getAvailablePort are tests in netty_unit_tests.clj that are starting a client before the server it connects to. I think getAvailablePort is the best we can do in those tests.