### PR TITLE
STORM-2678 Improve performance of LoadAwareShuffleGrouping

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/GrouperFactory.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/GrouperFactory.java
@@ -124,11 +124,6 @@ public class GrouperFactory {
         }
 
         @Override
-        public List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load) {
-            return customStreamGrouping.chooseTasks(taskId, values);
-        }
-
-        @Override
         public void prepare(WorkerTopologyContext context, GlobalStreamId stream, List<Integer> targetTasks) {
             customStreamGrouping.prepare(context, stream, targetTasks);
         }
@@ -231,11 +226,6 @@ public class GrouperFactory {
         @Override
         public void refreshLoad(LoadMapping loadMapping) {
 
-        }
-
-        @Override
-        public List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load) {
-            return null;
         }
 
         @Override

--- a/storm-client/src/jvm/org/apache/storm/daemon/GrouperFactory.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/GrouperFactory.java
@@ -119,6 +119,11 @@ public class GrouperFactory {
         }
 
         @Override
+        public void refreshLoad(LoadMapping loadMapping) {
+
+        }
+
+        @Override
         public List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load) {
             return customStreamGrouping.chooseTasks(taskId, values);
         }
@@ -223,6 +228,11 @@ public class GrouperFactory {
 
     // A no-op grouper
     public static final LoadAwareCustomStreamGrouping DIRECT = new LoadAwareCustomStreamGrouping() {
+        @Override
+        public void refreshLoad(LoadMapping loadMapping) {
+
+        }
+
         @Override
         public List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load) {
             return null;

--- a/storm-client/src/jvm/org/apache/storm/daemon/Task.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/Task.java
@@ -137,7 +137,7 @@ public class Task {
                 if (grouper == GrouperFactory.DIRECT) {
                     throw new IllegalArgumentException("Cannot do regular emit to direct stream");
                 }
-                List<Integer> compTasks = grouper.chooseTasks(taskId, values, loadMapping);
+                List<Integer> compTasks = grouper.chooseTasks(taskId, values);
                 outTasks.addAll(compTasks);
             }
         }

--- a/storm-client/src/jvm/org/apache/storm/executor/ExecutorShutdown.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/ExecutorShutdown.java
@@ -23,6 +23,7 @@ import org.apache.storm.daemon.Shutdownable;
 import org.apache.storm.daemon.Task;
 import org.apache.storm.generated.Credentials;
 import org.apache.storm.generated.ExecutorStats;
+import org.apache.storm.grouping.LoadMapping;
 import org.apache.storm.hooks.ITaskHook;
 import org.apache.storm.spout.ISpout;
 import org.apache.storm.task.IBolt;
@@ -66,6 +67,11 @@ public class ExecutorShutdown implements Shutdownable, IRunningExecutor {
                 Constants.CREDENTIALS_CHANGED_STREAM_ID);
         List<AddressedTuple> addressedTuple = Lists.newArrayList(new AddressedTuple(AddressedTuple.BROADCAST_DEST, tuple));
         executor.getReceiveQueue().publish(addressedTuple);
+    }
+
+    @Override
+    public void loadChanged(LoadMapping loadMapping) {
+        executor.reflectNewLoadMapping(loadMapping);
     }
 
     @Override

--- a/storm-client/src/jvm/org/apache/storm/executor/IRunningExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/IRunningExecutor.java
@@ -19,6 +19,7 @@ package org.apache.storm.executor;
 
 import org.apache.storm.generated.Credentials;
 import org.apache.storm.generated.ExecutorStats;
+import org.apache.storm.grouping.LoadMapping;
 
 import java.util.List;
 
@@ -27,5 +28,6 @@ public interface IRunningExecutor {
     ExecutorStats renderStats();
     List<Long> getExecutorId();
     void credentialsChanged(Credentials credentials);
+    void loadChanged(LoadMapping loadMapping);
     boolean getBackPressureFlag();
 }

--- a/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareCustomStreamGrouping.java
+++ b/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareCustomStreamGrouping.java
@@ -20,5 +20,6 @@ package org.apache.storm.grouping;
 import java.util.List;
 
 public interface LoadAwareCustomStreamGrouping extends CustomStreamGrouping {
+   void refreshLoad(LoadMapping loadMapping);
    List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load);
 }

--- a/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareCustomStreamGrouping.java
+++ b/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareCustomStreamGrouping.java
@@ -17,9 +17,6 @@
  */
 package org.apache.storm.grouping;
 
-import java.util.List;
-
 public interface LoadAwareCustomStreamGrouping extends CustomStreamGrouping {
    void refreshLoad(LoadMapping loadMapping);
-   List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load);
 }

--- a/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareShuffleGrouping.java
+++ b/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareShuffleGrouping.java
@@ -74,16 +74,6 @@ public class LoadAwareShuffleGrouping implements LoadAwareCustomStreamGrouping, 
 
     @Override
     public List<Integer> chooseTasks(int taskId, List<Object> values) {
-        throw new RuntimeException("NOT IMPLEMENTED");
-    }
-
-    @Override
-    public void refreshLoad(LoadMapping loadMapping) {
-        updateRing(loadMapping);
-    }
-
-    @Override
-    public List<Integer> chooseTasks(int taskId, List<Object> values, LoadMapping load) {
         int rightNow;
         while (true) {
             rightNow = current.incrementAndGet();
@@ -96,6 +86,11 @@ public class LoadAwareShuffleGrouping implements LoadAwareCustomStreamGrouping, 
             //race condition with another thread, and we lost
             // try again
         }
+    }
+
+    @Override
+    public void refreshLoad(LoadMapping loadMapping) {
+        updateRing(loadMapping);
     }
 
     private void updateRing(LoadMapping load) {

--- a/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareShuffleGrouping.java
+++ b/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareShuffleGrouping.java
@@ -62,7 +62,7 @@ public class LoadAwareShuffleGrouping implements LoadAwareCustomStreamGrouping, 
         }
 
         shuffleArray(choices);
-        current = new AtomicInteger(0);
+        current = new AtomicInteger(-1);
 
         // allocate another array to be switched
         prepareChoices = new int[CAPACITY];
@@ -150,7 +150,7 @@ public class LoadAwareShuffleGrouping implements LoadAwareCustomStreamGrouping, 
         choices = prepareChoices;
         prepareChoices = tempForSwap;
 
-        current.set(0);
+        current.set(-1);
     }
 
     private void shuffleArray(int[] arr) {

--- a/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
@@ -117,8 +117,7 @@ public class LoadAwareShuffleGroupingTest {
                 public int[] call() throws Exception {
                     int[] taskCounts = new int[availableTaskIds.size()];
                     for (int i = 1; i <= groupingExecutionsPerThread; i++) {
-                        List<Integer> taskIds = grouper.chooseTasks(inputTaskId,
-                            Lists.newArrayList(), loadMapping);
+                        List<Integer> taskIds = grouper.chooseTasks(inputTaskId, Lists.newArrayList());
 
                         // Validate a single task id return
                         assertNotNull("Not null taskId list returned", taskIds);
@@ -212,7 +211,7 @@ public class LoadAwareShuffleGroupingTest {
         List<Object> data = Lists.newArrayList(1, 2);
         int[] frequencies = new int[3];
         for (int i = 0 ; i < numMessages ; i++) {
-            List<Integer> tasks = shuffler.chooseTasks(1, data, load);
+            List<Integer> tasks = shuffler.chooseTasks(1, data);
             for (int task : tasks) {
                 frequencies[task]++;
             }
@@ -252,7 +251,7 @@ public class LoadAwareShuffleGroupingTest {
         List<Object> data = Lists.newArrayList(1, 2);
         int[] frequencies = new int[3]; // task id starts from 1
         for (int i = 0 ; i < numMessages ; i++) {
-            List<Integer> tasks = shuffler.chooseTasks(1, data, load);
+            List<Integer> tasks = shuffler.chooseTasks(1, data);
             for (int task : tasks) {
                 frequencies[task]++;
             }
@@ -361,7 +360,7 @@ public class LoadAwareShuffleGroupingTest {
 
         for (int i = 1; i <= totalEmits; i++) {
             List<Integer> taskIds = grouper
-                .chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+                .chooseTasks(inputTaskId, Lists.newArrayList());
 
             // Validate a single task id return
             assertNotNull("Not null taskId list returned", taskIds);
@@ -422,7 +421,7 @@ public class LoadAwareShuffleGroupingTest {
         long current = System.currentTimeMillis();
         int idx = 0;
         while (true) {
-            grouper.chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+            grouper.chooseTasks(inputTaskId, Lists.newArrayList());
 
             idx++;
             if (idx % 100000 == 0) {
@@ -435,7 +434,7 @@ public class LoadAwareShuffleGroupingTest {
 
         current = System.currentTimeMillis();
         for (int i = 1; i <= 2_000_000_000; i++) {
-            grouper.chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+            grouper.chooseTasks(inputTaskId, Lists.newArrayList());
         }
 
         LOG.info("Duration: {} ms", (System.currentTimeMillis() - current));
@@ -462,7 +461,7 @@ public class LoadAwareShuffleGroupingTest {
         long current = System.currentTimeMillis();
         int idx = 0;
         while (true) {
-            grouper.chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+            grouper.chooseTasks(inputTaskId, Lists.newArrayList());
 
             idx++;
             if (idx % 100000 == 0) {
@@ -482,7 +481,7 @@ public class LoadAwareShuffleGroupingTest {
                 public Long call() throws Exception {
                     long current = System.currentTimeMillis();
                     for (int i = 1; i <= groupingExecutionsPerThread; i++) {
-                        grouper.chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+                        grouper.chooseTasks(inputTaskId, Lists.newArrayList());
                     }
                     return System.currentTimeMillis() - current;
                 }

--- a/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
@@ -1,0 +1,399 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.grouping;
+
+import com.google.common.collect.Lists;
+import org.apache.storm.daemon.GrouperFactory;
+import org.apache.storm.generated.Grouping;
+import org.apache.storm.generated.NullStruct;
+import org.apache.storm.task.WorkerTopologyContext;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class LoadAwareShuffleGroupingTest {
+    private static final Logger LOG = LoggerFactory.getLogger(LoadAwareShuffleGroupingTest.class);
+
+    @Test
+    public void testLoadAwareShuffleGroupingWithEvenLoad() {
+        // just pick arbitrary number
+        final int numTasks = 7;
+        final LoadAwareShuffleGrouping grouper = new LoadAwareShuffleGrouping();
+
+        // Define our taskIds and loads
+        final List<Integer> availableTaskIds = getAvailableTaskIds(numTasks);
+        final LoadMapping loadMapping = buildLocalTasksEvenLoadMapping(availableTaskIds);
+
+        WorkerTopologyContext context = mock(WorkerTopologyContext.class);
+        grouper.prepare(context, null, availableTaskIds);
+
+        // Keep track of how many times we see each taskId
+        // distribution should be even for all nodes when loads are even
+        int desiredTaskCountPerTask = 5000;
+        int totalEmits = numTasks * desiredTaskCountPerTask;
+
+        int[] taskCounts = runChooseTasksWithVerification(grouper, totalEmits, numTasks, loadMapping);
+
+        for (int i = 0; i < numTasks; i++) {
+            assertEquals("Distribution should be even for all nodes", desiredTaskCountPerTask,
+                taskCounts[i]);
+        }
+    }
+
+    @Test
+    public void testLoadAwareShuffleGroupingWithEvenLoadMultiThreaded() throws InterruptedException, ExecutionException {
+        final int numTasks = 7;
+
+        final LoadAwareShuffleGrouping grouper = new LoadAwareShuffleGrouping();
+
+        // Task Id not used, so just pick a static value
+        final int inputTaskId = 100;
+        // Define our taskIds - the test expects these to be incrementing by one up from zero
+        final List<Integer> availableTaskIds = getAvailableTaskIds(numTasks);
+        final LoadMapping loadMapping = buildLocalTasksEvenLoadMapping(availableTaskIds);
+
+        final WorkerTopologyContext context = mock(WorkerTopologyContext.class);
+
+        // Call prepare with our available taskIds
+        grouper.prepare(context, null, availableTaskIds);
+
+        // triggers building ring
+        grouper.chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+
+        // calling chooseTasks should be finished before refreshing ring
+        // adjusting groupingExecutionsPerThread might be needed with really slow machine
+        // we allow race condition between refreshing ring and choosing tasks
+        // so it will not make exact even distribution, though diff is expected to be small
+        final int groupingExecutionsPerThread = numTasks * 5000;
+        final int numThreads = 10;
+
+        List<Callable<int[]>> threadTasks = Lists.newArrayList();
+        for (int x = 0; x < numThreads; x++) {
+            Callable<int[]> threadTask = new Callable<int[]>() {
+                @Override
+                public int[] call() throws Exception {
+                    int[] taskCounts = new int[availableTaskIds.size()];
+                    for (int i = 1; i <= groupingExecutionsPerThread; i++) {
+                        List<Integer> taskIds = grouper.chooseTasks(inputTaskId,
+                            Lists.newArrayList(), loadMapping);
+
+                        // Validate a single task id return
+                        assertNotNull("Not null taskId list returned", taskIds);
+                        assertEquals("Single task Id returned", 1, taskIds.size());
+
+                        int taskId = taskIds.get(0);
+
+                        assertTrue("TaskId should exist", taskId >= 0 && taskId < availableTaskIds.size());
+                        taskCounts[taskId]++;
+                    }
+                    return taskCounts;
+                }
+            };
+
+            // Add to our collection.
+            threadTasks.add(threadTask);
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadTasks.size());
+        List<Future<int[]>> taskResults = executor.invokeAll(threadTasks);
+
+        // Wait for all tasks to complete
+        int[] taskIdTotals = new int[numTasks];
+        for (Future taskResult: taskResults) {
+            while (!taskResult.isDone()) {
+                Thread.sleep(1000);
+            }
+            int[] taskDistributions = (int[]) taskResult.get();
+            for (int i = 0; i < taskDistributions.length; i++) {
+                taskIdTotals[i] += taskDistributions[i];
+            }
+        }
+
+        for (int i = 0; i < numTasks; i++) {
+            int expected = numThreads * groupingExecutionsPerThread / numTasks;
+            assertEquals("Distribution should be even for all nodes", expected, taskIdTotals[i]);
+        }
+    }
+
+    @Test
+    public void testLoadAwareShuffleGroupingWithUnevenLoad() {
+        // just pick arbitrary number
+        final int numTasks = 7;
+        final LoadAwareShuffleGrouping grouper = new LoadAwareShuffleGrouping();
+
+        // Define our taskIds and loads
+        final List<Integer> availableTaskIds = getAvailableTaskIds(numTasks);
+        final LoadMapping loadMapping = buildLocalTasksUnevenLoadMapping(availableTaskIds);
+
+        runDistributionVerificationTestWithUnevenLoad(numTasks, grouper, availableTaskIds,
+            loadMapping);
+    }
+
+    @Test
+    public void testLoadAwareShuffleGroupingWithRandomTasksAndRandomLoad() {
+        for (int trial = 0 ; trial < 100 ; trial++) {
+            // just pick arbitrary number in 5 ~ 100
+            final int numTasks = new Random().nextInt(96) + 5;
+            final LoadAwareShuffleGrouping grouper = new LoadAwareShuffleGrouping();
+
+            // Define our taskIds and loads
+            final List<Integer> availableTaskIds = getAvailableTaskIds(numTasks);
+            final LoadMapping loadMapping = buildLocalTasksRandomLoadMapping(availableTaskIds);
+
+            runDistributionVerificationTestWithUnevenLoad(numTasks, grouper, availableTaskIds,
+                loadMapping);
+        }
+    }
+
+    @Test
+    public void testShuffleLoadEven() {
+        // port test-shuffle-load-even
+        LoadAwareCustomStreamGrouping shuffler = GrouperFactory
+            .mkGrouper(null, "comp", "stream", null, Grouping.shuffle(new NullStruct()),
+                Lists.newArrayList(1, 2), Collections.emptyMap());
+        int numMessages = 100000;
+        int minPrCount = (int) (numMessages * 0.49);
+        int maxPrCount = (int) (numMessages * 0.51);
+        LoadMapping load = new LoadMapping();
+        Map<Integer, Double> loadInfoMap = new HashMap<>();
+        loadInfoMap.put(1, 0.0);
+        loadInfoMap.put(2, 0.0);
+        load.setLocal(loadInfoMap);
+
+        List<Object> data = Lists.newArrayList(1, 2);
+        int[] frequencies = new int[3];
+        for (int i = 0 ; i < numMessages ; i++) {
+            List<Integer> tasks = shuffler.chooseTasks(1, data, load);
+            for (int task : tasks) {
+                frequencies[task]++;
+            }
+        }
+
+        int load1 = frequencies[1];
+        int load2 = frequencies[2];
+
+        LOG.info("Frequency info: load1 = {}, load2 = {}", load1, load2);
+
+        assertTrue(load1 >= minPrCount);
+        assertTrue(load1 <= maxPrCount);
+        assertTrue(load2 >= minPrCount);
+        assertTrue(load2 <= maxPrCount);
+    }
+
+    @Test
+    public void testShuffleLoadUneven() {
+        // port test-shuffle-load-uneven
+        LoadAwareCustomStreamGrouping shuffler = GrouperFactory
+            .mkGrouper(null, "comp", "stream", null, Grouping.shuffle(new NullStruct()),
+                Lists.newArrayList(1, 2), Collections.emptyMap());
+        int numMessages = 100000;
+        int min1PrCount = (int) (numMessages * 0.32);
+        int max1PrCount = (int) (numMessages * 0.34);
+        int min2PrCount = (int) (numMessages * 0.65);
+        int max2PrCount = (int) (numMessages * 0.67);
+        LoadMapping load = new LoadMapping();
+        Map<Integer, Double> loadInfoMap = new HashMap<>();
+        loadInfoMap.put(1, 0.5);
+        loadInfoMap.put(2, 0.0);
+        load.setLocal(loadInfoMap);
+
+        List<Object> data = Lists.newArrayList(1, 2);
+        int[] frequencies = new int[3]; // task id starts from 1
+        for (int i = 0 ; i < numMessages ; i++) {
+            List<Integer> tasks = shuffler.chooseTasks(1, data, load);
+            for (int task : tasks) {
+                frequencies[task]++;
+            }
+        }
+
+        int load1 = frequencies[1];
+        int load2 = frequencies[2];
+
+        LOG.info("Frequency info: load1 = {}, load2 = {}", load1, load2);
+
+        assertTrue(load1 >= min1PrCount);
+        assertTrue(load1 <= max1PrCount);
+        assertTrue(load2 >= min2PrCount);
+        assertTrue(load2 <= max2PrCount);
+    }
+
+    private int[] runChooseTasksWithVerification(LoadAwareShuffleGrouping grouper, int totalEmits,
+        int numTasks, LoadMapping loadMapping) {
+        int[] taskCounts = new int[numTasks];
+
+        // Task Id not used, so just pick a static value
+        int inputTaskId = 100;
+
+        // triggers building ring
+        grouper.chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+
+        for (int i = 1; i <= totalEmits; i++) {
+            List<Integer> taskIds = grouper
+                .chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+
+            // Validate a single task id return
+            assertNotNull("Not null taskId list returned", taskIds);
+            assertEquals("Single task Id returned", 1, taskIds.size());
+
+            int taskId = taskIds.get(0);
+
+            assertTrue("TaskId should exist", taskId >= 0 && taskId < numTasks);
+            taskCounts[taskId]++;
+        }
+        return taskCounts;
+    }
+
+    private void runDistributionVerificationTestWithUnevenLoad(int numTasks,
+        LoadAwareShuffleGrouping grouper, List<Integer> availableTaskIds,
+        LoadMapping loadMapping) {
+        int[] loads = new int[numTasks];
+        int localTotal = 0;
+        List<Double> loadRate = new ArrayList<>();
+        for (int i = 0; i < numTasks; i++) {
+            int val = (int)(101 - (loadMapping.get(i) * 100));
+            loads[i] = val;
+            localTotal += val;
+        }
+
+        for (int i = 0; i < numTasks; i++) {
+            loadRate.add(loads[i] * 1.0 / localTotal);
+        }
+
+        WorkerTopologyContext context = mock(WorkerTopologyContext.class);
+        grouper.prepare(context, null, availableTaskIds);
+
+        // Keep track of how many times we see each taskId
+        int totalEmits = 5000 * numTasks;
+        int[] taskCounts = runChooseTasksWithVerification(grouper, totalEmits, numTasks, loadMapping);
+
+        int delta = (int) (totalEmits * 0.01);
+        for (int i = 0; i < numTasks; i++) {
+            int expected = (int) (totalEmits * loadRate.get(i));
+            assertTrue("Distribution should respect the task load with small delta",
+                taskCounts[i] >= expected - delta && taskCounts[i] <= expected + delta);
+        }
+    }
+
+    @Ignore
+    @Test
+    public void testBenchmarkLoadAwareShuffleGroupingEvenLoad() {
+        final int numTasks = 10;
+        List<Integer> availableTaskIds = getAvailableTaskIds(numTasks);
+        runSimpleBenchmark(new LoadAwareShuffleGrouping(), availableTaskIds,
+            buildLocalTasksEvenLoadMapping(availableTaskIds));
+    }
+
+    @Ignore
+    @Test
+    public void testBenchmarkLoadAwareShuffleGroupingUnevenLoad() {
+        final int numTasks = 10;
+        List<Integer> availableTaskIds = getAvailableTaskIds(numTasks);
+        runSimpleBenchmark(new LoadAwareShuffleGrouping(), availableTaskIds,
+            buildLocalTasksUnevenLoadMapping(availableTaskIds));
+    }
+
+    private List<Integer> getAvailableTaskIds(int numTasks) {
+        // this method should return sequential numbers starting at 0
+        final List<Integer> availableTaskIds = Lists.newArrayList();
+        for (int i = 0; i < numTasks; i++) {
+            availableTaskIds.add(i);
+        }
+        return availableTaskIds;
+    }
+
+    private LoadMapping buildLocalTasksEvenLoadMapping(List<Integer> availableTasks) {
+        LoadMapping loadMapping = new LoadMapping();
+        Map<Integer, Double> localLoadMap = new HashMap<>(availableTasks.size());
+        for (int i = 0; i < availableTasks.size(); i++) {
+            localLoadMap.put(availableTasks.get(i), 0.1);
+        }
+        loadMapping.setLocal(localLoadMap);
+        return loadMapping;
+    }
+
+    private LoadMapping buildLocalTasksUnevenLoadMapping(List<Integer> availableTasks) {
+        LoadMapping loadMapping = new LoadMapping();
+        Map<Integer, Double> localLoadMap = new HashMap<>(availableTasks.size());
+        for (int i = 0; i < availableTasks.size(); i++) {
+            localLoadMap.put(availableTasks.get(i), 0.1 * (i + 1));
+        }
+        loadMapping.setLocal(localLoadMap);
+        return loadMapping;
+    }
+
+    private LoadMapping buildLocalTasksRandomLoadMapping(List<Integer> availableTasks) {
+        LoadMapping loadMapping = new LoadMapping();
+        Map<Integer, Double> localLoadMap = new HashMap<>(availableTasks.size());
+        for (int i = 0; i < availableTasks.size(); i++) {
+            localLoadMap.put(availableTasks.get(i), Math.random());
+        }
+        loadMapping.setLocal(localLoadMap);
+        return loadMapping;
+    }
+
+    private void runSimpleBenchmark(LoadAwareCustomStreamGrouping grouper,
+        List<Integer> availableTaskIds, LoadMapping loadMapping) {
+        // Task Id not used, so just pick a static value
+        final int inputTaskId = 100;
+
+        WorkerTopologyContext context = mock(WorkerTopologyContext.class);
+        grouper.prepare(context, null, availableTaskIds);
+
+        // triggers building distribution ring
+        grouper.chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+
+        long current = System.currentTimeMillis();
+        int idx = 0;
+        while (true) {
+            grouper.chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+
+            idx++;
+            if (idx % 100000 == 0) {
+                // warm up 60 seconds
+                if (System.currentTimeMillis() - current >= 60_000) {
+                    break;
+                }
+            }
+        }
+
+        current = System.currentTimeMillis();
+        for (int i = 1; i <= 2_000_000_000 ; i++) {
+            grouper.chooseTasks(inputTaskId, Lists.newArrayList(), loadMapping);
+        }
+
+        System.out.println("Duration: " + (System.currentTimeMillis() - current) + " ms");
+    }
+}

--- a/storm-core/test/clj/org/apache/storm/grouping_test.clj
+++ b/storm-core/test/clj/org/apache/storm/grouping_test.clj
@@ -41,42 +41,6 @@
     (is (>= load2 min-prcnt))
     (is (<= load2 max-prcnt))))
 
-(deftest test-shuffle-load-even
- (let [shuffler (GrouperFactory/mkGrouper nil "comp" "stream" nil shuffle-grouping [(int 1) (int 2)] {})
-       num-messages 100000
-       min-prcnt (int (* num-messages 0.49))
-       max-prcnt (int (* num-messages 0.51))
-       load (LoadMapping.)
-       _ (.setLocal load {(int 1) 0.0 (int 2) 0.0})
-       data [1 2]
-       freq (frequencies (for [x (range 0 num-messages)] (.chooseTasks shuffler (int 1) data load)))
-       load1 (.get freq [(int 1)])
-       load2 (.get freq [(int 2)])]
-    (log-message "FREQ:" freq)
-    (is (>= load1 min-prcnt))
-    (is (<= load1 max-prcnt))
-    (is (>= load2 min-prcnt))
-    (is (<= load2 max-prcnt))))
-
-(deftest test-shuffle-load-uneven
- (let [shuffler (GrouperFactory/mkGrouper nil "comp" "stream" nil shuffle-grouping [(int 1) (int 2)] {})
-       num-messages 100000
-       min1-prcnt (int (* num-messages 0.32))
-       max1-prcnt (int (* num-messages 0.34))
-       min2-prcnt (int (* num-messages 0.65))
-       max2-prcnt (int (* num-messages 0.67))
-       load (LoadMapping.)
-       _ (.setLocal load {(int 1) 0.5 (int 2) 0.0})
-       data [1 2]
-       freq (frequencies (for [x (range 0 num-messages)] (.chooseTasks shuffler (int 1) data load)))
-       load1 (.get freq [(int 1)])
-       load2 (.get freq [(int 2)])]
-    (log-message "FREQ:" freq)
-    (is (>= load1 min1-prcnt))
-    (is (<= load1 max1-prcnt))
-    (is (>= load2 min2-prcnt))
-    (is (<= load2 max2-prcnt))))
-
 (deftest test-field
   (with-open [cluster (.build (doto (LocalCluster$Builder.)
                                 (.withSimulatedTime)

--- a/storm-core/test/clj/org/apache/storm/grouping_test.clj
+++ b/storm-core/test/clj/org/apache/storm/grouping_test.clj
@@ -32,7 +32,7 @@
        min-prcnt (int (* num-messages 0.49))
        max-prcnt (int (* num-messages 0.51))
        data [1 2]
-       freq (frequencies (for [x (range 0 num-messages)] (.chooseTasks shuffler (int 1) data nil)))
+       freq (frequencies (for [x (range 0 num-messages)] (.chooseTasks shuffler (int 1) data)))
        load1 (.get freq [(int 1)])
        load2 (.get freq [(int 2)])]
     (log-message "FREQ:" freq)


### PR DESCRIPTION
* construct ring which represents distribution of tasks based on load
* chooseTasks() just accesses the ring sequentially
* port related tests from Clojure to Java

I'm not expert of micro-benchmark but I also craft some of simple performance tests which you can see them from LoadAwareShuffleGroupingTest. They are `testBenchmarkLoadAwareShuffleGroupingEvenLoad` and `testBenchmarkLoadAwareShuffleGroupingUnevenLoad `, and I put `@Ignore` to avoid running unless we want to do performance test on.

Here's my observation on running them, using old and new LoadAwareShuffleGrouping:

> testBenchmarkLoadAwareShuffleGroupingEvenLoad (old)
Duration: 114470 ms
Duration: 115973 ms
Duration: 114807 ms

> testBenchmarkLoadAwareShuffleGroupingEvenLoad (new)
Duration: 106819 ms
Duration: 105857 ms
Duration: 106789 ms

> testBenchmarkLoadAwareShuffleGroupingUnevenLoad (old)
Duration: 113484 ms
Duration: 118152 ms
Duration: 112664 ms

> testBenchmarkLoadAwareShuffleGroupingUnevenLoad (new)
Duration: 106071 ms
Duration: 105938 ms
Duration: 106115 ms

You can see that modified LoadAwareShuffleGrouping is faster than before, 5% or more for single threaded access. Maybe would want to do multi-threading performance test, with keeping in mind that  accessing OutputCollector with single-thread is preferred over multi-threads.

This still respects thread-safety, and I think respecting thread-safety is better than before, given that we only allow one thread to update the ring, and we replace the new information at once, not updating information on the fly while other threads are referencing.
We still don't guard information with mutual-exclusion manner, but I think it is tolerable like we do before.

I'm planning to explore some more, mostly about reducing call System.currentTimeMillis() in chooseTasks(). I'll put additional commits if I find any more improvements: it will be easy to revert some if we don't want to.