### PR TITLE
STORM-2568: Fix getTopicsString

### DIFF
--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -40,6 +40,10 @@
     </developers>
 
     <dependencies>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
         <!--parent module dependency-->
         <dependency>
             <groupId>org.apache.storm</groupId>

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/NamedSubscription.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/NamedSubscription.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.storm.task.TopologyContext;
@@ -56,6 +57,6 @@ public class NamedSubscription extends Subscription {
 
     @Override
     public String getTopicsString() {
-        return String.valueOf(topics);
+        return StringUtils.join(topics, ",");
     }
 }

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/NamedSubscriptionTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/NamedSubscriptionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.apache.storm.kafka.spout;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+public class NamedSubscriptionTest {
+
+    private NamedSubscription namedSubscription;
+
+    @Test
+    public void testGetTopicsStringWithOneTopic() throws Exception {
+        Collection<String> topics = new ArrayList<>();
+        topics.add("test-topic1");
+
+        namedSubscription = new NamedSubscription(topics);
+
+        Assert.assertEquals(namedSubscription.getTopicsString(), "test-topic1");
+    }
+
+    @Test
+    public void testGetTopicsStringWithManyTopics() throws Exception {
+        Collection<String> topics = new ArrayList<>();
+        topics.add("test-topic1");
+        topics.add("test-topic2");
+        topics.add("test-topic3");
+
+        namedSubscription = new NamedSubscription(topics);
+
+        Assert.assertEquals(namedSubscription.getTopicsString(), "test-topic1,test-topic2,test-topic3");
+    }
+
+}


### PR DESCRIPTION
- String.valueOf returns square bracket, because 'topics' is Collection
- removed square bracket to use storm-kafka-monitor