### PR TITLE
Quick fix: report cassandra error messages to logger

### DIFF
--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/trident/state/CassandraState.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/trident/state/CassandraState.java
@@ -149,7 +149,7 @@ public class CassandraState implements State {
                 }
             }
         } catch (Exception e) {
-            LOG.warn("Batch retrieve operation is failed.");
+            LOG.warn("Batch retrieve operation is failed", e);
             throw new FailedException(e);
         }
         return batchRetrieveResult;


### PR DESCRIPTION
`CassandraState::batchRetrieve` does not report specific error messages when binding values or retrieving results goes wrong.

I think we should make exception message available to log in order to make debugging easier. Thank you.