### PR TITLE
STORM-2618: Add TridentKafkaStateUpdater for storm-kafka-client

### DIFF
--- a/docs/storm-kafka-client.md
+++ b/docs/storm-kafka-client.md
@@ -1,18 +1,18 @@
-#Storm Apache Kafka integration using the kafka-client jar
+# Storm Apache Kafka integration using the kafka-client jar
 This includes the new Apache Kafka consumer API.
 
-##Compatibility
+## Compatibility
 
 Apache Kafka versions 0.10 onwards
 
-##Writing to Kafka as part of your topology
+## Writing to Kafka as part of your topology
 You can create an instance of org.apache.storm.kafka.bolt.KafkaBolt and attach it as a component to your topology or if you
 are using trident you can use org.apache.storm.kafka.trident.TridentState, org.apache.storm.kafka.trident.TridentStateFactory and
 org.apache.storm.kafka.trident.TridentKafkaUpdater.
 
 You need to provide implementations for the following 2 interfaces
 
-###TupleToKafkaMapper and TridentTupleToKafkaMapper
+### TupleToKafkaMapper and TridentTupleToKafkaMapper
 These interfaces have 2 methods defined:
 
 ```java
@@ -28,7 +28,7 @@ reasons. Alternatively you could also specify a different key and message field 
 In the TridentKafkaState you must specify what is the field name for key and message as there is no default constructor.
 These should be specified while constructing an instance of FieldNameBasedTupleToKafkaMapper.
 
-###KafkaTopicSelector and trident KafkaTopicSelector
+### KafkaTopicSelector and trident KafkaTopicSelector
 This interface has only one method
 
 ```java
@@ -50,7 +50,7 @@ You can provide all the producer properties in your Storm topology by calling `K
 Section "Important configuration properties for the producer" for more details.
 These are also defined in `org.apache.kafka.clients.producer.ProducerConfig`
 
-###Using wildcard kafka topic match
+### Using wildcard kafka topic match
 You can do a wildcard topic match by adding the following config
 
 ```
@@ -62,7 +62,7 @@ You can do a wildcard topic match by adding the following config
 After this you can specify a wildcard topic for matching e.g. clickstream.*.log.  This will match all streams matching clickstream.my.log, clickstream.cart.log etc
 
 
-###Putting it all together
+### Putting it all together
 
 For the bolt :
 
@@ -122,7 +122,7 @@ For Trident:
                 .withProducerProperties(props)
                 .withKafkaTopicSelector(new DefaultTopicSelector("test"))
                 .withTridentTupleToKafkaMapper(new FieldNameBasedTupleToKafkaMapper("word", "count"));
-        stream.partitionPersist(stateFactory, fields, new TridentKafkaUpdater(), new Fields());
+        stream.partitionPersist(stateFactory, fields, new TridentKafkaStateUpdater(), new Fields());
 
         Config conf = new Config();
         StormSubmitter.submitTopology("kafkaTridentTest", conf, topology.build());
@@ -325,7 +325,7 @@ When selecting a kafka client version, you should ensure -
  2. The kafka client selected by you should be wire compatible with the broker. e.g. 0.9.x client will not work with 
  0.8.x broker. 
 
-#Kafka Spout Performance Tuning
+# Kafka Spout Performance Tuning
 
 The Kafka spout provides two internal parameters to control its performance. The parameters can be set using the [KafkaSpoutConfig] (https://github.com/apache/storm/blob/1.0.x-branch/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java) methods [setOffsetCommitPeriodMs] (https://github.com/apache/storm/blob/1.0.x-branch/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java#L189-L193) and [setMaxUncommittedOffsets] (https://github.com/apache/storm/blob/1.0.x-branch/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java#L211-L217). 
 
@@ -342,7 +342,7 @@ The [Kafka consumer config] (http://kafka.apache.org/documentation.html#consumer
 
 Depending on the structure of your Kafka cluster, distribution of the data, and availability of data to poll, these parameters will have to be configured appropriately. Please refer to the Kafka documentation on Kafka parameter tuning.
 
-###Default values
+### Default values
 
 Currently the Kafka spout has has the following default values, which have shown to give good performance in the test environment as described in this [blog post] (https://hortonworks.com/blog/microbenchmarking-storm-1-0-performance/)
 

--- a/external/storm-kafka-client/README.md
+++ b/external/storm-kafka-client/README.md
@@ -1,4 +1,5 @@
-#Storm Apache Kafka integration using the kafka-client jar (This includes the new Apache Kafka consumer API)
+# Storm Apache Kafka integration using the kafka-client jar
+This includes the new Apache Kafka consumer API.
 
 Spouts and Bolts that write to and read from Kafka through the kafka-client library.
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutBatchMetadata.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutBatchMetadata.java
@@ -37,7 +37,7 @@ public class KafkaTridentSpoutBatchMetadata<K,V> implements Serializable {
     // first offset of this batch
     private long firstOffset;               
     // last offset of this batch
-    private long lastOffset;                
+    private long lastOffset;
 
     public KafkaTridentSpoutBatchMetadata(TopicPartition topicPartition, long firstOffset, long lastOffset) {
         this.topicPartition = topicPartition;

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaStateUpdater.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaStateUpdater.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.kafka.trident;
+
+import java.util.List;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.state.BaseStateUpdater;
+import org.apache.storm.trident.tuple.TridentTuple;
+
+public class TridentKafkaStateUpdater extends BaseStateUpdater<TridentKafkaState> {
+
+    @Override
+    public void updateState(TridentKafkaState state, List<TridentTuple> tuples, TridentCollector collector) {
+        state.updateState(tuples, collector);
+    }
+}


### PR DESCRIPTION
* Added TridentKafkaStateUpdater, otherwise users have to create a class themselves.

usage scenario:
```
stream.partitionPersist(stateFactory, fields, new TridentKafkaStateUpdater(), new Fields());
```

* Fixed documents