### PR TITLE
[STORM-2133] add page-rendered-at timestamp on the UI

### DIFF
--- a/storm-core/src/ui/public/component.html
+++ b/storm-core/src/ui/public/component.html
@@ -74,6 +74,9 @@
       <p id="toggle-switch" style="display: block;" class="js-only"></p>
     </div>
   </div>
+  <div>
+    <p id="page-rendered-at-timestamp"></p>
+  </div>
 <script>
 $(document).ajaxStop($.unblockUI);
 $(document).ajaxStart(function(){
@@ -350,6 +353,8 @@ $(document).ready(function() {
         });
     });
 });
+
+getPageRenderedTimestamp("page-rendered-at-timestamp");
 
 function start_profiling() {
     var topologyId = $.url("?topology_id");

--- a/storm-core/src/ui/public/deep_search_result.html
+++ b/storm-core/src/ui/public/deep_search_result.html
@@ -41,6 +41,9 @@
   <div class="row">
     <div id="result"></div>
   </div>
+  <div>
+    <p id="page-rendered-at-timestamp"></p>
+  </div>
 </div>
 </body>
 <script type="text/javascript">
@@ -150,6 +153,8 @@ $(document).ready(function() {
         }
     });
 });
+
+getPageRenderedTimestamp("page-rendered-at-timestamp");
 
 </script>
 </html>

--- a/storm-core/src/ui/public/index.html
+++ b/storm-core/src/ui/public/index.html
@@ -94,6 +94,9 @@
       <div id="json-response-error"></div>
     </div>
   </div>
+  <div>
+    <p id="page-rendered-at-timestamp"></p>
+  </div>
 </div>
 </body>
 <script>
@@ -198,5 +201,8 @@ $(document).ready(function() {
         });
     });
   });
+
+  getPageRenderedTimestamp("page-rendered-at-timestamp");
+
 </script>
 </html>

--- a/storm-core/src/ui/public/js/script.js
+++ b/storm-core/src/ui/public/js/script.js
@@ -581,3 +581,6 @@ var makeOwnerSummaryTable = function(response, elId, parentId) {
     $(elId + ' [data-toggle="tooltip"]').tooltip();
 };
 
+function getPageRenderedTimestamp(eId) {
+    document.getElementById(eId).innerHTML = "Page rendered at: " + Date();
+};

--- a/storm-core/src/ui/public/logviewer_search.html
+++ b/storm-core/src/ui/public/logviewer_search.html
@@ -40,6 +40,9 @@
   <div class="row">
     <div id="result"></div>
   </div>
+  <div>
+    <p id="page-rendered-at-timestamp"></p>
+  </div>
 </div>
 </body>
 <script>
@@ -62,5 +65,8 @@ $(document).ready(function() {
        });
     });
   });
+
+getPageRenderedTimestamp("page-rendered-at-timestamp");
+
 </script>
 </html>

--- a/storm-core/src/ui/public/owner.html
+++ b/storm-core/src/ui/public/owner.html
@@ -80,6 +80,9 @@
     <div class="row">
         <div id="json-response-error" class="col-md-12"></div>
     </div>
+    <div>
+        <p id="page-rendered-at-timestamp"></p>
+    </div>
 </div>
 </body>
 <script>
@@ -200,6 +203,9 @@
             });
         });
     });
+
+    getPageRenderedTimestamp("page-rendered-at-timestamp");
+
 </script>
 
 </html>

--- a/storm-core/src/ui/public/search_result.html
+++ b/storm-core/src/ui/public/search_result.html
@@ -40,6 +40,9 @@
   <div class="row">
     <div id="result"></div>
   </div>
+  <div>
+    <p id="page-rendered-at-timestamp"></p>
+  </div>
 </div>
 </body>
 <script>
@@ -96,5 +99,8 @@ $(document).ready(function() {
        });
     });
   });
+
+  getPageRenderedTimestamp("page-rendered-at-timestamp");
+
 </script>
 </html>

--- a/storm-core/src/ui/public/supervisor.html
+++ b/storm-core/src/ui/public/supervisor.html
@@ -61,6 +61,9 @@
       <span id="toggle-sys" style="display: block;" class="js-only"></span>
     </div>
   </div>
+  <div>
+    <p id="page-rendered-at-timestamp"></p>
+  </div>
 </div>
 </body>
 
@@ -129,4 +132,7 @@ $(document).ready(function() {
         });
     });
 });
+
+getPageRenderedTimestamp("page-rendered-at-timestamp");
+
 </script>

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -92,6 +92,9 @@
   <div class="row">
     <div id="json-response-error" class="col-md-12"></div>
   </div>
+  <div>
+    <p id="page-rendered-at-timestamp"></p>
+  </div>
 </div>
 </body>
 <script>
@@ -448,6 +451,9 @@ $(document).ready(function() {
       }});
     });
  });
+
+getPageRenderedTimestamp("page-rendered-at-timestamp");
+
 </script>
 </html>
 


### PR DESCRIPTION
As a user, I would like a simple timestamp of when a UI page was rendered, so that, I can quickly check if the information is fresh.
This is mainly for the case of keeping browser tabs open for a long while during debugging. Seeing old data in your browser could harm the effort.    -Reported by @d2r 

see: https://issues.apache.org/jira/browse/STORM-2133

This PR adds timestamp on index, topology, supervisor, owner, component pages, etc. I didn't add timestamp on logviewer pages since logs have clear timestamps.  Please let me know if it's also needed. Thanks.