### PR TITLE
STORM-2503: Restore comparator logic in `DefaultResourceAwareStrategy`.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/DefaultResourceAwareStrategy.java
+++ b/storm-client/src/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/DefaultResourceAwareStrategy.java
@@ -521,7 +521,7 @@ public class DefaultResourceAwareStrategy implements IStrategy {
     }
 
     /**
-     * sort components by the number of in and out connections that need to be made
+     * sort components by the number of in and out connections that need to be made, in descending order
      *
      * @param componentMap The components that need to be sorted
      * @return a sorted set of components
@@ -555,7 +555,7 @@ public class DefaultResourceAwareStrategy implements IStrategy {
     }
 
     /**
-     * Sort a component's neighbors by the number of connections it needs to make with this component
+     * Sort a component's neighbors by the number of connections it needs to make with this component, in descending order
      *
      * @param thisComp     the component that we need to sort its neighbors
      * @param componentMap all the components to sort
@@ -567,9 +567,9 @@ public class DefaultResourceAwareStrategy implements IStrategy {
             public int compare(Component o1, Component o2) {
                 int connections1 = o1.execs.size() * thisComp.execs.size();
                 int connections2 = o2.execs.size() * thisComp.execs.size();
-                if (connections1 < connections2) {
+                if (connections1 > connections2) {
                     return -1;
-                } else if (connections1 > connections2) {
+                } else if (connections1 < connections2) {
                     return 1;
                 } else {
                     return o1.id.compareTo(o2.id);
@@ -581,7 +581,7 @@ public class DefaultResourceAwareStrategy implements IStrategy {
     }
 
     /**
-     * Order executors based on how many in and out connections it will potentially need to make.
+     * Order executors based on how many in and out connections it will potentially need to make, in descending order.
      * First order components by the number of in and out connections it will have.  Then iterate through the sorted list of components.
      * For each component sort the neighbors of that component by how many connections it will have to make with that component.
      * Add an executor from this component and then from each neighboring component in sorted order.  Do this until there is nothing left to schedule


### PR DESCRIPTION
This PR ensures consistent comparator ordering in the above class, using descending order in both `sortNeighbors` and `sortComponents` and adding comments to indicate descending order.

As requested by @jerrypeng on https://github.com/apache/storm/pull/2100.
@revans2