### PR TITLE
[STORM-2626] Provided a template for drpc-auth-acl.yaml

### DIFF
--- a/conf/drpc-auth-acl.yaml.example
+++ b/conf/drpc-auth-acl.yaml.example
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# For the function "functionName1", alice can perform client operations, and bob can
+# perform invocation operations.User should replace "functionName1","functionName2","alice","bob" with their own value
+drpc.authorizer.acl:
+  "functionName1":
+    "client.users":
+      - "alice"
+      - "bob"
+    "invocation.user": "bob"
+  "functionName2":
+    "client.users":
+      - "alice"


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2626](https://issues.apache.org/jira/browse/STORM-2626)

The default value of drpc.authorizer.acl.filename in defaults.yaml is "drpc-auth-acl.yaml",so I think we should provided a template for drpc-auth-acl.yaml.