### PR TITLE
[STORM-2637] fix ClassCastException in logviewer get-log-user-group-whitelist func…

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj
@@ -311,7 +311,7 @@
 
 (defn get-log-user-group-whitelist [fname]
   (let [wl-file (ServerConfigUtils/getLogMetaDataFile fname)
-        m (clojurify-structure (Utils/readYamlFile wl-file))]
+        m (clojurify-structure (Utils/readYamlFile (.toString wl-file)))]
     (if (not-nil? m)
       (do
         (let [user-wl (.get m LOGS-USERS)


### PR DESCRIPTION
In get-log-user-group-whitelist function, the getLogMetaDataFile function returns a File while the readYamlFile function requires a String.

see https://issues.apache.org/jira/browse/STORM-2637