### PR TITLE
[STORM-2713] when the connection to the first zkserver is timeout,storm-kafka's kafkaspout will throw a exception

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/DynamicBrokersReader.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/DynamicBrokersReader.java
@@ -110,7 +110,7 @@ public class DynamicBrokersReader {
             List<String> children = _curator.getChildren().forPath(topicBrokersPath);
             return children.size();
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            LOG.error(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2713](https://issues.apache.org/jira/browse/STORM-2713)
when the connection to the first zkserver is timeout,storm-kafka's kafkaspout will throw a exception without attempting to connect other zkserver,even zk can also work with one node down.