### PR TITLE
STORM-2673: add support for prioritizing nodes in scheduling

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -262,6 +262,20 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_SCHEDULER_STRATEGY = "topology.scheduler.strategy";
 
     /**
+     * A list of host names that this topology would prefer to be scheduled on (no guarantee is given though).
+     * This is intended for debugging only.
+     */
+    @isStringList
+    public static final String TOPOLOGY_SCHEDULER_FAVORED_NODES = "topology.scheduler.favored.nodes";
+
+    /**
+     * A list of host names that this topology would prefer to NOT be scheduled on (no guarantee is given though).
+     * This is intended for debugging only.
+     */
+    @isStringList
+    public static final String TOPOLOGY_SCHEDULER_UNFAVORED_NODES = "topology.scheduler.unfavored.nodes";
+
+    /**
      * How many executors to spawn for ackers.
      *
      * <p>By not setting this variable or setting it as null, Storm will set the number of acker executors

--- a/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
@@ -514,6 +514,18 @@ public class Cluster implements ISchedulingState {
             return false;
         }
 
+        //Lets see if we can make the Memory one fast too, at least in the failure case.
+        //The totalMemReq is not really that accurate because it does not include shared memory, but if it does not fit we know
+        // Even with shared it will not work
+        double minMemNeeded = td.getTotalMemReqTask(exec);
+        if (minMemNeeded > memoryAvailable) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Could not schedule {}:{} on {} not enough Mem {} > {}", td.getName(), exec, ws, minMemNeeded, memoryAvailable);
+            }
+            //Not enough minimum MEM no need to try any more
+            return false;
+        }
+
         double currentTotal = 0.0;
         double afterTotal = 0.0;
         double afterOnHeap = 0.0;


### PR DESCRIPTION
I really would like feedback on the configs and if it makes since to modify other schedulers to support this too.

Config:
I thought about using regexs for nodes instead of just a host name.  Would that be better? Would it make it simple for someone to prefer a large section of a cluster and essentially abuse the feature?

Other Schedulers:
The isolation scheduler possibly, where we could resort The HostAssignableSlots if the topology want to prioritize one host over another.  And then sort them back if they don't

The even scheduler is a little odd as it feels completely against what it stands for.  It would almost turn it into an odd hybrid with the isolation scheduler.

MT scheduler is so complex at this point I could do it, but only if someone really wants it.