### PR TITLE
STORM-2533 Visualization API returns "spout" for system components

### DIFF
--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -223,7 +223,9 @@
 
 (defn visualization-data
   [spout-bolt spout-comp-summs bolt-comp-summs window storm-id]
-  (let [components (for [[id spec] spout-bolt]
+  (let [components (for [[id spec] spout-bolt
+                         :when (or (contains? bolt-comp-summs id)
+                                   (contains? spout-comp-summs id))]
             [id
              (let [inputs (.get_inputs (.get_common spec))
                    bolt-summs (.get bolt-comp-summs id)

--- a/storm-core/src/ui/public/js/script.js
+++ b/storm-core/src/ui/public/js/script.js
@@ -469,8 +469,8 @@ function toggleComponents(elId) {
     });
 }
 
-function open_visualization() {
-    window.open('/visualize.html?id='+ $.url("?id"), '_blank');
+function open_visualization(sys) {
+    window.open('/visualize.html?id='+ $.url("?id") + "&sys=" + sys, '_blank');
 }
 
 function show_visualization(sys) {
@@ -482,7 +482,7 @@ function show_visualization(sys) {
                     Mustache.render($(template)
                         .filter("#topology-visualization-container-template")
                         .html(),
-                        {id: $.url("?id")}));
+                        {id: $.url("?id"), sys: sys}));
             }
         });
 

--- a/storm-core/src/ui/public/js/visualization.js
+++ b/storm-core/src/ui/public/js/visualization.js
@@ -321,7 +321,7 @@ function isStreamEnabled(streamIdSanitized) {
 var update = function() {
     if(visNS.shouldUpdate) {
         $.ajax({
-            url: "/api/v1/topology/"+$.url("?id")+"/visualization",
+            url: "/api/v1/topology/"+$.url("?id")+"/visualization?sys="+$.url("?sys"),
             success: function (data, status, jqXHR) {
                 json = data;
                 parseResponse(data);

--- a/storm-core/src/ui/public/templates/topology-page-template.html
+++ b/storm-core/src/ui/public/templates/topology-page-template.html
@@ -313,7 +313,7 @@
 </script>
 
 <script id="topology-visualization-container-template" type="text/html">
-<iframe src="/visualize.html?id={{id}}" width="100%" height="500px"></iframe>
+<iframe src="/visualize.html?id={{id}}&sys={{sys}}" width="100%" height="500px"></iframe>
 </script>
 
 <script id="topology-visualization-template" type="text/html">

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -340,8 +340,9 @@ $(document).ready(function() {
 
           jsError(function() {
             topologyVisualization.append(Mustache.render($(template).filter("#topology-visualization-template").html(), response));
-            $("#show-hide-visualization").click(function () { show_visualization(null) });
-            $("#open-visualization").click(function() { open_visualization(); });
+            var sys = $.cookies.get("sys") || "false";
+            $("#show-hide-visualization").click(function () { show_visualization(sys) });
+            $("#open-visualization").click(function() { open_visualization(sys); });
 
             config.append(Mustache.render($(template).filter("#topology-configuration-template").html(),formattedConfig));
             $('#topology-configuration td').jsonFormatter()


### PR DESCRIPTION
Please refer the issue link: 
https://issues.apache.org/jira/browse/STORM-2533
https://issues.apache.org/jira/browse/STORM-2534

* also fixed STORM-2534 Visualization API missing stats/instances for "system" components
* one thing which should be fixed in issue description is "__system" shouldn't be shown
  * it is also addressed from this patch