### PR TITLE
STORM-2536 excludes jersey 1.x from storm-autocreds

### DIFF
--- a/external/storm-autocreds/pom.xml
+++ b/external/storm-autocreds/pom.xml
@@ -61,6 +61,14 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>jersey-core</artifactId>
+                    <groupId>com.sun.jersey</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jersey-client</artifactId>
+                    <groupId>com.sun.jersey</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
* 1.x patch: #2144 

depdendency tree:

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ storm-autocreds ---
[INFO] org.apache.storm:storm-autocreds:jar:2.0.0-SNAPSHOT
[INFO] +- org.apache.storm:storm-client:jar:2.0.0-SNAPSHOT:provided
[INFO] |  +- uk.org.lidalia:sysout-over-slf4j:jar:1.0.2:provided
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.21:compile
[INFO] |  +- org.apache.logging.log4j:log4j-api:jar:2.8:provided
[INFO] |  +- org.apache.logging.log4j:log4j-core:jar:2.8:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.8:provided
[INFO] |  +- com.google.guava:guava:jar:16.0.1:compile
[INFO] |  +- org.apache.thrift:libthrift:jar:0.9.3:compile
[INFO] |  |  \- org.apache.httpcomponents:httpcore:jar:4.4.1:compile
[INFO] |  +- commons-io:commons-io:jar:2.5:compile
[INFO] |  +- commons-lang:commons-lang:jar:2.5:compile
[INFO] |  +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] |  +- com.lmax:disruptor:jar:3.3.2:provided
[INFO] |  +- com.googlecode.json-simple:json-simple:jar:1.1:provided
[INFO] |  +- org.yaml:snakeyaml:jar:1.11:provided
[INFO] |  +- io.netty:netty:jar:3.9.0.Final:compile
[INFO] |  +- com.esotericsoftware:kryo:jar:3.0.3:provided
[INFO] |  |  +- com.esotericsoftware:reflectasm:jar:1.10.1:provided
[INFO] |  |  |  \- org.ow2.asm:asm:jar:5.0.3:provided
[INFO] |  |  +- com.esotericsoftware:minlog:jar:1.3.0:provided
[INFO] |  |  \- org.objenesis:objenesis:jar:2.1:provided
[INFO] |  +- org.apache.zookeeper:zookeeper:jar:3.4.6:compile
[INFO] |  |  \- jline:jline:jar:0.9.94:compile
[INFO] |  +- org.apache.curator:curator-framework:jar:2.12.0:compile
[INFO] |  +- org.jgrapht:jgrapht-core:jar:0.9.0:provided
[INFO] |  +- javax.servlet:servlet-api:jar:2.5:compile
[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.3.3:compile
[INFO] |  \- org.apache.curator:curator-client:jar:2.12.0:compile
[INFO] +- org.apache.hadoop:hadoop-client:jar:2.6.1:compile
[INFO] |  +- org.apache.hadoop:hadoop-common:jar:2.6.1:compile
[INFO] |  |  +- commons-cli:commons-cli:jar:1.3.1:compile
[INFO] |  |  +- org.apache.commons:commons-math3:jar:3.1.1:compile
[INFO] |  |  +- xmlenc:xmlenc:jar:0.52:compile
[INFO] |  |  +- commons-httpclient:commons-httpclient:jar:3.1:compile
[INFO] |  |  +- commons-net:commons-net:jar:3.1:compile
[INFO] |  |  +- commons-configuration:commons-configuration:jar:1.6:compile
[INFO] |  |  |  +- commons-digester:commons-digester:jar:1.8:compile
[INFO] |  |  |  |  \- commons-beanutils:commons-beanutils:jar:1.7.0:compile
[INFO] |  |  |  \- commons-beanutils:commons-beanutils-core:jar:1.8.0:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.13:compile
[INFO] |  |  +- org.apache.avro:avro:jar:1.7.4:compile
[INFO] |  |  |  +- com.thoughtworks.paranamer:paranamer:jar:2.3:compile
[INFO] |  |  |  \- org.xerial.snappy:snappy-java:jar:1.0.4.1:compile
[INFO] |  |  +- com.google.code.gson:gson:jar:2.2.4:compile
[INFO] |  |  +- org.apache.curator:curator-recipes:jar:2.12.0:compile
[INFO] |  |  +- com.google.code.findbugs:jsr305:jar:1.3.9:compile
[INFO] |  |  +- org.htrace:htrace-core:jar:3.0.4:compile
[INFO] |  |  \- org.apache.commons:commons-compress:jar:1.4.1:compile
[INFO] |  |     \- org.tukaani:xz:jar:1.0:compile
[INFO] |  +- org.apache.hadoop:hadoop-hdfs:jar:2.6.1:compile
[INFO] |  |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
[INFO] |  |  \- xerces:xercesImpl:jar:2.9.1:compile
[INFO] |  |     \- xml-apis:xml-apis:jar:1.3.04:compile
[INFO] |  +- org.apache.hadoop:hadoop-mapreduce-client-app:jar:2.6.1:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-mapreduce-client-common:jar:2.6.1:compile
[INFO] |  |  |  +- org.apache.hadoop:hadoop-yarn-client:jar:2.6.1:compile
[INFO] |  |  |  \- org.apache.hadoop:hadoop-yarn-server-common:jar:2.6.1:compile
[INFO] |  |  \- org.apache.hadoop:hadoop-mapreduce-client-shuffle:jar:2.6.1:compile
[INFO] |  |     \- org.fusesource.leveldbjni:leveldbjni-all:jar:1.8:compile
[INFO] |  +- org.apache.hadoop:hadoop-yarn-api:jar:2.6.1:compile
[INFO] |  +- org.apache.hadoop:hadoop-mapreduce-client-core:jar:2.6.1:compile
[INFO] |  |  \- org.apache.hadoop:hadoop-yarn-common:jar:2.6.1:compile
[INFO] |  |     +- javax.xml.bind:jaxb-api:jar:2.2.2:compile
[INFO] |  |     |  +- javax.xml.stream:stax-api:jar:1.0-2:compile
[INFO] |  |     |  \- javax.activation:activation:jar:1.1:compile
[INFO] |  |     +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.13:compile
[INFO] |  |     \- org.codehaus.jackson:jackson-xc:jar:1.9.13:compile
[INFO] |  +- org.apache.hadoop:hadoop-mapreduce-client-jobclient:jar:2.6.1:compile
[INFO] |  \- org.apache.hadoop:hadoop-annotations:jar:2.6.1:compile
[INFO] +- org.apache.hbase:hbase-client:jar:1.1.0:compile
[INFO] |  +- org.apache.hbase:hbase-annotations:jar:1.1.0:compile
[INFO] |  |  +- jdk.tools:jdk.tools:jar:1.7:system
[INFO] |  |  \- log4j:log4j:jar:1.2.17:compile
[INFO] |  +- org.apache.hbase:hbase-common:jar:1.1.0:compile
[INFO] |  +- org.apache.hbase:hbase-protocol:jar:1.1.0:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.6:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
[INFO] |  +- io.netty:netty-all:jar:4.0.23.Final:compile
[INFO] |  +- org.apache.htrace:htrace-core:jar:3.1.0-incubating:compile
[INFO] |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13:compile
[INFO] |  +- org.jruby.jcodings:jcodings:jar:1.0.8:compile
[INFO] |  +- org.jruby.joni:joni:jar:2.1.2:compile
[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:2.5.1:compile
[INFO] |  |  \- org.apache.directory.server:apacheds-kerberos-codec:jar:2.0.0-M15:compile
[INFO] |  |     +- org.apache.directory.server:apacheds-i18n:jar:2.0.0-M15:compile
[INFO] |  |     +- org.apache.directory.api:api-asn1-api:jar:1.0.0-M20:compile
[INFO] |  |     \- org.apache.directory.api:api-util:jar:1.0.0-M20:compile
[INFO] |  \- com.github.stephenc.findbugs:findbugs-annotations:jar:1.3.9-1:compile
[INFO] +- org.apache.hive.hcatalog:hive-hcatalog-streaming:jar:0.14.0:compile
[INFO] |  +- org.apache.hive:hive-serde:jar:0.14.0:compile
[INFO] |  |  +- org.apache.hive:hive-common:jar:0.14.0:compile
[INFO] |  |  +- org.apache.hive:hive-shims:jar:0.14.0:compile
[INFO] |  |  |  +- org.apache.hive.shims:hive-shims-common:jar:0.14.0:compile
[INFO] |  |  |  +- org.apache.hive.shims:hive-shims-0.20:jar:0.14.0:runtime
[INFO] |  |  |  +- org.apache.hive.shims:hive-shims-common-secure:jar:0.14.0:compile
[INFO] |  |  |  +- org.apache.hive.shims:hive-shims-0.20S:jar:0.14.0:runtime
[INFO] |  |  |  \- org.apache.hive.shims:hive-shims-0.23:jar:0.14.0:runtime
[INFO] |  |  \- net.sf.opencsv:opencsv:jar:2.3:compile
[INFO] |  +- org.apache.hive:hive-metastore:jar:0.14.0:compile
[INFO] |  |  +- com.jolbox:bonecp:jar:0.8.0.RELEASE:compile
[INFO] |  |  +- org.apache.derby:derby:jar:10.10.1.1:compile
[INFO] |  |  +- org.datanucleus:datanucleus-api-jdo:jar:3.2.6:compile
[INFO] |  |  +- org.datanucleus:datanucleus-core:jar:3.2.10:compile
[INFO] |  |  +- org.datanucleus:datanucleus-rdbms:jar:3.2.9:compile
[INFO] |  |  +- commons-pool:commons-pool:jar:1.5.4:compile
[INFO] |  |  +- commons-dbcp:commons-dbcp:jar:1.4:compile
[INFO] |  |  +- javax.jdo:jdo-api:jar:3.0.1:compile
[INFO] |  |  |  \- javax.transaction:jta:jar:1.1:compile
[INFO] |  |  +- org.antlr:antlr-runtime:jar:3.4:compile
[INFO] |  |  |  +- org.antlr:stringtemplate:jar:3.2.1:compile
[INFO] |  |  |  \- antlr:antlr:jar:2.7.7:compile
[INFO] |  |  \- org.apache.thrift:libfb303:jar:0.9.0:compile
[INFO] |  +- org.apache.hive:hive-exec:jar:0.14.0:compile
[INFO] |  |  +- org.apache.hive:hive-ant:jar:0.14.0:compile
[INFO] |  |  |  \- org.apache.velocity:velocity:jar:1.5:compile
[INFO] |  |  |     \- oro:oro:jar:2.0.8:compile
[INFO] |  |  +- org.antlr:ST4:jar:4.0.4:compile
[INFO] |  |  +- org.apache.ant:ant:jar:1.9.1:compile
[INFO] |  |  |  \- org.apache.ant:ant-launcher:jar:1.9.1:compile
[INFO] |  |  +- org.codehaus.groovy:groovy-all:jar:2.1.6:compile
[INFO] |  |  +- stax:stax-api:jar:1.0.1:compile
[INFO] |  |  \- org.fusesource.jansi:jansi:jar:1.11:compile
[INFO] |  \- org.apache.hive:hive-cli:jar:0.14.0:compile
[INFO] |     \- org.apache.hive:hive-service:jar:0.14.0:compile
[INFO] |        +- net.sf.jpam:jpam:jar:1.1:compile
[INFO] |        \- org.eclipse.jetty.aggregate:jetty-all:jar:7.6.0.v20120127:compile
[INFO] |           +- org.apache.geronimo.specs:geronimo-jta_1.1_spec:jar:1.1.1:compile
[INFO] |           +- javax.mail:mail:jar:1.4.1:compile
[INFO] |           +- org.apache.geronimo.specs:geronimo-jaspic_1.0_spec:jar:1.0:compile
[INFO] |           +- org.apache.geronimo.specs:geronimo-annotation_1.0_spec:jar:1.1.1:compile
[INFO] |           \- asm:asm-commons:jar:3.1:compile
[INFO] |              \- asm:asm-tree:jar:3.1:compile
[INFO] |                 \- asm:asm:jar:3.1:compile
[INFO] +- org.apache.hive.hcatalog:hive-webhcat-java-client:jar:0.14.0:compile
[INFO] |  \- org.apache.hive.hcatalog:hive-hcatalog-core:jar:0.14.0:compile
[INFO] \- junit:junit:jar:4.11:test
[INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:test
```