### PR TITLE
STORM-2503: Fix lgtm.com alerts on equality and comparison operations.

### DIFF
--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/TransactionalWords.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/TransactionalWords.java
@@ -124,7 +124,7 @@ public class TransactionalWords {
       for (String key : _counts.keySet()) {
         CountValue val = COUNT_DATABASE.get(key);
         CountValue newVal;
-        if (val == null || !val.txid.equals(_id)) {
+        if (val == null || !val.txid.equals(_id.getTransactionId())) {
           newVal = new CountValue();
           newVal.txid = _id.getTransactionId();
           if (val != null) {

--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/ReadClusterState.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/ReadClusterState.java
@@ -195,7 +195,7 @@ public class ReadClusterState implements Runnable, AutoCloseable {
             }
             if (version == null) {
                 // ignore
-            } else if (version == recordedVersion) {
+            } else if (version.equals(recordedVersion)) {
                 updateAssignmentVersion.put(topoId, locAssignment);
             } else {
                 VersionedData<Assignment> assignmentVersion = stormClusterState.assignmentInfoWithVersion(topoId, callback);

--- a/storm-core/src/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/DefaultResourceAwareStrategy.java
+++ b/storm-core/src/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/DefaultResourceAwareStrategy.java
@@ -521,7 +521,7 @@ public class DefaultResourceAwareStrategy implements IStrategy {
     }
 
     /**
-     * sort components by the number of in and out connections that need to be made
+     * sort components by the number of in and out connections that need to be made, in descending order
      *
      * @param componentMap The components that need to be sorted
      * @return a sorted set of components
@@ -541,7 +541,7 @@ public class DefaultResourceAwareStrategy implements IStrategy {
                     connections2 += (componentMap.get(childId).execs.size() * o2.execs.size());
                 }
 
-                if (connections1 > connections1) {
+                if (connections1 > connections2) {
                     return -1;
                 } else if (connections1 < connections2) {
                     return 1;
@@ -555,7 +555,7 @@ public class DefaultResourceAwareStrategy implements IStrategy {
     }
 
     /**
-     * Sort a component's neighbors by the number of connections it needs to make with this component
+     * Sort a component's neighbors by the number of connections it needs to make with this component, in descending order
      *
      * @param thisComp     the component that we need to sort its neighbors
      * @param componentMap all the components to sort
@@ -581,7 +581,7 @@ public class DefaultResourceAwareStrategy implements IStrategy {
     }
 
     /**
-     * Order executors based on how many in and out connections it will potentially need to make.
+     * Order executors based on how many in and out connections it will potentially need to make, in descending order.
      * First order components by the number of in and out connections it will have.  Then iterate through the sorted list of components.
      * For each component sort the neighbors of that component by how many connections it will have to make with that component.
      * Add an executor from this component and then from each neighboring component in sorted order.  Do this until there is nothing left to schedule

--- a/storm-core/src/jvm/org/apache/storm/trident/windowing/StoreBasedTridentWindowManager.java
+++ b/storm-core/src/jvm/org/apache/storm/trident/windowing/StoreBasedTridentWindowManager.java
@@ -121,7 +121,7 @@ public class StoreBasedTridentWindowManager extends AbstractTridentWindowManager
         }
         String trimKey = key.substring(0, lastSepIndex);
         int secondLastSepIndex = trimKey.lastIndexOf(WindowsStore.KEY_SEPARATOR);
-        if (lastSepIndex < 0) {
+        if (secondLastSepIndex < 0) {
             throw new IllegalArgumentException("key "+key+" does not have second key separator '" + WindowsStore.KEY_SEPARATOR + "'");
         }
 

--- a/storm-core/test/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-core/test/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -25,6 +25,7 @@ import org.apache.storm.scheduler.Cluster;
 import org.apache.storm.scheduler.ExecutorDetails;
 import org.apache.storm.scheduler.INimbus;
 import org.apache.storm.scheduler.SchedulerAssignmentImpl;
+import org.apache.storm.scheduler.SchedulerAssignment;
 import org.apache.storm.scheduler.SupervisorDetails;
 import org.apache.storm.scheduler.Topologies;
 import org.apache.storm.scheduler.TopologyDetails;
@@ -47,13 +48,13 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
-
 
 public class TestDefaultResourceAwareStrategy {
 
@@ -111,55 +112,23 @@ public class TestDefaultResourceAwareStrategy {
         rs.prepare(conf);
         rs.schedule(topologies, cluster);
 
-        Map<String, List<String>> nodeToComps = new HashMap<String, List<String>>();
-        for (Map.Entry<ExecutorDetails, WorkerSlot> entry : cluster.getAssignments().get("testTopology-id").getExecutorToSlot().entrySet()) {
-            WorkerSlot ws = entry.getValue();
-            ExecutorDetails exec = entry.getKey();
-            if (!nodeToComps.containsKey(ws.getNodeId())) {
-                nodeToComps.put(ws.getNodeId(), new LinkedList<String>());
-            }
-            nodeToComps.get(ws.getNodeId()).add(topo.getExecutorToComponent().get(exec));
+        HashSet<HashSet<ExecutorDetails>> expectedScheduling = new HashSet<>();
+        expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(0, 0)))); //Spout
+        expectedScheduling.add(new HashSet<>(Arrays.asList(
+            new ExecutorDetails(2, 2), //bolt-1
+            new ExecutorDetails(3, 3), //bolt-2
+            new ExecutorDetails(6, 6)))); //bolt-3
+        expectedScheduling.add(new HashSet<>(Arrays.asList(
+            new ExecutorDetails(1, 1), //bolt-1
+            new ExecutorDetails(4, 4), //bolt-2
+            new ExecutorDetails(5, 5)))); //bolt-3
+        HashSet<HashSet<ExecutorDetails>> foundScheduling = new HashSet<>();
+        SchedulerAssignment assignment = cluster.getAssignmentById("testTopology-id");
+        for (Collection<ExecutorDetails> execs : assignment.getSlotToExecutors().values()) {
+            foundScheduling.add(new HashSet<>(execs));
         }
 
-        /**
-         * check for correct scheduling
-         * Since all the resource availabilites on nodes are the same in the beginining
-         * DefaultResourceAwareStrategy can arbitrarily pick one thus we must find if a particular scheduling
-         * exists on a node the the cluster.
-         */
-
-        //one node should have the below scheduling
-        List<String> node1 = new LinkedList<>();
-        node1.add("spout");
-        node1.add("bolt-1");
-        node1.add("bolt-2");
-        Assert.assertTrue("Check DefaultResourceAwareStrategy scheduling", checkDefaultStrategyScheduling(nodeToComps, node1));
-
-        //one node should have the below scheduling
-        List<String> node2 = new LinkedList<>();
-        node2.add("bolt-3");
-        node2.add("bolt-1");
-        node2.add("bolt-2");
-
-        Assert.assertTrue("Check DefaultResourceAwareStrategy scheduling", checkDefaultStrategyScheduling(nodeToComps, node2));
-
-        //one node should have the below scheduling
-        List<String> node3 = new LinkedList<>();
-        node3.add("bolt-3");
-
-        Assert.assertTrue("Check DefaultResourceAwareStrategy scheduling", checkDefaultStrategyScheduling(nodeToComps, node3));
-
-        //three used and one node should be empty
-        Assert.assertEquals("only three nodes should be used", 3, nodeToComps.size());
-    }
-
-    private boolean checkDefaultStrategyScheduling(Map<String, List<String>> nodeToComps, List<String> schedulingToFind) {
-        for (List<String> entry : nodeToComps.values()) {
-            if (schedulingToFind.containsAll(entry) && entry.containsAll(schedulingToFind)) {
-                return true;
-            }
-        }
-        return false;
+        Assert.assertEquals(expectedScheduling, foundScheduling);
     }
 
     /**

--- a/storm-core/test/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-core/test/jvm/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -116,11 +116,11 @@ public class TestDefaultResourceAwareStrategy {
         expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(0, 0)))); //Spout
         expectedScheduling.add(new HashSet<>(Arrays.asList(
             new ExecutorDetails(2, 2), //bolt-1
-            new ExecutorDetails(3, 3), //bolt-2
+            new ExecutorDetails(4, 4), //bolt-2
             new ExecutorDetails(6, 6)))); //bolt-3
         expectedScheduling.add(new HashSet<>(Arrays.asList(
             new ExecutorDetails(1, 1), //bolt-1
-            new ExecutorDetails(4, 4), //bolt-2
+            new ExecutorDetails(3, 3), //bolt-2
             new ExecutorDetails(5, 5)))); //bolt-3
         HashSet<HashSet<ExecutorDetails>> foundScheduling = new HashSet<>();
         SchedulerAssignment assignment = cluster.getAssignmentById("testTopology-id");


### PR DESCRIPTION
This PR is a port of https://github.com/apache/storm/pull/2100 and https://github.com/apache/storm/pull/2143 to `1.x-branch`, as suggested by @HeartSaVioR.
It fixes several alerts involving comparison operations found at https://lgtm.com/projects/g/apache/storm/alerts.
It also includes a fix to the test for `DefaultResourceAwareStrategy`, provided by @revans2.

Differences from the original PRs:
- there appears to be no `SubSystem` class in this branch, so the addition of a `hashCode` method to it is not ported here
- `SchedulerAssignmentImpl` does not have an `equals` method in this branch, so the addition of a `hashCode` method is not ported here
- the `DefaultResourceAwareStrategy::sortNeighbors` comparator logic that was incorrectly changed in #2100 and restored in #2143 is not altered here
