### PR TITLE
[STORM-2613] Tuples that aren't sampled shouldn't be considered for latency calcul…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
@@ -125,7 +125,7 @@ public class BoltExecutor extends Executor {
             boltObject.execute(tuple);
 
             Long ms = tuple.getExecuteSampleStartTime();
-            long delta = (ms != null) ? Time.deltaMs(ms) : 0;
+            long delta = (ms != null) ? Time.deltaMs(ms) : -1;
             if (isDebug) {
                 LOG.info("Execute done TUPLE {} TASK: {} DELTA: {}", tuple, taskId, delta);
             }


### PR DESCRIPTION

Set delta to -1 , so that time delay for tuples that aren't sampled will not be added in BoltExecutorStats
