### PR TITLE
Quick fix: remove duplicated IStormClusterState object in ReadClusterState.java

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
@@ -64,7 +64,6 @@ public class ReadClusterState implements Runnable, AutoCloseable {
     private final ContainerLauncher launcher;
     private final String host;
     private final LocalState localState;
-    private final IStormClusterState clusterState;
     private final AtomicReference<Map<Long, LocalAssignment>> cachedAssignments;
     
     public ReadClusterState(Supervisor supervisor) throws Exception {
@@ -77,7 +76,6 @@ public class ReadClusterState implements Runnable, AutoCloseable {
         this.localizer = supervisor.getAsyncLocalizer();
         this.host = supervisor.getHostName();
         this.localState = supervisor.getLocalState();
-        this.clusterState = supervisor.getStormClusterState();
         this.cachedAssignments = supervisor.getCurrAssignment();
         
         this.launcher = ContainerLauncher.make(superConf, assignmentId, supervisor.getSharedContext());
@@ -117,7 +115,7 @@ public class ReadClusterState implements Runnable, AutoCloseable {
 
     private Slot mkSlot(int port) throws Exception {
         return new Slot(localizer, superConf, launcher, host, port,
-                localState, clusterState, iSuper, cachedAssignments);
+                localState, stormClusterState, iSuper, cachedAssignments);
     }
     
     @Override


### PR DESCRIPTION
It seems to me that `private final IStormClusterState clusterState;` is a dup of ` private final IStormClusterState stormClusterState;`. So I removed `clusterState`.