### PR TITLE
[STORM-2738] The number of ackers should default to the number of actual running workers on RAS cluster

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -1501,4 +1501,12 @@ public class Utils {
     public static boolean isLocalhostAddress(String address) {
         return LOCALHOST_ADDRESSES.contains(address);
     }
+
+    public static <K, V> Map<K, V> merge(Map<? extends K, ? extends V> first, Map<? extends K, ? extends V> other) {
+        Map<K, V> ret = new HashMap<>(first);
+        if (other != null) {
+            ret.putAll(other);
+        }
+        return ret;
+    }
 }


### PR DESCRIPTION
**Problem**:
If `topology.acker.executors` is not set, the number of ackers will be equal to `topology.workers`. But on RAS cluster, we don't set `topology.workers` because the number of workers will be determined by the scheduler. So in this case, the number of ackers will always be 1.
For example, there are 5 workers but only 1 acker.
![image](https://user-images.githubusercontent.com/14900612/30453805-bc75493e-995f-11e7-8fd9-d17616620344.png)

**Analysis**:
The number of ackers has to be computed before scheduling happens, so it knows how to schedule the topology. The number of workers is not set until the topology is scheduled, so it is a bit of a chicken and egg problem.
**Solution**:
We could probably use the total amount of requested memory when the topology is submitted divided by the memory per worker to get an estimate that is better than 1.


JIRA at https://issues.apache.org/jira/browse/STORM-2738
