### PR TITLE
[STORM-2686] Add Locality Aware Shuffle Grouping

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -185,6 +185,7 @@ task.heartbeat.frequency.secs: 3
 task.refresh.poll.secs: 10
 task.credentials.poll.secs: 30
 task.backpressure.poll.secs: 30
+task.network.distance.calculator: org.apache.storm.task.DefaultTaskNetworkDistanceCalculator
 
 # now should be null by default
 topology.backpressure.enable: false

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -1523,6 +1523,13 @@ public class Config extends HashMap<String, Object> {
     public static final String TASK_REFRESH_POLL_SECS = "task.refresh.poll.secs";
 
     /**
+     * The plugin that will calculate the network distance between tasks
+     */
+    @NotNull
+    @isImplementationOfClass(implementsClass = org.apache.storm.task.ITaskNetworkDistanceCalculator.class)
+    public static final String TASK_NETWORK_DISTANCE_CALCULATOR_PLUGIN = "task.network.distance.calculator";
+
+    /**
      * The Access Control List for the DRPC Authorizer.
      * @see org.apache.storm.security.auth.authorizer.DRPCSimpleACLAuthorizer
      */

--- a/storm-client/src/jvm/org/apache/storm/coordination/BatchSubtopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/coordination/BatchSubtopologyBuilder.java
@@ -284,6 +284,38 @@ public class BatchSubtopologyBuilder {
             });
             return this;
         }
+
+        @Override
+        public BoltDeclarer localityAwareShuffleGrouping(final String component) {
+            addDeclaration(new InputDeclaration() {
+                @Override
+                public void declare(InputDeclarer declarer) {
+                    declarer.localityAwareShuffleGrouping(component);
+                }
+
+                @Override
+                public String getComponent() {
+                    return component;
+                }
+            });
+            return this;
+        }
+
+        @Override
+        public BoltDeclarer localityAwareShuffleGrouping(final String component, final String streamId) {
+            addDeclaration(new InputDeclaration() {
+                @Override
+                public void declare(InputDeclarer declarer) {
+                    declarer.localityAwareShuffleGrouping(component, streamId);
+                }
+
+                @Override
+                public String getComponent() {
+                    return component;
+                }
+            });
+            return this;
+        }
         
         @Override
         public BoltDeclarer noneGrouping(final String component) {

--- a/storm-client/src/jvm/org/apache/storm/daemon/GrouperFactory.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/GrouperFactory.java
@@ -28,6 +28,7 @@ import org.apache.storm.grouping.CustomStreamGrouping;
 import org.apache.storm.grouping.LoadAwareCustomStreamGrouping;
 import org.apache.storm.grouping.LoadAwareShuffleGrouping;
 import org.apache.storm.grouping.LoadMapping;
+import org.apache.storm.grouping.LocalityAwareShuffleGrouping;
 import org.apache.storm.grouping.ShuffleGrouping;
 import org.apache.storm.task.WorkerTopologyContext;
 import org.apache.storm.tuple.Fields;
@@ -78,6 +79,9 @@ public class GrouperFactory {
                 } else {
                     result = new LoadAwareShuffleGrouping();
                 }
+                break;
+            case LOCALITY_AWARE:
+                result = new LocalityAwareShuffleGrouping();
                 break;
             case NONE:
                 result = new NoneGrouper();

--- a/storm-client/src/jvm/org/apache/storm/generated/Grouping.java
+++ b/storm-client/src/jvm/org/apache/storm/generated/Grouping.java
@@ -61,6 +61,7 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
   private static final org.apache.thrift.protocol.TField CUSTOM_OBJECT_FIELD_DESC = new org.apache.thrift.protocol.TField("custom_object", org.apache.thrift.protocol.TType.STRUCT, (short)6);
   private static final org.apache.thrift.protocol.TField CUSTOM_SERIALIZED_FIELD_DESC = new org.apache.thrift.protocol.TField("custom_serialized", org.apache.thrift.protocol.TType.STRING, (short)7);
   private static final org.apache.thrift.protocol.TField LOCAL_OR_SHUFFLE_FIELD_DESC = new org.apache.thrift.protocol.TField("local_or_shuffle", org.apache.thrift.protocol.TType.STRUCT, (short)8);
+  private static final org.apache.thrift.protocol.TField LOCALITY_AWARE_FIELD_DESC = new org.apache.thrift.protocol.TField("locality_aware", org.apache.thrift.protocol.TType.STRUCT, (short)9);
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -71,7 +72,8 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
     DIRECT((short)5, "direct"),
     CUSTOM_OBJECT((short)6, "custom_object"),
     CUSTOM_SERIALIZED((short)7, "custom_serialized"),
-    LOCAL_OR_SHUFFLE((short)8, "local_or_shuffle");
+    LOCAL_OR_SHUFFLE((short)8, "local_or_shuffle"),
+    LOCALITY_AWARE((short)9, "locality_aware");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -102,6 +104,8 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
           return CUSTOM_SERIALIZED;
         case 8: // LOCAL_OR_SHUFFLE
           return LOCAL_OR_SHUFFLE;
+        case 9: // LOCALITY_AWARE
+          return LOCALITY_AWARE;
         default:
           return null;
       }
@@ -160,6 +164,8 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
     tmpMap.put(_Fields.CUSTOM_SERIALIZED, new org.apache.thrift.meta_data.FieldMetaData("custom_serialized", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING        , true)));
     tmpMap.put(_Fields.LOCAL_OR_SHUFFLE, new org.apache.thrift.meta_data.FieldMetaData("local_or_shuffle", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+        new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, NullStruct.class)));
+    tmpMap.put(_Fields.LOCALITY_AWARE, new org.apache.thrift.meta_data.FieldMetaData("locality_aware", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, NullStruct.class)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(Grouping.class, metaDataMap);
@@ -234,6 +240,12 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
     return x;
   }
 
+  public static Grouping locality_aware(NullStruct value) {
+    Grouping x = new Grouping();
+    x.set_locality_aware(value);
+    return x;
+  }
+
 
   @Override
   protected void checkType(_Fields setField, Object value) throws ClassCastException {
@@ -278,6 +290,11 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
           break;
         }
         throw new ClassCastException("Was expecting value of type NullStruct for field 'local_or_shuffle', but got " + value.getClass().getSimpleName());
+      case LOCALITY_AWARE:
+        if (value instanceof NullStruct) {
+          break;
+        }
+        throw new ClassCastException("Was expecting value of type NullStruct for field 'locality_aware', but got " + value.getClass().getSimpleName());
       default:
         throw new IllegalArgumentException("Unknown field id " + setField);
     }
@@ -376,6 +393,16 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
             return null;
           }
+        case LOCALITY_AWARE:
+          if (field.type == LOCALITY_AWARE_FIELD_DESC.type) {
+            NullStruct locality_aware;
+            locality_aware = new NullStruct();
+            locality_aware.read(iprot);
+            return locality_aware;
+          } else {
+            org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
+            return null;
+          }
         default:
           throw new IllegalStateException("setField wasn't null, but didn't match any of the case statements!");
       }
@@ -426,6 +453,10 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
       case LOCAL_OR_SHUFFLE:
         NullStruct local_or_shuffle = (NullStruct)value_;
         local_or_shuffle.write(oprot);
+        return;
+      case LOCALITY_AWARE:
+        NullStruct locality_aware = (NullStruct)value_;
+        locality_aware.write(oprot);
         return;
       default:
         throw new IllegalStateException("Cannot write union with unknown field " + setField_);
@@ -485,6 +516,11 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
           local_or_shuffle = new NullStruct();
           local_or_shuffle.read(iprot);
           return local_or_shuffle;
+        case LOCALITY_AWARE:
+          NullStruct locality_aware;
+          locality_aware = new NullStruct();
+          locality_aware.read(iprot);
+          return locality_aware;
         default:
           throw new IllegalStateException("setField wasn't null, but didn't match any of the case statements!");
       }
@@ -535,6 +571,10 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
         NullStruct local_or_shuffle = (NullStruct)value_;
         local_or_shuffle.write(oprot);
         return;
+      case LOCALITY_AWARE:
+        NullStruct locality_aware = (NullStruct)value_;
+        locality_aware.write(oprot);
+        return;
       default:
         throw new IllegalStateException("Cannot write union with unknown field " + setField_);
     }
@@ -559,6 +599,8 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
         return CUSTOM_SERIALIZED_FIELD_DESC;
       case LOCAL_OR_SHUFFLE:
         return LOCAL_OR_SHUFFLE_FIELD_DESC;
+      case LOCALITY_AWARE:
+        return LOCALITY_AWARE_FIELD_DESC;
       default:
         throw new IllegalArgumentException("Unknown field id " + setField);
     }
@@ -701,6 +743,20 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
     value_ = value;
   }
 
+  public NullStruct get_locality_aware() {
+    if (getSetField() == _Fields.LOCALITY_AWARE) {
+      return (NullStruct)getFieldValue();
+    } else {
+      throw new RuntimeException("Cannot get field 'locality_aware' because union is currently set to " + getFieldDesc(getSetField()).name);
+    }
+  }
+
+  public void set_locality_aware(NullStruct value) {
+    if (value == null) throw new NullPointerException();
+    setField_ = _Fields.LOCALITY_AWARE;
+    value_ = value;
+  }
+
   public boolean is_set_fields() {
     return setField_ == _Fields.FIELDS;
   }
@@ -738,6 +794,11 @@ public class Grouping extends org.apache.thrift.TUnion<Grouping, Grouping._Field
 
   public boolean is_set_local_or_shuffle() {
     return setField_ == _Fields.LOCAL_OR_SHUFFLE;
+  }
+
+
+  public boolean is_set_locality_aware() {
+    return setField_ == _Fields.LOCALITY_AWARE;
   }
 
 

--- a/storm-client/src/jvm/org/apache/storm/grouping/LocalityAwareShuffleGrouping.java
+++ b/storm-client/src/jvm/org/apache/storm/grouping/LocalityAwareShuffleGrouping.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.grouping;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.storm.generated.GlobalStreamId;
+import org.apache.storm.task.WorkerTopologyContext;
+
+public class LocalityAwareShuffleGrouping implements CustomStreamGrouping, Serializable {
+    private ConcurrentMap<Integer, ConcurrentMap<Integer, Double>> taskNetworkDistance;
+    private List<Integer> targetTasks;
+    private Random rand;
+
+    @Override
+    public void prepare(WorkerTopologyContext context, GlobalStreamId stream, List<Integer> targetTasks) {
+        rand = new Random();
+        taskNetworkDistance = context.getTaskNetworkDistance();
+        this.targetTasks = targetTasks;
+    }
+
+    /**
+     * Choose the target task with the minimum distance.
+     * If there are more than one task with the minimum distance, randomly pick one.
+     * @param taskId The source taskId
+     * @param values the values to group on
+     * @return The chosen tasks
+     */
+    @Override
+    public List<Integer> chooseTasks(int taskId, List<Object> values) {
+        if (taskNetworkDistance == null || taskNetworkDistance.isEmpty() || !taskNetworkDistance.containsKey(taskId)) {
+            int index = rand.nextInt(targetTasks.size());
+            return new ArrayList<>(targetTasks.get(index));
+        }
+
+        ConcurrentMap<Integer, Double> taskIdToDistance = taskNetworkDistance.get(taskId);
+
+        int sameDistanceAppearanceCount = 1;
+
+        double minDistance = Double.MAX_VALUE;
+        Integer closestTargetTask = targetTasks.get(0);
+        for (int i = 0; i < targetTasks.size(); ++i) {
+            Integer targetTaskId = targetTasks.get(i);
+            double distance = taskIdToDistance.getOrDefault(targetTaskId, Double.MAX_VALUE);
+            if (distance < minDistance) {
+                closestTargetTask = targetTaskId;
+                minDistance = distance;
+                sameDistanceAppearanceCount = 1;
+            } else if (distance == minDistance) {
+                ++sameDistanceAppearanceCount;
+                // accept this targetTask as the closest target task
+                // with the probability of 1/sameDistanceAppearanceCount
+                if (rand.nextFloat() < (1.0 / sameDistanceAppearanceCount)) {
+                    closestTargetTask = targetTaskId;
+                }
+            }
+        }
+
+        return Arrays.asList(closestTargetTask);
+    }
+
+}

--- a/storm-client/src/jvm/org/apache/storm/task/DefaultTaskNetworkDistanceCalculator.java
+++ b/storm-client/src/jvm/org/apache/storm/task/DefaultTaskNetworkDistanceCalculator.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.task;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.storm.Config;
+import org.apache.storm.cluster.IStormClusterState;
+import org.apache.storm.generated.NodeInfo;
+import org.apache.storm.networktopography.DNSToSwitchMapping;
+import org.apache.storm.utils.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This calculator calculates the network distance between tasks based on their physical locations:
+ * WORKER_LOCAL, HOST_LOCAL, RACK_LOCAL, UNKNOWN.
+ */
+public class DefaultTaskNetworkDistanceCalculator implements ITaskNetworkDistanceCalculator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultTaskNetworkDistanceCalculator.class);
+
+    private DNSToSwitchMapping dnsToSwitchMapping;
+    private Map<Integer, Set<Integer>> localTaskToOutboundTasks;
+    private NodeInfo localNodeInfo;
+
+    public void prepare(Map<String, Object> conf, IStormClusterState stormClusterState,
+                        NodeInfo localNodeInfo, Map<Integer, Set<Integer>> localTaskToOutboundTasks) {
+        dnsToSwitchMapping = ReflectionUtils.newInstance((String) conf.get(Config.STORM_NETWORK_TOPOGRAPHY_PLUGIN));
+        this.localTaskToOutboundTasks = localTaskToOutboundTasks;
+        this.localNodeInfo = localNodeInfo;
+    }
+
+    public void calculateOrUpdate(Map<Integer, NodeInfo> taskToNodePort,
+                                  ConcurrentMap<Integer, ConcurrentMap<Integer, Double>> taskNetworkDistance) {
+
+        Map<String, String> hostToRack = getHostToRackMapping(taskToNodePort);
+
+        for (Map.Entry<Integer, Set<Integer>> entry: localTaskToOutboundTasks.entrySet()) {
+            Integer sourceTaskId = entry.getKey();
+            Set<Integer> outboundTasks = entry.getValue();
+
+            ConcurrentMap<Integer, Double> targetTaskDistances;
+            if (!taskNetworkDistance.containsKey(sourceTaskId)) {
+                targetTaskDistances = new ConcurrentHashMap<>();
+                taskNetworkDistance.put(sourceTaskId, targetTaskDistances);
+            } else {
+                targetTaskDistances = taskNetworkDistance.get(sourceTaskId);
+            }
+
+            for (Integer targetTaskId: outboundTasks) {
+                NodeInfo targetNodeInfo = taskToNodePort.get(targetTaskId);
+                double dist = calculateDistance(this.localNodeInfo, targetNodeInfo, hostToRack).distance();
+                targetTaskDistances.put(targetTaskId, dist);
+
+                LOG.debug("Source: taskId: {}; nodePort: {}", sourceTaskId, localNodeInfo);
+                LOG.debug("Target: taskId: {}; nodePort: {}", targetTaskId, taskToNodePort.get(targetTaskId));
+                LOG.debug("SourceTask: {}; TargetTask: {}; Distance: {}", sourceTaskId, targetTaskId, dist);
+            }
+        }
+    }
+
+    private DistanceType calculateDistance(NodeInfo source, NodeInfo target, Map<String, String> hostToRack) {
+        if (source == null || target == null) {
+            return DistanceType.UNKNOWN;
+        }
+
+        String sourceRack = hostToRack.get(source.get_node());
+        String targetRack = hostToRack.get(target.get_node());
+
+        if(sourceRack != null && targetRack != null && sourceRack.equals(targetRack)) {
+            if(source.get_node().equals(target.get_node())) {
+                if(source.get_port().equals(target.get_port())) {
+                    return DistanceType.WORKER_LOCAL;
+                }
+                return DistanceType.HOST_LOCAL;
+            }
+            return DistanceType.RACK_LOCAL;
+        } else {
+            return DistanceType.UNKNOWN;
+        }
+    }
+
+    private Map<String, String> getHostToRackMapping(Map<Integer, NodeInfo> taskToNodePort) {
+        Set<String> hosts = new HashSet();
+
+        for (Map.Entry<Integer, NodeInfo> entry: taskToNodePort.entrySet()) {
+            hosts.add(entry.getValue().get_node());
+        }
+
+        return dnsToSwitchMapping.resolve(new ArrayList<>(hosts));
+    }
+
+    /**
+     * Hard coded distance between tasks.
+     */
+    enum DistanceType {
+        WORKER_LOCAL(0), // tasks in the same worker
+        HOST_LOCAL(10),  // tasks in the same host
+        RACK_LOCAL(50),  // tasks in the same rack
+        UNKNOWN(100);    // everything else
+
+        private final double distance;
+        DistanceType(double distance) {
+            this.distance = distance;
+        }
+
+        public double distance() {
+            return distance;
+        }
+    }
+}

--- a/storm-client/src/jvm/org/apache/storm/task/ITaskNetworkDistanceCalculator.java
+++ b/storm-client/src/jvm/org/apache/storm/task/ITaskNetworkDistanceCalculator.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.task;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.storm.cluster.IStormClusterState;
+import org.apache.storm.generated.NodeInfo;
+
+public interface ITaskNetworkDistanceCalculator {
+
+    /**
+     * Prepare before doing any calculation.
+     * @param conf The configuration
+     * @param stormClusterState The storm cluster state
+     * @param localNodeInfo The NodeInfo of this worker
+     * @param localTaskToOutboundTasks The map from task in this worker to related outbound tasks
+     */
+    void prepare(Map<String, Object> conf, IStormClusterState stormClusterState, NodeInfo localNodeInfo,
+                 Map<Integer, Set<Integer>> localTaskToOutboundTasks);
+
+    /**
+     * Calculate or update taskNetworkDistance.
+     * @param taskToNodePort The map from taskId to NodeInfo
+     * @param taskNetworkDistance The map from taskId to the map from targetTaskId to distance
+     */
+    void calculateOrUpdate(Map<Integer, NodeInfo> taskToNodePort,
+                                  ConcurrentMap<Integer, ConcurrentMap<Integer, Double>> taskNetworkDistance);
+
+}

--- a/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
@@ -17,7 +17,16 @@
  */
 package org.apache.storm.task;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.storm.generated.GlobalStreamId;
 import org.apache.storm.generated.Grouping;
 import org.apache.storm.generated.StormTopology;
@@ -30,16 +39,6 @@ import org.apache.storm.metric.api.CombinedMetric;
 import org.apache.storm.state.ISubscribedState;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.apache.commons.lang.NotImplementedException;
 import org.json.simple.JSONValue;
 
 /**
@@ -77,17 +76,39 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
                            Map<String, Object> executorData,
                            Map<Integer, Map<Integer, Map<String, IMetric>>> registeredMetrics,
                            AtomicBoolean openOrPrepareWasCalled) {
+        this(topology, topoConf, taskToComponent, componentToSortedTasks, componentToStreamToFields,
+                blobToLastKnownVersionShared, stormId, codeDir, pidDir, taskId, workerPort, workerTasks,
+                defaultResources, userResources,executorData, registeredMetrics,
+                openOrPrepareWasCalled, null);
+    }
+
+    public TopologyContext(StormTopology topology,
+                           Map<String, Object> topoConf,
+                           Map<Integer, String> taskToComponent,
+                           Map<String, List<Integer>> componentToSortedTasks,
+                           Map<String, Map<String, Fields>> componentToStreamToFields,
+                           Map<String, Long> blobToLastKnownVersionShared,
+                           String stormId,
+                           String codeDir,
+                           String pidDir,
+                           Integer taskId,
+                           Integer workerPort,
+                           List<Integer> workerTasks,
+                           Map<String, Object> defaultResources,
+                           Map<String, Object> userResources,
+                           Map<String, Object> executorData,
+                           Map<Integer, Map<Integer, Map<String, IMetric>>> registeredMetrics,
+                           AtomicBoolean openOrPrepareWasCalled,
+                           ConcurrentMap<Integer, ConcurrentMap<Integer, Double>> taskNetworkDistance) {
         super(topology, topoConf, taskToComponent, componentToSortedTasks,
                 componentToStreamToFields, stormId, codeDir, pidDir,
-                workerPort, workerTasks, defaultResources, userResources);
+                workerPort, workerTasks, defaultResources, userResources, taskNetworkDistance);
         _taskId = taskId;
         _executorData = executorData;
         _registeredMetrics = registeredMetrics;
         _openOrPrepareWasCalled = openOrPrepareWasCalled;
         blobToLastKnownVersion = blobToLastKnownVersionShared;
     }
-
-
 
     /**
      * All state from all subscribed state spouts streams will be synced with

--- a/storm-client/src/jvm/org/apache/storm/task/WorkerTopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/WorkerTopologyContext.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 
 public class WorkerTopologyContext extends GeneralTopologyContext {
@@ -34,7 +35,8 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
     private String _pidDir;
     Map<String, Object> _userResources;
     Map<String, Object> _defaultResources;
-    
+    private ConcurrentMap<Integer, ConcurrentMap<Integer, Double>> _taskNetworkDistance;
+
     public WorkerTopologyContext(
             StormTopology topology,
             Map<String, Object> topoConf,
@@ -48,6 +50,25 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
             List<Integer> workerTasks,
             Map<String, Object> defaultResources,
             Map<String, Object> userResources
+            ) {
+        this(topology, topoConf, taskToComponent, componentToSortedTasks, componentToStreamToFields, stormId,
+                codeDir, pidDir, workerPort, workerTasks, defaultResources, userResources, null);
+    }
+
+    public WorkerTopologyContext(
+            StormTopology topology,
+            Map<String, Object> topoConf,
+            Map<Integer, String> taskToComponent,
+            Map<String, List<Integer>> componentToSortedTasks,
+            Map<String, Map<String, Fields>> componentToStreamToFields,
+            String stormId,
+            String codeDir,
+            String pidDir,
+            Integer workerPort,
+            List<Integer> workerTasks,
+            Map<String, Object> defaultResources,
+            Map<String, Object> userResources,
+            ConcurrentMap<Integer, ConcurrentMap<Integer, Double>> taskNetworkDistance
             ) {
         super(topology, topoConf, taskToComponent, componentToSortedTasks, componentToStreamToFields, stormId);
         _codeDir = codeDir;
@@ -64,6 +85,7 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
         }
         _workerPort = workerPort;
         _workerTasks = workerTasks;
+        _taskNetworkDistance = taskNetworkDistance;
     }
 
     /**
@@ -72,6 +94,17 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
      */
     public List<Integer> getThisWorkerTasks() {
         return _workerTasks;
+    }
+
+    /**
+     * Get network distance between tasks.
+     * The result could null.
+     * Null result means that no network distance data available.
+     * Empty result means that the network distance data is available but it is empty.
+     * @return The map from taskId to targetTaskId to distance. Could be null.
+     */
+    public ConcurrentMap<Integer, ConcurrentMap<Integer, Double>> getTaskNetworkDistance() {
+        return _taskNetworkDistance;
     }
     
     public Integer getThisWorkerPort() {
@@ -103,4 +136,5 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
     public ExecutorService getSharedExecutor() {
         return (ExecutorService) _defaultResources.get(SHARED_EXECUTOR);
     }
+
 }

--- a/storm-client/src/jvm/org/apache/storm/topology/InputDeclarer.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/InputDeclarer.java
@@ -95,6 +95,22 @@ public interface InputDeclarer<T extends InputDeclarer> {
     public T localOrShuffleGrouping(String componentId, String streamId);
 
     /**
+     * Tuples are distributed in favor of tasks with closet network distance.
+     * @param componentId
+     * @return
+     */
+    public T localityAwareShuffleGrouping(String componentId);
+
+    /**
+     * Tuples are distributed in favor of tasks with closet network distance.
+     * @param componentId
+     * @param streamId
+     * @return
+     */
+    public T localityAwareShuffleGrouping(String componentId, String streamId);
+
+
+    /**
      * This grouping specifies that you don't care how the stream is grouped.
      * @param componentId
      * @return

--- a/storm-client/src/jvm/org/apache/storm/topology/TopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/TopologyBuilder.java
@@ -640,6 +640,14 @@ public class TopologyBuilder {
         public BoltDeclarer localOrShuffleGrouping(String componentId, String streamId) {
             return grouping(componentId, streamId, Grouping.local_or_shuffle(new NullStruct()));
         }
+
+        public BoltDeclarer localityAwareShuffleGrouping(String componentId) {
+            return localityAwareShuffleGrouping(componentId, Utils.DEFAULT_STREAM_ID);
+        }
+
+        public BoltDeclarer localityAwareShuffleGrouping(String componentId, String streamId) {
+            return grouping(componentId, streamId, Grouping.locality_aware(new NullStruct()));
+        }
         
         public BoltDeclarer noneGrouping(String componentId) {
             return noneGrouping(componentId, Utils.DEFAULT_STREAM_ID);

--- a/storm-client/src/jvm/org/apache/storm/transactional/TransactionalTopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/transactional/TransactionalTopologyBuilder.java
@@ -368,6 +368,38 @@ public class TransactionalTopologyBuilder {
             });
             return this;
         }
+
+        @Override
+        public BoltDeclarer localityAwareShuffleGrouping(final String component) {
+            addDeclaration(new InputDeclaration() {
+                @Override
+                public void declare(InputDeclarer declarer) {
+                    declarer.localityAwareShuffleGrouping(component);
+                }
+
+                @Override
+                public String getComponent() {
+                    return component;
+                }
+            });
+            return this;
+        }
+
+        @Override
+        public BoltDeclarer localityAwareShuffleGrouping(final String component, final String streamId) {
+            addDeclaration(new InputDeclaration() {
+                @Override
+                public void declare(InputDeclarer declarer) {
+                    declarer.localityAwareShuffleGrouping(component, streamId);
+                }
+
+                @Override
+                public String getComponent() {
+                    return component;
+                }
+            });
+            return this;
+        }
         
         @Override
         public BoltDeclarer noneGrouping(final String component) {

--- a/storm-client/src/jvm/org/apache/storm/trident/topology/TridentTopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/topology/TridentTopologyBuilder.java
@@ -517,12 +517,12 @@ public class TridentTopologyBuilder {
                 @Override
                 public void declare(InputDeclarer declarer) {
                     declarer.localOrShuffleGrouping(component);
-                }                
+                }
 
                 @Override
                 public String getComponent() {
                     return component;
-                }                
+                }
 
                 @Override
                 public String getStream() {
@@ -538,12 +538,12 @@ public class TridentTopologyBuilder {
                 @Override
                 public void declare(InputDeclarer declarer) {
                     declarer.localOrShuffleGrouping(component, streamId);
-                }                
+                }
 
                 @Override
                 public String getComponent() {
                     return component;
-                }                
+                }
 
                 @Override
                 public String getStream() {
@@ -552,7 +552,49 @@ public class TridentTopologyBuilder {
             });
             return this;
         }
-        
+
+        @Override
+        public BoltDeclarer localityAwareShuffleGrouping(final String component) {
+            addDeclaration(new InputDeclaration() {
+                @Override
+                public void declare(InputDeclarer declarer) {
+                    declarer.localityAwareShuffleGrouping(component);
+                }
+
+                @Override
+                public String getComponent() {
+                    return component;
+                }
+
+                @Override
+                public String getStream() {
+                    return null;
+                }
+            });
+            return this;
+        }
+
+        @Override
+        public BoltDeclarer localityAwareShuffleGrouping(final String component, final String streamId) {
+            addDeclaration(new InputDeclaration() {
+                @Override
+                public void declare(InputDeclarer declarer) {
+                    declarer.localityAwareShuffleGrouping(component, streamId);
+                }
+
+                @Override
+                public String getComponent() {
+                    return component;
+                }
+
+                @Override
+                public String getStream() {
+                    return streamId;
+                }
+            });
+            return this;
+        }
+
         @Override
         public BoltDeclarer noneGrouping(final String component) {
             addDeclaration(new InputDeclaration() {

--- a/storm-client/src/py/storm/ttypes.py
+++ b/storm-client/src/py/storm/ttypes.py
@@ -602,6 +602,7 @@ class Grouping:
    - custom_object
    - custom_serialized
    - local_or_shuffle
+   - locality_aware
   """
 
   thrift_spec = (
@@ -614,9 +615,10 @@ class Grouping:
     (6, TType.STRUCT, 'custom_object', (JavaObject, JavaObject.thrift_spec), None, ), # 6
     (7, TType.STRING, 'custom_serialized', None, None, ), # 7
     (8, TType.STRUCT, 'local_or_shuffle', (NullStruct, NullStruct.thrift_spec), None, ), # 8
+    (9, TType.STRUCT, 'locality_aware', (NullStruct, NullStruct.thrift_spec), None, ), # 9
   )
 
-  def __init__(self, fields=None, shuffle=None, all=None, none=None, direct=None, custom_object=None, custom_serialized=None, local_or_shuffle=None,):
+  def __init__(self, fields=None, shuffle=None, all=None, none=None, direct=None, custom_object=None, custom_serialized=None, local_or_shuffle=None, locality_aware=None,):
     self.fields = fields
     self.shuffle = shuffle
     self.all = all
@@ -625,6 +627,7 @@ class Grouping:
     self.custom_object = custom_object
     self.custom_serialized = custom_serialized
     self.local_or_shuffle = local_or_shuffle
+    self.locality_aware = locality_aware
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -686,6 +689,12 @@ class Grouping:
           self.local_or_shuffle.read(iprot)
         else:
           iprot.skip(ftype)
+      elif fid == 9:
+        if ftype == TType.STRUCT:
+          self.locality_aware = NullStruct()
+          self.locality_aware.read(iprot)
+        else:
+          iprot.skip(ftype)
       else:
         iprot.skip(ftype)
       iprot.readFieldEnd()
@@ -731,6 +740,10 @@ class Grouping:
       oprot.writeFieldBegin('local_or_shuffle', TType.STRUCT, 8)
       self.local_or_shuffle.write(oprot)
       oprot.writeFieldEnd()
+    if self.locality_aware is not None:
+      oprot.writeFieldBegin('locality_aware', TType.STRUCT, 9)
+      self.locality_aware.write(oprot)
+      oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
 
@@ -748,6 +761,7 @@ class Grouping:
     value = (value * 31) ^ hash(self.custom_object)
     value = (value * 31) ^ hash(self.custom_serialized)
     value = (value * 31) ^ hash(self.local_or_shuffle)
+    value = (value * 31) ^ hash(self.locality_aware)
     return value
 
   def __repr__(self):

--- a/storm-client/src/storm.thrift
+++ b/storm-client/src/storm.thrift
@@ -58,6 +58,7 @@ union Grouping {
   6: JavaObject custom_object;
   7: binary custom_serialized;
   8: NullStruct local_or_shuffle; // prefer sending to tasks in the same worker process, otherwise shuffle
+  9: NullStruct locality_aware; // locality aware shuffle grouping
 }
 
 struct StreamInfo {

--- a/storm-client/test/jvm/org/apache/storm/grouping/LocalityAwareShuffleGroupingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/grouping/LocalityAwareShuffleGroupingTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.grouping;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.storm.task.WorkerTopologyContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LocalityAwareShuffleGroupingTest {
+
+    ConcurrentMap<Integer, ConcurrentMap<Integer, Double>> taskNetworkDistance;
+    WorkerTopologyContext workerTopologyContext;
+    LocalityAwareShuffleGrouping localityAwareShuffleGrouping;
+    List<Integer> targetTasks;
+
+    @Before
+    public void initialize() {
+        taskNetworkDistance = new ConcurrentHashMap<>();
+        workerTopologyContext = new WorkerTopologyContext(null, null, null, null, null, null,
+                null, null, null, null, null, null, taskNetworkDistance);
+        targetTasks = new ArrayList<>();
+        localityAwareShuffleGrouping = new LocalityAwareShuffleGrouping();
+    }
+
+    @Test
+    public void testChooseTasks() throws Exception {
+
+        taskNetworkDistance.put(1, new ConcurrentHashMap<Integer, Double>(){{
+            put(2, 10.0);
+            put(3, 50.0);
+            put(4, 5.0);
+            put(5, 10.0);
+        }});
+
+
+        taskNetworkDistance.put(2, new ConcurrentHashMap<Integer, Double>(){{
+            put(1, 10.0);
+            put(3, 50.0);
+            put(4, 50.0);
+            put(5, 40.0);
+        }});
+
+        targetTasks.addAll(Arrays.asList(3, 4, 5, 6));
+
+        localityAwareShuffleGrouping.prepare(workerTopologyContext, null, targetTasks);
+
+        Assert.assertTrue(localityAwareShuffleGrouping.chooseTasks(1, null).get(0) == 4);
+        Assert.assertTrue(localityAwareShuffleGrouping.chooseTasks(2, null).get(0) == 5);
+    }
+
+}

--- a/storm-client/test/jvm/org/apache/storm/task/DefaultTaskNetworkDistanceCalculatorTest.java
+++ b/storm-client/test/jvm/org/apache/storm/task/DefaultTaskNetworkDistanceCalculatorTest.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.task;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.regex.PatternSyntaxException;
+import com.google.common.collect.Sets;
+import org.apache.storm.Config;
+import org.apache.storm.generated.NodeInfo;
+import org.apache.storm.networktopography.DNSToSwitchMapping;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultTaskNetworkDistanceCalculatorTest {
+
+    private ITaskNetworkDistanceCalculator iTaskNetworkDistanceCalculator;
+    private Map<Integer, Set<Integer>> localTaskToOutboundTasks;
+    @Before
+    public void initializeAndPrepare() {
+        iTaskNetworkDistanceCalculator = new DefaultTaskNetworkDistanceCalculator();
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(Config.STORM_NETWORK_TOPOGRAPHY_PLUGIN, DNSToSwitchMappingMock.class.getName());
+        localTaskToOutboundTasks = new HashMap<>();
+        //mock localTask to outbound task
+        localTaskToOutboundTasks.put(1, Sets.newHashSet(2,3,4,5));
+        iTaskNetworkDistanceCalculator.prepare(conf, null,
+                new NodeInfo("rack1_node1", new HashSet<>(Arrays.asList(6700L))), localTaskToOutboundTasks);
+    }
+
+    @Test
+    public void testCalculateOrUpdate() throws Exception {
+        Map<Integer, NodeInfo> taskToNodePort = new HashMap<>();
+        //task on the same worker
+        taskToNodePort.put(2, new NodeInfo("rack1_node1", new HashSet<>(Arrays.asList(6700L))));
+        //task on the same node, different worker
+        taskToNodePort.put(3, new NodeInfo("rack1_node1", new HashSet<>(Arrays.asList(6701L))));
+        //task on the same rack, different node
+        taskToNodePort.put(4, new NodeInfo("rack1_node2", new HashSet<>(Arrays.asList(6701L))));
+        //task on different rack
+        taskToNodePort.put(5, new NodeInfo("rack2_node3", new HashSet<>(Arrays.asList(6702L))));
+
+        ConcurrentMap<Integer, ConcurrentMap<Integer, Double>> taskNetworkDistance = new ConcurrentHashMap<>();
+
+        iTaskNetworkDistanceCalculator.calculateOrUpdate(taskToNodePort, taskNetworkDistance);
+
+        Assert.assertTrue(taskNetworkDistance.get(1).get(2) ==
+                DefaultTaskNetworkDistanceCalculator.DistanceType.WORKER_LOCAL.distance());
+        Assert.assertTrue(taskNetworkDistance.get(1).get(3) ==
+                DefaultTaskNetworkDistanceCalculator.DistanceType.HOST_LOCAL.distance());
+        Assert.assertTrue(taskNetworkDistance.get(1).get(4) ==
+                DefaultTaskNetworkDistanceCalculator.DistanceType.RACK_LOCAL.distance());
+        Assert.assertTrue(taskNetworkDistance.get(1).get(5) ==
+                DefaultTaskNetworkDistanceCalculator.DistanceType.UNKNOWN.distance());
+
+    }
+
+    public static class DNSToSwitchMappingMock implements DNSToSwitchMapping {
+
+        private final String UNKNOWN_RACK = "unknown_rack";
+
+        /**
+         * Identify the rack the node is on.
+         * @param names the list of hosts to resolve (can be empty)
+         * @return Map of hosts to resolved network paths
+         */
+        @Override
+        public Map<String, String> resolve(List<String> names) {
+            Map<String, String> ret = new HashMap<>();
+
+            for (String hostName: names) {
+                try {
+                    ret.put(hostName, hostName.split("_")[0]);
+                } catch (PatternSyntaxException e) {
+                    ret.put(hostName, UNKNOWN_RACK);
+                }
+            }
+
+            return ret;
+        }
+    }
+}


### PR DESCRIPTION
see: https://issues.apache.org/jira/browse/STORM-2686

We want to add a locality aware shuffle grouping to favor the target tasks in closest network distance.  

Currently the network distance is some hard coded values like: WORKER_LOCAL, HOST_LCOAL, RACK_LOCAL, and UNKNOWN (everything else). Further improvement could be using ping times between supervisors.

I am doing more integration testing and performance testing.