### PR TITLE
[STORM-2654] preserve the formatting of the exception stacktrace on UI

### DIFF
--- a/storm-core/src/ui/public/component.html
+++ b/storm-core/src/ui/public/component.html
@@ -342,6 +342,7 @@ $(document).ready(function() {
                 errorCells[i].style.color = "#9d261d";
                 errorCells[i].style.borderBottomColor = "#9d261d";
               }
+              errorCells[i].style.whiteSpace = "pre";
             }
             $('#component-summary [data-toggle="tooltip"]').tooltip();
             $('#component-actions [data-toggle="tooltip"]').tooltip();

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -356,6 +356,7 @@ $(document).ready(function() {
                 errorCells[i].style.color = "#9d261d";
                 errorCells[i].style.borderBottomColor = "#9d261d";
               }
+              errorCells[i].style.whiteSpace = "pre";
             }
             
             var errorTime = document.getElementsByClassName("errorTime");


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/STORM-2654
The stack trace is not formatted on UI.

![image](https://user-images.githubusercontent.com/14900612/28540592-87a8155e-707b-11e7-85c1-9dc658c26b21.png)
