### PR TITLE
[STORM-2674] catch NoNodeException when IStormClusterState tries to delete znodes in reportError function

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
+++ b/storm-core/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
@@ -659,7 +659,17 @@ public class StormClusterStateImpl implements IStormClusterState {
         });
 
         while (childrens.size() > 10) {
-            stateStorage.delete_node(path + ClusterUtils.ZK_SEPERATOR + childrens.remove(0));
+            String znodePath = path + ClusterUtils.ZK_SEPERATOR + childrens.remove(0);
+            try {
+                stateStorage.delete_node(znodePath);
+            } catch (Exception e) {
+                if (Utils.exceptionCauseIsInstanceOf(KeeperException.NoNodeException.class, e)) {
+                    // if the node is already deleted, do nothing
+                    LOG.warn("Could not find the znode: {}", znodePath);
+                } else {
+                    throw e;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fix in 1.x-branch.

see https://github.com/apache/storm/pull/2264