### PR TITLE
Change OracleJDK7 to OpenJDK7 in Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ sudo: required
 
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 before_install:
   - rvm use 2.1.5 --install


### PR DESCRIPTION
We've running issue on build failures on all PRs against 1.x version, due to using Oracle JDK 7 as JDK, which Oracle withdraws it.
Same issue is filed to Travis CI, and you can see the comment here: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879

Changed OracleJDK7 to OpenJDK7 and checked the build result against my fork: https://travis-ci.org/HeartSaVioR/storm/builds/266178126

This should be ported back to all 1.x version line branches.
