### PR TITLE
[STORM-2699] Put all the version information of third party component into the main pom 

### DIFF
--- a/external/storm-cassandra/pom.xml
+++ b/external/storm-cassandra/pom.xml
@@ -38,7 +38,6 @@
         <guava.version>16.0.1</guava.version>
         <commons-lang3.version>3.3</commons-lang3.version>
         <cassandra.driver.core.version>3.1.2</cassandra.driver.core.version>
-        <cassandra.version>2.1.7</cassandra.version>
     </properties>
 
     <developers>

--- a/external/storm-druid/pom.xml
+++ b/external/storm-druid/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>io.druid</groupId>
             <artifactId>tranquility-core_2.11</artifactId>
-            <version>0.8.2</version>
+            <version>${druid.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.jersey</groupId>

--- a/external/storm-elasticsearch/pom.xml
+++ b/external/storm-elasticsearch/pom.xml
@@ -42,7 +42,6 @@
     </developers>
 
     <properties>
-        <elasticsearch.version>5.2.2</elasticsearch.version>
         <elasticsearch.test.version>2.4.4</elasticsearch.test.version>
     </properties>
 

--- a/external/storm-hbase/pom.xml
+++ b/external/storm-hbase/pom.xml
@@ -35,10 +35,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <hdfs.version>${hadoop.version}</hdfs.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.storm</groupId>

--- a/external/storm-mongodb/pom.xml
+++ b/external/storm-mongodb/pom.xml
@@ -35,10 +35,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <mongodb.version>3.2.0</mongodb.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.storm</groupId>

--- a/external/storm-pmml/pom.xml
+++ b/external/storm-pmml/pom.xml
@@ -41,10 +41,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <jpmml.version>1.0.22</jpmml.version>
-    </properties>
-
     <dependencies>
         <!--parent module dependency-->
         <dependency>

--- a/external/storm-redis/pom.xml
+++ b/external/storm-redis/pom.xml
@@ -40,10 +40,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <jedis.version>2.9.0</jedis.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.storm</groupId>

--- a/external/storm-rocketmq/pom.xml
+++ b/external/storm-rocketmq/pom.xml
@@ -39,10 +39,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <rocketmq.version>4.0.0-incubating</rocketmq.version>
-    </properties>
-
     <dependencies>
         <!--parent module dependency-->
         <dependency>

--- a/external/storm-solr/pom.xml
+++ b/external/storm-solr/pom.xml
@@ -69,13 +69,13 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
-            <version>5.2.1</version>
+            <version>${solr.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-test-framework</artifactId>
-            <version>5.2.1</version>
+            <version>${solr.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,7 @@
         <clojure-contrib.version>1.2.0</clojure-contrib.version>
         <hive.version>0.14.0</hive.version>
         <hadoop.version>2.6.1</hadoop.version>
+        <hdfs.version>${hadoop.version}</hdfs.version>
         <hbase.version>1.1.0</hbase.version>
         <kryo.version>3.0.3</kryo.version>
         <servlet.version>2.5</servlet.version>
@@ -285,8 +286,15 @@
         <metrics-clojure.version>2.5.1</metrics-clojure.version>
         <hdrhistogram.version>2.1.7</hdrhistogram.version>
         <hamcrest.version>1.3</hamcrest.version>
-
+        <cassandra.version>2.1.7</cassandra.version>
+        <druid.version>0.8.2</druid.version>
+        <elasticsearch.version>5.2.2</elasticsearch.version>
         <calcite.version>1.11.0</calcite.version>
+        <mongodb.version>3.2.0</mongodb.version>
+        <solr.version>5.2.1</solr.version>
+        <jpmml.version>1.0.22</jpmml.version>
+        <jedis.version>2.9.0</jedis.version>
+        <rocketmq.version>4.0.0-incubating</rocketmq.version>
 
         <jackson.version>2.6.3</jackson.version>
         <maven-surefire.version>2.18.1</maven-surefire.version>


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2699](https://issues.apache.org/jira/browse/STORM-2699)
I think it's better to put all the version information of third party components into the main pom for more efficient version control
