### PR TITLE
STORM-2663: Add Powershell port of storm.sh and deprecate storm.cmd. …

### DIFF
--- a/bin/storm.cmd
+++ b/bin/storm.cmd
@@ -42,6 +42,8 @@
   if not "%storm-command%" == "jar" (
     set set_storm_options=true
   )
+  
+  @echo This script is deprecated. Please use the Powershell storm.ps1 script instead
 
   call %~dp0storm-config.cmd
 

--- a/bin/storm.ps1
+++ b/bin/storm.ps1
@@ -1,0 +1,68 @@
+﻿# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Resolve links - $PSCommandPath may be a softlink
+$PRG = $PSCommandPath;
+
+while((Get-Item $PRG).LinkType -eq "SymbolicLink") {
+  $PRG = (Get-Item $PRG).Target;
+}
+
+# Check for Python version
+$PythonVersion = (& python -V 2>&1)[0].ToString().Split(" ")[1];
+$PythonMajor = [int]$PythonVersion.Split(".")[0];
+$PythonMinor = [int]$PythonVersion.Split(".")[1];
+$PythonNumVersion = $PythonMajor * 10 + $PythonMinor;
+if($PythonNumVersion -le 26) {
+  echo "Need python version > 2.6";
+  exit 1;
+}
+
+$STORM_BIN_DIR = Split-Path -Parent $PRG;
+$env:STORM_BASE_DIR = Split-Path -Parent $STORM_BIN_DIR;
+
+# Check to see if the conf dir or file is given as an optional argument
+if($args.Length -ge 1) {
+  if("--config" -eq $args.get(0)) {
+    $ConfFile = $args.get(1);
+    if(-not (Test-Path $ConfFile)) {
+      echo ("Error: Path {0} does not exist" -f $ConfFile);
+      exit 1;
+    }
+    if((Get-Item $ConfFile).PsIsContainer) {
+      $ConfFile=[io.path]::combine($ConfFile, "storm.yaml");
+    }
+    if(-not (Test-Path $ConfFile)) {
+      echo ("Error: Path {0} does not exist" -f $ConfFile);
+      exit 1;
+    }
+    $STORM_CONF_FILE = $ConfFile;
+    $STORM_CONF_DIR = Split-Path -Parent $STORM_CONF_FILE;
+  } 
+}
+
+$env:STORM_CONF_DIR = if($STORM_CONF_DIR -ne $null) { $STORM_CONF_DIR; } else { [io.path]::combine($env:STORM_BASE_DIR, "conf"); }
+$env:STORM_CONF_FILE = if($STORM_CONF_FILE -ne $null) { $STORM_CONF_FILE; } else { [io.path]::combine($env:STORM_BASE_DIR, "conf", "storm.yaml"); }
+
+$StormEnvPath = [io.path]::combine($env:STORM_CONF_DIR, "storm-env.ps1");
+if(Test-Path $StormEnvPath) {
+  . $StormEnvPath;
+}
+
+& ([io.path]::combine("$STORM_BIN_DIR", "storm.py")) $args;
+
+exit $LastExitCode

--- a/bin/storm.py
+++ b/bin/storm.py
@@ -66,6 +66,12 @@ def init_storm_env():
     for option in options:
         value = config.get('environment', option)
         os.environ[option] = value
+        
+def get_java_cmd():
+    cmd = 'java' if not is_windows() else 'java.exe'
+    if JAVA_HOME:
+        cmd = os.path.join(JAVA_HOME, 'bin', cmd)
+    return cmd
 
 normclasspath = cygpath if sys.platform == 'cygwin' else identity
 STORM_DIR = os.sep.join(os.path.realpath( __file__ ).split(os.sep)[:-2])
@@ -91,7 +97,7 @@ CONFIG_OPTS = []
 CONFFILE = ""
 JAR_JVM_OPTS = shlex.split(os.getenv('STORM_JAR_JVM_OPTS', ''))
 JAVA_HOME = os.getenv('JAVA_HOME', None)
-JAVA_CMD = 'java' if not JAVA_HOME else os.path.join(JAVA_HOME, 'bin', 'java')
+JAVA_CMD = get_java_cmd(); 
 if JAVA_HOME and not os.path.exists(JAVA_CMD):
     print("ERROR:  JAVA_HOME is invalid.  Could not find bin/java at %s." % JAVA_HOME)
     sys.exit(1)
@@ -276,6 +282,7 @@ def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]
             ret = sub.check_output(all_args, stderr=sub.STDOUT)
             print(ret)
         except sub.CalledProcessError as e:
+            print(e.output)
             sys.exit(e.returncode)
     else:
         os.execvp(JAVA_CMD, all_args)

--- a/conf/storm-env.ps1
+++ b/conf/storm-env.ps1
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set Storm specific environment variables here.
+
+# The java implementation to use.
+$env:JAVA_HOME = $env:JAVA_HOME;
+
+#$env:STORM_CONF_DIR = ""

--- a/storm-dist/binary/src/main/assembly/binary.xml
+++ b/storm-dist/binary/src/main/assembly/binary.xml
@@ -349,6 +349,12 @@
             <fileMode>0755</fileMode>
         </file>
         <file>
+            <source>${project.basedir}/../../conf/storm-env.ps1</source>
+            <outputDirectory>/conf</outputDirectory>
+            <destName>storm-env.ps1</destName>
+            <fileMode>0755</fileMode>
+        </file>
+        <file>
             <source>${project.basedir}/../../VERSION</source>
             <outputDirectory>/</outputDirectory>
             <destName>RELEASE</destName>


### PR DESCRIPTION
…Backports STORM-2558 and STORM-2641.

See https://issues.apache.org/jira/browse/STORM-2663

Apart from the deprecation warning in storm.cmd this has already been reviewed as part of https://github.com/apache/storm/pull/2165 and https://github.com/apache/storm/pull/2225.