### PR TITLE
STORM-2500: remove call to waitUntilReady

### DIFF
--- a/storm-core/src/clj/org/apache/storm/pacemaker/pacemaker_state_factory.clj
+++ b/storm-core/src/clj/org/apache/storm/pacemaker/pacemaker_state_factory.clj
@@ -106,14 +106,13 @@
 (defn get-pacemaker-write-client [conf servers client-pool]
   ;; Client should be created in case of an exception or first write call
   ;; Shutdown happens in the retry loop
-  (try 
-    (.waitUntilReady
-     (let [client (get @client-pool (first @servers))]
-       (if (nil? client)
-         (do
-           (swap! client-pool merge {(first @servers) (PacemakerClient. conf (first @servers))})
-           (get @client-pool (first @servers)))
-         client)))
+  (try
+    (let [client (get @client-pool (first @servers))]
+      (if (nil? client)
+        (do
+          (swap! client-pool merge {(first @servers) (PacemakerClient. conf (first @servers))})
+          (get @client-pool (first @servers)))
+        client))
     (catch Exception e
       (throw e))))
 


### PR DESCRIPTION
In 1.1.x PacemakerClient was refactored so waitUntilReady was private, and called by the send method. But this clojure reference remained, causing pacemaker to fail to initialize. AFAIK this reference can simply be removed, as waitForReady is called on send. However, I'm not very familiar with the code base. I applied this patch to our own cluster with success. 