### PR TITLE
STORM-2750：fix HBaseSecurityUtil double_checked locking

### DIFF
--- a/external/storm-autocreds/src/main/java/org/apache/storm/hbase/security/HBaseSecurityUtil.java
+++ b/external/storm-autocreds/src/main/java/org/apache/storm/hbase/security/HBaseSecurityUtil.java
@@ -45,7 +45,7 @@ public class HBaseSecurityUtil {
     public static final String HBASE_KEYTAB_FILE_KEY = "hbase.keytab.file";
     public static final String HBASE_PRINCIPAL_KEY = "hbase.kerberos.principal";
 
-    private static UserProvider legacyProvider = null;
+    private static volatile UserProvider legacyProvider = null;
 
     private HBaseSecurityUtil() {
     }

--- a/external/storm-autocreds/src/main/java/org/apache/storm/hbase/security/HBaseSecurityUtil.java
+++ b/external/storm-autocreds/src/main/java/org/apache/storm/hbase/security/HBaseSecurityUtil.java
@@ -45,7 +45,7 @@ public class HBaseSecurityUtil {
     public static final String HBASE_KEYTAB_FILE_KEY = "hbase.keytab.file";
     public static final String HBASE_PRINCIPAL_KEY = "hbase.kerberos.principal";
 
-    private static volatile UserProvider legacyProvider = null;
+    private static volatile  UserProvider legacyProvider = null;
 
     private HBaseSecurityUtil() {
     }


### PR DESCRIPTION
update HBaseSecurityUtil singleton to fix double_checked locking.
See url link for details: http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html
