### PR TITLE
#2645 -- Update storm.py to be python3 compatible

### DIFF
--- a/storm-multilang/python/src/main/resources/resources/storm.py
+++ b/storm-multilang/python/src/main/resources/resources/storm.py
@@ -109,7 +109,7 @@ def emitBolt(tup, stream=None, anchors = [], directTask=None):
     m = {"command": "emit"}
     if stream is not None:
         m["stream"] = stream
-    m["anchors"] = map(lambda a: a.id, anchors)
+    m["anchors"] = [a.id for a in anchors]
     if directTask is not None:
         m["task"] = directTask
     m["tuple"] = tup


### PR DESCRIPTION
Function `emitBolt()` emits a `map`, which is not json serializeble in python3. It should be changed to return a `list` in order to be json serializeble.