### PR TITLE
[STORM-2685] Calculate and update taskNetworkDistance in WorkerState periodically

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -185,6 +185,7 @@ task.heartbeat.frequency.secs: 3
 task.refresh.poll.secs: 10
 task.credentials.poll.secs: 30
 task.backpressure.poll.secs: 30
+task.network.distance.calculator: org.apache.storm.task.DefaultTaskNetworkDistanceCalculator
 
 # now should be null by default
 topology.backpressure.enable: false

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -1523,6 +1523,13 @@ public class Config extends HashMap<String, Object> {
     public static final String TASK_REFRESH_POLL_SECS = "task.refresh.poll.secs";
 
     /**
+     * The plugin that will calculate the network distance between tasks
+     */
+    @NotNull
+    @isImplementationOfClass(implementsClass = org.apache.storm.task.ITaskNetworkDistanceCalculator.class)
+    public static final String TASK_NETWORK_DISTANCE_CALCULATOR_PLUGIN = "task.network.distance.calculator";
+
+    /**
      * The Access Control List for the DRPC Authorizer.
      * @see org.apache.storm.security.auth.authorizer.DRPCSimpleACLAuthorizer
      */

--- a/storm-client/src/jvm/org/apache/storm/task/DefaultTaskNetworkDistanceCalculator.java
+++ b/storm-client/src/jvm/org/apache/storm/task/DefaultTaskNetworkDistanceCalculator.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.task;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.storm.Config;
+import org.apache.storm.cluster.IStormClusterState;
+import org.apache.storm.generated.NodeInfo;
+import org.apache.storm.networktopography.DNSToSwitchMapping;
+import org.apache.storm.utils.ReflectionUtils;
+
+/**
+ * This calculator calculates the network distance between tasks based on their physical locations:
+ * WORKER_LOCAL, HOST_LOCAL, RACK_LOCAL, UNKNOWN.
+ */
+public class DefaultTaskNetworkDistanceCalculator implements ITaskNetworkDistanceCalculator {
+
+    private DNSToSwitchMapping dnsToSwitchMapping;
+
+    public void prepare(Map<String, Object> conf, IStormClusterState stormClusterState) {
+        dnsToSwitchMapping = ReflectionUtils.newInstance((String) conf.get(Config.STORM_NETWORK_TOPOGRAPHY_PLUGIN));
+    }
+
+    public void calculateOrUpdate(Map<Integer, NodeInfo> taskToNodePort,
+                                  ConcurrentHashMap<Integer, ConcurrentHashMap<Integer, Double>> taskNetworkDistance) {
+
+        Map<String, String> hostToRack = getHostToRackMapping(taskToNodePort);
+
+        for (Map.Entry<Integer, NodeInfo> entry: taskToNodePort.entrySet()) {
+            Integer sourceTaskId = entry.getKey();
+            NodeInfo sourceNodeInfo = entry.getValue();
+
+            ConcurrentHashMap<Integer, Double> targetTaskDistances;
+            if (!taskNetworkDistance.containsKey(sourceTaskId)) {
+                targetTaskDistances = new ConcurrentHashMap<>();
+                taskNetworkDistance.put(sourceTaskId, targetTaskDistances);
+            } else {
+                targetTaskDistances = taskNetworkDistance.get(sourceTaskId);
+                targetTaskDistances.clear();
+            }
+
+            for (Map.Entry<Integer, NodeInfo> targetEntry: taskToNodePort.entrySet()) {
+                Integer targetTaskId = targetEntry.getKey();
+                NodeInfo targetNodeInfo = targetEntry.getValue();
+
+                // storm task doesn't transmit tuples to itself
+                if (!sourceTaskId.equals(targetTaskId)) {
+                    targetTaskDistances.put(targetTaskId,
+                            calculateDistance(sourceNodeInfo, targetNodeInfo, hostToRack).distance());
+                }
+            }
+
+        }
+    }
+
+    private DistanceType calculateDistance(NodeInfo source, NodeInfo target, Map<String, String> hostToRack) {
+        if(source.get_port().equals(target.get_port())) {
+            return DistanceType.WORKER_LOCAL;
+        } else if(source.get_node().equals(target.get_node())) {
+            return DistanceType.HOST_LOCAL;
+        } else {
+            String sourceRack = hostToRack.get(source.get_node());
+            String targetRack = hostToRack.get(target.get_node());
+            if(sourceRack != null && targetRack != null && sourceRack.equals(targetRack)) {
+                return DistanceType.RACK_LOCAL;
+            } else {
+                return DistanceType.UNKNOWN;
+            }
+        }
+    }
+
+    private Map<String, String> getHostToRackMapping(Map<Integer, NodeInfo> taskToNodePort) {
+        Map<String, String> hostToRack = new HashMap<>();
+
+        Set<String> hosts = new HashSet();
+
+        for (Map.Entry<Integer, NodeInfo> entry: taskToNodePort.entrySet()) {
+            hosts.add(entry.getValue().get_node());
+        }
+
+        return dnsToSwitchMapping.resolve(new ArrayList<>(hosts));
+    }
+
+    /**
+     * Hard coded distance between tasks.
+     */
+    enum DistanceType {
+        WORKER_LOCAL(0), // tasks in the same worker
+        HOST_LOCAL(10),  // tasks in the same host
+        RACK_LOCAL(50),  // tasks in the same rack
+        UNKNOWN(100);    // everything else
+
+        private final double distance;
+        DistanceType(double distance) {
+            this.distance = distance;
+        }
+
+        public double distance() {
+            return distance;
+        }
+    }
+}

--- a/storm-client/src/jvm/org/apache/storm/task/ITaskNetworkDistanceCalculator.java
+++ b/storm-client/src/jvm/org/apache/storm/task/ITaskNetworkDistanceCalculator.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.task;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.storm.cluster.IStormClusterState;
+import org.apache.storm.generated.NodeInfo;
+
+public interface ITaskNetworkDistanceCalculator {
+
+    /**
+     * Prepare before doing any calculation.
+     * @param conf The configuration
+     * @param stormClusterState The storm cluster state
+     */
+    void prepare(Map<String, Object> conf, IStormClusterState stormClusterState);
+
+    /**
+     * Calculate or update taskNetworkDistance.
+     * @param taskToNodePort The map from taskId to NodeInfo
+     * @param taskNetworkDistance The map from taskId to the map from targetTaskId to distance
+     */
+    void calculateOrUpdate(Map<Integer, NodeInfo> taskToNodePort,
+                                  ConcurrentHashMap<Integer, ConcurrentHashMap<Integer, Double>> taskNetworkDistance);
+
+}

--- a/storm-client/test/jvm/org/apache/storm/task/DefaultTaskNetworkDistanceCalculatorTest.java
+++ b/storm-client/test/jvm/org/apache/storm/task/DefaultTaskNetworkDistanceCalculatorTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.task;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.PatternSyntaxException;
+import org.apache.storm.Config;
+import org.apache.storm.generated.NodeInfo;
+import org.apache.storm.networktopography.DNSToSwitchMapping;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultTaskNetworkDistanceCalculatorTest {
+
+    private ITaskNetworkDistanceCalculator iTaskNetworkDistanceCalculator;
+
+    @Before
+    public void initializeAndPrepare() {
+        iTaskNetworkDistanceCalculator = new DefaultTaskNetworkDistanceCalculator();
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(Config.STORM_NETWORK_TOPOGRAPHY_PLUGIN, DNSToSwitchMappingMock.class.getName());
+        iTaskNetworkDistanceCalculator.prepare(conf, null);
+    }
+
+    @Test
+    public void testCalculateOrUpdate() throws Exception {
+        Map<Integer, NodeInfo> taskToNodePort = new HashMap<>();
+
+        //the task to check
+        taskToNodePort.put(1, new NodeInfo("rack1_node1", new HashSet<>(Arrays.asList(6700L))));
+        //task on the same worker
+        taskToNodePort.put(2, new NodeInfo("rack1_node1", new HashSet<>(Arrays.asList(6700L))));
+        //task on the same node, different worker
+        taskToNodePort.put(3, new NodeInfo("rack1_node1", new HashSet<>(Arrays.asList(6701L))));
+        //task on the same rack, different node
+        taskToNodePort.put(4, new NodeInfo("rack1_node2", new HashSet<>(Arrays.asList(6701L))));
+        //task on different rack
+        taskToNodePort.put(5, new NodeInfo("rack2_node3", new HashSet<>(Arrays.asList(6702L))));
+
+        ConcurrentHashMap<Integer, ConcurrentHashMap<Integer, Double>> taskNetworkDistance = new ConcurrentHashMap<>();
+
+        iTaskNetworkDistanceCalculator.calculateOrUpdate(taskToNodePort, taskNetworkDistance);
+
+        Assert.assertTrue(taskNetworkDistance.get(1).get(2) ==
+                DefaultTaskNetworkDistanceCalculator.DistanceType.WORKER_LOCAL.distance());
+        Assert.assertTrue(taskNetworkDistance.get(1).get(3) ==
+                DefaultTaskNetworkDistanceCalculator.DistanceType.HOST_LOCAL.distance());
+        Assert.assertTrue(taskNetworkDistance.get(1).get(4) ==
+                DefaultTaskNetworkDistanceCalculator.DistanceType.RACK_LOCAL.distance());
+        Assert.assertTrue(taskNetworkDistance.get(1).get(5) ==
+                DefaultTaskNetworkDistanceCalculator.DistanceType.UNKNOWN.distance());
+
+    }
+
+    public static class DNSToSwitchMappingMock implements DNSToSwitchMapping {
+
+        private final String UNKNOWN_RACK = "unknown_rack";
+
+        /**
+         * Identify the rack the node is on.
+         * @param names the list of hosts to resolve (can be empty)
+         * @return Map of hosts to resolved network paths
+         */
+        @Override
+        public Map<String, String> resolve(List<String> names) {
+            Map<String, String> ret = new HashMap<>();
+
+            for (String hostName: names) {
+                try {
+                    ret.put(hostName, hostName.split("_")[0]);
+                } catch (PatternSyntaxException e) {
+                    ret.put(hostName, UNKNOWN_RACK);
+                }
+            }
+
+            return ret;
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2685

Preparing for LocalityAwareShuffleGrouping.

Update taskNetworkDistance periodically. Next step is to populate the taskNetworkDistance to WorkerTopologyContext so that Grouping can access to it.