### PR TITLE
STORM-2443 Fix issues on changing log level

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/LogConfigManager.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/LogConfigManager.java
@@ -111,6 +111,9 @@ public class LogConfigManager {
     // also called from processLogConfigChange
     public void resetLogLevels() {
         TreeMap<String, LogLevel> latestLogLevelMap = latestLogConfig.get();
+
+        LOG.debug("Resetting log levels: Latest log config is {}", latestLogLevelMap);
+
         LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
 
         for (String loggerName : latestLogLevelMap.descendingKeySet()) {
@@ -120,12 +123,12 @@ public class LogConfigManager {
             if (timeout < Time.currentTimeMillis()) {
                 LOG.info("{}: Resetting level to {}", loggerName, resetLogLevel);
                 setLoggerLevel(loggerContext, loggerName, resetLogLevel);
+                latestLogConfig.getAndUpdate(input -> {
+                    TreeMap<String, LogLevel> result = new TreeMap<>(input);
+                    result.remove(loggerName);
+                    return result;
+                });
             }
-            latestLogConfig.getAndUpdate(input -> {
-                TreeMap<String, LogLevel> result = new TreeMap<>(input);
-                result.remove(loggerName);
-                return result;
-            });
         }
         loggerContext.updateLoggers();
     }

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -903,7 +903,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     private static void setLoggerTimeouts(LogLevel level) {
         int timeoutSecs = level.get_reset_log_level_timeout_secs();
         if (timeoutSecs > 0) {
-            level.set_reset_log_level_timeout_epoch(Time.currentTimeSecs() + timeoutSecs);
+            level.set_reset_log_level_timeout_epoch(Time.currentTimeMillis() + Time.secsToMillis(timeoutSecs));
         } else {
             level.unset_reset_log_level_timeout_epoch();
         }
@@ -2752,11 +2752,14 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             if (mergedLogConfig == null) {
                 mergedLogConfig = new LogConfig();
             }
-            Map<String, LogLevel> namedLoggers = mergedLogConfig.get_named_logger_level();
-            for (LogLevel level: namedLoggers.values()) {
-                level.set_action(LogLevelAction.UNCHANGED);
+
+            if (mergedLogConfig.is_set_named_logger_level()) {
+                Map<String, LogLevel> namedLoggers = mergedLogConfig.get_named_logger_level();
+                for (LogLevel level: namedLoggers.values()) {
+                    level.set_action(LogLevelAction.UNCHANGED);
+                }
             }
-            
+
             if (config.is_set_named_logger_level()) {
                 for (Entry<String, LogLevel> entry: config.get_named_logger_level().entrySet()) {
                     LogLevel logConfig = entry.getValue();


### PR DESCRIPTION
* Addressed below issues
  * Nimbus throws error when changing log level on UI topology page
  * Log configs in worker are removed even they're not timed out and never reset
  * The unit of epoch between backend and frontend are different
    * second in backend, millisecond in frontend
    * millisecond is right so fixed it

The above issues seem to be only in master branch.