### PR TITLE
[STORM2751] Removing AsyncLoggerContext from Supervisor Configuration

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -739,7 +739,6 @@ def supervisor(klass="org.apache.storm.daemon.supervisor.Supervisor"):
     cppaths = [CLUSTER_CONF_DIR]
     jvmopts = parse_args(confvalue("supervisor.childopts", cppaths)) + [
         "-Dlogfile.name=" + STORM_SUPERVISOR_LOG_FILE,
-        "-DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector",
         "-Dlog4j.configurationFile=" + os.path.join(get_log4j2_conf_dir(), "cluster.xml"),
     ]
     exec_storm_class(


### PR DESCRIPTION
If disk can not keep it up with all logging, the {{AsyncLoggingContext}} causes large heap memory be utilized causing the JVM to churn CPU.
