### PR TITLE
STORM-2594: Apply new code style to storm-rocketmq

### DIFF
--- a/docs/storm-rocketmq.md
+++ b/docs/storm-rocketmq.md
@@ -6,10 +6,10 @@ Storm/Trident integration for [RocketMQ](https://rocketmq.incubator.apache.org/)
 ## Read from Topic
 The spout included in this package for reading data from a topic.
 
-### RocketMQSpout
-To use the `RocketMQSpout`,  you construct an instance of it by specifying a Properties instance which including rocketmq configs.
-RocketMQSpout uses RocketMQ MQPushConsumer as the default implementation. PushConsumer is a high level consumer API, wrapping the pulling details. Looks like broker push messages to consumer.
-RocketMQSpout will retry 3(use `SpoutConfig.DEFAULT_MESSAGES_MAX_RETRY` to change the value) times when messages are failed.
+### RocketMqSpout
+To use the `RocketMqSpout`,  you construct an instance of it by specifying a Properties instance which including rocketmq configs.
+RocketMqSpout uses RocketMQ MQPushConsumer as the default implementation. PushConsumer is a high level consumer API, wrapping the pulling details. Looks like broker push messages to consumer.
+RocketMqSpout will retry 3(use `SpoutConfig.DEFAULT_MESSAGES_MAX_RETRY` to change the value) times when messages are failed.
 
  ```java
         Properties properties = new Properties();
@@ -17,7 +17,7 @@ RocketMQSpout will retry 3(use `SpoutConfig.DEFAULT_MESSAGES_MAX_RETRY` to chang
         properties.setProperty(SpoutConfig.CONSUMER_GROUP, group);
         properties.setProperty(SpoutConfig.CONSUMER_TOPIC, topic);
 
-        RocketMQSpout spout = new RocketMQSpout(properties);
+        RocketMqSpout spout = new RocketMqSpout(properties);
  ```
 
 
@@ -51,18 +51,18 @@ public interface TopicSelector extends Serializable {
 `storm-rocketmq` includes general purpose `TopicSelector` implementations called `DefaultTopicSelector` and `FieldNameBasedTopicSelector`.
 
 
-### RocketMQBolt
-To use the `RocketMQBolt`, you construct an instance of it by specifying TupleToMessageMapper, TopicSelector and Properties instances.
-RocketMQBolt send messages async by default. You can change this by invoking `withAsync(false)`.
+### RocketMqBolt
+To use the `RocketMqBolt`, you construct an instance of it by specifying TupleToMessageMapper, TopicSelector and Properties instances.
+RocketMqBolt send messages async by default. You can change this by invoking `withAsync(false)`.
 
  ```java
         TupleToMessageMapper mapper = new FieldNameBasedTupleToMessageMapper("word", "count");
         TopicSelector selector = new DefaultTopicSelector(topic);
 
         properties = new Properties();
-        properties.setProperty(RocketMQConfig.NAME_SERVER_ADDR, nameserverAddr);
+        properties.setProperty(RocketMqConfig.NAME_SERVER_ADDR, nameserverAddr);
 
-        RocketMQBolt insertBolt = new RocketMQBolt()
+        RocketMqBolt insertBolt = new RocketMqBolt()
                 .withMapper(mapper)
                 .withSelector(selector)
                 .withProperties(properties);
@@ -76,19 +76,19 @@ We support trident persistent state that can be used with trident topologies. To
         TopicSelector selector = new DefaultTopicSelector(topic);
 
         Properties properties = new Properties();
-        properties.setProperty(RocketMQConfig.NAME_SERVER_ADDR, nameserverAddr);
+        properties.setProperty(RocketMqConfig.NAME_SERVER_ADDR, nameserverAddr);
 
-        RocketMQState.Options options = new RocketMQState.Options()
+        RocketMqState.Options options = new RocketMqState.Options()
                 .withMapper(mapper)
                 .withSelector(selector)
                 .withProperties(properties);
 
-        StateFactory factory = new RocketMQStateFactory(options);
+        StateFactory factory = new RocketMqStateFactory(options);
 
         TridentTopology topology = new TridentTopology();
         Stream stream = topology.newStream("spout1", spout);
 
         stream.partitionPersist(factory, fields,
-                new RocketMQStateUpdater(), new Fields());
+                new RocketMqStateUpdater(), new Fields());
  ```
 

--- a/examples/storm-rocketmq-examples/src/main/java/org/apache/storm/rocketmq/topology/WordCountTopology.java
+++ b/examples/storm-rocketmq-examples/src/main/java/org/apache/storm/rocketmq/topology/WordCountTopology.java
@@ -22,14 +22,14 @@ import org.apache.storm.LocalCluster;
 import org.apache.storm.LocalCluster.LocalTopology;
 import org.apache.storm.StormSubmitter;
 import org.apache.storm.generated.StormTopology;
-import org.apache.storm.rocketmq.RocketMQConfig;
+import org.apache.storm.rocketmq.RocketMqConfig;
 import org.apache.storm.rocketmq.SpoutConfig;
-import org.apache.storm.rocketmq.bolt.RocketMQBolt;
+import org.apache.storm.rocketmq.bolt.RocketMqBolt;
 import org.apache.storm.rocketmq.common.mapper.FieldNameBasedTupleToMessageMapper;
 import org.apache.storm.rocketmq.common.mapper.TupleToMessageMapper;
 import org.apache.storm.rocketmq.common.selector.DefaultTopicSelector;
 import org.apache.storm.rocketmq.common.selector.TopicSelector;
-import org.apache.storm.rocketmq.spout.RocketMQSpout;
+import org.apache.storm.rocketmq.spout.RocketMqSpout;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.tuple.Fields;
 
@@ -49,7 +49,7 @@ public class WordCountTopology {
         properties.setProperty(SpoutConfig.CONSUMER_GROUP, CONSUMER_GROUP);
         properties.setProperty(SpoutConfig.CONSUMER_TOPIC, CONSUMER_TOPIC);
 
-        RocketMQSpout spout = new RocketMQSpout(properties);
+        RocketMqSpout spout = new RocketMqSpout(properties);
 
         WordCounter bolt = new WordCounter();
 
@@ -57,9 +57,9 @@ public class WordCountTopology {
         TopicSelector selector = new DefaultTopicSelector(topic);
 
         properties = new Properties();
-        properties.setProperty(RocketMQConfig.NAME_SERVER_ADDR, nameserverAddr);
+        properties.setProperty(RocketMqConfig.NAME_SERVER_ADDR, nameserverAddr);
 
-        RocketMQBolt insertBolt = new RocketMQBolt()
+        RocketMqBolt insertBolt = new RocketMqBolt()
                 .withMapper(mapper)
                 .withSelector(selector)
                 .withProperties(properties);

--- a/examples/storm-rocketmq-examples/src/main/java/org/apache/storm/rocketmq/trident/WordCountTrident.java
+++ b/examples/storm-rocketmq-examples/src/main/java/org/apache/storm/rocketmq/trident/WordCountTrident.java
@@ -22,14 +22,14 @@ import org.apache.storm.LocalCluster;
 import org.apache.storm.LocalCluster.LocalTopology;
 import org.apache.storm.StormSubmitter;
 import org.apache.storm.generated.StormTopology;
-import org.apache.storm.rocketmq.RocketMQConfig;
+import org.apache.storm.rocketmq.RocketMqConfig;
 import org.apache.storm.rocketmq.common.mapper.FieldNameBasedTupleToMessageMapper;
 import org.apache.storm.rocketmq.common.mapper.TupleToMessageMapper;
 import org.apache.storm.rocketmq.common.selector.DefaultTopicSelector;
 import org.apache.storm.rocketmq.common.selector.TopicSelector;
-import org.apache.storm.rocketmq.trident.state.RocketMQState;
-import org.apache.storm.rocketmq.trident.state.RocketMQStateFactory;
-import org.apache.storm.rocketmq.trident.state.RocketMQStateUpdater;
+import org.apache.storm.rocketmq.trident.state.RocketMqState;
+import org.apache.storm.rocketmq.trident.state.RocketMqStateFactory;
+import org.apache.storm.rocketmq.trident.state.RocketMqStateUpdater;
 import org.apache.storm.trident.Stream;
 import org.apache.storm.trident.TridentTopology;
 import org.apache.storm.trident.state.StateFactory;
@@ -55,20 +55,20 @@ public class WordCountTrident {
         TopicSelector selector = new DefaultTopicSelector(topic);
 
         Properties properties = new Properties();
-        properties.setProperty(RocketMQConfig.NAME_SERVER_ADDR, nameserverAddr);
+        properties.setProperty(RocketMqConfig.NAME_SERVER_ADDR, nameserverAddr);
 
-        RocketMQState.Options options = new RocketMQState.Options()
+        RocketMqState.Options options = new RocketMqState.Options()
                 .withMapper(mapper)
                 .withSelector(selector)
                 .withProperties(properties);
 
-        StateFactory factory = new RocketMQStateFactory(options);
+        StateFactory factory = new RocketMqStateFactory(options);
 
         TridentTopology topology = new TridentTopology();
         Stream stream = topology.newStream("spout1", spout);
 
         stream.partitionPersist(factory, fields,
-                new RocketMQStateUpdater(), new Fields());
+                new RocketMqStateUpdater(), new Fields());
 
         return topology.build();
     }

--- a/external/storm-rocketmq/README.md
+++ b/external/storm-rocketmq/README.md
@@ -6,10 +6,10 @@ Storm/Trident integration for [RocketMQ](https://rocketmq.incubator.apache.org/)
 ## Read from Topic
 The spout included in this package for reading data from a topic.
 
-### RocketMQSpout
-To use the `RocketMQSpout`,  you construct an instance of it by specifying a Properties instance which including rocketmq configs.
-RocketMQSpout uses RocketMQ MQPushConsumer as the default implementation. PushConsumer is a high level consumer API, wrapping the pulling details. Looks like broker push messages to consumer.
-RocketMQSpout will retry 3(use `SpoutConfig.DEFAULT_MESSAGES_MAX_RETRY` to change the value) times when messages are failed.
+### RocketMqSpout
+To use the `RocketMqSpout`,  you construct an instance of it by specifying a Properties instance which including rocketmq configs.
+RocketMqSpout uses RocketMQ MQPushConsumer as the default implementation. PushConsumer is a high level consumer API, wrapping the pulling details. Looks like broker push messages to consumer.
+RocketMqSpout will retry 3(use `SpoutConfig.DEFAULT_MESSAGES_MAX_RETRY` to change the value) times when messages are failed.
 
  ```java
         Properties properties = new Properties();
@@ -17,7 +17,7 @@ RocketMQSpout will retry 3(use `SpoutConfig.DEFAULT_MESSAGES_MAX_RETRY` to chang
         properties.setProperty(SpoutConfig.CONSUMER_GROUP, group);
         properties.setProperty(SpoutConfig.CONSUMER_TOPIC, topic);
 
-        RocketMQSpout spout = new RocketMQSpout(properties);
+        RocketMqSpout spout = new RocketMqSpout(properties);
  ```
 
 
@@ -51,18 +51,18 @@ public interface TopicSelector extends Serializable {
 `storm-rocketmq` includes general purpose `TopicSelector` implementations called `DefaultTopicSelector` and `FieldNameBasedTopicSelector`.
 
 
-### RocketMQBolt
-To use the `RocketMQBolt`, you construct an instance of it by specifying TupleToMessageMapper, TopicSelector and Properties instances.
-RocketMQBolt send messages async by default. You can change this by invoking `withAsync(false)`.
+### RocketMqBolt
+To use the `RocketMqBolt`, you construct an instance of it by specifying TupleToMessageMapper, TopicSelector and Properties instances.
+RocketMqBolt send messages async by default. You can change this by invoking `withAsync(false)`.
 
  ```java
         TupleToMessageMapper mapper = new FieldNameBasedTupleToMessageMapper("word", "count");
         TopicSelector selector = new DefaultTopicSelector(topic);
 
         properties = new Properties();
-        properties.setProperty(RocketMQConfig.NAME_SERVER_ADDR, nameserverAddr);
+        properties.setProperty(RocketMqConfig.NAME_SERVER_ADDR, nameserverAddr);
 
-        RocketMQBolt insertBolt = new RocketMQBolt()
+        RocketMqBolt insertBolt = new RocketMqBolt()
                 .withMapper(mapper)
                 .withSelector(selector)
                 .withProperties(properties);
@@ -76,20 +76,20 @@ We support trident persistent state that can be used with trident topologies. To
         TopicSelector selector = new DefaultTopicSelector(topic);
 
         Properties properties = new Properties();
-        properties.setProperty(RocketMQConfig.NAME_SERVER_ADDR, nameserverAddr);
+        properties.setProperty(RocketMqConfig.NAME_SERVER_ADDR, nameserverAddr);
 
-        RocketMQState.Options options = new RocketMQState.Options()
+        RocketMqState.Options options = new RocketMqState.Options()
                 .withMapper(mapper)
                 .withSelector(selector)
                 .withProperties(properties);
 
-        StateFactory factory = new RocketMQStateFactory(options);
+        StateFactory factory = new RocketMqStateFactory(options);
 
         TridentTopology topology = new TridentTopology();
         Stream stream = topology.newStream("spout1", spout);
 
         stream.partitionPersist(factory, fields,
-                new RocketMQStateUpdater(), new Fields());
+                new RocketMqStateUpdater(), new Fields());
  ```
 
 

--- a/external/storm-rocketmq/pom.xml
+++ b/external/storm-rocketmq/pom.xml
@@ -74,9 +74,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
-                <configuration>
-                    <maxAllowedViolations>100</maxAllowedViolations>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/ConsumerMessage.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/ConsumerMessage.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq;
 
 import org.apache.rocketmq.common.message.MessageExt;

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/DefaultMessageBodySerializer.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/DefaultMessageBodySerializer.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq;
 
 import java.nio.charset.StandardCharsets;
@@ -25,7 +26,7 @@ public class DefaultMessageBodySerializer implements MessageBodySerializer {
      * Currently, we just convert string to bytes using UTF-8 charset.
      * Note: in this way, object.toString() method is invoked.
      * @param body RocketMQ Message body
-     * @return
+     * @return serialized byte[]
      */
     @Override
     public byte[] serialize(Object body) {

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/DefaultMessageRetryManager.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/DefaultMessageRetryManager.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq;
 
 import java.util.Map;
@@ -24,14 +25,20 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * An implementation of MessageRetryManager
+ * An implementation of MessageRetryManager.
  */
-public class DefaultMessageRetryManager implements MessageRetryManager{
+public class DefaultMessageRetryManager implements MessageRetryManager {
     private Map<String,ConsumerMessage> cache = new ConcurrentHashMap<>(500);
     private BlockingQueue<ConsumerMessage> queue;
     private int maxRetry;
     private int ttl;
 
+    /**
+     * DefaultMessageRetryManager Constructor.
+     * @param queue messages BlockingQueue
+     * @param maxRetry max retry times
+     * @param ttl TTL
+     */
     public DefaultMessageRetryManager(BlockingQueue<ConsumerMessage> queue, int maxRetry, int ttl) {
         this.queue = queue;
         this.maxRetry = maxRetry;
@@ -53,10 +60,12 @@ public class DefaultMessageRetryManager implements MessageRetryManager{
         }, period, period);
     }
 
+    @Override
     public void ack(String id) {
         cache.remove(id);
     }
 
+    @Override
     public void fail(String id) {
         ConsumerMessage message = cache.remove(id);
         if (message == null) {
@@ -70,16 +79,13 @@ public class DefaultMessageRetryManager implements MessageRetryManager{
         }
     }
 
+    @Override
     public void mark(ConsumerMessage message) {
         message.setTimestamp(System.currentTimeMillis());
         cache.put(message.getId(), message);
     }
 
-    /**
-     * Whether the message need retry.
-     * @param message
-     * @return
-     */
+    @Override
     public boolean needRetry(ConsumerMessage message) {
         return message.getRetries() < maxRetry;
     }

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/MessageBodySerializer.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/MessageBodySerializer.java
@@ -15,13 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq;
 
 import java.io.Serializable;
 
 /**
- * RocketMQ message body serializer
+ * RocketMQ message body serializer.
  */
-public interface MessageBodySerializer extends Serializable{
+public interface MessageBodySerializer extends Serializable {
     byte[] serialize(Object body);
 }

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/MessageRetryManager.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/MessageRetryManager.java
@@ -15,35 +15,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq;
 
 /**
- * Interface for messages retry manager
+ * Interface for messages retry manager.
  */
 public interface MessageRetryManager {
     /**
      * Remove from the cache. Message with the id is successful.
-     * @param id
+     * @param id message id
      */
     void ack(String id);
 
     /**
      * Remove from the cache. Message with the id is failed.
      * Invoke retry logics if necessary.
-     * @param id
+     * @param id message id
      */
     void fail(String id);
 
     /**
      * Mark message in the cache.
-     * @param message
+     * @param message message
      */
     void mark(ConsumerMessage message);
 
     /**
      * Whether the message need retry.
-     * @param message
-     * @return
+     * @param message ConsumerMessage
+     * @return true if need retry, otherwise false
      */
     boolean needRetry(ConsumerMessage message);
 

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/RocketMqConfig.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/RocketMqConfig.java
@@ -15,7 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq;
+
+import static org.apache.storm.rocketmq.RocketMqUtils.getInteger;
+
+import java.util.Properties;
+import java.util.UUID;
 
 import org.apache.commons.lang.Validate;
 import org.apache.rocketmq.client.ClientConfig;
@@ -25,15 +31,10 @@ import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
 import org.apache.rocketmq.remoting.common.RemotingUtil;
 
-import java.util.Properties;
-import java.util.UUID;
-
-import static org.apache.storm.rocketmq.RocketMQUtils.getInteger;
-
 /**
- * RocketMQConfig for Consumer/Producer
+ * RocketMqConfig for Consumer/Producer.
  */
-public class RocketMQConfig {
+public class RocketMqConfig {
     // common
     public static final String NAME_SERVER_ADDR = "nameserver.addr"; // Required
 
@@ -43,7 +44,7 @@ public class RocketMQConfig {
     public static final String DEFAULT_CLIENT_IP = RemotingUtil.getLocalAddress();
 
     public static final String CLIENT_CALLBACK_EXECUTOR_THREADS = "client.callback.executor.threads";
-    public static final int DEFAULT_CLIENT_CALLBACK_EXECUTOR_THREADS = Runtime.getRuntime().availableProcessors();;
+    public static final int DEFAULT_CLIENT_CALLBACK_EXECUTOR_THREADS = Runtime.getRuntime().availableProcessors();
 
     public static final String NAME_SERVER_POLL_INTERVAL = "nameserver.poll.interval";
     public static final int DEFAULT_NAME_SERVER_POLL_INTERVAL = 30000; // 30 seconds
@@ -87,6 +88,11 @@ public class RocketMQConfig {
     public static final int DEFAULT_CONSUMER_MAX_THREADS = 64;
 
 
+    /**
+     * Build Producer Configs.
+     * @param props Properties
+     * @param producer DefaultMQProducer
+     */
     public static void buildProducerConfigs(Properties props, DefaultMQProducer producer) {
         buildCommonConfigs(props, producer);
 
@@ -103,6 +109,11 @@ public class RocketMQConfig {
                 PRODUCER_TIMEOUT, DEFAULT_PRODUCER_TIMEOUT));
     }
 
+    /**
+     * Build Consumer Configs.
+     * @param props Properties
+     * @param consumer DefaultMQPushConsumer
+     */
     public static void buildConsumerConfigs(Properties props, DefaultMQPushConsumer consumer) {
         buildCommonConfigs(props, consumer);
 
@@ -141,6 +152,11 @@ public class RocketMQConfig {
         }
     }
 
+    /**
+     * Build Common Configs.
+     * @param props Properties
+     * @param client ClientConfig
+     */
     public static void buildCommonConfigs(Properties props, ClientConfig client) {
         String namesvr = props.getProperty(NAME_SERVER_ADDR);
         Validate.notEmpty(namesvr);

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/RocketMqUtils.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/RocketMqUtils.java
@@ -15,18 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.rocketmq;
 
-import org.apache.rocketmq.common.message.Message;
-import org.apache.storm.rocketmq.spout.scheme.KeyValueScheme;
-import org.apache.storm.spout.Scheme;
+package org.apache.storm.rocketmq;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
 
-public final class RocketMQUtils {
+import org.apache.rocketmq.common.message.Message;
+import org.apache.storm.rocketmq.spout.scheme.KeyValueScheme;
+import org.apache.storm.spout.Scheme;
+
+public final class RocketMqUtils {
 
     public static int getInteger(Properties props, String key, int defaultValue) {
         return Integer.parseInt(props.getProperty(key, String.valueOf(defaultValue)));
@@ -36,6 +37,11 @@ public final class RocketMQUtils {
         return Boolean.parseBoolean(props.getProperty(key, String.valueOf(defaultValue)));
     }
 
+    /**
+     * Create Scheme by Properties.
+     * @param props Properties
+     * @return Scheme
+     */
     public static Scheme createScheme(Properties props) {
         String schemeString = props.getProperty(SpoutConfig.SCHEME, SpoutConfig.DEFAULT_SCHEME);
         Scheme scheme;
@@ -49,6 +55,12 @@ public final class RocketMQUtils {
         return scheme;
     }
 
+    /**
+     * Generate Storm tuple values by Message and Scheme.
+     * @param msg RocketMQ Message
+     * @param scheme Scheme for deserializing
+     * @return tuple values
+     */
     public static List<Object> generateTuples(Message msg, Scheme scheme) {
         List<Object> tup;
         String rawKey = msg.getKeys();

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/SpoutConfig.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/SpoutConfig.java
@@ -15,11 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq;
 
 import org.apache.storm.rocketmq.spout.scheme.StringScheme;
 
-public class SpoutConfig extends RocketMQConfig {
+public class SpoutConfig extends RocketMqConfig {
     public static final String QUEUE_SIZE = "spout.queue.size";
 
     public static final String MESSAGES_MAX_RETRY = "spout.messages.max.retry";

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/bolt/RocketMqBolt.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/bolt/RocketMqBolt.java
@@ -15,8 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.bolt;
 
+import java.util.Map;
+import java.util.Properties;
 import org.apache.commons.lang.Validate;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
@@ -24,7 +27,7 @@ import org.apache.rocketmq.client.producer.MQProducer;
 import org.apache.rocketmq.client.producer.SendCallback;
 import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.common.message.Message;
-import org.apache.storm.rocketmq.RocketMQConfig;
+import org.apache.storm.rocketmq.RocketMqConfig;
 import org.apache.storm.rocketmq.common.mapper.TupleToMessageMapper;
 import org.apache.storm.rocketmq.common.selector.TopicSelector;
 import org.apache.storm.task.OutputCollector;
@@ -35,11 +38,8 @@ import org.apache.storm.tuple.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-import java.util.Properties;
-
-public class RocketMQBolt implements IRichBolt {
-    private static final Logger LOG = LoggerFactory.getLogger(RocketMQBolt.class);
+public class RocketMqBolt implements IRichBolt {
+    private static final Logger LOG = LoggerFactory.getLogger(RocketMqBolt.class);
 
     private static MQProducer producer;
     private OutputCollector collector;
@@ -54,10 +54,10 @@ public class RocketMQBolt implements IRichBolt {
 
         // Since RocketMQ Producer is thread-safe, RocketMQBolt uses a single
         // producer instance across threads to improve the performance.
-        synchronized (RocketMQBolt.class) {
+        synchronized (RocketMqBolt.class) {
             if (producer == null) {
                 producer = new DefaultMQProducer();
-                RocketMQConfig.buildProducerConfigs(properties, (DefaultMQProducer)producer);
+                RocketMqConfig.buildProducerConfigs(properties, (DefaultMQProducer)producer);
 
                 try {
                     producer.start();
@@ -73,22 +73,22 @@ public class RocketMQBolt implements IRichBolt {
         Validate.notNull(mapper, "TupleToMessageMapper can not be null");
     }
 
-    public RocketMQBolt withSelector(TopicSelector selector) {
+    public RocketMqBolt withSelector(TopicSelector selector) {
         this.selector = selector;
         return this;
     }
 
-    public RocketMQBolt withMapper(TupleToMessageMapper mapper) {
+    public RocketMqBolt withMapper(TupleToMessageMapper mapper) {
         this.mapper = mapper;
         return this;
     }
 
-    public RocketMQBolt withAsync(boolean async) {
+    public RocketMqBolt withAsync(boolean async) {
         this.async = async;
         return this;
     }
 
-    public RocketMQBolt withProperties(Properties properties) {
+    public RocketMqBolt withProperties(Properties properties) {
         this.properties = properties;
         return this;
     }
@@ -150,7 +150,7 @@ public class RocketMQBolt implements IRichBolt {
 
     @Override
     public void cleanup() {
-        synchronized (RocketMQBolt.class) {
+        synchronized (RocketMqBolt.class) {
             if (producer != null) {
                 producer.shutdown();
                 producer = null;

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/mapper/FieldNameBasedTupleToMessageMapper.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/mapper/FieldNameBasedTupleToMessageMapper.java
@@ -15,13 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.common.mapper;
 
 import org.apache.storm.rocketmq.DefaultMessageBodySerializer;
 import org.apache.storm.rocketmq.MessageBodySerializer;
 import org.apache.storm.tuple.ITuple;
-
-import java.nio.charset.StandardCharsets;
 
 public class FieldNameBasedTupleToMessageMapper implements TupleToMessageMapper {
     public static final String BOLT_KEY = "key";
@@ -34,6 +33,11 @@ public class FieldNameBasedTupleToMessageMapper implements TupleToMessageMapper 
         this(BOLT_KEY, BOLT_MESSAGE);
     }
 
+    /**
+     * FieldNameBasedTupleToMessageMapper Constructor.
+     * @param boltKeyField tuple field for selecting the key
+     * @param boltMessageField  tuple field for selecting the value
+     */
     public FieldNameBasedTupleToMessageMapper(String boltKeyField, String boltMessageField) {
         this.boltKeyField = boltKeyField;
         this.boltMessageField = boltMessageField;
@@ -55,9 +59,9 @@ public class FieldNameBasedTupleToMessageMapper implements TupleToMessageMapper 
     }
 
     /**
-     * using this method can override the default  MessageBodySerializer
-     * @param serializer
-     * @return
+     * using this method can override the default  MessageBodySerializer.
+     * @param serializer MessageBodySerializer
+     * @return this object
      */
     public FieldNameBasedTupleToMessageMapper withMessageBodySerializer(MessageBodySerializer serializer) {
         this.messageBodySerializer = serializer;

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/mapper/TupleToMessageMapper.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/mapper/TupleToMessageMapper.java
@@ -15,16 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.common.mapper;
 
-import org.apache.storm.tuple.ITuple;
-
 import java.io.Serializable;
+import org.apache.storm.tuple.ITuple;
 
 /**
  * Interface defining a mapping from storm tuple to rocketmq key and message.
  */
 public interface TupleToMessageMapper extends Serializable {
+
     String getKeyFromTuple(ITuple tuple);
+
     byte[] getValueFromTuple(ITuple tuple);
 }

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/selector/DefaultTopicSelector.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/selector/DefaultTopicSelector.java
@@ -15,9 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.common.selector;
 
-import org.apache.storm.rocketmq.RocketMQConfig;
+import org.apache.storm.rocketmq.RocketMqConfig;
 import org.apache.storm.tuple.ITuple;
 
 public class DefaultTopicSelector implements TopicSelector {
@@ -30,7 +31,7 @@ public class DefaultTopicSelector implements TopicSelector {
     }
 
     public DefaultTopicSelector(final String topicName) {
-        this(topicName, RocketMQConfig.DEFAULT_TAG);
+        this(topicName, RocketMqConfig.DEFAULT_TAG);
     }
 
     @Override

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/selector/FieldNameBasedTopicSelector.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/selector/FieldNameBasedTopicSelector.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.common.selector;
 
 import org.apache.storm.tuple.ITuple;
@@ -33,7 +34,13 @@ public class FieldNameBasedTopicSelector implements TopicSelector {
     private final String tagFieldName;
     private final String defaultTagName;
 
-
+    /**
+     * FieldNameBasedTopicSelector Constructor.
+     * @param topicFieldName field name used for selecting topic
+     * @param defaultTopicName default field name used for selecting topic
+     * @param tagFieldName field name used for selecting tag
+     * @param defaultTagName default field name used for selecting tag
+     */
     public FieldNameBasedTopicSelector(String topicFieldName, String defaultTopicName, String tagFieldName, String defaultTagName) {
         this.topicFieldName = topicFieldName;
         this.defaultTopicName = defaultTopicName;

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/selector/TopicSelector.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/common/selector/TopicSelector.java
@@ -15,13 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.common.selector;
 
+import java.io.Serializable;
 import org.apache.storm.tuple.ITuple;
 
-import java.io.Serializable;
-
 public interface TopicSelector extends Serializable {
+
     String getTopic(ITuple tuple);
+
     String getTag(ITuple tuple);
 }

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/spout/scheme/KeyValueScheme.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/spout/scheme/KeyValueScheme.java
@@ -15,12 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.rocketmq.spout.scheme;
 
-import org.apache.storm.spout.Scheme;
+package org.apache.storm.rocketmq.spout.scheme;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+import org.apache.storm.spout.Scheme;
 
 public interface KeyValueScheme extends Scheme {
     List<Object> deserializeKeyAndValue(ByteBuffer key, ByteBuffer value);

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/spout/scheme/StringKeyValueScheme.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/spout/scheme/StringKeyValueScheme.java
@@ -15,19 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.spout.scheme;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.storm.tuple.Values;
 
 import java.nio.ByteBuffer;
 import java.util.List;
+
+import org.apache.storm.tuple.Values;
 
 public class StringKeyValueScheme extends StringScheme implements KeyValueScheme {
 
     @Override
     public List<Object> deserializeKeyAndValue(ByteBuffer key, ByteBuffer value) {
-        if ( key == null ) {
+        if (key == null) {
             return deserialize(value);
         }
         String keyString = StringScheme.deserializeString(key);

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/spout/scheme/StringScheme.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/spout/scheme/StringScheme.java
@@ -15,16 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.storm.rocketmq.spout.scheme;
 
-import org.apache.storm.spout.Scheme;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Values;
-import org.apache.storm.utils.Utils;
+package org.apache.storm.rocketmq.spout.scheme;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.apache.storm.spout.Scheme;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Utils;
 
 public class StringScheme implements Scheme {
     public static final String STRING_SCHEME_KEY = "str";
@@ -33,12 +33,17 @@ public class StringScheme implements Scheme {
         return new Values(deserializeString(bytes));
     }
 
-    public static String deserializeString(ByteBuffer string) {
-        if (string.hasArray()) {
-            int base = string.arrayOffset();
-            return new String(string.array(), base + string.position(), string.remaining());
+    /**
+     * Deserialize ByteBuffer to String.
+     * @param byteBuffer input ByteBuffer
+     * @return deserialized string
+     */
+    public static String deserializeString(ByteBuffer byteBuffer) {
+        if (byteBuffer.hasArray()) {
+            int base = byteBuffer.arrayOffset();
+            return new String(byteBuffer.array(), base + byteBuffer.position(), byteBuffer.remaining());
         } else {
-            return new String(Utils.toByteArray(string), StandardCharsets.UTF_8);
+            return new String(Utils.toByteArray(byteBuffer), StandardCharsets.UTF_8);
         }
     }
 

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/trident/state/RocketMqState.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/trident/state/RocketMqState.java
@@ -15,14 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.trident.state;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import org.apache.commons.lang.Validate;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.client.producer.MQProducer;
 import org.apache.rocketmq.common.message.Message;
-import org.apache.storm.rocketmq.RocketMQConfig;
+import org.apache.storm.rocketmq.RocketMqConfig;
 import org.apache.storm.rocketmq.common.mapper.TupleToMessageMapper;
 import org.apache.storm.rocketmq.common.selector.TopicSelector;
 import org.apache.storm.topology.FailedException;
@@ -32,19 +38,14 @@ import org.apache.storm.trident.tuple.TridentTuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+public class RocketMqState implements State {
 
-public class RocketMQState implements State {
-
-    private static final Logger LOG = LoggerFactory.getLogger(RocketMQState.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RocketMqState.class);
 
     private Options options;
     private MQProducer producer;
 
-    protected RocketMQState(Map map, Options options) {
+    protected RocketMqState(Map map, Options options) {
         this.options = options;
     }
 
@@ -73,7 +74,7 @@ public class RocketMQState implements State {
         Validate.notEmpty(options.properties, "Producer properties can not be empty");
 
         producer = new DefaultMQProducer();
-        RocketMQConfig.buildProducerConfigs(options.properties, (DefaultMQProducer)producer);
+        RocketMqConfig.buildProducerConfigs(options.properties, (DefaultMQProducer)producer);
 
         try {
             producer.start();
@@ -92,6 +93,11 @@ public class RocketMQState implements State {
         LOG.debug("commit is noop.");
     }
 
+    /**
+     * Update the RocketMQ state.
+     * @param tuples trident tuples
+     * @param collector trident collector
+     */
     public void updateState(List<TridentTuple> tuples, TridentCollector collector) {
         try {
             for (TridentTuple tuple : tuples) {

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/trident/state/RocketMqStateFactory.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/trident/state/RocketMqStateFactory.java
@@ -15,20 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.trident.state;
 
-import org.apache.storm.trident.operation.TridentCollector;
-import org.apache.storm.trident.state.BaseStateUpdater;
-import org.apache.storm.trident.tuple.TridentTuple;
+import java.util.Map;
 
-import java.util.List;
+import org.apache.storm.task.IMetricsContext;
+import org.apache.storm.trident.state.State;
+import org.apache.storm.trident.state.StateFactory;
 
-public class RocketMQStateUpdater extends BaseStateUpdater<RocketMQState>  {
+public class RocketMqStateFactory implements StateFactory {
+
+    private RocketMqState.Options options;
+
+    public RocketMqStateFactory(RocketMqState.Options options) {
+        this.options = options;
+    }
 
     @Override
-    public void updateState(RocketMQState state, List<TridentTuple> tuples,
-                            TridentCollector collector) {
-        state.updateState(tuples, collector);
+    public State makeState(Map<String, Object> conf, IMetricsContext metrics,
+            int partitionIndex, int numPartitions) {
+        RocketMqState state = new RocketMqState(conf, options);
+        state.prepare();
+        return state;
     }
 
 }

--- a/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/trident/state/RocketMqStateUpdater.java
+++ b/external/storm-rocketmq/src/main/java/org/apache/storm/rocketmq/trident/state/RocketMqStateUpdater.java
@@ -15,28 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.trident.state;
 
-import org.apache.storm.task.IMetricsContext;
-import org.apache.storm.trident.state.State;
-import org.apache.storm.trident.state.StateFactory;
+import java.util.List;
 
-import java.util.Map;
+import org.apache.storm.trident.operation.TridentCollector;
+import org.apache.storm.trident.state.BaseStateUpdater;
+import org.apache.storm.trident.tuple.TridentTuple;
 
-public class RocketMQStateFactory implements StateFactory {
-
-    private RocketMQState.Options options;
-
-    public RocketMQStateFactory(RocketMQState.Options options) {
-        this.options = options;
-    }
+public class RocketMqStateUpdater extends BaseStateUpdater<RocketMqState>  {
 
     @Override
-    public State makeState(Map<String, Object> conf, IMetricsContext metrics,
-            int partitionIndex, int numPartitions) {
-        RocketMQState state = new RocketMQState(conf, options);
-        state.prepare();
-        return state;
+    public void updateState(RocketMqState state, List<TridentTuple> tuples,
+                            TridentCollector collector) {
+        state.updateState(tuples, collector);
     }
 
 }

--- a/external/storm-rocketmq/src/test/java/org/apache/storm/rocketmq/TestMessageRetryManager.java
+++ b/external/storm-rocketmq/src/test/java/org/apache/storm/rocketmq/TestMessageRetryManager.java
@@ -15,21 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq;
 
-import org.apache.rocketmq.common.message.MessageExt;
-import org.apache.storm.utils.Utils;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.storm.utils.Utils;
+import org.junit.Before;
+import org.junit.Test;
 
 public class TestMessageRetryManager {
     MessageRetryManager messageRetryManager;


### PR DESCRIPTION
Reduce the max allowed violation count to 0.

Changed the class names including MQ to Mq. 
>Since storm-rocketmq is only merged into master branch and storm 2.0 hasn't been released, so the changes should hurt nothing.