### PR TITLE
[STORM-2627] The annotation of storm.zookeeper.topology.auth.scheme in Config.java is wrong

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -967,7 +967,7 @@ public class Config extends HashMap<String, Object> {
     public static final String STORM_ZOOKEEPER_SUPERACL = "storm.zookeeper.superACL";
 
     /**
-     * The topology Zookeeper authentication scheme to use, e.g. "digest". Defaults to no authentication.
+     * The topology Zookeeper authentication scheme to use, e.g. "digest". It is the internal config and user shouldn't set it.
      */
     @isString
     public static final String STORM_ZOOKEEPER_TOPOLOGY_AUTH_SCHEME="storm.zookeeper.topology.auth.scheme";


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2627](https://issues.apache.org/jira/browse/STORM-2627)

The annotation of "storm.zookeeper.topology.auth.scheme" in Config.java is wrong.As StormSubmitter.java,line 91, says "STORM_ZOOKEEPER_TOPOLOGY_AUTH_SCHEME is should always be set to digest.", the annotation of "storm.zookeeper.topology.auth.scheme" in Config.java should be consistent with it.