### PR TITLE
[STORM-2564] We should provide a template for storm-cluster-auth.yaml

### DIFF
--- a/conf/storm-cluster-auth.yaml.example
+++ b/conf/storm-cluster-auth.yaml.example
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########### Users should replace ${user} and ${pwd} with their own username and password
+#storm.zookeeper.auth.payload：${user}:${pwd}


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2564](https://issues.apache.org/jira/browse/STORM-2564)
As the configuration which named storm.zookeeper.auth.payload should be filled in "storm-cluster-auth.yaml",and there isn't such a file.So, I think we should provide a template for storm-cluster-auth.yaml.