### PR TITLE
[STORM-2730] Add in config options for acker cpu and memory

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -227,6 +227,28 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_COMPONENT_CPU_PCORE_PERCENT = "topology.component.cpu.pcore.percent";
 
     /**
+     * The maximum amount of memory an instance of an acker will take on heap. This enables the scheduler
+     * to allocate slots on machines with enough available memory.  A default value will be set for this config if user does not override
+     */
+    @isPositiveNumber(includeZero = true)
+    public static final String TOPOLOGY_ACKER_RESOURCES_ONHEAP_MEMORY_MB = "topology.acker.resources.onheap.memory.mb";
+
+    /**
+     * The maximum amount of memory an instance of an acker will take off heap. This enables the scheduler
+     * to allocate slots on machines with enough available memory.  A default value will be set for this config if user does not override
+     */
+    @isPositiveNumber(includeZero = true)
+    public static final String TOPOLOGY_ACKER_RESOURCES_OFFHEAP_MEMORY_MB = "topology.acker.resources.offheap.memory.mb";
+
+    /**
+     * The config indicates the percentage of cpu for a core an instance(executor) of an acker will use.
+     * Assuming the a core value to be 100, a value of 10 indicates 10% of the core.
+     * The P in PCORE represents the term "physical".  A default value will be set for this config if user does not override
+     */
+    @isPositiveNumber(includeZero = true)
+    public static final String TOPOLOGY_ACKER_CPU_PCORE_PERCENT = "topology.acker.cpu.pcore.percent";
+
+    /**
      * The class name of the {@link org.apache.storm.state.StateProvider} implementation. If not specified
      * defaults to {@link org.apache.storm.state.InMemoryKeyValueStateProvider}. This can be overridden
      * at the component level.


### PR DESCRIPTION
[JIRA-STORM-2730](https://issues.apache.org/jira/browse/STORM-2730)
 
Add config options for acker cpu and memory.

A test:
Config: 
 `topology.acker.resources.onheap.memory.mb: 100` `topology.component.resources.onheap.memory.mb: 128` 

![image](https://user-images.githubusercontent.com/14900612/30344935-d755b68c-97c8-11e7-9463-5f2110d86aa2.png)
