### PR TITLE
STORM-2231 Fix multi-threads issue on executor send queue

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/Executor.java
@@ -387,7 +387,7 @@ public abstract class Executor implements Callable, EventHandler<Object> {
         int waitTimeOutMs = ObjectReader.getInt(topoConf.get(Config.TOPOLOGY_DISRUPTOR_WAIT_TIMEOUT_MILLIS));
         int batchSize = ObjectReader.getInt(topoConf.get(Config.TOPOLOGY_DISRUPTOR_BATCH_SIZE));
         int batchTimeOutMs = ObjectReader.getInt(topoConf.get(Config.TOPOLOGY_DISRUPTOR_BATCH_TIMEOUT_MILLIS));
-        return new DisruptorQueue("executor" + executorId + "-send-queue", ProducerType.SINGLE,
+        return new DisruptorQueue("executor" + executorId + "-send-queue", ProducerType.MULTI,
                 sendSize, waitTimeOutMs, batchSize, batchTimeOutMs);
     }
 


### PR DESCRIPTION
[STORM-2231](https://issues.apache.org/jira/browse/STORM-2231) is an issue to report broken thread-safety on output collector. We mostly considered about grouper implementation, but there's a spot in other side as well.

In DisruptorQueue, each incoming threads have each ThreadLocalBatcher, meaning that 'synchronized' in add() can synchronize incoming thread and background flusher thread, but not among incoming threads.
Hopefully DisruptorQueue publish*() are implemented to respect thread-safety, but it relies on RingBuffer producer option (Sequencer in RingBuffer), and unfortunately we set producer to SINGLE, not MULTI for executor batch queue. It seems to be one of optimization but we seemed to miss a spot.  

So there're two simple options to choose: just using same ThreadLocalBatcher instance for all incoming thread (class name should be changed) or just changing producer mode to MULTI. This patch addresses later option, because it is just simple, and expected to be faster than former.

The change is expected to bring any kind of performance hit, so may also need to do some performance tests against the patch.

@revans2 Could you take a look at? It is related to disruptor batching.