### PR TITLE
[STORM-2655] fix: log users cannot view worker.log on Storm UI on sec…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/DefaultPrincipalToLocal.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/DefaultPrincipalToLocal.java
@@ -36,7 +36,8 @@ public class DefaultPrincipalToLocal implements IPrincipalToLocal {
      * @param principal the principal to convert
      * @return The local user name.
      */
-    public String toLocal(Principal principal) {
-      return principal == null ? null : principal.getName();
+    @Override
+    public String toLocal(String principal) {
+      return principal;
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/IPrincipalToLocal.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/IPrincipalToLocal.java
@@ -37,5 +37,9 @@ public interface IPrincipalToLocal {
      * @param principal the principal to convert
      * @return The local user name.
      */
-    public String toLocal(Principal principal);
+    default public String toLocal(Principal principal) {
+        return principal == null ? null : toLocal(principal.getName());
+    }
+
+    public String toLocal(String principalName);
 }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/KerberosPrincipalToLocal.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/KerberosPrincipalToLocal.java
@@ -37,9 +37,10 @@ public class KerberosPrincipalToLocal implements IPrincipalToLocal {
      * @param principal the principal to convert
      * @return The local user name.
      */
-    public String toLocal(Principal principal) {
+    @Override
+    public String toLocal(String principal) {
       //This technically does not conform with rfc1964, but should work so
       // long as you don't have any really odd names in your KDC.
-      return principal == null ? null : principal.getName().split("[/@]")[0];
+      return principal == null ? null : principal.split("[/@]")[0];
     }
 }

--- a/storm-client/test/jvm/org/apache/storm/security/auth/AuthUtilsTestMock.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/AuthUtilsTestMock.java
@@ -57,7 +57,7 @@ public class AuthUtilsTestMock implements IAutoCredentials,
 
     // IPrincipalToLocal 
     @Override
-    public String toLocal(Principal principal) {
+    public String toLocal(String principal) {
         return null;
     }
 


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/STORM-2655

solution: add princialToLocal inside of isAuthorizedLogUser function.
