### PR TITLE
Try fixing travis build by explicitly setting dist and updating integ…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ env:
   - MODULES='!storm-client,!storm-server,!storm-core'
   - MODULES='INTEGRATION-TEST'
 
+dist: trusty
+sudo: required
+
 language: java
 jdk:
   - oraclejdk8

--- a/integration-test/run-it.sh
+++ b/integration-test/run-it.sh
@@ -55,7 +55,7 @@ else
         ( cd "${STORM_SRC_DIR}/storm-dist/binary" && mvn clean package -Dgpg.skip=true )
     fi
     (( $(find "${STORM_SRC_DIR}/storm-dist/binary" -iname 'apache-storm*.zip' | wc -l) == 1 )) || die "expected exactly one zip file, did you run: cd ${STORM_SRC_DIR}/storm-dist/binary && mvn clean package -Dgpg.skip=true"
-    zookeeper_version=3.3.5*
+    zookeeper_version=3.4.5*
 fi
 
 storm_binary_zip=$(find "${STORM_SRC_DIR}/storm-dist" -iname '*.zip')


### PR DESCRIPTION
…ration test Zookeeper version

It looks like Travis has begun moving builds to Trusty from Precise (https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming). This causes the integration test to fail, because it refers to an older Zookeeper version that isn't available in Trusty.