### PR TITLE
STORM-2734: Fix checkstyle crash when running release:prepare goal. A…

### DIFF
--- a/examples/storm-loadgen/pom.xml
+++ b/examples/storm-loadgen/pom.xml
@@ -114,7 +114,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>maven-checkstyle-plugin</artifactId>
         <!--Note - the version would be inherited-->
         <configuration>
-          <maxAllowedViolations>0</maxAllowedViolations>
+          <maxAllowedViolations>3</maxAllowedViolations>
         </configuration>
       </plugin>
     </plugins>

--- a/external/storm-cassandra/pom.xml
+++ b/external/storm-cassandra/pom.xml
@@ -130,7 +130,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>577</maxAllowedViolations>
+                    <maxAllowedViolations>578</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-elasticsearch/pom.xml
+++ b/external/storm-elasticsearch/pom.xml
@@ -147,7 +147,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>64</maxAllowedViolations>
+                    <maxAllowedViolations>69</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -256,7 +256,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>2221</maxAllowedViolations>
+                    <maxAllowedViolations>2223</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -110,15 +110,14 @@
       </exclusions>
     </dependency>
     <dependency>
-	    <groupId>org.apache.calcite</groupId>
-	    <artifactId>calcite-core</artifactId>
-      <version>0.9.2-incubating</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
+        <groupId>org.apache.calcite</groupId>
+        <artifactId>calcite-core</artifactId>
+        <exclusions>
+            <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
@@ -146,12 +145,6 @@
       <artifactId>libthrift</artifactId>
       <version>0.9.3</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.calcite</groupId>
-      <artifactId>calcite-core</artifactId>
-      <version>${calcite.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.storm</groupId>

--- a/external/storm-jms/pom.xml
+++ b/external/storm-jms/pom.xml
@@ -94,7 +94,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>232</maxAllowedViolations>
+                    <maxAllowedViolations>235</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/ByTopicRecordTranslator.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/ByTopicRecordTranslator.java
@@ -61,8 +61,9 @@ public class ByTopicRecordTranslator<K, V> implements RecordTranslator<K, V> {
     }
     
     /**
+     * Create a record translator with the given default translator.
      * @param defaultTranslator a translator that will be used for all topics not explicitly set
-     *     elsewhere.
+     *     with one of the variants of {@link #forTopic(java.lang.String, org.apache.storm.kafka.spout.RecordTranslator) }.
      */
     public ByTopicRecordTranslator(RecordTranslator<K,V> defaultTranslator) {
         this.defaultTranslator = defaultTranslator;

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -332,7 +332,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
     }
 
     /**
-     * Creates a tuple from the kafka record and emits it if it was not yet emitted
+     * Creates a tuple from the kafka record and emits it if it was not yet emitted.
      *
      * @param record to be emitted
      * @return true if tuple was emitted. False if tuple has been acked or has been emitted and is pending ack or fail

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryService.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutRetryService.java
@@ -54,6 +54,7 @@ public interface KafkaSpoutRetryService extends Serializable {
     boolean retainAll(Collection<TopicPartition> topicPartitions);
 
     /**
+     * Gets the earliest retriable offsets.
      * @return The earliest retriable offset for each TopicPartition that has
      *     offsets ready to be retried, i.e. for which a tuple has failed
      *     and has retry time less than current time.

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/RecordTranslator.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/RecordTranslator.java
@@ -32,7 +32,7 @@ public interface RecordTranslator<K, V> extends Serializable, Func<ConsumerRecor
     public static final List<String> DEFAULT_STREAM = Collections.singletonList("default");
     
     /**
-     * Translate the ConsumerRecord into a list of objects that can be emitted
+     * Translate the ConsumerRecord into a list of objects that can be emitted.
      * @param record the record to translate
      * @return the objects in the tuple.  Return a {@link KafkaTuple}
      *     if you want to route the tuple to a non-default stream.

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/subscription/ManualPartitioner.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/subscription/ManualPartitioner.java
@@ -32,7 +32,7 @@ import org.apache.storm.task.TopologyContext;
 @FunctionalInterface
 public interface ManualPartitioner extends Serializable {
     /**
-     * Get the partitions for this assignment
+     * Get the partitions for this assignment.
      * @param allPartitions all of the partitions that the set of spouts want to subscribe to, in a strict ordering
      * @param context the context of the topology
      * @return the subset of the partitions that this spout should use.

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/subscription/Subscription.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/subscription/Subscription.java
@@ -40,6 +40,7 @@ public abstract class Subscription implements Serializable {
     public abstract <K, V> void subscribe(KafkaConsumer<K,V> consumer, ConsumerRebalanceListener listener, TopologyContext context);
     
     /**
+     * Get the topics string.
      * @return A human-readable string representing the subscribed topics.
      */
     public abstract String getTopicsString();

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/subscription/TopicFilter.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/subscription/TopicFilter.java
@@ -31,6 +31,7 @@ public interface TopicFilter extends Serializable {
     List<TopicPartition> getFilteredTopicPartitions(KafkaConsumer<?, ?> consumer);
     
     /**
+     * Get the topics string.
      * @return A human-readable string representing the topics that pass the filter.
      */
     String getTopicsString();

--- a/external/storm-mqtt/pom.xml
+++ b/external/storm-mqtt/pom.xml
@@ -105,7 +105,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven-surefire.version}</version>
                 <configuration>
                     <forkMode>perTest</forkMode>
                     <enableAssertions>false</enableAssertions>

--- a/external/storm-opentsdb/pom.xml
+++ b/external/storm-opentsdb/pom.xml
@@ -102,7 +102,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>94</maxAllowedViolations>
+                    <maxAllowedViolations>99</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/external/storm-pmml/pom.xml
+++ b/external/storm-pmml/pom.xml
@@ -81,7 +81,7 @@
                 <!--Note - the version would be inherited-->
                 <configuration>
 
-                    <maxAllowedViolations>65</maxAllowedViolations>
+                    <maxAllowedViolations>67</maxAllowedViolations>
                 </configuration>
             </plugin>
         </plugins>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -38,6 +38,7 @@
         <regression.downloadWorkerLogs>false</regression.downloadWorkerLogs>
         <storm.conf.dir>/etc/storm/conf</storm.conf.dir>
         <hadoop.conf.dir>/etc/hadoop/conf</hadoop.conf.dir>
+        <skipTests>true</skipTests>
     </properties>
 
     <profiles>
@@ -88,49 +89,12 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>src/main/java</sourceDirectory>
-        <testSourceDirectory>src/test/java</testSourceDirectory>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.4.1</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
+                <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
 
@@ -138,6 +102,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <skipTests>${skipTests}</skipTests>
                     <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
                     <argLine>-Xmx1024m</argLine>
                     <properties>

--- a/integration-test/run-it.sh
+++ b/integration-test/run-it.sh
@@ -86,4 +86,4 @@ for i in {1..20} ; do
     sleep 6
 done
 list_storm_processes
-mvn test -DfailIfNoTests=false -Dstorm.version=${STORM_VERSION} -Dui.url=http://localhost:8744
+mvn test -DfailIfNoTests=false -DskipTests=false -Dstorm.version=${STORM_VERSION} -Dui.url=http://localhost:8744

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>10</version>
+        <version>18</version>
     </parent>
 
 
@@ -298,7 +298,6 @@
         <rocketmq.version>4.0.0-incubating</rocketmq.version>
 
         <jackson.version>2.6.3</jackson.version>
-        <maven-surefire.version>2.18.1</maven-surefire.version>
         <!-- Kafka version used by old storm-kafka spout code -->
         <storm.kafka.version>0.8.2.2</storm.kafka.version>
         <storm.kafka.artifact.id>kafka_2.10</storm.kafka.artifact.id>
@@ -367,10 +366,11 @@
         <module>external/storm-jms</module>
         <module>external/storm-pmml</module>
         <module>external/storm-rocketmq</module>
+        <module>integration-test</module>
 
         <!-- examples -->
         <module>examples/storm-starter</module>
-	<module>examples/storm-loadgen</module>
+        <module>examples/storm-loadgen</module>
         <module>examples/storm-mongodb-examples</module>
         <module>examples/storm-redis-examples</module>
         <module>examples/storm-opentsdb-examples</module>
@@ -552,7 +552,7 @@
                             <execution>
                                 <id>attach-sources</id>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -568,7 +568,7 @@
                             <execution>
                                 <id>attach-javadocs</id>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
                             <execution>
@@ -1104,7 +1104,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire.version}</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <excludedGroups>${java.unit.test.exclude}</excludedGroups>
@@ -1117,7 +1117,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>${maven-surefire.version}</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <includes>
                             <include>${java.integration.test.include}</include>
@@ -1150,7 +1150,7 @@
                             <artifactId>checkstyle</artifactId>
                             <!-- If you change this, you should also update the storm_checkstyle.xml file to be
                             based on the google_checks.xml from the version of checkstyle you are choosing. -->
-                            <version>7.7</version>
+                            <version>8.2</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -1193,41 +1193,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.2.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-                <plugin>
                     <groupId>com.theoryinpractise</groupId>
                     <artifactId>clojure-maven-plugin</artifactId>
                     <version>1.7.1</version>
@@ -1235,29 +1200,8 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>2.16</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>2.4.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/sql/storm-sql-core/pom.xml
+++ b/sql/storm-sql-core/pom.xml
@@ -170,7 +170,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>1283</maxAllowedViolations>
+                    <maxAllowedViolations>1286</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-checkstyle/src/main/resources/storm/storm_checkstyle.xml
+++ b/storm-checkstyle/src/main/resources/storm/storm_checkstyle.xml
@@ -19,7 +19,7 @@
 
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <!--
     The original file came from here:
@@ -87,9 +87,7 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="140"/>
-        </module>
+        <module name="LeftCurly"/>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
             <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
@@ -127,6 +125,18 @@
         <module name="SeparatorWrap">
             <property name="id" value="SeparatorWrapComma"/>
             <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/258 -->
+            <property name="id" value="SeparatorWrapEllipsis"/>
+            <property name="tokens" value="ELLIPSIS"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/259 -->
+            <property name="id" value="SeparatorWrapArrayDeclarator"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
             <property name="option" value="EOL"/>
         </module>
         <module name="SeparatorWrap">

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -136,7 +136,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>3584</maxAllowedViolations>
+                    <maxAllowedViolations>3626</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-webapp/pom.xml
+++ b/storm-webapp/pom.xml
@@ -143,7 +143,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>4</maxAllowedViolations>
+                    <maxAllowedViolations>8</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
…ttach storm-integration-test as a module. Fix other minor issues with the POMs.

https://issues.apache.org/jira/browse/STORM-2734

Changes:
* Upgrade Checkstyle to latest version, update storm checkstyle to be based on the latest google.xml. It seems like Checkstyle got a little better at finding instances of missing Javadoc, hence the extra violations.
* Update to latest Apache parent POM. This is to resolve an issue breaking the release:prepare goal (or any build running with -Papache-release), where maven-sources-plugin:jar causes some lifecycle phases to run multiple times. For most modules this is not a problem, but storm-sql-core ends up running checkstyle (validate phase) twice per project. The second execution includes generated files in the sources directory, which causes a stack overflow in checkstyle. The latest Apache parent uses maven-sources-plugin:jar-no-fork which doesn't repeat lifecycle phases. More here http://blog.peterlynch.ca/2010/05/maven-how-to-prevent-generate-sources.html
* Remove pluginmanagement plugins also set in Apache parent POM.
* Add integration-test as a module, make it skip tests when run normally, and skip deploy during release. This way the version will be kept in sync with the rest of Storm.
* Calcite-core was declared in multiple versions in storm-hive, one compile scope, one test scope. I made it use the calcite version from the root pom.
* Fix new checkstyle violations in storm-kafka-client.