### PR TITLE
STORM-2538: New kafka spout emits duplicate tuples

### DIFF
--- a/examples/storm-kafka-client-examples/src/main/java/org/apache/storm/kafka/trident/TridentKafkaClientWordCountNamedTopics.java
+++ b/examples/storm-kafka-client-examples/src/main/java/org/apache/storm/kafka/trident/TridentKafkaClientWordCountNamedTopics.java
@@ -27,17 +27,11 @@ import org.apache.storm.generated.InvalidTopologyException;
 import org.apache.storm.kafka.spout.Func;
 import org.apache.storm.kafka.spout.KafkaSpoutConfig;
 import org.apache.storm.kafka.spout.KafkaSpoutRetryExponentialBackoff;
-import org.apache.storm.kafka.spout.KafkaSpoutRetryExponentialBackoff.TimeInterval;
 import org.apache.storm.kafka.spout.KafkaSpoutRetryService;
+import org.apache.storm.kafka.spout.internal.TimeInterval;
 import org.apache.storm.kafka.spout.trident.KafkaTridentSpoutOpaque;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Values;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.EARLIEST;
 
 import java.io.Serializable;
 import java.util.Arrays;

--- a/examples/storm-kafka-examples/src/main/java/org/apache/storm/kafka/trident/KafkaProducerTopology.java
+++ b/examples/storm-kafka-examples/src/main/java/org/apache/storm/kafka/trident/KafkaProducerTopology.java
@@ -54,7 +54,7 @@ public class KafkaProducerTopology {
     /**
      * @return the Storm config for the topology that publishes sentences to kafka using a kafka bolt.
      */
-    private static Properties newProps(final String brokerUrl, final String topicName) {
+    static Properties newProps(final String brokerUrl, final String topicName) {
         return new Properties() {{
             put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerUrl);
             put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");

--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -67,6 +67,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
         <!--test dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/TimeInterval.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/TimeInterval.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.internal;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+
+public class TimeInterval implements Serializable {
+    private final long lengthNanos;
+    private final TimeUnit timeUnit;
+    private final long length;
+
+    /**
+     * @param length length of the time interval in the units specified by {@link TimeUnit}
+     * @param timeUnit unit used to specify a time interval on which to specify a time unit
+     */
+    public TimeInterval(long length, TimeUnit timeUnit) {
+        this.lengthNanos = timeUnit.toNanos(length);
+        this.timeUnit = timeUnit;
+        this.length = length;
+    }
+
+    public static TimeInterval seconds(long length) {
+        return new TimeInterval(length, TimeUnit.SECONDS);
+    }
+
+    public static TimeInterval milliSeconds(long length) {
+        return new TimeInterval(length, TimeUnit.MILLISECONDS);
+    }
+
+    public static TimeInterval microSeconds(long length) {
+        return new TimeInterval(length, TimeUnit.MICROSECONDS);
+    }
+
+    public long getLengthNanos() {
+        return lengthNanos;
+    }
+
+    public TimeUnit getTimeUnit() {
+        return timeUnit;
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    @Override
+    public String toString() {
+        return "TimeInterval{" +
+                "length=" + length +
+                ", timeUnit=" + timeUnit +
+                '}';
+    }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/Timer.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/Timer.java
@@ -17,8 +17,9 @@
  */
 package org.apache.storm.kafka.spout.internal;
 
-import java.util.concurrent.TimeUnit;
 import org.apache.storm.utils.Time;
+
+import java.util.concurrent.TimeUnit;
 
 public class Timer {
     private final long delay;
@@ -71,5 +72,13 @@ public class Timer {
             start = Time.nanoTime();
         }
         return expired;
+    }
+
+    public boolean isExpired() {
+        return Time.nanoTime() - start >= periodNanos;
+    }
+
+    public void reset() {
+        start = Time.nanoTime();
     }
 }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/tasks/FixedDelayStartupTask.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/tasks/FixedDelayStartupTask.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.internal.tasks;
+
+import org.apache.storm.kafka.spout.internal.TimeInterval;
+import org.apache.storm.kafka.spout.internal.Timer;
+
+public class FixedDelayStartupTask implements PreFetchTask {
+    private Timer timer;
+
+    public FixedDelayStartupTask(Timer timer) {
+        this.timer = timer;
+    }
+
+    public static FixedDelayStartupTask forTimeInterval(TimeInterval timeInterval) {
+        return new FixedDelayStartupTask(new Timer(0, timeInterval.getLength(), timeInterval.getTimeUnit()));
+    }
+
+    @Override
+    public void start() {
+        timer.reset();
+    }
+
+    @Override
+    public boolean isComplete() {
+        return timer.isExpired();
+    }
+
+    @Override
+    public void stop() { }
+
+    @Override
+    public void close() { }
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/tasks/PreFetchTask.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/tasks/PreFetchTask.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.internal.tasks;
+
+public interface PreFetchTask {
+    void start();
+    boolean isComplete();
+    void stop();
+    void close();
+}

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/tasks/PreFetchTasksManager.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/tasks/PreFetchTasksManager.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.internal.tasks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Handles all tasks that must be performed before fetch can occur. In the case of the
+ * KafkaBolt
+ * may it be one time task, or recurrent tasks, for example, after a consumer rebalance
+ */
+public class PreFetchTasksManager {
+    protected static final Logger LOG = LoggerFactory.getLogger(PreFetchTasksManager.class);
+
+    private List<PreFetchTask> tasks;
+
+    public PreFetchTasksManager() {
+        this(new ArrayList<PreFetchTask>());
+    }
+
+    public PreFetchTasksManager(List<PreFetchTask> tasks) {
+        this.tasks = tasks;
+    }
+
+    /**
+     * @return the internal index of this task. Can be used to remove the task .
+     */
+    public int addTask(PreFetchTask task) {
+        tasks.add(task);
+        return tasks.size() - 1;
+    }
+
+    public void removeTask(int taskIndex) {
+        tasks.remove(taskIndex);
+    }
+
+    public void startAll() {
+        for (PreFetchTask task : tasks) {
+            task.start();
+        }
+    }
+
+    public boolean allCompleted() {
+        boolean result = true;
+        for (PreFetchTask task : tasks) {
+            result &= task.isComplete();
+        }
+        LOG.debug("All prefetch tasks complete = {}", result);
+        return result;
+    }
+
+    public void stopAll() {
+        for (PreFetchTask task : tasks) {
+            task.stop();
+        }
+    }
+
+    public void closeAll() {
+        for (PreFetchTask task : tasks) {
+            task.close();
+        }
+    }
+
+    public List<PreFetchTask> getTasks() {
+        return Collections.unmodifiableList(tasks);
+    }
+}

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/MaxUncommittedOffsetTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/MaxUncommittedOffsetTest.java
@@ -15,6 +15,24 @@
  */
 package org.apache.storm.kafka.spout;
 
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.storm.kafka.KafkaUnitRule;
+import org.apache.storm.kafka.spout.builders.SingleTopicKafkaSpoutConfiguration;
+import org.apache.storm.kafka.spout.internal.TimeInterval;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.utils.Time;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.apache.storm.kafka.spout.builders.SingleTopicKafkaSpoutConfiguration.getKafkaSpoutConfigBuilder;
 import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -29,22 +47,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.storm.kafka.KafkaUnitRule;
-import org.apache.storm.kafka.spout.builders.SingleTopicKafkaSpoutConfiguration;
-import org.apache.storm.spout.SpoutOutputCollector;
-import org.apache.storm.task.TopologyContext;
-import org.apache.storm.utils.Time;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.MockitoAnnotations;
 
 public class MaxUncommittedOffsetTest {
 
@@ -63,8 +65,8 @@ public class MaxUncommittedOffsetTest {
         .setOffsetCommitPeriodMs(commitOffsetPeriodMs)
         .setMaxPollRecords(maxPollRecords)
         .setMaxUncommittedOffsets(maxUncommittedOffsets)
-        .setRetry(new KafkaSpoutRetryExponentialBackoff(KafkaSpoutRetryExponentialBackoff.TimeInterval.seconds(initialRetryDelaySecs), KafkaSpoutRetryExponentialBackoff.TimeInterval.seconds(0),
-            1, KafkaSpoutRetryExponentialBackoff.TimeInterval.seconds(initialRetryDelaySecs))) //Retry once after a minute
+        .setRetry(new KafkaSpoutRetryExponentialBackoff(TimeInterval.seconds(initialRetryDelaySecs), TimeInterval.seconds(0),
+            1, TimeInterval.seconds(initialRetryDelaySecs))) //Retry once after a minute
         .build();
     private KafkaSpout<String, String> spout;
 

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainNamedTopics.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/test/KafkaSpoutTopologyMainNamedTopics.java
@@ -18,13 +18,6 @@
 
 package org.apache.storm.kafka.spout.test;
 
-import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.EARLIEST;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.List;
-
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.storm.Config;
 import org.apache.storm.LocalCluster;
@@ -35,11 +28,18 @@ import org.apache.storm.kafka.spout.Func;
 import org.apache.storm.kafka.spout.KafkaSpout;
 import org.apache.storm.kafka.spout.KafkaSpoutConfig;
 import org.apache.storm.kafka.spout.KafkaSpoutRetryExponentialBackoff;
-import org.apache.storm.kafka.spout.KafkaSpoutRetryExponentialBackoff.TimeInterval;
 import org.apache.storm.kafka.spout.KafkaSpoutRetryService;
+import org.apache.storm.kafka.spout.internal.TimeInterval;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Values;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.List;
+
+import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.EARLIEST;
 
 public class KafkaSpoutTopologyMainNamedTopics {
     private static final String TOPIC_2_STREAM = "test_2_stream";
@@ -116,6 +116,7 @@ public class KafkaSpoutTopologyMainNamedTopics {
                 .setOffsetCommitPeriodMs(10_000)
                 .setFirstPollOffsetStrategy(EARLIEST)
                 .setMaxUncommittedOffsets(250)
+                .setInitialStartupDelay(TimeInterval.seconds(2))
                 .build();
     }
 


### PR DESCRIPTION
  - Refactored TimeInterval out of KafkaSpoutRetryExponentialBackoff
  - Configurable pre-fetch tasks to be run before spout starts processing tuples
       - Configurable fixed delay task before activation
       - Consumer rebalance task not to poll any data during rebalance