### PR TITLE
[STORM-2607] Offset consumer + 1

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutMessageId.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutMessageId.java
@@ -52,7 +52,7 @@ public class KafkaSpoutMessageId implements Serializable {
      */
     public KafkaSpoutMessageId(TopicPartition topicPart, long offset, boolean emitted) {
         this.topicPart = topicPart;
-        this.offset = offset;
+        this.offset = offset + 1;
         this.emitted = emitted;
     }
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutMessageId.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutMessageId.java
@@ -52,7 +52,7 @@ public class KafkaSpoutMessageId implements Serializable {
      */
     public KafkaSpoutMessageId(TopicPartition topicPart, long offset, boolean emitted) {
         this.topicPart = topicPart;
-        this.offset = offset + 1;
+        this.offset = offset;
         this.emitted = emitted;
     }
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
@@ -118,6 +118,8 @@ public class OffsetManager {
 
         OffsetAndMetadata nextCommitOffsetAndMetadata = null;
         if (nextCommitMsg != null) {
+            //The committed offset should be the next message
+            nextCommitOffset = nextCommitOffset + 1;
             nextCommitOffsetAndMetadata = new OffsetAndMetadata(nextCommitOffset, nextCommitMsg.getMetadata(Thread.currentThread()));
             LOG.debug("topic-partition [{}] has offsets [{}-{}] ready to be committed",
                 tp, committedOffset + 1, nextCommitOffsetAndMetadata.offset());
@@ -162,7 +164,7 @@ public class OffsetManager {
         LOG.debug("Committed offsets [{}-{} = {}] for topic-partition [{}].",
                     preCommitCommittedOffsets + 1, this.committedOffset, numCommittedOffsets, tp);
         
-        return numCommittedOffsets;
+        return numCommittedOffsets - 1;// The committed offset should be the next message
     }
 
     public long getCommittedOffset() {

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
@@ -125,7 +125,7 @@ public class OffsetManager {
             nextCommitOffsetAndMetadata = new OffsetAndMetadata(nextEarliestUncommittedOffset,
                 nextCommitMsg.getMetadata(Thread.currentThread()));
             LOG.debug("topic-partition [{}] has offsets [{}-{}] ready to be committed",
-                tp, earliestUncommittedOffset, nextCommitOffsetAndMetadata.offset());
+                tp, earliestUncommittedOffset, nextCommitOffsetAndMetadata.offset() - 1);
         } else {
             LOG.debug("topic-partition [{}] has NO offsets ready to be committed", tp);
         }

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/SingleTopicKafkaSpoutTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/SingleTopicKafkaSpoutTest.java
@@ -114,7 +114,7 @@ public class SingleTopicKafkaSpoutTest {
         Map<TopicPartition, OffsetAndMetadata> commits = commitCapture.getValue();
         assertThat("Expected commits for only one topic partition", commits.entrySet().size(), is(1));
         OffsetAndMetadata offset = commits.entrySet().iterator().next().getValue();
-        assertThat("Expected committed offset to cover all emitted messages", offset.offset(), is(messageCount - 1));
+        assertThat("Expected committed offset to cover all emitted messages", offset.offset(), is(messageCount));
     }
 
     @Test


### PR DESCRIPTION
When i put a message in a partition, the storm-kafka-client consume this message.
But storm-kafka-client commit the offset -1.
storm-kafka-client: 1.1.0
storm-core : 1.1.0
kafka: 0.10.2.0
Steps to bug
#1 - Insert message in kafka
#2 - Read with storm Spout this topic
#3 - Get the offset for the consumer group and the offset is always offset -1

https://issues.apache.org/jira/browse/STORM-2607