### PR TITLE
STORM-2369 [storm-redis] Use binary type for State management

### DIFF
--- a/docs/State-checkpointing.md
+++ b/docs/State-checkpointing.md
@@ -70,6 +70,48 @@ json config with the following properties.
     }
 }
 ```
+ 
+For Redis Cluster state this is a json config with the following properties.
+ 
+```
+ {
+   "keyClass": "Optional fully qualified class name of the Key type.",
+   "valueClass": "Optional fully qualified class name of the Value type.",
+   "keySerializerClass": "Optional Key serializer implementation class.",
+   "valueSerializerClass": "Optional Value Serializer implementation class.",
+   "jedisClusterConfig": {
+     "nodes": ["localhost:7379", "localhost:7380", "localhost:7381"],
+     "timeout": 2000,
+     "maxRedirections": 5
+   }
+ }
+```
+
+NOTE: If you used Redis state with Storm version 1.1.0 or earlier, you would need to also migrate your state since the representation of state has changed  
+from Base64-encoded string to binary to reduce huge overhead. Storm provides a migration tool to help, which is placed on `storm-redis-example` module.
+
+Please download the source from download page or clone the project, and type below command:
+
+```
+mvn clean install -DskipTests
+cd examples/storm-redis-examples
+<storm-installation-dir>/bin/storm jar target/storm-redis-examples-*.jar org.apache.storm.redis.tools.Base64ToBinaryStateMigrationUtil [options]
+```
+
+Supported options are listed here:
+
+```
+ -d,--dbnum <arg>       Redis DB number (default: 0)
+ -h,--host <arg>        Redis hostname (default: localhost)
+ -n,--namespace <arg>   REQUIRED the list of namespace to migrate.
+ -p,--port <arg>        Redis port (default: 6379)
+    --password <arg>    Redis password (default: no password)
+```
+
+You can provide multiple `namespace` options to migrate multiple namespaces at once. 
+(e.g.: `--namespace total-7 --namespace partialsum-3`)
+Other options are not mandatory.
+Please note that you need to also migrate the key starting with "$checkpointspout-" since it's internal namespace of state. 
 
 ## Checkpoint mechanism
 Checkpoint is triggered by an internal checkpoint spout at the specified `topology.state.checkpoint.interval.ms`. If there is

--- a/examples/storm-redis-examples/pom.xml
+++ b/examples/storm-redis-examples/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>storm-redis</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/storm-redis-examples/src/main/java/org/apache/storm/redis/tools/Base64ToBinaryStateMigrationUtil.java
+++ b/examples/storm-redis-examples/src/main/java/org/apache/storm/redis/tools/Base64ToBinaryStateMigrationUtil.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.redis.tools;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.storm.redis.common.commands.RedisCommands;
+import org.apache.storm.redis.common.config.JedisPoolConfig;
+import org.apache.storm.redis.common.container.RedisCommandsContainerBuilder;
+import org.apache.storm.redis.common.container.RedisCommandsInstanceContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import redis.clients.util.SafeEncoder;
+
+
+public class Base64ToBinaryStateMigrationUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(Base64ToBinaryStateMigrationUtil.class);
+    private static final String OPTION_REDIS_HOST_SHORT = "h";
+    private static final String OPTION_REDIS_HOST_LONG = "host";
+    private static final String OPTION_REDIS_PORT_SHORT = "p";
+    private static final String OPTION_REDIS_PORT_LONG = "port";
+    private static final String OPTION_REDIS_PASSWORD_LONG = "password";
+    private static final String OPTION_REDIS_DB_NUM_SHORT = "d";
+    private static final String OPTION_REDIS_DB_NUM_LONG = "dbnum";
+    private static final String OPTION_NAMESPACE_SHORT = "n";
+    private static final String OPTION_NAMESPACE_LONG = "namespace";
+
+    private final RedisCommandsInstanceContainer container;
+
+    public Base64ToBinaryStateMigrationUtil(JedisPoolConfig poolConfig) {
+        this(RedisCommandsContainerBuilder.build(poolConfig));
+    }
+
+    public Base64ToBinaryStateMigrationUtil(RedisCommandsInstanceContainer container) {
+        this.container = container;
+    }
+
+    private void migrate(String namespace) {
+        String prepareNamespace = namespace + "$prepare";
+
+        RedisCommands commands = null;
+        try {
+            commands = container.getInstance();
+
+            migrateHashIfExists(commands, prepareNamespace);
+            migrateHashIfExists(commands, namespace);
+        } finally {
+            container.returnInstance(commands);
+        }
+
+    }
+
+    private void migrateHashIfExists(RedisCommands commands, String key) {
+        if (commands.exists(key)) {
+            LOG.info("Migrating '{}'...", key);
+
+            String backupKey = key + "_old";
+
+            LOG.info("Backing up current state '{}' to '{}'...", key, backupKey);
+            commands.rename(key, backupKey);
+
+            LOG.info("Reading current state '{}'...", key);
+            Map<String, String> currentValueMap = commands.hgetAll(key);
+
+            LOG.info("Converting state...");
+            Map<byte[], byte[]> convertedValueMap = convertBase64MapToBinaryMap(currentValueMap);
+
+            LOG.info("Pushing converted state to '{}'...", key);
+            commands.hmset(SafeEncoder.encode(key), convertedValueMap);
+        }
+    }
+
+    private Map<byte[], byte[]> convertBase64MapToBinaryMap(Map<String, String> base64Map) {
+        Map<byte[], byte[]> binaryMap = new HashMap<>();
+        for (Map.Entry<String, String> entry : base64Map.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            byte[] binaryKey = Base64.decodeBase64(key);
+            byte[] binaryValue = Base64.decodeBase64(value);
+
+            binaryMap.put(binaryKey, binaryValue);
+        }
+
+        return binaryMap;
+    }
+
+    /**
+     * Main entry.
+     *
+     * @param args command line arguments
+     * @throws IOException IOException
+     * @throws ParseException ParseException
+     */
+    public static void main(String[] args) throws IOException, ParseException {
+        Options options = buildOptions();
+        CommandLineParser parser = new DefaultParser();
+        CommandLine commandLine = parser.parse(options, args);
+
+        if (!commandLine.hasOption(OPTION_NAMESPACE_LONG)) {
+            printUsageAndExit(options, OPTION_NAMESPACE_LONG + " is required");
+        }
+
+        String[] namespaces = commandLine.getOptionValues(OPTION_NAMESPACE_LONG);
+        String host = commandLine.getOptionValue(OPTION_REDIS_HOST_LONG, "localhost");
+        String portStr = commandLine.getOptionValue(OPTION_REDIS_PORT_LONG, "6379");
+        String password = commandLine.getOptionValue(OPTION_REDIS_PASSWORD_LONG);
+        String dbNumStr = commandLine.getOptionValue(OPTION_REDIS_DB_NUM_LONG, "0");
+
+        JedisPoolConfig jedisPoolConfig = new JedisPoolConfig.Builder()
+                .setHost(host)
+                .setPort(Integer.parseInt(portStr))
+                .setPassword(password)
+                .setDatabase(Integer.parseInt(dbNumStr))
+                .setTimeout(2000)
+                .build();
+
+        Base64ToBinaryStateMigrationUtil migrationUtil = new Base64ToBinaryStateMigrationUtil(jedisPoolConfig);
+
+        for (String namespace : namespaces) {
+            migrationUtil.migrate(namespace);
+        }
+
+        LOG.info("Done...");
+    }
+
+    private static Options buildOptions() {
+        Options options = new Options();
+        options.addOption(OPTION_NAMESPACE_SHORT, OPTION_NAMESPACE_LONG, true, "REQUIRED the list of namespace to migrate.");
+        options.addOption(OPTION_REDIS_HOST_SHORT, OPTION_REDIS_HOST_LONG, true, "Redis hostname (default: localhost)");
+        options.addOption(OPTION_REDIS_PORT_SHORT, OPTION_REDIS_PORT_LONG, true, "Redis port (default: 6379)");
+        options.addOption(null, OPTION_REDIS_PASSWORD_LONG, true, "Redis password (default: no password)");
+        options.addOption(OPTION_REDIS_DB_NUM_SHORT, OPTION_REDIS_DB_NUM_LONG, true, "Redis DB number (default: 0)");
+        return options;
+    }
+
+    private static void printUsageAndExit(Options options, String message) {
+        LOG.error(message);
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.printHelp("Base64ToBinaryStateMigrationUtil ", options);
+        System.exit(1);
+    }
+
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.bolt;
 
 import org.apache.storm.task.OutputCollector;
@@ -37,7 +38,8 @@ import java.util.Map;
  * Due to environment abstraction, AbstractRedisBolt provides JedisCommands which contains only single key operations.
  * <p/>
  * Custom Bolts may want to follow this pattern:
- * <p><blockquote><pre>
+ * <p/>
+ * <blockquote><pre>
  * JedisCommands jedisCommands = null;
  * try {
  *     jedisCommand = getInstance();
@@ -50,7 +52,6 @@ import java.util.Map;
  * </pre></blockquote>
  *
  */
-// TODO: Separate Jedis / JedisCluster to provide full operations for each environment to users
 public abstract class AbstractRedisBolt extends BaseTickTupleAwareRichBolt {
     protected OutputCollector collector;
 
@@ -60,7 +61,8 @@ public abstract class AbstractRedisBolt extends BaseTickTupleAwareRichBolt {
     private JedisClusterConfig jedisClusterConfig;
 
     /**
-     * Constructor for single Redis environment (JedisPool)
+     * Constructor for single Redis environment (JedisPool).
+     *
      * @param config configuration for initializing JedisPool
      */
     public AbstractRedisBolt(JedisPoolConfig config) {
@@ -68,7 +70,8 @@ public abstract class AbstractRedisBolt extends BaseTickTupleAwareRichBolt {
     }
 
     /**
-     * Constructor for Redis Cluster environment (JedisCluster)
+     * Constructor for Redis Cluster environment (JedisCluster).
+     *
      * @param config configuration for initializing JedisCluster
      */
     public AbstractRedisBolt(JedisClusterConfig config) {

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/adapter/RedisCommandsAdapterJedis.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/adapter/RedisCommandsAdapterJedis.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.redis.common.adapter;
+
+import org.apache.storm.redis.common.commands.RedisCommands;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Adapter class to make Jedis instance play with BinaryRedisCommands interface.
+ */
+public class RedisCommandsAdapterJedis implements RedisCommands, Closeable {
+    private Jedis jedis;
+
+    public RedisCommandsAdapterJedis(Jedis resource) {
+        jedis = resource;
+    }
+
+    @Override
+    public byte[] hget(byte[] key, byte[] field) {
+        return jedis.hget(key, field);
+    }
+
+    @Override
+    public Boolean exists(byte[] key) {
+        return jedis.exists(key);
+    }
+
+    @Override
+    public String hmset(byte[] key, Map<byte[], byte[]> fieldValues) {
+        return jedis.hmset(key, fieldValues);
+    }
+
+    @Override
+    public Map<byte[], byte[]> hgetAll(byte[] key) {
+        return jedis.hgetAll(key);
+    }
+
+    @Override
+    public Long hdel(byte[] key, byte[]... fields) {
+        return jedis.hdel(key, fields);
+    }
+
+    @Override
+    public Long del(byte[] key) {
+        return jedis.del(key);
+    }
+
+    @Override
+    public Long del(String key) {
+        return jedis.del(key);
+    }
+
+    @Override
+    public String rename(byte[] oldkey, byte[] newkey) {
+        return jedis.rename(oldkey, newkey);
+    }
+
+    @Override
+    public String rename(String oldkey, String newkey) {
+        return jedis.rename(oldkey, newkey);
+    }
+
+    @Override
+    public ScanResult<Map.Entry<byte[], byte[]>> hscan(byte[] key, byte[] cursor, ScanParams params) {
+        return jedis.hscan(key, cursor, params);
+    }
+
+    @Override
+    public boolean exists(String key) {
+        return jedis.exists(key);
+    }
+
+    @Override
+    public Map<String, String> hgetAll(String key) {
+        return jedis.hgetAll(key);
+    }
+
+    @Override
+    public String hmset(String key, Map<String, String> fieldValues) {
+        return jedis.hmset(key, fieldValues);
+    }
+
+    @Override
+    public void close() throws IOException {
+        jedis.close();
+    }
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/adapter/RedisCommandsAdapterJedisCluster.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/adapter/RedisCommandsAdapterJedisCluster.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.redis.common.adapter;
+
+import org.apache.storm.redis.common.commands.RedisCommands;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Adapter class to make JedisCluster instance play with BinaryRedisCommands interface.
+ */
+public class RedisCommandsAdapterJedisCluster implements RedisCommands, Closeable {
+    private JedisCluster jedisCluster;
+
+    public RedisCommandsAdapterJedisCluster(JedisCluster jedisCluster) {
+        this.jedisCluster = jedisCluster;
+    }
+
+    @Override
+    public byte[] hget(byte[] key, byte[] field) {
+        return jedisCluster.hget(key, field);
+    }
+
+    @Override
+    public Boolean exists(byte[] key) {
+        return jedisCluster.exists(key);
+    }
+
+    @Override
+    public String hmset(byte[] key, Map<byte[], byte[]> fieldValues) {
+        return jedisCluster.hmset(key, fieldValues);
+    }
+
+    @Override
+    public Map<byte[], byte[]> hgetAll(byte[] key) {
+        return jedisCluster.hgetAll(key);
+    }
+
+    @Override
+    public Long hdel(byte[] key, byte[]... fields) {
+        return jedisCluster.hdel(key, fields);
+    }
+
+    @Override
+    public Long del(byte[] key) {
+        return jedisCluster.del(key);
+    }
+
+    @Override
+    public Long del(String key) {
+        return jedisCluster.del(key);
+    }
+
+    @Override
+    public String rename(byte[] oldkey, byte[] newkey) {
+        return jedisCluster.rename(oldkey, newkey);
+    }
+
+    @Override
+    public String rename(String oldkey, String newkey) {
+        return jedisCluster.rename(oldkey, newkey);
+    }
+
+    @Override
+    public ScanResult<Map.Entry<byte[], byte[]>> hscan(byte[] key, byte[] cursor, ScanParams params) {
+        return jedisCluster.hscan(key, cursor, params);
+    }
+
+    @Override
+    public boolean exists(String key) {
+        return jedisCluster.exists(key);
+    }
+
+    @Override
+    public Map<String, String> hgetAll(String key) {
+        return jedisCluster.hgetAll(key);
+    }
+
+    @Override
+    public String hmset(String key, Map<String, String> fieldValues) {
+        return jedisCluster.hmset(key, fieldValues);
+    }
+
+    @Override
+    public void close() throws IOException {
+        jedisCluster.close();
+    }
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/commands/RedisCommands.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/commands/RedisCommands.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.redis.common.commands;
+
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+
+import java.util.Map;
+
+/**
+ * This interface represents Jedis methods exhaustively which are used on storm-redis.
+ *
+ * This is a workaround since Jedis and JedisCluster doesn't implement same interface for binary type of methods,
+ * and unify binary methods and string methods into one interface.
+ */
+public interface RedisCommands {
+    // common
+    Boolean exists(byte[] key);
+
+    boolean exists(String key);
+
+    Long del(byte[] key);
+
+    Long del(String key);
+
+    String rename(byte[] oldkey, byte[] newkey);
+
+    String rename(String oldkey, String newkey);
+
+    // hash
+    byte[] hget(byte[] key, byte[] field);
+
+    Map<byte[], byte[]> hgetAll(byte[] key);
+
+    Map<String,String> hgetAll(String key);
+
+    String hmset(byte[] key, Map<byte[], byte[]> fieldValues);
+
+    String hmset(String key, Map<String, String> fieldValues);
+
+    Long hdel(byte[] key, byte[]... fields);
+
+    ScanResult<Map.Entry<byte[], byte[]>> hscan(byte[] key, byte[] cursor, ScanParams params);
+}

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisClusterConfig.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisClusterConfig.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.common.config;
 
 import com.google.common.base.Preconditions;
@@ -34,6 +35,10 @@ public class JedisClusterConfig implements Serializable {
     private int timeout;
     private int maxRedirections;
     private String password;
+
+    // for jackson
+    public JedisClusterConfig() {
+    }
 
     /**
      * Constructor

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisPoolConfig.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/config/JedisPoolConfig.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.common.config;
 
 import redis.clients.jedis.Protocol;
@@ -36,7 +37,7 @@ public class JedisPoolConfig implements Serializable {
     public JedisPoolConfig() {
     }
     /**
-     * Constructor
+     * Constructor.
      * <p/>
      * You can use JedisPoolConfig.Builder() for leaving some fields to apply default value.
      *

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisClusterContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisClusterContainer.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.common.container;
 
 import redis.clients.jedis.JedisCluster;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/RedisCommandsContainerBuilder.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/RedisCommandsContainerBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.storm.redis.common.container;
 
 import org.apache.storm.redis.common.config.JedisClusterConfig;
@@ -24,9 +23,9 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
 
 /**
- * Container Builder which helps abstraction of two env. - single instance or Redis Cluster.
+ * The binary version of container builder which helps abstraction of two env. - single instance or Redis Cluster.
  */
-public class JedisCommandsContainerBuilder {
+public class RedisCommandsContainerBuilder {
 
     // FIXME: We're using default config since it cannot be serialized
     // We still needs to provide some options externally
@@ -37,9 +36,9 @@ public class JedisCommandsContainerBuilder {
      * @param config configuration for JedisPool
      * @return container for single Redis environment
      */
-    public static JedisCommandsInstanceContainer build(JedisPoolConfig config) {
+    public static RedisCommandsInstanceContainer build(JedisPoolConfig config) {
         JedisPool jedisPool = new JedisPool(DEFAULT_POOL_CONFIG, config.getHost(), config.getPort(), config.getTimeout(), config.getPassword(), config.getDatabase());
-        return new JedisContainer(jedisPool);
+        return new RedisContainer(jedisPool);
     }
 
     /**
@@ -47,8 +46,8 @@ public class JedisCommandsContainerBuilder {
      * @param config configuration for JedisCluster
      * @return container for Redis Cluster environment
      */
-    public static JedisCommandsInstanceContainer build(JedisClusterConfig config) {
-        JedisCluster jedisCluster = new JedisCluster(config.getNodes(), config.getTimeout(), config.getTimeout(), config.getMaxRedirections(), config.getPassword(), DEFAULT_POOL_CONFIG);
-        return new JedisClusterContainer(jedisCluster);
+    public static RedisCommandsInstanceContainer build(JedisClusterConfig config) {
+        JedisCluster jedisCluster = new JedisCluster(config.getNodes(), config.getTimeout(), config.getMaxRedirections(), DEFAULT_POOL_CONFIG);
+        return new RedisClusterContainer(jedisCluster);
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/RedisCommandsInstanceContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/RedisCommandsInstanceContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,32 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.storm.redis.common.container;
 
-import redis.clients.jedis.JedisCommands;
+import org.apache.storm.redis.common.commands.RedisCommands;
 
 import java.io.Closeable;
 
 /**
- * Interfaces for containers which stores instances implementing JedisCommands.
+ * Interfaces for containers which stores instances implementing RedisCommands.
  */
-public interface JedisCommandsInstanceContainer extends Closeable {
+public interface RedisCommandsInstanceContainer extends Closeable {
     /**
      * Borrows instance from container.
-     * @return instance which implements JedisCommands
+     * @return instance which implements RedisCommands
      */
-    JedisCommands getInstance();
+    RedisCommands getInstance();
 
     /**
      * Returns instance to container.
-     * @param jedisCommands borrowed instance
+     * @param redisCommands borrowed instance
      */
-    void returnInstance(JedisCommands jedisCommands);
-
-    /**
-     * Release Container
-     */
-    @Override
-    public void close();
+    void returnInstance(RedisCommands redisCommands);
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/RedisContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/RedisContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,18 +18,16 @@
 
 package org.apache.storm.redis.common.container;
 
+import org.apache.storm.redis.common.adapter.RedisCommandsAdapterJedis;
+import org.apache.storm.redis.common.commands.RedisCommands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.JedisCommands;
 import redis.clients.jedis.JedisPool;
 
 import java.io.Closeable;
 import java.io.IOException;
 
-/**
- * Container for managing Jedis instances.
- */
-public class JedisContainer implements JedisCommandsInstanceContainer {
+public class RedisContainer implements RedisCommandsInstanceContainer {
     private static final Logger LOG = LoggerFactory.getLogger(JedisContainer.class);
 
     private JedisPool jedisPool;
@@ -38,7 +36,7 @@ public class JedisContainer implements JedisCommandsInstanceContainer {
      * Constructor
      * @param jedisPool JedisPool which actually manages Jedis instances
      */
-    public JedisContainer(JedisPool jedisPool) {
+    public RedisContainer(JedisPool jedisPool) {
         this.jedisPool = jedisPool;
     }
 
@@ -46,21 +44,21 @@ public class JedisContainer implements JedisCommandsInstanceContainer {
      * {@inheritDoc}
      */
     @Override
-    public JedisCommands getInstance() {
-        return jedisPool.getResource();
+    public RedisCommands getInstance() {
+        return new RedisCommandsAdapterJedis(jedisPool.getResource());
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void returnInstance(JedisCommands jedisCommands) {
-        if (jedisCommands == null) {
+    public void returnInstance(RedisCommands redisCommands) {
+        if (redisCommands == null) {
             return;
         }
 
         try {
-            ((Closeable) jedisCommands).close();
+            ((Closeable) redisCommands).close();
         } catch (IOException e) {
             LOG.error("Failed to close (return) instance to pool");
         }
@@ -70,7 +68,7 @@ public class JedisContainer implements JedisCommandsInstanceContainer {
      * {@inheritDoc}
      */
     @Override
-    public void close() {
+    public void close() throws IOException {
         jedisPool.close();
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/state/RedisKeyValueStateIterator.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/state/RedisKeyValueStateIterator.java
@@ -18,153 +18,97 @@
 
 package org.apache.storm.redis.state;
 
-import com.google.common.collect.Iterators;
-import com.google.common.collect.PeekingIterator;
-
-import java.util.AbstractMap;
-import java.util.HashSet;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
 
-import org.apache.storm.redis.common.container.JedisCommandsInstanceContainer;
-import org.apache.storm.redis.utils.RedisEncoder;
+import org.apache.storm.redis.common.commands.RedisCommands;
+import org.apache.storm.redis.common.container.RedisCommandsInstanceContainer;
+import org.apache.storm.state.BaseBinaryStateIterator;
+import org.apache.storm.state.DefaultStateEncoder;
 import org.apache.storm.state.Serializer;
 
-import redis.clients.jedis.JedisCommands;
+import org.apache.storm.state.StateEncoder;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
 /**
  * An iterator over {@link RedisKeyValueState}.
  */
-public class RedisKeyValueStateIterator<K, V> implements Iterator<Map.Entry<K, V>> {
+public class RedisKeyValueStateIterator<K, V> extends BaseBinaryStateIterator<K, V> {
 
-    private final String namespace;
-    private final PeekingIterator<Map.Entry<String, String>> pendingPrepareIterator;
-    private final PeekingIterator<Map.Entry<String, String>> pendingCommitIterator;
-    private final RedisEncoder<K, V> decoder;
-    private final JedisCommandsInstanceContainer jedisContainer;
+    private final byte[] namespace;
+    private final StateEncoder<K, V, byte[], byte[]> encoder;
+    private final RedisCommandsInstanceContainer container;
     private final ScanParams scanParams;
-    private final Set<String> providedKeys;
 
-    private PeekingIterator<Map.Entry<String, String>> cachedResultIterator;
-    private String cursor;
-    private boolean firstLoad = true;
-    private PeekingIterator<Map.Entry<String, String>> pendingIterator;
+    private Iterator<Map.Entry<byte[], byte[]>> cachedResultIterator;
+    private byte[] cursor;
 
     /**
      * Constructor.
      *
      * @param namespace The namespace of State
-     * @param jedisContainer The instance of JedisContainter
+     * @param container The instance of RedisCommandsInstanceContainer
      * @param pendingPrepareIterator The iterator of pendingPrepare
      * @param pendingCommitIterator The iterator of pendingCommit
      * @param chunkSize The size of chunk to get entries from Redis
      * @param keySerializer The serializer of key
      * @param valueSerializer The serializer of value
      */
-    public RedisKeyValueStateIterator(String namespace, JedisCommandsInstanceContainer jedisContainer,
-                                      Iterator<Map.Entry<String, String>> pendingPrepareIterator,
-                                      Iterator<Map.Entry<String, String>> pendingCommitIterator,
+    public RedisKeyValueStateIterator(byte[] namespace, RedisCommandsInstanceContainer container,
+                                      Iterator<Map.Entry<byte[], byte[]>> pendingPrepareIterator,
+                                      Iterator<Map.Entry<byte[], byte[]>> pendingCommitIterator,
                                       int chunkSize, Serializer<K> keySerializer,
                                       Serializer<V> valueSerializer) {
+        super(pendingPrepareIterator, pendingCommitIterator);
         this.namespace = namespace;
-        this.pendingPrepareIterator = Iterators.peekingIterator(pendingPrepareIterator);
-        this.pendingCommitIterator = Iterators.peekingIterator(pendingCommitIterator);
-        this.jedisContainer = jedisContainer;
-        this.decoder = new RedisEncoder<K, V>(keySerializer, valueSerializer);
+        this.container = container;
+        this.encoder = new DefaultStateEncoder<K, V>(keySerializer, valueSerializer);
         this.scanParams = new ScanParams().count(chunkSize);
-        this.cursor = ScanParams.SCAN_POINTER_START;
-        this.providedKeys = new HashSet<>();
+        this.cursor = ScanParams.SCAN_POINTER_START_BINARY;
     }
 
     @Override
-    public boolean hasNext() {
-        if (seekToAvailableEntry(pendingPrepareIterator)) {
-            pendingIterator = pendingPrepareIterator;
-            return true;
-        }
-
-        if (seekToAvailableEntry(pendingCommitIterator)) {
-            pendingIterator = pendingCommitIterator;
-            return true;
-        }
-
-        if (firstLoad) {
-            // load the first part of entries
-            loadChunkFromRedis();
-            firstLoad = false;
-        }
-
-        while (true) {
-            if (seekToAvailableEntry(cachedResultIterator)) {
-                pendingIterator = cachedResultIterator;
-                return true;
-            }
-
-            if (cursor.equals(ScanParams.SCAN_POINTER_START)) {
-                break;
-            }
-
-            loadChunkFromRedis();
-        }
-
-        pendingIterator = null;
-        return false;
+    protected Iterator<Map.Entry<byte[], byte[]>> loadChunkFromStateStorage() {
+        loadChunkFromRedis();
+        return cachedResultIterator;
     }
 
     @Override
-    public Map.Entry<K, V> next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
-        }
-        Map.Entry<String, String> redisKeyValue = pendingIterator.next();
-        K key = decoder.decodeKey(redisKeyValue.getKey());
-        V value = decoder.decodeValue(redisKeyValue.getValue());
-
-        providedKeys.add(redisKeyValue.getKey());
-        return new AbstractMap.SimpleEntry(key, value);
+    protected boolean isEndOfDataFromStorage() {
+        return (cachedResultIterator == null || !cachedResultIterator.hasNext())
+            && Arrays.equals(cursor, ScanParams.SCAN_POINTER_START_BINARY);
     }
 
     @Override
-    public void remove() {
-        throw new UnsupportedOperationException();
+    protected K decodeKey(byte[] key) {
+        return encoder.decodeKey(key);
     }
 
-    private boolean seekToAvailableEntry(PeekingIterator<Map.Entry<String, String>> iterator) {
-        if (iterator != null) {
-            while (iterator.hasNext()) {
-                Map.Entry<String, String> entry = iterator.peek();
-                if (!providedKeys.contains(entry.getKey())) {
-                    if (entry.getValue().equals(RedisEncoder.TOMBSTONE)) {
-                        providedKeys.add(entry.getKey());
-                    } else {
-                        return true;
-                    }
-                }
+    @Override
+    protected V decodeValue(byte[] value) {
+        return encoder.decodeValue(value);
+    }
 
-                iterator.next();
-            }
-        }
-
-        return false;
+    @Override
+    protected boolean isTombstoneValue(byte[] value) {
+        return Arrays.equals(value, encoder.getTombstoneValue());
     }
 
     private void loadChunkFromRedis() {
-        JedisCommands commands = null;
+        RedisCommands commands = null;
         try {
-            commands = jedisContainer.getInstance();
-            ScanResult<Map.Entry<String, String>> scanResult = commands.hscan(namespace, cursor, scanParams);
-            List<Map.Entry<String, String>> result = scanResult.getResult();
+            commands = container.getInstance();
+            ScanResult<Map.Entry<byte[], byte[]>> scanResult = commands.hscan(namespace, cursor, scanParams);
+            List<Map.Entry<byte[], byte[]>> result = scanResult.getResult();
             if (result != null) {
-                cachedResultIterator = Iterators.peekingIterator(result.iterator());
+                cachedResultIterator = result.iterator();
             }
-            cursor = scanResult.getStringCursor();
+            cursor = scanResult.getCursorAsBytes();
         } finally {
-            jedisContainer.returnInstance(commands);
+            container.returnInstance(commands);
         }
     }
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/state/RedisKeyValueStateProvider.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/state/RedisKeyValueStateProvider.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.redis.state;
 
+import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.apache.storm.state.DefaultStateSerializer;
 import org.apache.storm.state.Serializer;
 import org.apache.storm.state.State;
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.storm.redis.common.config.JedisPoolConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import redis.clients.jedis.JedisCluster;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,7 +67,18 @@ public class RedisKeyValueStateProvider implements StateProvider {
     }
 
     private RedisKeyValueState getRedisKeyValueState(String namespace, StateConfig config) throws Exception {
-        return new RedisKeyValueState(namespace, getJedisPoolConfig(config), getKeySerializer(config), getValueSerializer(config));
+        JedisPoolConfig jedisPoolConfig = getJedisPoolConfig(config);
+        JedisClusterConfig jedisClusterConfig = getJedisClusterConfig(config);
+
+        if (jedisPoolConfig == null && jedisClusterConfig == null) {
+            jedisPoolConfig = buildDefaultJedisPoolConfig();
+        }
+
+        if (jedisPoolConfig != null) {
+            return new RedisKeyValueState(namespace, jedisPoolConfig, getKeySerializer(config), getValueSerializer(config));
+        } else {
+            return new RedisKeyValueState(namespace, jedisClusterConfig, getKeySerializer(config), getValueSerializer(config));
+        }
     }
 
     private Serializer getKeySerializer(StateConfig config) throws Exception {
@@ -95,15 +108,24 @@ public class RedisKeyValueStateProvider implements StateProvider {
     }
 
     private JedisPoolConfig getJedisPoolConfig(StateConfig config) {
-        return config.jedisPoolConfig != null ? config.jedisPoolConfig : new JedisPoolConfig.Builder().build();
+        return config.jedisPoolConfig;
     }
 
-    static class StateConfig {
-        String keyClass;
-        String valueClass;
-        String keySerializerClass;
-        String valueSerializerClass;
-        JedisPoolConfig jedisPoolConfig;
+    private JedisClusterConfig getJedisClusterConfig(StateConfig config) {
+        return config.jedisClusterConfig;
+    }
+
+    private JedisPoolConfig buildDefaultJedisPoolConfig() {
+        return new JedisPoolConfig.Builder().build();
+    }
+
+    public static class StateConfig {
+        public String keyClass;
+        public String valueClass;
+        public String keySerializerClass;
+        public String valueSerializerClass;
+        public JedisPoolConfig jedisPoolConfig;
+        public JedisClusterConfig jedisClusterConfig;
 
         @Override
         public String toString() {
@@ -113,6 +135,7 @@ public class RedisKeyValueStateProvider implements StateProvider {
                     ", keySerializerClass='" + keySerializerClass + '\'' +
                     ", valueSerializerClass='" + valueSerializerClass + '\'' +
                     ", jedisPoolConfig=" + jedisPoolConfig +
+                    ", jedisClusterConfig=" + jedisClusterConfig +
                     '}';
         }
     }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/AbstractRedisStateQuerier.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/AbstractRedisStateQuerier.java
@@ -6,15 +6,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.trident.state;
 
 import org.apache.storm.tuple.Values;
@@ -37,59 +38,59 @@ import java.util.List;
  * @param <T> type of State
  */
 public abstract class AbstractRedisStateQuerier<T extends State> extends BaseQueryFunction<T, List<Values>> {
-	private final RedisLookupMapper lookupMapper;
-	protected final RedisDataTypeDescription.RedisDataType dataType;
-	protected final String additionalKey;
+    private final RedisLookupMapper lookupMapper;
+    protected final RedisDataTypeDescription.RedisDataType dataType;
+    protected final String additionalKey;
 
-	/**
-	 * Constructor
-	 *
-	 * @param lookupMapper mapper for querying
-	 */
-	public AbstractRedisStateQuerier(RedisLookupMapper lookupMapper) {
-		this.lookupMapper = lookupMapper;
+    /**
+     * Constructor
+     *
+     * @param lookupMapper mapper for querying
+     */
+    public AbstractRedisStateQuerier(RedisLookupMapper lookupMapper) {
+        this.lookupMapper = lookupMapper;
 
-		RedisDataTypeDescription dataTypeDescription = lookupMapper.getDataTypeDescription();
-		this.dataType = dataTypeDescription.getDataType();
-		this.additionalKey = dataTypeDescription.getAdditionalKey();
-	}
+        RedisDataTypeDescription dataTypeDescription = lookupMapper.getDataTypeDescription();
+        this.dataType = dataTypeDescription.getDataType();
+        this.additionalKey = dataTypeDescription.getAdditionalKey();
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public List<List<Values>> batchRetrieve(T state, List<TridentTuple> inputs) {
-		List<List<Values>> values = Lists.newArrayList();
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<List<Values>> batchRetrieve(T state, List<TridentTuple> inputs) {
+        List<List<Values>> values = Lists.newArrayList();
 
-		List<String> keys = Lists.newArrayList();
-		for (TridentTuple input : inputs) {
-			keys.add(lookupMapper.getKeyFromTuple(input));
-		}
+        List<String> keys = Lists.newArrayList();
+        for (TridentTuple input : inputs) {
+            keys.add(lookupMapper.getKeyFromTuple(input));
+        }
 
-		List<String> redisVals = retrieveValuesFromRedis(state, keys);
-		for (int i = 0 ; i < redisVals.size() ; i++) {
-			values.add(lookupMapper.toTuple(inputs.get(i), redisVals.get(i)));
-		}
+        List<String> redisVals = retrieveValuesFromRedis(state, keys);
+        for (int i = 0; i < redisVals.size(); i++) {
+            values.add(lookupMapper.toTuple(inputs.get(i), redisVals.get(i)));
+        }
 
-		return values;
-	}
+        return values;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void execute(TridentTuple tuple, List<Values> values, TridentCollector collector) {
-		for (Values value : values) {
-			collector.emit(value);
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(TridentTuple tuple, List<Values> values, TridentCollector collector) {
+        for (Values value : values) {
+            collector.emit(value);
+        }
+    }
 
-	/**
-	 * Retrieves values from Redis that each value is corresponding to each key.
-	 *
-	 * @param state State for handling query
-	 * @param keys keys having state values
-	 * @return values which are corresponding to keys
-	 */
-	protected abstract List<String> retrieveValuesFromRedis(T state, List<String> keys);
+    /**
+     * Retrieves values from Redis that each value is corresponding to each key.
+     *
+     * @param state State for handling query
+     * @param keys keys having state values
+     * @return values which are corresponding to keys
+     */
+    protected abstract List<String> retrieveValuesFromRedis(T state, List<String> keys);
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/AbstractRedisStateUpdater.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/AbstractRedisStateUpdater.java
@@ -6,15 +6,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.trident.state;
 
 import org.apache.storm.redis.common.mapper.RedisDataTypeDescription;
@@ -37,60 +38,60 @@ import java.util.Map;
  * @param <T> type of State
  */
 public abstract class AbstractRedisStateUpdater<T extends State> extends BaseStateUpdater<T> {
-	private final RedisStoreMapper storeMapper;
+    private final RedisStoreMapper storeMapper;
 
-	protected int expireIntervalSec = 0;
-	protected final RedisDataTypeDescription.RedisDataType dataType;
-	protected final String additionalKey;
+    protected int expireIntervalSec = 0;
+    protected final RedisDataTypeDescription.RedisDataType dataType;
+    protected final String additionalKey;
 
-	/**
-	 * Constructor
-	 *
-	 * @param storeMapper mapper for storing
-	 */
-	public AbstractRedisStateUpdater(RedisStoreMapper storeMapper) {
-		this.storeMapper = storeMapper;
-		RedisDataTypeDescription dataTypeDescription = storeMapper.getDataTypeDescription();
-		this.dataType = dataTypeDescription.getDataType();
-		this.additionalKey = dataTypeDescription.getAdditionalKey();
-	}
+    /**
+     * Constructor
+     *
+     * @param storeMapper mapper for storing
+     */
+    public AbstractRedisStateUpdater(RedisStoreMapper storeMapper) {
+        this.storeMapper = storeMapper;
+        RedisDataTypeDescription dataTypeDescription = storeMapper.getDataTypeDescription();
+        this.dataType = dataTypeDescription.getDataType();
+        this.additionalKey = dataTypeDescription.getAdditionalKey();
+    }
 
-	/**
-	 * Sets expire (time to live) if needed
-	 *
-	 * @param expireIntervalSec time to live in seconds
-	 */
-	public void setExpireInterval(int expireIntervalSec) {
-		if (expireIntervalSec > 0) {
-			this.expireIntervalSec = expireIntervalSec;
-		} else {
-			this.expireIntervalSec = 0;
-		}
-	}
+    /**
+     * Sets expire (time to live) if needed
+     *
+     * @param expireIntervalSec time to live in seconds
+     */
+    public void setExpireInterval(int expireIntervalSec) {
+        if (expireIntervalSec > 0) {
+            this.expireIntervalSec = expireIntervalSec;
+        } else {
+            this.expireIntervalSec = 0;
+        }
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void updateState(T state, List<TridentTuple> inputs,
-			TridentCollector collector) {
-		Map<String, String> keyToValue = new HashMap<String, String>();
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void updateState(T state, List<TridentTuple> inputs,
+                            TridentCollector collector) {
+        Map<String, String> keyToValue = new HashMap<String, String>();
 
-		for (TridentTuple input : inputs) {
-			String key = storeMapper.getKeyFromTuple(input);
-			String value = storeMapper.getValueFromTuple(input);
+        for (TridentTuple input : inputs) {
+            String key = storeMapper.getKeyFromTuple(input);
+            String value = storeMapper.getValueFromTuple(input);
 
-			keyToValue.put(key, value);
-		}
+            keyToValue.put(key, value);
+        }
 
-		updateStatesToRedis(state, keyToValue);
-	}
+        updateStatesToRedis(state, keyToValue);
+    }
 
-	/**
-	 * Updates (key, value) pairs to Redis.
-	 *
-	 * @param state State for handling query
-	 * @param keyToValue (key, value) pairs
-	 */
-	protected abstract void updateStatesToRedis(T state, Map<String, String> keyToValue);
+    /**
+     * Updates (key, value) pairs to Redis.
+     *
+     * @param state State for handling query
+     * @param keyToValue (key, value) pairs
+     */
+    protected abstract void updateStatesToRedis(T state, Map<String, String> keyToValue);
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/KeyFactory.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/KeyFactory.java
@@ -6,15 +6,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.trident.state;
 
 import java.io.Serializable;
@@ -29,12 +30,12 @@ public interface KeyFactory extends Serializable {
      * @param key state key
      * @return Redis key
      */
-	String build(List<Object> key);
+    String build(List<Object> key);
 
     /**
      * Default Key Factory
      */
-	class DefaultKeyFactory implements KeyFactory {
+    class DefaultKeyFactory implements KeyFactory {
         /**
          * {@inheritDoc}
          * <p/>
@@ -46,12 +47,12 @@ public interface KeyFactory extends Serializable {
          * @see KeyFactory#build(List)
          */
         @Override
-		public String build(List<Object> key) {
-			if (key.size() != 1)
-				throw new RuntimeException("Default KeyFactory does not support compound keys");
+        public String build(List<Object> key) {
+            if (key.size() != 1)
+                throw new RuntimeException("Default KeyFactory does not support compound keys");
 
-			return (String) key.get(0);
-		}
-	}
+            return (String) key.get(0);
+        }
+    }
 }
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/Options.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/Options.java
@@ -6,15 +6,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.trident.state;
 
 import org.apache.storm.redis.common.mapper.RedisDataTypeDescription;
@@ -29,12 +30,12 @@ import java.io.Serializable;
  * @param <T> value's type class
  */
 public class Options<T> implements Serializable {
-	private static final RedisDataTypeDescription DEFAULT_REDIS_DATATYPE = new RedisDataTypeDescription(RedisDataTypeDescription.RedisDataType.STRING);
+    private static final RedisDataTypeDescription DEFAULT_REDIS_DATATYPE = new RedisDataTypeDescription(RedisDataTypeDescription.RedisDataType.STRING);
 
-	public int localCacheSize = 1000;
-	public String globalKey = "$REDIS-MAP-STATE-GLOBAL";
-	public KeyFactory keyFactory = null;
-	public Serializer<T> serializer = null;
-	public RedisDataTypeDescription dataTypeDescription = DEFAULT_REDIS_DATATYPE;
-	public int expireIntervalSec = 0;
+    public int localCacheSize = 1000;
+    public String globalKey = "$REDIS-MAP-STATE-GLOBAL";
+    public KeyFactory keyFactory = null;
+    public Serializer<T> serializer = null;
+    public RedisDataTypeDescription dataTypeDescription = DEFAULT_REDIS_DATATYPE;
+    public int expireIntervalSec = 0;
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterMapState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterMapState.java
@@ -6,15 +6,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.trident.state;
 
 import org.apache.storm.task.IMetricsContext;
@@ -231,11 +232,11 @@ public class RedisClusterMapState<T> extends AbstractRedisMapState<T> {
         @Override
         public State makeState(@SuppressWarnings("rawtypes") Map<String, Object> conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
             JedisCluster jedisCluster = new JedisCluster(jedisClusterConfig.getNodes(),
-                                                            jedisClusterConfig.getTimeout(),
-                                                            jedisClusterConfig.getTimeout(),
-                                                            jedisClusterConfig.getMaxRedirections(),
-                                                            jedisClusterConfig.getPassword(),
-                                                            DEFAULT_POOL_CONFIG);
+                    jedisClusterConfig.getTimeout(),
+                    jedisClusterConfig.getTimeout(),
+                    jedisClusterConfig.getMaxRedirections(),
+                    jedisClusterConfig.getPassword(),
+                    DEFAULT_POOL_CONFIG);
 
             RedisClusterMapState state = new RedisClusterMapState(jedisCluster, options, serializer, keyFactory);
             CachedMap c = new CachedMap(state, options.localCacheSize);
@@ -303,21 +304,21 @@ public class RedisClusterMapState<T> extends AbstractRedisMapState<T> {
         String[] stringKeys = keys.toArray(new String[keys.size()]);
         RedisDataTypeDescription description = this.options.dataTypeDescription;
         switch (description.getDataType()) {
-        case STRING:
-            List<String> values = Lists.newArrayList();
+            case STRING:
+                List<String> values = Lists.newArrayList();
 
-            for (String stringKey : keys) {
-                String value = jedisCluster.get(stringKey);
-                values.add(value);
-            }
+                for (String stringKey : keys) {
+                    String value = jedisCluster.get(stringKey);
+                    values.add(value);
+                }
 
-            return values;
+                return values;
 
-        case HASH:
-            return jedisCluster.hmget(description.getAdditionalKey(), stringKeys);
+            case HASH:
+                return jedisCluster.hmget(description.getAdditionalKey(), stringKeys);
 
-        default:
-            throw new IllegalArgumentException("Cannot process such data type: " + description.getDataType());
+            default:
+                throw new IllegalArgumentException("Cannot process such data type: " + description.getDataType());
         }
     }
 
@@ -328,25 +329,25 @@ public class RedisClusterMapState<T> extends AbstractRedisMapState<T> {
     protected void updateStatesToRedis(Map<String, String> keyValues) {
         RedisDataTypeDescription description = this.options.dataTypeDescription;
         switch (description.getDataType()) {
-        case STRING:
-            for (Map.Entry<String, String> kvEntry : keyValues.entrySet()) {
-                if(this.options.expireIntervalSec > 0){
-                    jedisCluster.setex(kvEntry.getKey(), this.options.expireIntervalSec, kvEntry.getValue());
-                } else {
-                    jedisCluster.set(kvEntry.getKey(), kvEntry.getValue());
+            case STRING:
+                for (Map.Entry<String, String> kvEntry : keyValues.entrySet()) {
+                    if (this.options.expireIntervalSec > 0) {
+                        jedisCluster.setex(kvEntry.getKey(), this.options.expireIntervalSec, kvEntry.getValue());
+                    } else {
+                        jedisCluster.set(kvEntry.getKey(), kvEntry.getValue());
+                    }
                 }
-            }
-            break;
+                break;
 
-        case HASH:
-            jedisCluster.hmset(description.getAdditionalKey(), keyValues);
-            if (this.options.expireIntervalSec > 0) {
-                jedisCluster.expire(description.getAdditionalKey(), this.options.expireIntervalSec);
-            }
-            break;
+            case HASH:
+                jedisCluster.hmset(description.getAdditionalKey(), keyValues);
+                if (this.options.expireIntervalSec > 0) {
+                    jedisCluster.expire(description.getAdditionalKey(), this.options.expireIntervalSec);
+                }
+                break;
 
-        default:
-            throw new IllegalArgumentException("Cannot process such data type: " + description.getDataType());
+            default:
+                throw new IllegalArgumentException("Cannot process such data type: " + description.getDataType());
         }
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterState.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.trident.state;
 
 import org.apache.storm.task.IMetricsContext;

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterStateQuerier.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/trident/state/RedisClusterStateQuerier.java
@@ -6,15 +6,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.trident.state;
 
 import org.apache.storm.redis.common.mapper.RedisLookupMapper;
@@ -50,14 +51,14 @@ public class RedisClusterStateQuerier extends AbstractRedisStateQuerier<RedisClu
 
             for (String key : keys) {
                 switch (dataType) {
-                case STRING:
-                    redisVals.add(jedisCluster.get(key));
-                    break;
-                case HASH:
-                    redisVals.add(jedisCluster.hget(additionalKey, key));
-                    break;
-                default:
-                    throw new IllegalArgumentException("Cannot process such data type: " + dataType);
+                    case STRING:
+                        redisVals.add(jedisCluster.get(key));
+                        break;
+                    case HASH:
+                        redisVals.add(jedisCluster.hget(additionalKey, key));
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Cannot process such data type: " + dataType);
                 }
             }
 

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/state/DefaultStateSerializerTest.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/state/DefaultStateSerializerTest.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.redis.state;
 
 import org.apache.storm.spout.CheckPointState;

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateIteratorTest.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateIteratorTest.java
@@ -18,25 +18,26 @@
 
 package org.apache.storm.redis.state;
 
-import org.apache.storm.redis.common.container.JedisCommandsInstanceContainer;
-import org.apache.storm.redis.utils.RedisEncoder;
+import com.google.common.primitives.UnsignedBytes;
+import org.apache.storm.redis.common.adapter.RedisCommandsAdapterJedis;
+import org.apache.storm.redis.common.container.RedisCommandsInstanceContainer;
+import org.apache.storm.state.DefaultStateEncoder;
 import org.apache.storm.state.DefaultStateSerializer;
 import org.apache.storm.state.Serializer;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.TreeMap;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,105 +47,53 @@ import static org.mockito.Mockito.when;
  */
 public class RedisKeyValueStateIteratorTest {
 
-    private String namespace;
-    private JedisCommandsInstanceContainer mockContainer;
-    private Jedis mockJedis;
+    private byte[] namespace;
+    private RedisCommandsInstanceContainer mockContainer;
+    private RedisCommandsAdapterJedis mockJedis;
     private int chunkSize = 1000;
-    private Serializer<String> keySerializer = new DefaultStateSerializer<>();
-    private Serializer<String> valueSerializer = new DefaultStateSerializer<>();
-    private RedisEncoder<String, String> encoder;
+    private Serializer<byte[]> keySerializer = new DefaultStateSerializer<>();
+    private Serializer<byte[]> valueSerializer = new DefaultStateSerializer<>();
+    private DefaultStateEncoder<byte[], byte[]> encoder;
 
     @Before
     public void setUp() {
-        namespace = "namespace";
-        mockContainer = mock(JedisCommandsInstanceContainer.class);
-        mockJedis = mock(Jedis.class);
+        namespace = "namespace".getBytes();
+        mockContainer = mock(RedisCommandsInstanceContainer.class);
+        mockJedis = mock(RedisCommandsAdapterJedis.class);
         when(mockContainer.getInstance()).thenReturn(mockJedis);
 
-        encoder = new RedisEncoder<>(keySerializer, valueSerializer);
-    }
-
-    @Test
-    public void testGetEntriesFromPendingPrepare() {
-        Map<String, String> pendingPrepare = new TreeMap<>();
-        putEncodedKeyValueToMap(pendingPrepare, "key0", "value0");
-        putTombstoneToMap(pendingPrepare, "key1");
-        putEncodedKeyValueToMap(pendingPrepare, "key2", "value2");
-
-        Map<String, String> pendingCommit = new TreeMap<>();
-
-        ScanResult<Map.Entry<String, String>> scanResult = new ScanResult<Map.Entry<String, String>>(
-                ScanParams.SCAN_POINTER_START, new ArrayList<>());
-        when(mockJedis.hscan(eq(namespace), anyString(), any(ScanParams.class))).thenReturn(scanResult);
-
-        RedisKeyValueStateIterator<String, String> kvIterator =
-                new RedisKeyValueStateIterator<>(namespace, mockContainer, pendingPrepare.entrySet().iterator(),
-                        pendingCommit.entrySet().iterator(), chunkSize, keySerializer, valueSerializer);
-
-        assertNextEntry(kvIterator, "key0", "value0");
-
-        // key1 shouldn't in iterator
-
-        assertNextEntry(kvIterator, "key2", "value2");
-
-        assertFalse(kvIterator.hasNext());
-    }
-
-    @Test
-    public void testGetEntriesFromPendingCommit() {
-        Map<String, String> pendingPrepare = new TreeMap<>();
-
-        Map<String, String> pendingCommit = new TreeMap<>();
-        putEncodedKeyValueToMap(pendingCommit, "key0", "value0");
-        putTombstoneToMap(pendingCommit, "key1");
-        putEncodedKeyValueToMap(pendingCommit, "key2", "value2");
-
-        ScanResult<Map.Entry<String, String>> scanResult = new ScanResult<Map.Entry<String, String>>(
-                ScanParams.SCAN_POINTER_START, new ArrayList<>());
-        when(mockJedis.hscan(eq(namespace), anyString(), any(ScanParams.class))).thenReturn(scanResult);
-
-        RedisKeyValueStateIterator<String, String> kvIterator =
-                new RedisKeyValueStateIterator<>(namespace, mockContainer, pendingPrepare.entrySet().iterator(),
-                        pendingCommit.entrySet().iterator(), chunkSize, keySerializer, valueSerializer);
-
-        assertNextEntry(kvIterator, "key0", "value0");
-
-        // key1 shouldn't in iterator
-
-        assertNextEntry(kvIterator, "key2", "value2");
-
-        assertFalse(kvIterator.hasNext());
+        encoder = new DefaultStateEncoder<>(keySerializer, valueSerializer);
     }
 
     @Test
     public void testGetEntriesFromFirstPartOfChunkInRedis() {
         // pendingPrepare has no entries
-        Map<String, String> pendingPrepare = new TreeMap<>();
+        NavigableMap<byte[], byte[]> pendingPrepare = getBinaryTreeMap();
 
         // pendingCommit has no entries
-        Map<String, String> pendingCommit = new TreeMap<>();
+        NavigableMap<byte[], byte[]> pendingCommit = getBinaryTreeMap();
 
         // Redis has a chunk but no more
-        Map<String, String> chunkMap = new TreeMap<>();
-        putEncodedKeyValueToMap(chunkMap, "key0", "value0");
-        putEncodedKeyValueToMap(chunkMap, "key2", "value2");
+        NavigableMap<byte[], byte[]> chunkMap = getBinaryTreeMap();
+        putEncodedKeyValueToMap(chunkMap, "key0".getBytes(), "value0".getBytes());
+        putEncodedKeyValueToMap(chunkMap, "key2".getBytes(), "value2".getBytes());
 
-        ScanResult<Map.Entry<String, String>> scanResultFirst = new ScanResult<>(
-                "12345", new ArrayList<>(chunkMap.entrySet()));
-        ScanResult<Map.Entry<String, String>> scanResultSecond = new ScanResult<>(
-                ScanParams.SCAN_POINTER_START, new ArrayList<>());
-        when(mockJedis.hscan(eq(namespace), anyString(), any(ScanParams.class)))
+        ScanResult<Map.Entry<byte[], byte[]>> scanResultFirst = new ScanResult<>(
+                "12345".getBytes(), new ArrayList<>(chunkMap.entrySet()));
+        ScanResult<Map.Entry<byte[], byte[]>> scanResultSecond = new ScanResult<>(
+                ScanParams.SCAN_POINTER_START_BINARY, new ArrayList<Map.Entry<byte[], byte[]>>());
+        when(mockJedis.hscan(eq(namespace), any(byte[].class), any(ScanParams.class)))
                 .thenReturn(scanResultFirst, scanResultSecond);
 
-        RedisKeyValueStateIterator<String, String> kvIterator =
+        RedisKeyValueStateIterator<byte[], byte[]> kvIterator =
                 new RedisKeyValueStateIterator<>(namespace, mockContainer, pendingPrepare.entrySet().iterator(),
                         pendingCommit.entrySet().iterator(), chunkSize, keySerializer, valueSerializer);
 
-        assertNextEntry(kvIterator, "key0", "value0");
+        assertNextEntry(kvIterator, "key0".getBytes(), "value0".getBytes());
 
         // key1 shouldn't in iterator
 
-        assertNextEntry(kvIterator, "key2", "value2");
+        assertNextEntry(kvIterator, "key2".getBytes(), "value2".getBytes());
 
         assertFalse(kvIterator.hasNext());
     }
@@ -152,113 +101,117 @@ public class RedisKeyValueStateIteratorTest {
     @Test
     public void testGetEntriesFromThirdPartOfChunkInRedis() {
         // pendingPrepare has no entries
-        Map<String, String> pendingPrepare = new TreeMap<>();
+        NavigableMap<byte[], byte[]> pendingPrepare = getBinaryTreeMap();
 
         // pendingCommit has no entries
-        Map<String, String> pendingCommit = new TreeMap<>();
+        NavigableMap<byte[], byte[]> pendingCommit = getBinaryTreeMap();
 
         // Redis has three chunks which last chunk only has entries
-        Map<String, String> chunkMap = new TreeMap<>();
-        putEncodedKeyValueToMap(chunkMap, "key0", "value0");
-        putEncodedKeyValueToMap(chunkMap, "key2", "value2");
+        NavigableMap<byte[], byte[]> chunkMap = getBinaryTreeMap();
+        putEncodedKeyValueToMap(chunkMap, "key0".getBytes(), "value0".getBytes());
+        putEncodedKeyValueToMap(chunkMap, "key2".getBytes(), "value2".getBytes());
 
-        ScanResult<Map.Entry<String, String>> scanResultFirst = new ScanResult<>(
-                "12345", new ArrayList<>());
-        ScanResult<Map.Entry<String, String>> scanResultSecond = new ScanResult<>(
-                "23456", new ArrayList<>());
-        ScanResult<Map.Entry<String, String>> scanResultThird = new ScanResult<>(
-                ScanParams.SCAN_POINTER_START, new ArrayList<>(chunkMap.entrySet()));
-        when(mockJedis.hscan(eq(namespace), anyString(), any(ScanParams.class)))
+        ScanResult<Map.Entry<byte[], byte[]>> scanResultFirst = new ScanResult<>(
+                "12345".getBytes(), new ArrayList<Map.Entry<byte[], byte[]>>());
+        ScanResult<Map.Entry<byte[], byte[]>> scanResultSecond = new ScanResult<>(
+                "23456".getBytes(), new ArrayList<Map.Entry<byte[], byte[]>>());
+        ScanResult<Map.Entry<byte[], byte[]>> scanResultThird = new ScanResult<>(
+                ScanParams.SCAN_POINTER_START_BINARY, new ArrayList<>(chunkMap.entrySet()));
+        when(mockJedis.hscan(eq(namespace), any(byte[].class), any(ScanParams.class)))
                 .thenReturn(scanResultFirst, scanResultSecond, scanResultThird);
 
-        RedisKeyValueStateIterator<String, String> kvIterator =
+        RedisKeyValueStateIterator<byte[], byte[]> kvIterator =
                 new RedisKeyValueStateIterator<>(namespace, mockContainer, pendingPrepare.entrySet().iterator(),
                         pendingCommit.entrySet().iterator(), chunkSize, keySerializer, valueSerializer);
 
-        assertNextEntry(kvIterator, "key0", "value0");
+        assertNextEntry(kvIterator, "key0".getBytes(), "value0".getBytes());
 
         // key1 shouldn't in iterator
 
-        assertNextEntry(kvIterator, "key2", "value2");
+        assertNextEntry(kvIterator, "key2".getBytes(), "value2".getBytes());
 
         assertFalse(kvIterator.hasNext());
     }
 
     @Test
     public void testGetEntriesRemovingDuplicationKeys() {
-        Map<String, String> pendingPrepare = new TreeMap<>();
-        putEncodedKeyValueToMap(pendingPrepare, "key0", "value0");
-        putTombstoneToMap(pendingPrepare, "key1");
+        NavigableMap<byte[], byte[]> pendingPrepare = getBinaryTreeMap();
+        putEncodedKeyValueToMap(pendingPrepare, "key0".getBytes(), "value0".getBytes());
+        putTombstoneToMap(pendingPrepare, "key1".getBytes());
 
-        Map<String, String> pendingCommit = new TreeMap<>();
-        putEncodedKeyValueToMap(pendingCommit, "key1", "value1");
-        putEncodedKeyValueToMap(pendingCommit, "key2", "value2");
+        NavigableMap<byte[], byte[]> pendingCommit = getBinaryTreeMap();
+        putEncodedKeyValueToMap(pendingCommit, "key1".getBytes(), "value1".getBytes());
+        putEncodedKeyValueToMap(pendingCommit, "key2".getBytes(), "value2".getBytes());
 
-        Map<String, String> chunkMap = new TreeMap<>();
-        putEncodedKeyValueToMap(chunkMap, "key2", "value2");
-        putEncodedKeyValueToMap(chunkMap, "key3", "value3");
+        NavigableMap<byte[], byte[]> chunkMap = getBinaryTreeMap();
+        putEncodedKeyValueToMap(chunkMap, "key2".getBytes(), "value2".getBytes());
+        putEncodedKeyValueToMap(chunkMap, "key3".getBytes(), "value3".getBytes());
 
-        Map<String, String> chunkMap2 = new TreeMap<>();
-        putEncodedKeyValueToMap(chunkMap2, "key3", "value3");
-        putEncodedKeyValueToMap(chunkMap2, "key4", "value4");
+        NavigableMap<byte[], byte[]> chunkMap2 = getBinaryTreeMap();
+        putEncodedKeyValueToMap(chunkMap2, "key3".getBytes(), "value3".getBytes());
+        putEncodedKeyValueToMap(chunkMap2, "key4".getBytes(), "value4".getBytes());
 
-        ScanResult<Map.Entry<String, String>> scanResultFirst = new ScanResult<>(
-                "12345", new ArrayList<>(chunkMap.entrySet()));
-        ScanResult<Map.Entry<String, String>> scanResultSecond = new ScanResult<>(
-                "23456", new ArrayList<>(chunkMap2.entrySet()));
-        ScanResult<Map.Entry<String, String>> scanResultThird = new ScanResult<>(
-                ScanParams.SCAN_POINTER_START, new ArrayList<>());
-        when(mockJedis.hscan(eq(namespace), anyString(), any(ScanParams.class)))
+        ScanResult<Map.Entry<byte[], byte[]>> scanResultFirst = new ScanResult<>(
+                "12345".getBytes(), new ArrayList<>(chunkMap.entrySet()));
+        ScanResult<Map.Entry<byte[], byte[]>> scanResultSecond = new ScanResult<>(
+                "23456".getBytes(), new ArrayList<>(chunkMap2.entrySet()));
+        ScanResult<Map.Entry<byte[], byte[]>> scanResultThird = new ScanResult<>(
+                ScanParams.SCAN_POINTER_START_BINARY, new ArrayList<Map.Entry<byte[], byte[]>>());
+        when(mockJedis.hscan(eq(namespace), any(byte[].class), any(ScanParams.class)))
                 .thenReturn(scanResultFirst, scanResultSecond, scanResultThird);
 
-        RedisKeyValueStateIterator<String, String> kvIterator =
+        RedisKeyValueStateIterator<byte[], byte[]> kvIterator =
                 new RedisKeyValueStateIterator<>(namespace, mockContainer, pendingPrepare.entrySet().iterator(),
                         pendingCommit.entrySet().iterator(), chunkSize, keySerializer, valueSerializer);
 
         // keys shouldn't appear twice
 
-        assertNextEntry(kvIterator, "key0", "value0");
+        assertNextEntry(kvIterator, "key0".getBytes(), "value0".getBytes());
 
         // key1 shouldn't be in iterator since it's marked as deleted
 
-        assertNextEntry(kvIterator, "key2", "value2");
-        assertNextEntry(kvIterator, "key3", "value3");
-        assertNextEntry(kvIterator, "key4", "value4");
+        assertNextEntry(kvIterator, "key2".getBytes(), "value2".getBytes());
+        assertNextEntry(kvIterator, "key3".getBytes(), "value3".getBytes());
+        assertNextEntry(kvIterator, "key4".getBytes(), "value4".getBytes());
 
         assertFalse(kvIterator.hasNext());
     }
 
     @Test
     public void testGetEntryNotAvailable() {
-        Map<String, String> pendingPrepare = new TreeMap<>();
+        NavigableMap<byte[], byte[]> pendingPrepare = getBinaryTreeMap();
 
-        Map<String, String> pendingCommit = new TreeMap<>();
+        NavigableMap<byte[], byte[]> pendingCommit = getBinaryTreeMap();
 
-        ScanResult<Map.Entry<String, String>> scanResult = new ScanResult<>(
-                ScanParams.SCAN_POINTER_START, new ArrayList<>());
-        when(mockJedis.hscan(eq(namespace), anyString(), any(ScanParams.class)))
+        ScanResult<Map.Entry<byte[], byte[]>> scanResult = new ScanResult<>(
+                ScanParams.SCAN_POINTER_START_BINARY, new ArrayList<Map.Entry<byte[], byte[]>>());
+        when(mockJedis.hscan(eq(namespace), any(byte[].class), any(ScanParams.class)))
                 .thenReturn(scanResult);
 
-        RedisKeyValueStateIterator<String, String> kvIterator =
+        RedisKeyValueStateIterator<byte[], byte[]> kvIterator =
                 new RedisKeyValueStateIterator<>(namespace, mockContainer, pendingPrepare.entrySet().iterator(),
                         pendingCommit.entrySet().iterator(), chunkSize, keySerializer, valueSerializer);
 
         assertFalse(kvIterator.hasNext());
     }
 
-    private void assertNextEntry(RedisKeyValueStateIterator<String, String> kvIterator, String expectedKey,
-                                 String expectedValue) {
+    private void assertNextEntry(RedisKeyValueStateIterator<byte[], byte[]> kvIterator, byte[] expectedKey,
+                                 byte[] expectedValue) {
         assertTrue(kvIterator.hasNext());
-        Map.Entry<String, String> entry = kvIterator.next();
-        assertEquals(expectedKey, entry.getKey());
-        assertEquals(expectedValue, entry.getValue());
+        Map.Entry<byte[], byte[]> entry = kvIterator.next();
+        assertArrayEquals(expectedKey, entry.getKey());
+        assertArrayEquals(expectedValue, entry.getValue());
     }
 
-    private void putEncodedKeyValueToMap(Map<String, String> map, String key, String value) {
+    private void putEncodedKeyValueToMap(NavigableMap<byte[], byte[]> map, byte[] key, byte[] value) {
         map.put(encoder.encodeKey(key), encoder.encodeValue(value));
     }
 
-    private void putTombstoneToMap(Map<String, String> map, String key) {
-        map.put(encoder.encodeKey(key), RedisEncoder.TOMBSTONE);
+    private void putTombstoneToMap(NavigableMap<byte[], byte[]> map, byte[] key) {
+        map.put(encoder.encodeKey(key), encoder.getTombstoneValue());
+    }
+
+    private TreeMap<byte[], byte[]> getBinaryTreeMap() {
+        return new TreeMap<>(UnsignedBytes.lexicographicalComparator());
     }
 }

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
@@ -17,97 +17,127 @@
  */
 package org.apache.storm.redis.state;
 
-import com.google.common.base.Optional;
+import com.google.common.primitives.UnsignedBytes;
+import org.apache.storm.redis.common.commands.RedisCommands;
+import org.apache.storm.redis.common.container.RedisCommandsInstanceContainer;
 import org.apache.storm.state.DefaultStateSerializer;
-import org.apache.storm.redis.common.container.JedisCommandsInstanceContainer;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import redis.clients.jedis.BinaryClient;
-import redis.clients.jedis.JedisCommands;
-import redis.clients.jedis.ScanResult;
-import redis.clients.jedis.SortingParams;
-import redis.clients.jedis.Tuple;
+import redis.clients.util.SafeEncoder;
 
 import java.util.HashMap;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Set;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
 import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link RedisKeyValueState}
+ *
+ * NOTE: The type of key for mockMap is String, which should be byte[],
+ * since but byte[] doesn't implement equals() so taking workaround to make life happier.
+ * It shouldn't make issues on Redis side, since raw type of Redis is binary.
  */
 public class RedisKeyValueStateTest {
-    JedisCommandsInstanceContainer mockContainer;
-    JedisCommands mockCommands;
+    RedisCommandsInstanceContainer mockContainer;
+    RedisCommands mockCommands;
     RedisKeyValueState<String, String> keyValueState;
 
     @Before
     public void setUp() {
-        final Map<String, Map<String, String>> mockMap = new HashMap<>();
-        mockContainer = Mockito.mock(JedisCommandsInstanceContainer.class);
-        mockCommands = Mockito.mock(JedisCommands.class);
+        final NavigableMap<byte[], NavigableMap<byte[], byte[]>> mockMap =
+                new ConcurrentSkipListMap<>(UnsignedBytes.lexicographicalComparator());
+        mockContainer = Mockito.mock(RedisCommandsInstanceContainer.class);
+        mockCommands = Mockito.mock(RedisCommands.class);
         Mockito.when(mockContainer.getInstance()).thenReturn(mockCommands);
         ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> stringArgumentCaptor2 = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Map> mapArgumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        Mockito.when(mockCommands.exists(Mockito.any(byte[].class)))
+                .thenAnswer(new Answer<Boolean>() {
+                    @Override
+                    public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        return exists(mockMap, (byte[]) args[0]);
+                    }
+                });
+
+        Mockito.when(mockCommands.del(Mockito.any(byte[].class)))
+                .thenAnswer(new Answer<Long>() {
+                    @Override
+                    public Long answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        return del(mockMap, (byte[]) args[0]);
+                    }
+                });
+
+        Mockito.when(mockCommands.hmset(Mockito.any(byte[].class), Mockito.anyMap()))
+                .thenAnswer(new Answer<String>() {
+                    @Override
+                    public String answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        return hmset(mockMap, (byte[]) args[0], (Map<byte[], byte[]>) args[1]);
+                    }
+                });
+
+        Mockito.when(mockCommands.hget(Mockito.any(byte[].class), Mockito.any(byte[].class)))
+                .thenAnswer(new Answer<byte[]>() {
+                    @Override
+                    public byte[] answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        return hget(mockMap, (byte[]) args[0], (byte[]) args[1]);
+                    }
+                });
+
+        Mockito.when(mockCommands.hdel(Mockito.any(byte[].class), Mockito.<byte[]>anyVararg()))
+                .thenAnswer(new Answer<Long>() {
+                    @Override
+                    public Long answer(InvocationOnMock invocation) throws Throwable {
+                        Object[] args = invocation.getArguments();
+                        int argsSize = args.length;
+                        byte[][] fields = Arrays.asList(args).subList(1, argsSize).toArray(new byte[argsSize - 1][]);
+                        return hdel(mockMap, (byte[]) args[0], fields);
+                    }
+                });
 
         Mockito.when(mockCommands.exists(Mockito.anyString()))
                 .thenAnswer(new Answer<Boolean>() {
                     @Override
                     public Boolean answer(InvocationOnMock invocation) throws Throwable {
                         Object[] args = invocation.getArguments();
-                        return mockMap.containsKey((String) args[0]);
+                        return exists(mockMap, (String) args[0]);
                     }
                 });
-
 
         Mockito.when(mockCommands.hmset(Mockito.anyString(), Mockito.anyMap()))
                 .thenAnswer(new Answer<String>() {
                     @Override
                     public String answer(InvocationOnMock invocation) throws Throwable {
                         Object[] args = invocation.getArguments();
-                        return hmset(mockMap, (String) args[0], (Map) args[1]);
+                        return hmset(mockMap, (String) args[0], (Map<String, String>) args[1]);
                     }
                 });
 
-        Mockito.when(mockCommands.del(Mockito.anyString()))
-                .thenAnswer(new Answer<Long>() {
+        Mockito.when(mockCommands.hgetAll(Mockito.anyString()))
+                .thenAnswer(new Answer<Map<String, String>>() {
                     @Override
-                    public Long answer(InvocationOnMock invocation) throws Throwable {
+                    public Map<String, String> answer(InvocationOnMock invocation) throws Throwable {
                         Object[] args = invocation.getArguments();
-                        return del(mockMap, (String) args[0]);
-                    }
-                });
-
-        Mockito.when(mockCommands.hget(Mockito.anyString(), Mockito.anyString()))
-                .thenAnswer(new Answer<String>() {
-                    @Override
-                    public String answer(InvocationOnMock invocation) throws Throwable {
-                        Object[] args = invocation.getArguments();
-                        return hget(mockMap, (String) args[0], (String) args[1]);
-                    }
-                });
-
-        Mockito.when(mockCommands.hdel(Mockito.anyString(), Mockito.<String>anyVararg()))
-                .thenAnswer(new Answer<Long>() {
-                    @Override
-                    public Long answer(InvocationOnMock invocation) throws Throwable {
-                        Object[] args = invocation.getArguments();
-                        int argsSize = args.length;
-                        String[] fields = Arrays.asList(args).subList(1, argsSize).toArray(new String[argsSize - 1]);
-                        return hdel(mockMap, (String) args[0], fields);
+                        return hgetAll(mockMap, (String) args[0]);
                     }
                 });
 
         keyValueState = new RedisKeyValueState<String, String>("test", mockContainer, new DefaultStateSerializer<String>(),
                                                                new DefaultStateSerializer<String>());
     }
-
 
     @Test
     public void testPutAndGet() throws Exception {
@@ -172,36 +202,73 @@ public class RedisKeyValueStateTest {
         };
     }
 
-    private String hmset(Map<String, Map<String, String>> mockMap, String key, Map value) {
-        Map<String, String> currentValue = mockMap.get(key);
+    private Boolean exists(NavigableMap<byte[], NavigableMap<byte[], byte[]>> mockMap, byte[] key) {
+        return mockMap.containsKey(key);
+    }
+
+    private String hmset(NavigableMap<byte[], NavigableMap<byte[], byte[]>> mockMap, byte[] key, Map<byte[], byte[]> value) {
+        NavigableMap<byte[], byte[]> currentValue = mockMap.get(key);
         if (currentValue == null) {
-            currentValue = new HashMap<>();
+            currentValue = new TreeMap<>(UnsignedBytes.lexicographicalComparator());
         }
-        currentValue.putAll(value);
+
+        for (Map.Entry<byte[], byte[]> entry : value.entrySet()) {
+            currentValue.put(entry.getKey(), entry.getValue());
+        }
+
         mockMap.put(key, currentValue);
         return "";
     }
 
-    private Long del(Map<String, Map<String, String>> mockMap, String key) {
+    private Long del(NavigableMap<byte[], NavigableMap<byte[], byte[]>> mockMap, byte[] key) {
         if (mockMap.remove(key) == null)
             return 0L;
         else
             return 1L;
     }
 
-    private String hget(Map<String, Map<String, String>> mockMap, String namespace, String key) {
+    private byte[] hget(NavigableMap<byte[], NavigableMap<byte[], byte[]>> mockMap, byte[] namespace, byte[] key) {
         if (mockMap.containsKey(namespace)) {
             return mockMap.get(namespace).get(key);
         }
         return null;
     }
 
-    private Long hdel(Map<String, Map<String, String>> mockMap, String namespace, String ... keys) {
+    private Long hdel(NavigableMap<byte[], NavigableMap<byte[], byte[]>> mockMap, byte[] namespace, byte[] ... keys) {
         Long count = 0L;
-        for (String key: keys) {
+        for (byte[] key: keys) {
             if (mockMap.get(namespace).remove(key) != null) count++;
         }
         return count;
     }
 
+    private Boolean exists(NavigableMap<byte[], NavigableMap<byte[], byte[]>> mockMap, String key) {
+        return mockMap.containsKey(SafeEncoder.encode(key));
+    }
+
+
+    private String hmset(NavigableMap<byte[], NavigableMap<byte[], byte[]>> mockMap, String key, Map<String, String> value) {
+        NavigableMap<byte[], byte[]> currentValue = mockMap.get(SafeEncoder.encode(key));
+        if (currentValue == null) {
+            currentValue = new TreeMap<>(UnsignedBytes.lexicographicalComparator());
+        }
+
+        for (Map.Entry<String, String> entry : value.entrySet()) {
+            currentValue.put(SafeEncoder.encode(entry.getKey()), SafeEncoder.encode(entry.getValue()));
+        }
+
+        mockMap.put(SafeEncoder.encode(key), currentValue);
+        return "";
+    }
+
+    private Map<String, String> hgetAll(NavigableMap<byte[], NavigableMap<byte[], byte[]>> mockMap, String key) {
+        Map<byte[], byte[]> currentValue = mockMap.get(SafeEncoder.encode(key));
+
+        Map<String, String> converted = new HashMap<>(currentValue.size());
+        for (Map.Entry<byte[], byte[]> entry : currentValue.entrySet()) {
+            converted.put(SafeEncoder.encode(entry.getKey()), SafeEncoder.encode(entry.getValue()));
+        }
+
+        return converted;
+    }
 }

--- a/storm-client/src/jvm/org/apache/storm/state/BaseBinaryStateIterator.java
+++ b/storm-client/src/jvm/org/apache/storm/state/BaseBinaryStateIterator.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.state;
+
+import com.google.common.collect.Iterators;
+import com.google.common.primitives.UnsignedBytes;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ * Base implementation of iterator over {@link KeyValueState} which encoded types of key and value are both binary type.
+ */
+public abstract class BaseBinaryStateIterator<K, V> extends BaseStateIterator<K, V, byte[], byte[]> {
+
+    /**
+     * Constructor.
+     *
+     * @param pendingPrepareIterator The iterator of pendingPrepare
+     * @param pendingCommitIterator The iterator of pendingCommit
+     */
+    public BaseBinaryStateIterator(Iterator<Map.Entry<byte[], byte[]>> pendingPrepareIterator,
+                                   Iterator<Map.Entry<byte[], byte[]>> pendingCommitIterator) {
+        super(Iterators.peekingIterator(pendingPrepareIterator), Iterators.peekingIterator(pendingCommitIterator),
+                new TreeSet<>(UnsignedBytes.lexicographicalComparator()));
+    }
+
+    /**
+     * Load some part of state KVs from storage and returns iterator of cached data from storage.
+     *
+     * @return Iterator of loaded state KVs
+     */
+    protected abstract Iterator<Map.Entry<byte[], byte[]>> loadChunkFromStateStorage();
+
+    /**
+     * Check whether end of data is reached from storage state KVs.
+     *
+     * @return whether end of data is reached from storage state KVs
+     */
+    protected abstract boolean isEndOfDataFromStorage();
+
+    /**
+     * Decode key to convert byte array to state key type.
+     *
+     * @param key byte array encoded key
+     * @return Decoded value of key
+     */
+    protected abstract K decodeKey(byte[] key);
+
+    /**
+     * Decode value to convert byte array to state value type.
+     *
+     * @param value byte array encoded value
+     * @return Decoded value of value
+     */
+    protected abstract V decodeValue(byte[] value);
+
+    /**
+     * Check whether the value is tombstone (deletion mark) value.
+     *
+     * @param value the value to check
+     * @return true if the value is tombstone, false otherwise
+     */
+    protected abstract boolean isTombstoneValue(byte[] value);
+
+}

--- a/storm-client/src/jvm/org/apache/storm/state/BaseStateIterator.java
+++ b/storm-client/src/jvm/org/apache/storm/state/BaseStateIterator.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.state;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
+
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Base implementation of iterator over {@link KeyValueState}. Encoded/Decoded types of key and value are all generic.
+ */
+public abstract class BaseStateIterator<K, V, KENCODED, VENCODED> implements Iterator<Map.Entry<K, V>> {
+
+    private final PeekingIterator<Map.Entry<KENCODED, VENCODED>> pendingPrepareIterator;
+    private final PeekingIterator<Map.Entry<KENCODED, VENCODED>> pendingCommitIterator;
+    private final Set<KENCODED> providedKeys;
+
+    private boolean firstLoad = true;
+    private PeekingIterator<Map.Entry<KENCODED, VENCODED>> pendingIterator;
+    private PeekingIterator<Map.Entry<KENCODED, VENCODED>> cachedResultIterator;
+
+    /**
+     * Constructor.
+     *
+     * @param pendingPrepareIterator The iterator of pendingPrepare
+     * @param pendingCommitIterator The iterator of pendingCommit
+     * @param initialProvidedKeys The initial value of provided keys
+     */
+    public BaseStateIterator(Iterator<Map.Entry<KENCODED, VENCODED>> pendingPrepareIterator,
+                             Iterator<Map.Entry<KENCODED, VENCODED>> pendingCommitIterator,
+                             Set<KENCODED> initialProvidedKeys) {
+        this.pendingPrepareIterator = Iterators.peekingIterator(pendingPrepareIterator);
+        this.pendingCommitIterator = Iterators.peekingIterator(pendingCommitIterator);
+        this.providedKeys = initialProvidedKeys;
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (seekToAvailableEntry(pendingPrepareIterator)) {
+            pendingIterator = pendingPrepareIterator;
+            return true;
+        }
+
+        if (seekToAvailableEntry(pendingCommitIterator)) {
+            pendingIterator = pendingCommitIterator;
+            return true;
+        }
+
+
+        if (firstLoad) {
+            // load the first part of entries
+            fillCachedResultIterator();
+            firstLoad = false;
+        }
+
+        while (true) {
+            if (seekToAvailableEntry(cachedResultIterator)) {
+                pendingIterator = cachedResultIterator;
+                return true;
+            }
+
+            if (isEndOfDataFromStorage()) {
+                break;
+            }
+
+            fillCachedResultIterator();
+        }
+
+        pendingIterator = null;
+        return false;
+    }
+
+    private void fillCachedResultIterator() {
+        Iterator<Map.Entry<KENCODED, VENCODED>> iterator = loadChunkFromStateStorage();
+        if (iterator != null) {
+            cachedResultIterator = Iterators.peekingIterator(iterator);
+        } else {
+            cachedResultIterator = null;
+        }
+    }
+
+    @Override
+    public Map.Entry<K, V> next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        Map.Entry<KENCODED, VENCODED> keyValue = pendingIterator.next();
+
+        K key = decodeKey(keyValue.getKey());
+        V value = decodeValue(keyValue.getValue());
+
+        providedKeys.add(keyValue.getKey());
+        return new AbstractMap.SimpleEntry(key, value);
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Load some part of state KVs from storage and returns iterator of cached data from storage.
+     *
+     * @return Iterator of loaded state KVs
+     */
+    protected abstract Iterator<Map.Entry<KENCODED, VENCODED>> loadChunkFromStateStorage();
+
+    /**
+     * Check whether end of data is reached from storage state KVs.
+     *
+     * @return whether end of data is reached from storage state KVs
+     */
+    protected abstract boolean isEndOfDataFromStorage();
+
+    /**
+     * Decode key to convert encoded type of key to state key type.
+     *
+     * @param key raw type of encoded key
+     * @return Decoded value of key
+     */
+    protected abstract K decodeKey(KENCODED key);
+
+    /**
+     * Decode value to convert encoded type of value to state value type.
+     *
+     * @param value raw type of encoded value
+     * @return Decoded value of value
+     */
+    protected abstract V decodeValue(VENCODED value);
+
+    /**
+     * Check whether the value is tombstone (deletion mark) value.
+     *
+     * @param value the value to check
+     * @return true if the value is tombstone, false otherwise
+     */
+    protected abstract boolean isTombstoneValue(VENCODED value);
+
+    private boolean seekToAvailableEntry(PeekingIterator<Map.Entry<KENCODED, VENCODED>> iterator) {
+        if (iterator != null) {
+            while (iterator.hasNext()) {
+                Map.Entry<KENCODED, VENCODED> entry = iterator.peek();
+                if (!providedKeys.contains(entry.getKey())) {
+                    if (isTombstoneValue(entry.getValue())) {
+                        providedKeys.add(entry.getKey());
+                    } else {
+                        return true;
+                    }
+                }
+
+                iterator.next();
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/storm-client/src/jvm/org/apache/storm/state/DefaultStateEncoder.java
+++ b/storm-client/src/jvm/org/apache/storm/state/DefaultStateEncoder.java
@@ -15,27 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.redis.utils;
+
+package org.apache.storm.state;
 
 import com.google.common.base.Optional;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.storm.state.DefaultStateSerializer;
-import org.apache.storm.state.Serializer;
-
 /**
- * Helper class for encoding/decoding redis key values.
+ * Default state encoder class for encoding/decoding key values. This class assumes encoded types of key and value are
+ * both binary (byte array) due to keep backward compatibility.
  */
-public class RedisEncoder<K, V> {
+public class DefaultStateEncoder<K, V> implements StateEncoder<K, V, byte[], byte[]> {
 
     public static final Serializer<Optional<byte[]>> internalValueSerializer = new DefaultStateSerializer<>();
 
-    public static final String TOMBSTONE = encode(internalValueSerializer.serialize(Optional.absent()));
+    public static final byte[] TOMBSTONE = internalValueSerializer.serialize(Optional.<byte[]>absent());
 
     private final Serializer<K> keySerializer;
     private final Serializer<V> valueSerializer;
 
-    public RedisEncoder(Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+    public DefaultStateEncoder(Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         this.keySerializer = keySerializer;
         this.valueSerializer = valueSerializer;
     }
@@ -48,32 +46,29 @@ public class RedisEncoder<K, V> {
         return valueSerializer;
     }
 
-    public String encodeKey(K key) {
-        return encode(keySerializer.serialize(key));
+    public byte[] encodeKey(K key) {
+        return keySerializer.serialize(key);
     }
 
-    public String encodeValue(V value) {
-        return encode(internalValueSerializer.serialize(
-                    Optional.of(valueSerializer.serialize(value))));
+    public byte[] encodeValue(V value) {
+        return internalValueSerializer.serialize(
+                    Optional.of(valueSerializer.serialize(value)));
     }
 
-    public K decodeKey(String redisKey) {
-        return keySerializer.deserialize(decode(redisKey));
+    public K decodeKey(byte[] encodedKey) {
+        return keySerializer.deserialize(encodedKey);
     }
 
-    public V decodeValue(String redisValue) {
-        Optional<byte[]> internalValue = internalValueSerializer.deserialize(decode(redisValue));
+    public V decodeValue(byte[] encodedValue) {
+        Optional<byte[]> internalValue = internalValueSerializer.deserialize(encodedValue);
         if (internalValue.isPresent()) {
             return valueSerializer.deserialize(internalValue.get());
         }
         return null;
     }
 
-    private static String encode(byte[] bytes) {
-        return Base64.encodeBase64String(bytes);
-    }
-
-    private static byte[] decode(String s) {
-        return Base64.decodeBase64(s);
+    @Override
+    public byte[] getTombstoneValue() {
+        return TOMBSTONE;
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/state/StateEncoder.java
+++ b/storm-client/src/jvm/org/apache/storm/state/StateEncoder.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.state;
+
+/**
+ * The interface of State Encoder.
+ */
+public interface StateEncoder<K, V, KENCODED, VENCODED> {
+    /**
+     * Encode key.
+     *
+     * @param key the value of key (K type)
+     * @return the encoded value of key (KENCODED type)
+     */
+    KENCODED encodeKey(K key);
+
+    /**
+     * Encode value.
+     *
+     * @param value the value of value (V type)
+     * @return the encoded value of value (VENCODED type)
+     */
+    VENCODED encodeValue(V value);
+
+    /**
+     * Decode key.
+     *
+     * @param encodedKey the value of key (KRAW type)
+     * @return the decoded value of key (K type)
+     */
+    K decodeKey(KENCODED encodedKey);
+
+    /**
+     * Decode value.
+     *
+     * @param encodedValue the value of key (VENCODED type)
+     * @return the decoded value of key (V type)
+     */
+    V decodeValue(VENCODED encodedValue);
+
+    /**
+     * Get the tombstone value (deletion mark).
+     *
+     * @return the tomestone value (VENCODED type)
+     */
+    VENCODED getTombstoneValue();
+}

--- a/storm-client/test/jvm/org/apache/storm/state/BaseBinaryStateIteratorTest.java
+++ b/storm-client/test/jvm/org/apache/storm/state/BaseBinaryStateIteratorTest.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.state;
+
+import com.google.common.primitives.UnsignedBytes;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link BaseBinaryStateIterator}.
+ */
+public class BaseBinaryStateIteratorTest {
+  private DefaultStateEncoder<byte[], byte[]> encoder;
+
+  @Before
+  public void setUp() {
+    Serializer<byte[]> keySerializer = new DefaultStateSerializer<>();
+    Serializer<byte[]> valueSerializer = new DefaultStateSerializer<>();
+    encoder = new DefaultStateEncoder<>(keySerializer, valueSerializer);
+  }
+
+  @Test
+  public void testGetEntriesFromPendingPrepare() {
+    NavigableMap<byte[], byte[]> pendingPrepare = getBinaryTreeMap();
+    putEncodedKeyValueToMap(pendingPrepare, "key0".getBytes(), "value0".getBytes());
+    putTombstoneToMap(pendingPrepare, "key1".getBytes());
+    putEncodedKeyValueToMap(pendingPrepare, "key2".getBytes(), "value2".getBytes());
+
+    NavigableMap<byte[], byte[]> pendingCommit = getBinaryTreeMap();
+
+    MockBinaryStateIterator kvIterator = new MockBinaryStateIterator(
+        pendingPrepare.entrySet().iterator(), pendingCommit.entrySet().iterator());
+
+    assertNextEntry(kvIterator, "key0".getBytes(), "value0".getBytes());
+
+    // key1 shouldn't in iterator
+
+    assertNextEntry(kvIterator, "key2".getBytes(), "value2".getBytes());
+
+    assertFalse(kvIterator.hasNext());
+  }
+
+  @Test
+  public void testGetEntriesFromPendingCommit() {
+    NavigableMap<byte[], byte[]> pendingPrepare = getBinaryTreeMap();
+
+    NavigableMap<byte[], byte[]> pendingCommit = getBinaryTreeMap();
+    putEncodedKeyValueToMap(pendingCommit, "key0".getBytes(), "value0".getBytes());
+    putTombstoneToMap(pendingCommit, "key1".getBytes());
+    putEncodedKeyValueToMap(pendingCommit, "key2".getBytes(), "value2".getBytes());
+
+    MockBinaryStateIterator kvIterator = new MockBinaryStateIterator(
+        pendingPrepare.entrySet().iterator(), pendingCommit.entrySet().iterator());
+
+    assertNextEntry(kvIterator, "key0".getBytes(), "value0".getBytes());
+
+    // key1 shouldn't in iterator
+
+    assertNextEntry(kvIterator, "key2".getBytes(), "value2".getBytes());
+
+    assertFalse(kvIterator.hasNext());
+  }
+
+  @Test
+  public void testGetEntriesRemovingDuplicationKeys() {
+    NavigableMap<byte[], byte[]> pendingPrepare = getBinaryTreeMap();
+    putEncodedKeyValueToMap(pendingPrepare, "key0".getBytes(), "value0".getBytes());
+    putTombstoneToMap(pendingPrepare, "key1".getBytes());
+
+    NavigableMap<byte[], byte[]> pendingCommit = getBinaryTreeMap();
+    putEncodedKeyValueToMap(pendingCommit, "key1".getBytes(), "value1".getBytes());
+    putEncodedKeyValueToMap(pendingCommit, "key2".getBytes(), "value2".getBytes());
+
+    MockBinaryStateIterator kvIterator = new MockBinaryStateIterator(
+        pendingPrepare.entrySet().iterator(), pendingCommit.entrySet().iterator());
+
+    // keys shouldn't appear twice
+
+    assertNextEntry(kvIterator, "key0".getBytes(), "value0".getBytes());
+
+    // key1 shouldn't be in iterator since it's marked as deleted
+
+    assertNextEntry(kvIterator, "key2".getBytes(), "value2".getBytes());
+
+    assertFalse(kvIterator.hasNext());
+  }
+
+  @Test
+  public void testGetEntryNotAvailable() {
+    NavigableMap<byte[], byte[]> pendingPrepare = getBinaryTreeMap();
+
+    NavigableMap<byte[], byte[]> pendingCommit = getBinaryTreeMap();
+
+    MockBinaryStateIterator kvIterator = new MockBinaryStateIterator(
+        pendingPrepare.entrySet().iterator(), pendingCommit.entrySet().iterator());
+
+    assertFalse(kvIterator.hasNext());
+  }
+
+  private void assertNextEntry(BaseBinaryStateIterator<byte[], byte[]> kvIterator, byte[] expectedKey,
+      byte[] expectedValue) {
+    assertTrue(kvIterator.hasNext());
+    Map.Entry<byte[], byte[]> entry = kvIterator.next();
+    assertArrayEquals(expectedKey, entry.getKey());
+    assertArrayEquals(expectedValue, entry.getValue());
+  }
+
+  private void putEncodedKeyValueToMap(NavigableMap<byte[], byte[]> map, byte[] key, byte[] value) {
+    map.put(encoder.encodeKey(key), encoder.encodeValue(value));
+  }
+
+  private void putTombstoneToMap(NavigableMap<byte[], byte[]> map, byte[] key) {
+    map.put(encoder.encodeKey(key), encoder.getTombstoneValue());
+  }
+
+  private TreeMap<byte[], byte[]> getBinaryTreeMap() {
+    return new TreeMap<>(UnsignedBytes.lexicographicalComparator());
+  }
+}
+
+class MockBinaryStateIterator extends BaseBinaryStateIterator<byte[], byte[]> {
+  private DefaultStateEncoder<byte[], byte[]> encoder;
+
+  /**
+   * Constructor.
+   *
+   * @param pendingPrepareIterator The iterator of pendingPrepare
+   * @param pendingCommitIterator  The iterator of pendingCommit
+   */
+  public MockBinaryStateIterator(Iterator<Map.Entry<byte[], byte[]>> pendingPrepareIterator,
+      Iterator<Map.Entry<byte[], byte[]>> pendingCommitIterator) {
+    super(pendingPrepareIterator, pendingCommitIterator);
+    Serializer<byte[]> keySerializer = new DefaultStateSerializer<>();
+    Serializer<byte[]> valueSerializer = new DefaultStateSerializer<>();
+    encoder = new DefaultStateEncoder<>(keySerializer, valueSerializer);
+  }
+
+  @Override
+  protected Iterator<Map.Entry<byte[], byte[]>> loadChunkFromStateStorage() {
+    // no data
+    return null;
+  }
+
+  @Override
+  protected boolean isEndOfDataFromStorage() {
+    return true;
+  }
+
+  @Override
+  protected byte[] decodeKey(byte[] key) {
+    return encoder.decodeKey(key);
+  }
+
+  @Override
+  protected byte[] decodeValue(byte[] value) {
+    return encoder.decodeValue(value);
+  }
+
+  @Override
+  protected boolean isTombstoneValue(byte[] value) {
+    return Arrays.equals(value, encoder.getTombstoneValue());
+  }
+}


### PR DESCRIPTION
* introduce new command interface and relevant containers
  * new command interface will contain both binary and string commands in near future
* change RedisKeyValue to use byte[] for State key and value management instead of String
  * get rid of Base64 encode/decode on RedisEncoder, and also SafeEncoder.encode() in Jedis internal
* users can select either Redis single server or Redis Cluster by passing JedisPoolConfig or JedisClusterConfig
* implement binary based KV state iterator
* Provide a tool to migrate old base64 state to the new binary state
  * migration tool is placed to storm-redis-examples
  * the module is easy to create uber jar hence easy to run the class
* document how to build and use migration tool

This patch is equivalent to #1950. Please note that there're some other changes for fixing checkstyle. I didn't address all of them, but my patch exceeded the limit so I ended up to fix some in this patch. 