### PR TITLE
Nitpicky cosmetic change - use "Uptime" instead of "UpTime" 

### DIFF
--- a/storm-core/src/ui/public/templates/index-page-template.html
+++ b/storm-core/src/ui/public/templates/index-page-template.html
@@ -87,7 +87,7 @@
                 <span data-toggle="tooltip" data-placement="top" title="Storm version this nimbus host is running.">Version</span>
             </th>
             <th>
-                <span data-toggle="tooltip" data-placement="left" title="Time since this nimbus host has been running.">UpTime</span>
+                <span data-toggle="tooltip" data-placement="left" title="Time since this nimbus host has been running.">Uptime</span>
             </th>
         </tr>
         </thead>


### PR DESCRIPTION
"Uptime" spelling is used elsewhere in index.html, so this change makes everything consistent.