### PR TITLE
[STORM-2704] Check blob permission before submitting the topology

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -561,15 +561,8 @@ public class StormSubmitter {
         public void onCompleted(String srcFile, String targetFile, long totalBytes);
     }
 
-    private static void validateConfs(Map<String, Object> topoConf, StormTopology topology) throws IllegalArgumentException, InvalidTopologyException {
+    private static void validateConfs(Map<String, Object> topoConf, StormTopology topology) throws IllegalArgumentException, InvalidTopologyException, AuthorizationException {
         ConfigValidation.validateFields(topoConf);
-        Utils.validateTopologyBlobStoreMap(topoConf, getListOfKeysFromBlobStore(topoConf));
-    }
-
-    private static Set<String> getListOfKeysFromBlobStore(Map<String, Object> topoConf) {
-        try (NimbusBlobStore client = new NimbusBlobStore()) {
-            client.prepare(topoConf);
-            return Sets.newHashSet(client.listKeys());
-        }
+        Utils.validateTopologyBlobStoreMap(topoConf);
     }
 }

--- a/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
+++ b/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
@@ -20,7 +20,6 @@ package org.apache.storm;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.storm.generated.InvalidTopologyException;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.validation.ConfigValidation;
 import org.apache.storm.validation.ConfigValidation.*;
@@ -34,11 +33,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
 
 public class TestConfigValidate {
 
@@ -82,21 +81,6 @@ public class TestConfigValidate {
         conf.put(Config.STORM_MESSAGING_NETTY_AUTHENTICATION, "invalid");
 
         ConfigValidation.validateFields(conf);
-    }
-
-    @Test(expected = InvalidTopologyException.class)
-    public void testValidateTopologyBlobStoreMap() throws InvalidTopologyException {
-        Map<String, Object> topoConf = new HashMap<>();
-        Map<String,Map> topologyMap = new HashMap<>();
-        topologyMap.put("key1", new HashMap<String,String>());
-        topologyMap.put("key2", new HashMap<String,String>());
-        topoConf.put(Config.TOPOLOGY_BLOBSTORE_MAP, topologyMap);
-        HashSet<String> keySet = new HashSet<>();
-        keySet.add("key1");
-        keySet.add("key2");
-        Utils.validateTopologyBlobStoreMap(topoConf, keySet);
-        keySet.remove("key2");
-        Utils.validateTopologyBlobStoreMap(topoConf, keySet);
     }
 
     @Test

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2529,7 +2529,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 }
             }
             validateTopologyWorkerMaxHeapSizeConfigs(topoConf, topology);
-            Utils.validateTopologyBlobStoreMap(topoConf, Sets.newHashSet(blobStore.listKeys()));
+            Utils.validateTopologyBlobStoreMap(topoConf);
             long uniqueNum = submittedCount.incrementAndGet();
             String topoId = topoName + "-" + uniqueNum + "-" + Time.currentTimeSecs();
             Map<String, String> creds = null;

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2529,7 +2529,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 }
             }
             validateTopologyWorkerMaxHeapSizeConfigs(topoConf, topology);
-            Utils.validateTopologyBlobStoreMap(topoConf);
+            Utils.validateTopologyBlobStoreMap(topoConf, blobStore);
             long uniqueNum = submittedCount.incrementAndGet();
             String topoId = topoName + "-" + uniqueNum + "-" + Time.currentTimeSecs();
             Map<String, String> creds = null;


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/STORM-2704

The original code only checks if the keys in `topology.blobstore.map` exist in the BlobStore.  We need to check the ACL as well.