### PR TITLE
STORM-2619: Correct the JDK version in Setting-up-a-Storm-cluster.md

### DIFF
--- a/docs/Setting-up-a-Storm-cluster.md
+++ b/docs/Setting-up-a-Storm-cluster.md
@@ -29,7 +29,7 @@ A few notes about Zookeeper deployment:
 
 Next you need to install Storm's dependencies on Nimbus and the worker machines. These are:
 
-1. Java 7
+1. Java 8
 2. Python 2.6.6
 
 These are the versions of the dependencies that have been tested with Storm. Storm may or may not work with different versions of Java and/or Python.


### PR DESCRIPTION
The Storm 2.0 needs JDK 1.8+