### PR TITLE
Quick fix: remove storm-rename-hack dependency

### DIFF
--- a/storm-dist/binary/final-package/pom.xml
+++ b/storm-dist/binary/final-package/pom.xml
@@ -36,11 +36,6 @@
             <artifactId>storm-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>storm-rename-hack</artifactId>
-            <version>${project.version}</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Since storm-rename-hack is removed, I think we should remove the dependency.