### PR TITLE
[STORM-2676] Error class name for log in JsonRecordHiveMapper.java.

### DIFF
--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/JsonRecordHiveMapper.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/JsonRecordHiveMapper.java
@@ -38,7 +38,7 @@ import java.text.SimpleDateFormat;
 import java.io.IOException;
 
 public class JsonRecordHiveMapper implements HiveMapper {
-    private static final Logger LOG = LoggerFactory.getLogger(DelimitedRecordHiveMapper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JsonRecordHiveMapper.class);
     private Fields columnFields;
     private Fields partitionFields;
     private String timeFormat;


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2676](https://issues.apache.org/jira/browse/STORM-2676)
The class in "LoggerFactory.getLogger()" should be JsonRecordHiveMapper.class.