### PR TITLE
STORM-2733: Better load aware shuffle implementation

### DIFF
--- a/examples/storm-loadgen/README.md
+++ b/examples/storm-loadgen/README.md
@@ -47,6 +47,7 @@ storm jar storm-loadgen.jar org.apache.storm.loadgen.GenLoad [options] [capture_
 | -t,--test-time &lt;MINS> | How long to run the tests for in mins (defaults to 5) |
 | --throughput &lt;MULTIPLIER(:TOPO:COMP)?> | How much to scale the topology up or down in throughput. If a topology + component is supplied only that component will be scaled. If topo or component is blank or a `'*'` all topologies or components matched will be scaled. Only 1 scaling rule, the most specific, will be applied to a component. Providing a topology name is considered more specific than not providing one.(defaults to 1.0 no scaling)|
 | -w,--report-window &lt;INTERVAL_SECS> | How long of a rolling window should be in each report.  Will be rounded up to the next report interval boundary. default 30|
+| --imbalance &lt;MS(:COUNT)?:TOPO:COMP> | The number of ms that the first COUNT of TOPO:COMP will wait before processing.  This creates an imbalance that helps test load aware groupings. By default there is no imbalance unless specificed by the captrue file. |
 
 ## ThroughputVsLatency
 A word count topology with metrics reporting like the `GenLoad` command.
@@ -68,6 +69,7 @@ storm jar storm-loadgen.jar org.apache.storm.loadgen.ThroughputVsLatency [option
 | --spouts &lt;NUM>| Number of spouts to use (defaults to 1) |
 | -t,--test-time &lt;MINS>| How long to run the tests for in mins (defaults to 5) |
 | -w,--report-window &lt;INTERVAL_SECS>| How long of a rolling window should be in each report.  Will be rounded up to the next report interval boundary.|
+| --splitter-imbalance &lt;MS(:COUNT)?> | The number of ms that the first COUNT splitters will wait before processing.  This creates an imbalance that helps test load aware groupings (defaults to 0:1)|
 
 # Reporters
 Reporters provide a way to store various statistics about a running topology. There are currently a few supported reporters
@@ -140,6 +142,7 @@ There are a lot of different metrics supported
 |throughput_adjust| The adjustment to the throughput in `GenLoad`. | GenLoad
 |topo_throughput| A list of topology/component specific adjustment rules to the throughput in `GenLoad`. | GenLoad
 |local\_or\_shuffle| true if shuffles were replaced with local or shuffle in GenLoad. | GenLoad
+|slow\_execs| A list of topology/component specific adjustment rules to the slowExecutorPattern in `GenLoad`. | GenLoad
 
 There are also some generic rules that you can use for some metrics.  Any metric that starts with `"conf:"` will be the config for that.  It does not include config overrides from the `GenLoad` file.
 
@@ -170,6 +173,8 @@ Spouts and bolts have the same format.
 | streams | The streams that are produced by this bolt or spout |
 | cpuLoad | The number of cores this component needs for resource aware scheduling |
 | memoryLoad | The amount of memory in MB that this component needs for resource aware scheduling |
+| slowExecutorPattern.slownessMs | an Optional number of ms to slow down the exec + process latency for some of this component (defaults to 0) |
+| slowExecutorPattern.count | the number of components to slow down (defaults to 1) | 
 
 ### Output Streams
 

--- a/examples/storm-loadgen/pom.xml
+++ b/examples/storm-loadgen/pom.xml
@@ -114,7 +114,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>maven-checkstyle-plugin</artifactId>
         <!--Note - the version would be inherited-->
         <configuration>
-          <maxAllowedViolations>3</maxAllowedViolations>
+          <maxAllowedViolations>0</maxAllowedViolations>
         </configuration>
       </plugin>
     </plugins>

--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/ExecAndProcessLatencyEngine.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/ExecAndProcessLatencyEngine.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.loadgen;
+
+import java.io.Serializable;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * A more accurate sleep implementation.
+ */
+public class ExecAndProcessLatencyEngine implements Serializable {
+    private static final long NANO_IN_MS = TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS);
+    private final SlowExecutorPattern skewedPattern;
+
+    public static long toNano(double ms) {
+        return (long)(ms * NANO_IN_MS);
+    }
+
+    private final AtomicLong parkOffset = new AtomicLong(0);
+    private Random rand;
+    private ScheduledExecutorService timer;
+
+    public ExecAndProcessLatencyEngine() {
+        this(null);
+    }
+
+    public ExecAndProcessLatencyEngine(SlowExecutorPattern skewedPattern) {
+        this.skewedPattern = skewedPattern;
+    }
+
+    public void prepare() {
+        this.rand = ThreadLocalRandom.current();
+        this.timer = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    /**
+     * Sleep for a set number of nano seconds.
+     * @param start the start time of the sleep
+     * @param sleepAmount how many nano seconds after start when we should stop.
+     */
+    public void sleepNano(long start, long sleepAmount) {
+        long endTime = start + sleepAmount;
+        // A small control algorithm to adjust the amount of time that we sleep to make it more accurate
+        long newEnd = endTime - parkOffset.get();
+        long diff = newEnd - start;
+        //There are some different levels of accuracy here, and we want to deal with all of them
+        if (diff <= 1_000) {
+            //We are done, nothing that short is going to work here
+        } else if (diff < NANO_IN_MS) {
+            //Busy wait...
+            long sum = 0;
+            while (System.nanoTime() < newEnd) {
+                for (long i = 0; i < 1_000_000; i++) {
+                    sum += i;
+                }
+            }
+        } else {
+            //More accurate that thread.sleep, but still not great
+            LockSupport.parkNanos(newEnd - System.nanoTime());
+        }
+        parkOffset.addAndGet((System.nanoTime() - endTime) / 2);
+    }
+
+    public void sleepNano(long nano) {
+        sleepNano(System.nanoTime(), nano);
+    }
+
+    public void sleepUntilNano(long endTime) {
+        long start = System.nanoTime();
+        sleepNano(start, endTime - start);
+    }
+
+    /**
+     * Simulate both process and exec times.
+     * @param executorIndex the index of this executor.  It is used to skew the latencies.
+     * @param startTimeNs when the executor started in nano-seconds.
+     * @param in the metrics for the input stream (or null if you don't want to use them).
+     * @param r what to run when the process latency is up.  Note that this may run on a separate thread after this method call has
+     *     completed.
+     */
+    public void simulateProcessAndExecTime(int executorIndex, long startTimeNs, InputStream in, Runnable r) {
+        long extraTimeNs = skewedPattern == null ? 0 : toNano(skewedPattern.getExtraSlowness(executorIndex));
+        long endExecNs = startTimeNs + extraTimeNs + (in == null ? 0 : ExecAndProcessLatencyEngine.toNano(in.execTime.nextRandom(rand)));
+        long endProcNs = startTimeNs + extraTimeNs + (in == null ? 0 : ExecAndProcessLatencyEngine.toNano(in.processTime.nextRandom(rand)));
+
+        if ((endProcNs - 1_000_000) < endExecNs) {
+            sleepUntilNano(endProcNs);
+            r.run();
+        } else {
+            timer.schedule(() -> {
+                r.run();
+            }, Math.max(0, endProcNs - System.nanoTime()), TimeUnit.NANOSECONDS);
+        }
+
+        sleepUntilNano(endExecNs);
+    }
+}

--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/LoadMetricsServer.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/LoadMetricsServer.java
@@ -586,7 +586,7 @@ public class LoadMetricsServer extends HttpForwardingMetricsServer {
     }
 
 
-    static class FixedWidthReporter extends  ColumnsFileReporter {
+    static class FixedWidthReporter extends ColumnsFileReporter {
         public final String longFormat;
         public final String stringFormat;
 
@@ -649,7 +649,7 @@ public class LoadMetricsServer extends HttpForwardingMetricsServer {
         }
     }
 
-    static class SepValReporter extends  ColumnsFileReporter {
+    static class SepValReporter extends ColumnsFileReporter {
         private final String separator;
 
         public SepValReporter(String separator, String path, Map<String, String> query, Map<String, MetricExtractor> extractorsMap)

--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/NormalDistStats.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/NormalDistStats.java
@@ -123,7 +123,7 @@ public class NormalDistStats implements Serializable {
     }
 
     /**
-     * Generate a random number that follows the statistical distribution
+     * Generate a random number that follows the statistical distribution.
      * @param rand the random number generator to use
      * @return the next number that should follow the statistical distribution.
      */

--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/OutputStream.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/OutputStream.java
@@ -105,7 +105,7 @@ public class OutputStream implements Serializable {
     }
 
     /**
-     * Create a new stream with stats
+     * Create a new stream with stats.
      * @param id the id of the stream
      * @param rate the rate of tuples being emitted on this stream
      * @param areKeysSkewed true if keys are skewed else false.  For skewed keys

--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/SlowExecutorPattern.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/SlowExecutorPattern.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.loadgen;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.storm.utils.ObjectReader;
+
+/**
+ * A repeating pattern of skewedness in processing times.  This is used to simulate an executor that slows down.
+ */
+public class SlowExecutorPattern implements Serializable {
+    private static final Pattern PARSER = Pattern.compile("\\s*(?<slowness>[^:]+)\\s*(?::\\s*(?<count>[0-9]+))?\\s*");
+    public final double maxSlownessMs;
+    public final int count;
+
+    /**
+     * Parses a string (command line) representation of "&lt;SLOWNESS&gt;(:&lt;COUNT&gt;)?".
+     * @param strRepresentation the string representation to parse
+     * @return the corresponding SlowExecutorPattern.
+     */
+    public static SlowExecutorPattern fromString(String strRepresentation) {
+        Matcher m = PARSER.matcher(strRepresentation);
+        if (!m.matches()) {
+            throw new IllegalArgumentException(strRepresentation + " is not in the form <SLOWNESS>(:<COUNT>)?");
+        }
+        double slownessMs = Double.valueOf(m.group("slowness"));
+        String c = m.group("count");
+        int count = c == null ? 1 : Integer.valueOf(c);
+        return new SlowExecutorPattern(slownessMs, count);
+    }
+
+    /**
+     * Creates a SlowExecutorPattern from a Map config.
+     * @param conf the conf to parse.
+     * @return the corresponding SlowExecutorPattern.
+     */
+    public static SlowExecutorPattern fromConf(Map<String, Object> conf) {
+        double slowness = ObjectReader.getDouble(conf.get("slownessMs"), 0.0);
+        int count = ObjectReader.getInt(conf.get("count"), 1);
+        return new SlowExecutorPattern(slowness, count);
+    }
+
+    /**
+     * Convert this to a Config map.
+     * @return the corresponding Config map to this.
+     */
+    public Map<String, Object> toConf() {
+        Map<String, Object> ret = new HashMap<>();
+        ret.put("slownessMs", maxSlownessMs);
+        ret.put("count", count);
+        return ret;
+    }
+
+    public SlowExecutorPattern(double maxSlownessMs, int count) {
+        this.count = count;
+        this.maxSlownessMs = maxSlownessMs;
+    }
+
+    public double getExtraSlowness(int index) {
+        return (index >= count) ? 0 : maxSlownessMs;
+    }
+
+}

--- a/storm-client/src/jvm/org/apache/storm/daemon/Task.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/Task.java
@@ -62,7 +62,6 @@ public class Task {
     private TopologyContext systemTopologyContext;
     private TopologyContext userTopologyContext;
     private WorkerTopologyContext workerTopologyContext;
-    private LoadMapping loadMapping;
     private Integer taskId;
     private String componentId;
     private Object taskObject; // Spout/Bolt object
@@ -84,7 +83,6 @@ public class Task {
         this.builtInMetrics = BuiltinMetricsUtil.mkData(executor.getType(), this.executorStats);
         this.workerTopologyContext = executor.getWorkerTopologyContext();
         this.emitSampler = ConfigUtils.mkStatsSampler(topoConf);
-        this.loadMapping = workerData.getLoadMapping();
         this.systemTopologyContext = mkTopologyContext(workerData.getSystemTopology());
         this.userTopologyContext = mkTopologyContext(workerData.getTopology());
         this.taskObject = mkTaskObject();

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -286,7 +286,7 @@ public class Worker implements Shutdownable, DaemonCommon {
     }
 
     public void doRefreshLoad() {
-        workerState.refreshLoad();
+        workerState.refreshLoad(executorsAtom.get());
 
         final List<IRunningExecutor> executors = executorsAtom.get();
         for (IRunningExecutor executor : executors) {

--- a/storm-client/src/jvm/org/apache/storm/executor/ExecutorShutdown.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/ExecutorShutdown.java
@@ -31,6 +31,7 @@ import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.AddressedTuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.DisruptorQueue;
 import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,11 +45,16 @@ public class ExecutorShutdown implements Shutdownable, IRunningExecutor {
     private final Executor executor;
     private final List<Utils.SmartThread> threads;
     private final Map<Integer, Task> taskDatas;
+    private final DisruptorQueue receiveQueue;
+    private final DisruptorQueue sendQueue;
 
-    public ExecutorShutdown(Executor executor, List<Utils.SmartThread> threads, Map<Integer, Task> taskDatas) {
+    public ExecutorShutdown(Executor executor, List<Utils.SmartThread> threads, Map<Integer, Task> taskDatas,
+                            DisruptorQueue receiveQueue, DisruptorQueue sendQueue) {
         this.executor = executor;
         this.threads = threads;
         this.taskDatas = taskDatas;
+        this.receiveQueue = receiveQueue;
+        this.sendQueue = sendQueue;
     }
 
     @Override
@@ -77,6 +83,16 @@ public class ExecutorShutdown implements Shutdownable, IRunningExecutor {
     @Override
     public boolean getBackPressureFlag() {
         return executor.getBackpressure();
+    }
+
+    @Override
+    public DisruptorQueue getReceiveQueue() {
+        return receiveQueue;
+    }
+
+    @Override
+    public DisruptorQueue getSendQueue() {
+        return sendQueue;
     }
 
     @Override

--- a/storm-client/src/jvm/org/apache/storm/executor/IRunningExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/IRunningExecutor.java
@@ -22,6 +22,7 @@ import org.apache.storm.generated.ExecutorStats;
 import org.apache.storm.grouping.LoadMapping;
 
 import java.util.List;
+import org.apache.storm.utils.DisruptorQueue;
 
 public interface IRunningExecutor {
 
@@ -30,4 +31,6 @@ public interface IRunningExecutor {
     void credentialsChanged(Credentials credentials);
     void loadChanged(LoadMapping loadMapping);
     boolean getBackPressureFlag();
+    DisruptorQueue getReceiveQueue();
+    DisruptorQueue getSendQueue();
 }

--- a/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
@@ -70,7 +70,7 @@ public class BoltExecutor extends Executor {
                 ((ICredentialsListener) boltObject).setCredentials(credentials);
             }
             if (Constants.SYSTEM_COMPONENT_ID.equals(componentId)) {
-                Map<String, DisruptorQueue> map = ImmutableMap.of("sendqueue", transferQueue, "receive", receiveQueue,
+                Map<String, DisruptorQueue> map = ImmutableMap.of("sendqueue", sendQueue, "receive", receiveQueue,
                         "transfer", workerData.getTransferQueue());
                 BuiltinMetricsUtil.registerQueueMetrics(map, topoConf, userContext);
 
@@ -78,7 +78,7 @@ public class BoltExecutor extends Executor {
                 BuiltinMetricsUtil.registerIconnectionClientMetrics(cachedNodePortToSocket, topoConf, userContext);
                 BuiltinMetricsUtil.registerIconnectionServerMetric(workerData.getReceiver(), topoConf, userContext);
             } else {
-                Map<String, DisruptorQueue> map = ImmutableMap.of("sendqueue", transferQueue, "receive", receiveQueue);
+                Map<String, DisruptorQueue> map = ImmutableMap.of("sendqueue", sendQueue, "receive", receiveQueue);
                 BuiltinMetricsUtil.registerQueueMetrics(map, topoConf, userContext);
             }
 

--- a/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
@@ -118,7 +118,7 @@ public class SpoutExecutor extends Executor {
             this.outputCollectors.add(outputCollector);
 
             taskData.getBuiltInMetrics().registerAll(topoConf, taskData.getUserContext());
-            Map<String, DisruptorQueue> map = ImmutableMap.of("sendqueue", transferQueue, "receive", receiveQueue);
+            Map<String, DisruptorQueue> map = ImmutableMap.of("sendqueue", sendQueue, "receive", receiveQueue);
             BuiltinMetricsUtil.registerQueueMetrics(map, topoConf, taskData.getUserContext());
 
             if (spoutObject instanceof ICredentialsListener) {
@@ -152,7 +152,7 @@ public class SpoutExecutor extends Executor {
                             spout.activate();
                         }
                     }
-                    if (!transferQueue.isFull() && !throttleOn && !reachedMaxSpoutPending) {
+                    if (!sendQueue.isFull() && !throttleOn && !reachedMaxSpoutPending) {
                         for (ISpout spout : spouts) {
                             spout.nextTuple();
                         }


### PR DESCRIPTION
I have run several tests that show this works much better at big imbalances in processing latency than did the previous shuffle implementations.

I ran some simple performance tests and because `chooseTasks` didn't change the performance was more or less identical to what was here before.

The plan on how this would work with STORM-2686 (adding distance to shuffle) is that we would have 4 different weights (worker local, node local, rack local, and everywhere).  Each time we update the load we update all of the weights, for the min load currently in the locality group.  This is because executors may move from one group to another as things are rescheduled, so we need a way to keep it consistent.  

We can then test a few different ways of selecting the group we want to target.  Currently we are thinking we will select the most local group that has a maximum load < .5 falling back to everything if we cannot find one.