### PR TITLE
[STORM-2700] Should not check Blobstore ACL if the validation is disabled

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/Localizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/Localizer.java
@@ -523,7 +523,7 @@ public class Localizer {
         out = new FileOutputStream(downloadFile);
         numTries++;
         try {
-          if (!ServerUtils.canUserReadBlob(blobstore.getBlobMeta(key), user)) {
+          if (!ServerUtils.canUserReadBlob(blobstore.getBlobMeta(key), user, conf)) {
             throw new AuthorizationException(user + " does not have READ access to " + key);
           }
           InputStreamWithMeta in = blobstore.getBlob(key);

--- a/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
@@ -377,7 +377,12 @@ public class ServerUtils {
         return nimbusBlobVersion;
     }
 
-    public static boolean canUserReadBlob(ReadableBlobMeta meta, String user) {
+    public static boolean canUserReadBlob(ReadableBlobMeta meta, String user, Map<String, Object> conf) {
+
+        if (!ObjectReader.getBoolean(conf.get(Config.STORM_BLOBSTORE_ACL_VALIDATION_ENABLED), false)) {
+            return true;
+        }
+
         SettableBlobMeta settable = meta.get_settable();
         for (AccessControl acl : settable.get_acl()) {
             if (acl.get_type().equals(AccessControlType.OTHER) && (acl.get_access() & BlobStoreAclHandler.READ) > 0) {

--- a/storm-server/src/test/java/org/apache/storm/localizer/LocalizerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/LocalizerTest.java
@@ -508,6 +508,8 @@ public class LocalizerTest {
     Map<String, Object> conf = new HashMap();
     // set clean time really high so doesn't kick in
     conf.put(DaemonConfig.SUPERVISOR_LOCALIZER_CACHE_CLEANUP_INTERVAL_MS, 60 * 60 * 1000);
+    // enable blobstore acl validation
+    conf.put(Config.STORM_BLOBSTORE_ACL_VALIDATION_ENABLED, true);
 
     String topo1 = "topo1";
     String key1 = "key1";


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/STORM-2700

`canUserReadBlob ` function should take `STORM_BLOBSTORE_ACL_VALIDATION_ENABLED` config into consideration. 

Tested it manually.