### PR TITLE
[STORM-2729] Fix NPE in WorkerState runWorkerStartHooks and runWorkerShutdownHooks methods

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -583,20 +583,22 @@ public class WorkerState {
 
     public void runWorkerStartHooks() {
         WorkerTopologyContext workerContext = getWorkerTopologyContext();
-        for (ByteBuffer hook : topology.get_worker_hooks()) {
-            byte[] hookBytes = Utils.toByteArray(hook);
-            BaseWorkerHook hookObject = Utils.javaDeserialize(hookBytes, BaseWorkerHook.class);
-            hookObject.start(topologyConf, workerContext);
-
+        if (topology.is_set_worker_hooks()) {
+            for (ByteBuffer hook : topology.get_worker_hooks()) {
+                byte[] hookBytes = Utils.toByteArray(hook);
+                BaseWorkerHook hookObject = Utils.javaDeserialize(hookBytes, BaseWorkerHook.class);
+                hookObject.start(topologyConf, workerContext);
+            }
         }
     }
 
     public void runWorkerShutdownHooks() {
-        for (ByteBuffer hook : topology.get_worker_hooks()) {
-            byte[] hookBytes = Utils.toByteArray(hook);
-            BaseWorkerHook hookObject = Utils.javaDeserialize(hookBytes, BaseWorkerHook.class);
-            hookObject.shutdown();
-
+        if (topology.is_set_worker_hooks()) {
+            for (ByteBuffer hook : topology.get_worker_hooks()) {
+                byte[] hookBytes = Utils.toByteArray(hook);
+                BaseWorkerHook hookObject = Utils.javaDeserialize(hookBytes, BaseWorkerHook.class);
+                hookObject.shutdown();
+            }
         }
     }
 


### PR DESCRIPTION
worker_hooks is an optional field in StormTopology struct (storm.thrift). So when we call get_worker_hooks(), we need to check is_set_worker_hooks().

We probably want to pay attention to optional fields when we write the code because this can be a common issue for all thrift structs. We should always check is_set_xxx before we call get_xxx if xxx is an optional field.

For details, see https://issues.apache.org/jira/browse/STORM-2729.


