### PR TITLE
STORM-2712: accept arbitrary number of rows per tuple in storm-cassandra

### DIFF
--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/trident/state/TridentResultSetValuesMapper.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/trident/state/TridentResultSetValuesMapper.java
@@ -44,6 +44,8 @@ public class TridentResultSetValuesMapper implements CQLResultSetValuesMapper {
     @Override
     public List<List<Values>> map(Session session, Statement statement, ITuple tuple) {
         List<List<Values>> list = new ArrayList<>();
+        List<Values> innerList = new LinkedList<>();
+        list.add(innerList);
         ResultSet resultSet = session.execute(statement);
         for (Row row : resultSet) {
             final Values values = new Values();
@@ -54,9 +56,7 @@ public class TridentResultSetValuesMapper implements CQLResultSetValuesMapper {
                     values.add(row.getObject(field));
                 }
             }
-            list.add(new LinkedList<Values>() {{
-                add(values);
-            }});
+            innerList.add(values);
         }
         return list;
     }


### PR DESCRIPTION
Current implementation in `TridentResultSetValuesMapper::map` restricts a SELECT query to return one row. In `StateQueryProcessor::finishBatch`, it checks the equality between the result size of `batchRetrieve` and input tuple size. When the number of result rows is less than 1 or greater than 1, it breaks the condition and an exception is thrown.

We should accept arbitrary number of rows by adjusting List dimensions.