### PR TITLE
STORM-2666: Fix storm-kafka-client spout sometimes emitting messages …

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang.Validate;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -146,10 +147,13 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
     // =========== Consumer Rebalance Listener - On the same thread as the caller ===========
     private class KafkaSpoutConsumerRebalanceListener implements ConsumerRebalanceListener {
 
+        private Collection<TopicPartition> previousAssignment = new HashSet<>();
+        
         @Override
         public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
             LOG.info("Partitions revoked. [consumer-group={}, consumer={}, topic-partitions={}]",
-                kafkaSpoutConfig.getConsumerGroupId(), kafkaConsumer, partitions);
+                    kafkaSpoutConfig.getConsumerGroupId(), kafkaConsumer, partitions);
+            previousAssignment = partitions;
             if (isAtLeastOnce() && initialized) {
                 initialized = false;
                 commitOffsetsForAckedTuples();
@@ -175,20 +179,14 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                  * Emitted messages for partitions that are no longer assigned to this spout can't
                  * be acked and should not be retried, hence remove them from emitted collection.
                  */
-                Set<TopicPartition> partitionsSet = new HashSet<>(partitions);
-                Iterator<KafkaSpoutMessageId> msgIdIterator = emitted.iterator();
-                while (msgIdIterator.hasNext()) {
-                    KafkaSpoutMessageId msgId = msgIdIterator.next();
-                    if (!partitionsSet.contains(msgId.getTopicPartition())) {
-                        msgIdIterator.remove();
-                    }
-                }
+                emitted.removeIf(msgId -> !partitions.contains(msgId.getTopicPartition()));
             }
 
-            for (TopicPartition tp : partitions) {
+            Set<TopicPartition> newPartitions = new HashSet<>(partitions);
+            newPartitions.removeAll(previousAssignment);
+            for (TopicPartition tp : newPartitions) {
                 final OffsetAndMetadata committedOffset = kafkaConsumer.committed(tp);
                 final long fetchOffset = doSeek(tp, committedOffset);
-                // Add offset managers for the new partitions.
                 // If this partition was previously assigned to this spout, leave the acked offsets as they were to resume where it left off
                 if (isAtLeastOnce() && !offsetManagers.containsKey(tp)) {
                     offsetManagers.put(tp, new OffsetManager(tp, fetchOffset));
@@ -202,18 +200,14 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
          * sets the cursor to the location dictated by the first poll strategy and returns the fetch offset.
          */
         private long doSeek(TopicPartition tp, OffsetAndMetadata committedOffset) {
-            long fetchOffset;
             if (committedOffset != null) {             // offset was committed for this TopicPartition
                 if (firstPollOffsetStrategy.equals(EARLIEST)) {
                     kafkaConsumer.seekToBeginning(Collections.singleton(tp));
-                    fetchOffset = kafkaConsumer.position(tp);
                 } else if (firstPollOffsetStrategy.equals(LATEST)) {
                     kafkaConsumer.seekToEnd(Collections.singleton(tp));
-                    fetchOffset = kafkaConsumer.position(tp);
                 } else {
                     // By default polling starts at the last committed offset. +1 to point fetch to the first uncommitted offset.
-                    fetchOffset = committedOffset.offset() + 1;
-                    kafkaConsumer.seek(tp, fetchOffset);
+                    kafkaConsumer.seek(tp, committedOffset.offset() + 1);
                 }
             } else {    // no commits have ever been done, so start at the beginning or end depending on the strategy
                 if (firstPollOffsetStrategy.equals(EARLIEST) || firstPollOffsetStrategy.equals(UNCOMMITTED_EARLIEST)) {
@@ -221,9 +215,8 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                 } else if (firstPollOffsetStrategy.equals(LATEST) || firstPollOffsetStrategy.equals(UNCOMMITTED_LATEST)) {
                     kafkaConsumer.seekToEnd(Collections.singleton(tp));
                 }
-                fetchOffset = kafkaConsumer.position(tp);
             }
-            return fetchOffset;
+            return kafkaConsumer.position(tp);
         }
     }
 
@@ -231,7 +224,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
     @Override
     public void nextTuple() {
         try {
-            if (initialized) {
+            if (initialized) {             
                 if (commit()) {
                     commitOffsetsForAckedTuples();
                 }
@@ -342,12 +335,15 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
      */
     private boolean emitTupleIfNotEmitted(ConsumerRecord<K, V> record) {
         final TopicPartition tp = new TopicPartition(record.topic(), record.partition());
-        final KafkaSpoutMessageId msgId = retryService.getMessageId(record);
+        final KafkaSpoutMessageId msgId = retryService.getMessageId(tp, record.offset());
         if (offsetManagers.containsKey(tp) && offsetManagers.get(tp).contains(msgId)) {   // has been acked
             LOG.trace("Tuple for record [{}] has already been acked. Skipping", record);
         } else if (emitted.contains(msgId)) {   // has been emitted and it's pending ack or fail
             LOG.trace("Tuple for record [{}] has already been emitted. Skipping", record);
         } else {
+            Validate.isTrue(kafkaConsumer.committed(tp) == null || kafkaConsumer.committed(tp).offset() < kafkaConsumer.position(tp),
+                "The spout is about to emit a message that has already been committed."
+                + " This should never occur, and indicates a bug in the spout");
             final List<Object> tuple = kafkaSpoutConfig.getTranslator().apply(record);
             if (isEmitTuple(tuple)) {
                 final boolean isScheduled = retryService.isScheduled(msgId);
@@ -411,6 +407,23 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
             for (Map.Entry<TopicPartition, OffsetAndMetadata> tpOffset : nextCommitOffsets.entrySet()) {
                 //Update the OffsetManager for each committed partition, and update numUncommittedOffsets
                 final TopicPartition tp = tpOffset.getKey();
+                long position = kafkaConsumer.position(tp);
+                long committedOffset = tpOffset.getValue().offset();
+                if (position < committedOffset) {
+                    /*
+                     * The position is behind the committed offset. This can happen in some cases, e.g. if a message failed,
+                     * lots of (more than max.poll.records) later messages were acked, and the failed message then gets acked. 
+                     * The consumer may only be part way through "catching up" to where it was when it went back to retry the failed tuple. 
+                     * Skip the consumer forward to the committed offset drop the current waiting to emit list,
+                     * since it'll likely contain committed offsets.
+                     */
+                    LOG.debug("Consumer fell behind committed offset. Catching up. Position was [{}], skipping to [{}]",
+                        position, committedOffset);
+                    kafkaConsumer.seek(tp, committedOffset);
+                    waitingToEmit = null;
+                }
+                
+                
                 final OffsetManager offsetManager = offsetManagers.get(tp);
                 long numCommittedOffsets = offsetManager.commit(tpOffset.getValue());
                 numUncommittedOffsets -= numCommittedOffsets;
@@ -440,6 +453,8 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                 LOG.debug("Received direct ack for message [{}], associated with null tuple", msgId);
             }
         } else {
+            Validate.isTrue(!retryService.isScheduled(msgId), "The message id " + msgId + " is queued for retry while being acked."
+                + " This should never occur barring errors in the RetryService implementation or the spout code.");
             offsetManagers.get(msgId.getTopicPartition()).addToAckMsgs(msgId);
             emitted.remove(msgId);
         }
@@ -460,6 +475,8 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                 + " Partitions may have been reassigned. Ignoring message [{}]", msgId);
             return;
         }
+        Validate.isTrue(!retryService.isScheduled(msgId), "The message id " + msgId + " is queued for retry while being failed."
+            + " This should never occur barring errors in the RetryService implementation or the spout code.");
         msgId.incrementNumFails();
         if (!retryService.schedule(msgId)) {
             LOG.debug("Reached maximum number of retries. Message [{}] being marked as acked.", msgId);

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryService.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryService.java
@@ -21,7 +21,6 @@ package org.apache.storm.kafka.spout;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 
 /**
@@ -85,10 +84,11 @@ public interface KafkaSpoutRetryService extends Serializable {
     int readyMessageCount();
 
     /**
-     * Gets the {@link KafkaSpoutMessageId} for the given record.
-     * @param record The record to fetch the id for
+     * Gets the {@link KafkaSpoutMessageId} for the record on the given topic partition and offset.
+     * @param topicPartition The topic partition of the record
+     * @param offset The offset of the record
      * @return The id the record was scheduled for retry with,
      *     or a new {@link KafkaSpoutMessageId} if the record was not scheduled for retry.
      */
-    KafkaSpoutMessageId getMessageId(ConsumerRecord<?, ?> record);
+    KafkaSpoutMessageId getMessageId(TopicPartition topicPartition, long offset);
 }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
@@ -99,7 +99,7 @@ public class OffsetManager {
                     LOG.debug("Processed non contiguous offset."
                         + " (committedOffset+1) is no longer part of the topic."
                         + " Committed: [{}], Processed: [{}]", committedOffset, currOffset);
-                    final Long nextEmittedOffset = emittedOffsets.ceiling(nextCommitOffset);
+                    final Long nextEmittedOffset = emittedOffsets.ceiling(nextCommitOffset + 1);
                     if (nextEmittedOffset != null && currOffset == nextEmittedOffset) {
                         nextCommitMsg = currAckedMsg;
                         nextCommitOffset = currOffset;
@@ -110,9 +110,9 @@ public class OffsetManager {
                     }
                 }
             } else {
-                //Received a redundant ack. Ignore and continue processing.
-                LOG.warn("topic-partition [{}] has unexpected offset [{}]. Current committed Offset [{}]",
-                    tp, currOffset, committedOffset);
+                throw new IllegalStateException("The offset [" + currOffset + "] is below the current committed "
+                    + "offset [" + committedOffset + "] for [" + tp + "]."
+                    + " This should not be possible, and likely indicates a bug in the spout's acking or emit logic.");
             }
         }
 

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutRetryExponentialBackoffTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutRetryExponentialBackoffTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.kafka.spout.KafkaSpoutRetryExponentialBackoff.TimeInterval;
+import org.apache.storm.utils.Time;
+import org.apache.storm.utils.Time.SimulatedTime;
+import org.junit.Test;
+
+public class KafkaSpoutRetryExponentialBackoffTest {
+    
+    private final TopicPartition testTopic = new TopicPartition("topic", 0);
+    private final TopicPartition testTopic2 = new TopicPartition("other-topic", 0);
+
+    private KafkaSpoutRetryExponentialBackoff createNoWaitRetryService() {
+        return new KafkaSpoutRetryExponentialBackoff(TimeInterval.seconds(0), TimeInterval.seconds(0), 1, TimeInterval.seconds(0));
+    }
+
+    private KafkaSpoutRetryExponentialBackoff createOneSecondWaitRetryService() {
+        return new KafkaSpoutRetryExponentialBackoff(TimeInterval.seconds(1), TimeInterval.seconds(0), 1, TimeInterval.seconds(1));
+    }
+
+    @Test
+    public void testCanScheduleRetry() {
+        KafkaSpoutRetryExponentialBackoff retryService = createNoWaitRetryService();
+        long offset = 0;
+        KafkaSpoutMessageId msgId = retryService.getMessageId(testTopic, offset);
+        msgId.incrementNumFails();
+
+        boolean scheduled = retryService.schedule(msgId);
+
+        assertThat("The service must schedule the message for retry", scheduled, is(true));
+        KafkaSpoutMessageId retrievedMessageId = retryService.getMessageId(testTopic, offset);
+        assertThat("The service should return the original message id when asked for the same tp/offset twice", retrievedMessageId, sameInstance(msgId));
+        assertThat(retryService.isScheduled(msgId), is(true));
+        assertThat(retryService.isReady(msgId), is(true));
+        assertThat(retryService.readyMessageCount(), is(1));
+        assertThat(retryService.earliestRetriableOffsets(), is(Collections.singletonMap(testTopic, msgId.offset())));
+    }
+
+    @Test
+    public void testCanRescheduleRetry() {
+        try (SimulatedTime time = new SimulatedTime()) {
+
+            KafkaSpoutRetryExponentialBackoff retryService = createOneSecondWaitRetryService();
+            long offset = 0;
+            KafkaSpoutMessageId msgId = retryService.getMessageId(testTopic, offset);
+            msgId.incrementNumFails();
+
+            retryService.schedule(msgId);
+            Time.advanceTime(500);
+            boolean scheduled = retryService.schedule(msgId);
+
+            assertThat("The service must be able to reschedule an already scheduled id", scheduled, is(true));
+            Time.advanceTime(500);
+            assertThat("The message should not be ready for retry yet since it was rescheduled", retryService.isReady(msgId), is(false));
+            assertThat(retryService.isScheduled(msgId), is(true));
+            assertThat(retryService.earliestRetriableOffsets(), is(Collections.emptyMap()));
+            assertThat(retryService.readyMessageCount(), is(0));
+            Time.advanceTime(500);
+            assertThat("The message should be ready for retry once the full delay has passed", retryService.isReady(msgId), is(true));
+            assertThat(retryService.isScheduled(msgId), is(true));
+            assertThat(retryService.earliestRetriableOffsets(), is(Collections.singletonMap(testTopic, msgId.offset())));
+            assertThat(retryService.readyMessageCount(), is(1));
+        }
+    }
+    
+    @Test
+    public void testCannotContainMultipleSchedulesForId() {
+        try (SimulatedTime time = new SimulatedTime()) {
+
+            KafkaSpoutRetryExponentialBackoff retryService = createOneSecondWaitRetryService();
+            long offset = 0;
+            KafkaSpoutMessageId msgId = retryService.getMessageId(testTopic, offset);
+            msgId.incrementNumFails();
+
+            retryService.schedule(msgId);
+            Time.advanceTime(500);
+            boolean scheduled = retryService.schedule(msgId);
+            
+            retryService.remove(msgId);
+            assertThat("The message should no longer be scheduled", retryService.isScheduled(msgId), is(false));
+            Time.advanceTime(500);
+            assertThat("The message should not be ready for retry because it isn't scheduled", retryService.isReady(msgId), is(false));
+        }
+    }
+
+    @Test
+    public void testCanRemoveRetry() {
+        KafkaSpoutRetryExponentialBackoff retryService = createNoWaitRetryService();
+        long offset = 0;
+        KafkaSpoutMessageId msgId = retryService.getMessageId(testTopic, offset);
+        msgId.incrementNumFails();
+
+        retryService.schedule(msgId);
+        boolean removed = retryService.remove(msgId);
+
+        assertThat(removed, is(true));
+        assertThat(retryService.isScheduled(msgId), is(false));
+        assertThat(retryService.isReady(msgId), is(false));
+        assertThat(retryService.earliestRetriableOffsets(), is(Collections.emptyMap()));
+        assertThat(retryService.readyMessageCount(), is(0));
+    }
+
+    @Test
+    public void testCanHandleMultipleTopics() {
+        try (SimulatedTime time = new SimulatedTime()) {
+            //Tests that isScheduled, isReady and earliestRetriableOffsets are mutually consistent when there are messages from multiple partitions scheduled
+            KafkaSpoutRetryExponentialBackoff retryService = createOneSecondWaitRetryService();
+            long offset = 0;
+
+            KafkaSpoutMessageId msgIdTp1 = retryService.getMessageId(testTopic, offset);
+            KafkaSpoutMessageId msgIdTp2 = retryService.getMessageId(testTopic2, offset);
+            msgIdTp1.incrementNumFails();
+            msgIdTp2.incrementNumFails();
+
+            boolean scheduledOne = retryService.schedule(msgIdTp1);
+            Time.advanceTime(500);
+            boolean scheduledTwo = retryService.schedule(msgIdTp2);
+
+            //The retry schedules for two messages should be unrelated
+            assertThat(scheduledOne, is(true));
+            assertThat(retryService.isScheduled(msgIdTp1), is(true));
+            assertThat(scheduledTwo, is(true));
+            assertThat(retryService.isScheduled(msgIdTp2), is(true));
+            assertThat(retryService.isReady(msgIdTp1), is(false));
+            assertThat(retryService.isReady(msgIdTp2), is(false));
+
+            Time.advanceTime(500);
+            assertThat(retryService.isReady(msgIdTp1), is(true));
+            assertThat(retryService.isReady(msgIdTp2), is(false));
+            assertThat(retryService.earliestRetriableOffsets(), is(Collections.singletonMap(testTopic, offset)));
+
+            Time.advanceTime(500);
+            assertThat(retryService.isReady(msgIdTp2), is(true));
+            Map<TopicPartition, Long> earliestOffsets = new HashMap<>();
+            earliestOffsets.put(testTopic, offset);
+            earliestOffsets.put(testTopic2, offset);
+            assertThat(retryService.earliestRetriableOffsets(), is(earliestOffsets));
+
+            //The service must be able to remove retry schedules for unnecessary partitions
+            retryService.retainAll(Collections.singleton(testTopic2));
+            assertThat(retryService.isScheduled(msgIdTp1), is(false));
+            assertThat(retryService.isScheduled(msgIdTp2), is(true));
+            assertThat(retryService.isReady(msgIdTp1), is(false));
+            assertThat(retryService.isReady(msgIdTp2), is(true));
+            assertThat(retryService.earliestRetriableOffsets(), is(Collections.singletonMap(testTopic2, offset)));
+        }
+    }
+
+    @Test
+    public void testCanHandleMultipleMessagesOnPartition() {
+        try (SimulatedTime time = new SimulatedTime()) {
+            //Tests that isScheduled, isReady and earliestRetriableOffsets are mutually consistent when there are multiple messages scheduled on a partition
+            KafkaSpoutRetryExponentialBackoff retryService = createOneSecondWaitRetryService();
+            long offset = 0;
+
+            KafkaSpoutMessageId msgIdEarliest = retryService.getMessageId(testTopic, offset);
+            KafkaSpoutMessageId msgIdLatest = retryService.getMessageId(testTopic, offset + 1);
+            msgIdEarliest.incrementNumFails();
+            msgIdLatest.incrementNumFails();
+
+            retryService.schedule(msgIdEarliest);
+            Time.advanceTime(500);
+            retryService.schedule(msgIdLatest);
+
+            assertThat(retryService.isScheduled(msgIdEarliest), is(true));
+            assertThat(retryService.isScheduled(msgIdLatest), is(true));
+
+            Time.advanceTime(500);
+            assertThat(retryService.isReady(msgIdEarliest), is(true));
+            assertThat(retryService.isReady(msgIdLatest), is(false));
+            assertThat(retryService.earliestRetriableOffsets(), is(Collections.singletonMap(testTopic, msgIdEarliest.offset())));
+
+            Time.advanceTime(500);
+            assertThat(retryService.isReady(msgIdEarliest), is(true));
+            assertThat(retryService.isReady(msgIdLatest), is(true));
+            assertThat(retryService.earliestRetriableOffsets(), is(Collections.singletonMap(testTopic, msgIdEarliest.offset())));
+
+            retryService.remove(msgIdEarliest);
+            assertThat(retryService.earliestRetriableOffsets(), is(Collections.singletonMap(testTopic, msgIdLatest.offset())));
+        }
+    }
+
+    @Test
+    public void testMaxRetries() {
+        try (SimulatedTime time = new SimulatedTime()) {
+            int maxRetries = 3;
+            KafkaSpoutRetryExponentialBackoff retryService = new KafkaSpoutRetryExponentialBackoff(TimeInterval.seconds(0), TimeInterval.seconds(0), maxRetries, TimeInterval.seconds(0));
+            long offset = 0;
+
+            KafkaSpoutMessageId msgId = retryService.getMessageId(testTopic, offset);
+            for (int i = 0; i < maxRetries; i++) {
+                msgId.incrementNumFails();
+            }
+
+            //Should be allowed to retry 3 times, in addition to original try
+            boolean scheduled = retryService.schedule(msgId);
+
+            assertThat(scheduled, is(true));
+            assertThat(retryService.isScheduled(msgId), is(true));
+
+            retryService.remove(msgId);
+            msgId.incrementNumFails();
+            boolean rescheduled = retryService.schedule(msgId);
+
+            assertThat("The message should not be allowed to retry once the limit is reached", rescheduled, is(false));
+            assertThat(retryService.isScheduled(msgId), is(false));
+        }
+    }
+
+    @Test
+    public void testMaxDelay() {
+        try (SimulatedTime time = new SimulatedTime()) {
+            int maxDelaySecs = 2;
+            KafkaSpoutRetryExponentialBackoff retryService = new KafkaSpoutRetryExponentialBackoff(TimeInterval.seconds(500), TimeInterval.seconds(0), 1, TimeInterval.seconds(maxDelaySecs));
+            long offset = 0;
+
+            KafkaSpoutMessageId msgId = retryService.getMessageId(testTopic, offset);
+            msgId.incrementNumFails();
+
+            retryService.schedule(msgId);
+
+            Time.advanceTimeSecs(maxDelaySecs);
+            assertThat("The message should be ready for retry after the max delay", retryService.isReady(msgId), is(true));
+        }
+    }
+
+    private void validateBackoff(int expectedBackoffSeconds, KafkaSpoutMessageId msgId, KafkaSpoutRetryExponentialBackoff retryService) {
+        Time.advanceTimeSecs(expectedBackoffSeconds - 1);
+        assertThat("The message should not be ready for retry until the backoff has expired", retryService.isReady(msgId), is(false));
+        Time.advanceTimeSecs(1);
+        assertThat(retryService.isReady(msgId), is(true));
+    }
+
+    @Test
+    public void testExponentialBackoff() {
+        try (SimulatedTime time = new SimulatedTime()) {
+            KafkaSpoutRetryExponentialBackoff retryService = new KafkaSpoutRetryExponentialBackoff(TimeInterval.seconds(0), TimeInterval.seconds(4), Integer.MAX_VALUE, TimeInterval.seconds(Integer.MAX_VALUE));
+            long offset = 0;
+
+            KafkaSpoutMessageId msgId = retryService.getMessageId(testTopic, offset);
+            msgId.incrementNumFails();
+            msgId.incrementNumFails(); //First failure is the initial delay, so not interesting
+
+            //Expecting 4*2^(failCount-1)
+            List<Integer> expectedBackoffsSecs = Arrays.asList(new Integer[]{8, 16, 32});
+            
+            for (Integer expectedBackoffSecs : expectedBackoffsSecs) {
+                retryService.schedule(msgId);
+
+                Time.advanceTimeSecs(expectedBackoffSecs - 1);
+                assertThat("The message should not be ready for retry until backoff " + expectedBackoffSecs + " has expired", retryService.isReady(msgId), is(false));
+                Time.advanceTimeSecs(1);
+                assertThat("The message should be ready for retry once backoff " + expectedBackoffSecs + " has expired", retryService.isReady(msgId), is(true));
+
+                msgId.incrementNumFails();
+                retryService.remove(msgId);
+            }
+        }
+    }
+
+}

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/internal/OffsetManagerTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/internal/OffsetManagerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.kafka.spout.internal;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.NoSuchElementException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.kafka.spout.KafkaSpoutMessageId;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class OffsetManagerTest {
+
+    @Rule
+    public ExpectedException expect = ExpectedException.none();
+
+    @Test
+    public void testSkipMissingOffsetsWhenFindingNextCommitOffsetWithGapInMiddleOfAcked() {
+        /*If topic compaction is enabled in Kafka, we sometimes need to commit past a gap of deleted offsets
+         * Since the Kafka consumer should return offsets in order, we can assume that if a message is acked
+         * then any prior message will have been emitted at least once.
+         * If we see an acked message and some of the offsets preceding it were not emitted, they must have been compacted away and should be skipped.
+         */
+        
+        TopicPartition tp = new TopicPartition("test", 0);
+        OffsetManager manager = new OffsetManager(tp, 0);
+        
+        manager.addToEmitMsgs(0);
+        manager.addToEmitMsgs(1);
+        manager.addToEmitMsgs(2);
+        //3, 4 compacted away
+        manager.addToEmitMsgs(5);
+        manager.addToEmitMsgs(6);
+        manager.addToAckMsgs(new KafkaSpoutMessageId(tp, 0));
+        manager.addToAckMsgs(new KafkaSpoutMessageId(tp, 1));
+        manager.addToAckMsgs(new KafkaSpoutMessageId(tp, 2));
+        manager.addToAckMsgs(new KafkaSpoutMessageId(tp, 6));
+        
+        assertThat("The offset manager should not skip past offset 5 which is still pending", manager.findNextCommitOffset().offset(), is(2L));
+        
+        manager.addToAckMsgs(new KafkaSpoutMessageId(tp, 5));
+        
+        assertThat("The offset manager should skip past the gap in acked messages, since the messages were not emitted", 
+            manager.findNextCommitOffset().offset(), is(6L));
+    }
+    
+    @Test
+    public void testSkipMissingOffsetsWhenFindingNextCommitOffsetWithGapBeforeAcked() {
+        
+        TopicPartition tp = new TopicPartition("test", 0);
+        OffsetManager manager = new OffsetManager(tp, 0);
+        
+        //0-4 compacted away
+        manager.addToEmitMsgs(5);
+        manager.addToEmitMsgs(6);
+        manager.addToAckMsgs(new KafkaSpoutMessageId(tp, 6));
+        
+        assertThat("The offset manager should not skip past offset 5 which is still pending", manager.findNextCommitOffset(), is(nullValue()));
+        
+        manager.addToAckMsgs(new KafkaSpoutMessageId(tp, 5));
+        
+        assertThat("The offset manager should skip past the gap in acked messages, since the messages were not emitted", 
+            manager.findNextCommitOffset().offset(), is(6L));
+    }
+
+}


### PR DESCRIPTION
…that were already committed. Expand tests, add some runtime validation, minor refactoring to increase code readability. Ensure OffsetManager commits as many offsets as possible when an offset void (deleted offsets) occurs, rather than just up to the gap.

See https://issues.apache.org/jira/browse/STORM-2666. I suspect this issue was also the root cause of the double acks we saw in https://github.com/apache/storm/pull/1679.

The following changes are made here:
* Make OffsetManager commit as many offsets as possible when there is a gap in emitted offsets due to offsets being deleted from Kafka. We used to have to do two commits to get past a gap, because the OffsetManager would stop in findNextCommitOffset at the last offset before the gap, commit up to the gap, and then have to do another round to commit the acked tuples past the gap. It should now just pick the highest acked tuple to commit immediately, as long as the previous unacked tuples were not emitted.
* Fix case where the KafkaConsumer position could fall behind the committed offset. This can happen in some cases where there are a lot of acked uncommitted tuples, and an older tuple is preventing commit because it needs to be retried. Once the failed tuple is retried, all the acked tuples are committed, but the consumer position isn't necessarily caught up. 
* Don't seek the consumer on partition reassignment for partitions that were previously assigned. Since the spout keeps the emitted/acked state for those partitions, we shouldn't be moving the consumer offset.
* Minor changes to the retry service, mainly stopping iterations once it has found what it was looking for.
* Add in some Validate calls to ensure that the spout state is good, e.g. check that the spout doesn't try to emit tuples that are already committed.
* Add more tests