### PR TITLE
[STORM-2559] There are three configurations in defaults.yaml haven't been used in storm.

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -49,9 +49,6 @@ storm.nimbus.retry.times: 5
 storm.nimbus.retry.interval.millis: 2000
 storm.nimbus.retry.intervalceiling.millis: 60000
 storm.auth.simple-white-list.users: []
-storm.auth.simple-acl.users: []
-storm.auth.simple-acl.users.commands: []
-storm.auth.simple-acl.admins: []
 storm.cluster.state.store: "org.apache.storm.cluster.ZKStateStorageFactory"
 storm.meta.serialization.delegate: "org.apache.storm.serialization.GzipThriftSerializationDelegate"
 storm.codedistributor.class: "org.apache.storm.codedistributor.LocalFileSystemCodeDistributor"


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2559](https://issues.apache.org/jira/browse/STORM-2559)
There are three configurations,storm.auth.simple-acl.users: [],storm.auth.simple-acl.users.commands: [] and storm.auth.simple-acl.admins: [], in defaults.conf haven't been used in storm.So I think it should be removed from defaults.yaml.