### PR TITLE
[STORM-2602] storm.zookeeper.topology.auth.payload doesn't work even you set it

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -78,21 +78,18 @@ public class StormSubmitter {
     @SuppressWarnings("unchecked")
     public static Map prepareZookeeperAuthentication(Map<String, Object> conf) {
         Map toRet = new HashMap();
-
+        String secretPayload = (String) conf.get(Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD);
         // Is the topology ZooKeeper authentication configuration unset?
         if (! conf.containsKey(Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD) ||
                 conf.get(Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD) == null ||
                 !  validateZKDigestPayload((String)
                     conf.get(Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD))) {
-
-            String secretPayload = generateZookeeperDigestSecretPayload();
-            toRet.put(Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD, secretPayload);
+            secretPayload = generateZookeeperDigestSecretPayload();
             LOG.info("Generated ZooKeeper secret payload for MD5-digest: " + secretPayload);
         }
-
+        toRet.put(Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD, secretPayload);
         // This should always be set to digest.
         toRet.put(Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_SCHEME, "digest");
-
         return toRet;
     }
 

--- a/storm-core/test/clj/org/apache/storm/submitter_test.clj
+++ b/storm-core/test/clj/org/apache/storm/submitter_test.clj
@@ -26,7 +26,7 @@
           result (StormSubmitter/prepareZookeeperAuthentication conf)
           actual-payload (.get result STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD)
           actual-scheme (.get result STORM-ZOOKEEPER-TOPOLOGY-AUTH-SCHEME)]
-      (is (nil? actual-payload))
+      (is (= "foobar:12345" actual-payload))
       (is (= "digest" actual-scheme))))
 
   (testing "Scheme is set to digest if not already."
@@ -34,7 +34,7 @@
           result (StormSubmitter/prepareZookeeperAuthentication conf)
           actual-payload (.get result STORM-ZOOKEEPER-TOPOLOGY-AUTH-PAYLOAD)
           actual-scheme (.get result STORM-ZOOKEEPER-TOPOLOGY-AUTH-SCHEME)]
-      (is (nil? actual-payload))
+      (is (= "foobar:12345" actual-payload))
       (is (= "digest" actual-scheme))))
 
   (testing "A payload is generated when no payload is present."


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2602](https://issues.apache.org/jira/browse/STORM-2602)
"storm.zookeeper.topology.auth.payload" doesn't work even you have set it,because there doesn't use it when the value of STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD isn't null or other abnormal condition.