### PR TITLE
[STORM-2644] Show message when result not found on deep search page

### DIFF
--- a/storm-core/src/ui/public/deep_search_result.html
+++ b/storm-core/src/ui/public/deep_search_result.html
@@ -97,11 +97,26 @@ $(document).ready(function() {
             file.count = count;
             file.logviewerPort = logviewerPort;
             file.search_archived = search_archived;
+            if (file.matches == 0) {
+               file.resultNotFound = true;
+            }
             var searchTemplate = $(template).filter("#search-result-identified-template").html();
             var rendered = Mustache.render(searchTemplate, file);
             var elemId = elem_id_for_host(host);
             $("#"+elemId).remove();
-            $("#search-result-table > tbody").append(rendered);
+            if (file.resultNotFound) {
+                // if no result found,
+                // and there is no "aResult" or "noResult" element exists,
+                // append "resultNotFound" element
+                if (!$("#aResult").length && !$("#noResult").length) {
+                    $("#search-result-table > tbody").append(rendered);
+                }
+            } else {
+              // if a result found, remove "noResult" element,
+              // and append the result
+              $("#noResult").remove();
+              $("#search-result-table > tbody").append(rendered);
+            }
         }
 
 

--- a/storm-core/src/ui/public/templates/deep-search-result-page-template.html
+++ b/storm-core/src/ui/public/templates/deep-search-result-page-template.html
@@ -29,11 +29,17 @@
 </script>
 <script id="search-result-identified-template" type="text/html">
     {{#matches}}
-    <tr>
+    <tr id="aResult">
       <td><a href="http://{{host}}:{{logviewerPort}}/logviewer_search.html?file={{fileName}}&search={{searchString}}">{{host}}:{{port}}</a></td>
       <td><pre>{{beforeString}}<b><a href="{{logviewerURL}}">{{matchString}}</a></b>{{afterString}}</pre></td>
     </tr>
     {{/matches}}
+    {{#resultNotFound}}
+    <tr id="noResult">
+      <td>Result Not Found</td>
+      <td></td>
+    </tr>
+    {{/resultNotFound}}
 </script>
 <script id="search-form-template" type="text/html">
   <div id="search-form-container" class="search-box">


### PR DESCRIPTION
Deep search shows a blank area if no results are found. see https://issues.apache.org/jira/browse/STORM-2644

![image](https://user-images.githubusercontent.com/14900612/28389389-82e92d84-6c9b-11e7-9594-8e9690e22724.png)

Show some message to avoid confusion about whether the searching is finished or not.