### PR TITLE
STORM-2682: Fix issues with null owner on rolling upgrade (1.0.x)

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Slot.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Slot.java
@@ -749,6 +749,17 @@ public class Slot extends Thread implements AutoCloseable {
                     LOG.info("SLOT {}: Changing current assignment from {} to {}", staticState.port, dynamicState.currentAssignment, nextState.currentAssignment);
                     saveNewAssignment(nextState.currentAssignment);
                 }
+
+                if (equivalent(nextState.newAssignment, nextState.currentAssignment) &&
+                    nextState.currentAssignment != null && nextState.currentAssignment.get_owner() == null &&
+                    nextState.newAssignment != null && nextState.newAssignment.get_owner() != null) {
+                    //This is an odd case for a rolling upgrade where the user on the old assignment may be null,
+                    // but not on the new one.  Although in all other ways they are the same.
+                    // If this happens we want to use the assignment with the owner.
+                    LOG.info("Updating assignment to save owner {}", nextState.newAssignment.get_owner());
+                    saveNewAssignment(nextState.newAssignment);
+                    nextState = nextState.withCurrentAssignment(nextState.container, nextState.newAssignment);
+                }
                 
                 // clean up the profiler actions that are not being processed
                 removed.removeAll(dynamicState.profileActions);

--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/timer/UpdateBlobs.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/timer/UpdateBlobs.java
@@ -67,9 +67,14 @@ public class UpdateBlobs implements Runnable {
             for (String stormId : downloadedStormIds) {
                 LocalAssignment la = assignedStormIds.get(stormId);
                 if (la != null) {
-                    String stormRoot = ConfigUtils.supervisorStormDistRoot(conf, stormId);
-                    LOG.debug("Checking Blob updates for storm topology id {} With target_dir: {}", stormId, stormRoot);
-                    updateBlobsForTopology(conf, stormId, supervisor.getLocalizer(), la.get_owner());
+                    if (la.get_owner() == null) {
+                        //We got a case where the local assignment is not up to date, no point in going on...
+                        LOG.warn("The blobs will not be updated for {} until the local assignment is updated...", stormId);
+                    } else {
+                        String stormRoot = ConfigUtils.supervisorStormDistRoot(conf, stormId);
+                        LOG.debug("Checking Blob updates for storm topology id {} With target_dir: {}", stormId, stormRoot);
+                        updateBlobsForTopology(conf, stormId, supervisor.getLocalizer(), la.get_owner());
+                    }
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
This is the 1.0.x version of  #2266 and should probably apply cleanly to all of the 1.x line of releases.

This prevents doing a clean rolling upgrade from 1.0.3 to 1.0.4 and 1.1.0 to 1.1.1.  We should look at getting this in and possibly doing another release ASAP.