### PR TITLE
STORM-2659: Add daemon.name variable to storm.cmd to fix log4j logging

### DIFF
--- a/bin/storm.cmd
+++ b/bin/storm.cmd
@@ -145,6 +145,7 @@
 
 :drpc
   set CLASS=org.apache.storm.daemon.drpc
+  set STORM_OPTS=%STORM_OPTS% -Ddaemon.name=drpc
   "%JAVA%" -client -Dstorm.options= -Dstorm.conf.file= -cp "%CLASSPATH%" org.apache.storm.command.config_value drpc.childopts > %CMD_TEMP_FILE%
   FOR /F "delims=" %%i in (%CMD_TEMP_FILE%) do (
      FOR /F "tokens=1,* delims= " %%a in ("%%i") do (
@@ -171,6 +172,7 @@
 
 :logviewer
   set CLASS=org.apache.storm.daemon.logviewer
+  set STORM_OPTS=%STORM_OPTS% -Ddaemon.name=logviewer
    "%JAVA%" -client -Dstorm.options= -Dstorm.conf.file= -cp "%CLASSPATH%" org.apache.storm.command.config_value logviewer.childopts > %CMD_TEMP_FILE%
   FOR /F "delims=" %%i in (%CMD_TEMP_FILE%) do (
      FOR /F "tokens=1,* delims= " %%a in ("%%i") do (
@@ -183,6 +185,7 @@
 
 :nimbus
   set CLASS=org.apache.storm.daemon.nimbus
+  set STORM_OPTS=%STORM_OPTS% -Ddaemon.name=nimbus
   "%JAVA%" -client -Dstorm.options= -Dstorm.conf.file= -cp "%CLASSPATH%" org.apache.storm.command.config_value nimbus.childopts > %CMD_TEMP_FILE%
   FOR /F "delims=" %%i in (%CMD_TEMP_FILE%) do (
      FOR /F "tokens=1,* delims= " %%a in ("%%i") do (
@@ -215,6 +218,7 @@
   
 :supervisor
   set CLASS=org.apache.storm.daemon.supervisor.Supervisor
+  set STORM_OPTS=%STORM_OPTS% -Ddaemon.name=supervisor
   "%JAVA%" -client -Dstorm.options= -Dstorm.conf.file= -cp "%CLASSPATH%" org.apache.storm.command.config_value supervisor.childopts > %CMD_TEMP_FILE%
   FOR /F "delims=" %%i in (%CMD_TEMP_FILE%) do (
      FOR /F "tokens=1,* delims= " %%a in ("%%i") do (
@@ -227,6 +231,7 @@
 
 :ui
   set CLASS=org.apache.storm.ui.core
+  set STORM_OPTS=%STORM_OPTS% -Ddaemon.name=ui
   set CLASSPATH=%CLASSPATH%;%STORM_HOME%
   "%JAVA%" -client -Dstorm.options= -Dstorm.conf.file= -cp "%CLASSPATH%" org.apache.storm.command.config_value ui.childopts > %CMD_TEMP_FILE%
   FOR /F "delims=" %%i in (%CMD_TEMP_FILE%) do (


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/STORM-2659

The python script was updated to handle this (https://github.com/apache/storm/blob/v1.1.1/bin/storm.py#L260), but it seems like storm.cmd was missed.