### PR TITLE
[STORM-2744] add in restart timeout for backpressure

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -190,6 +190,8 @@ task.backpressure.poll.secs: 30
 topology.backpressure.enable: false
 backpressure.disruptor.high.watermark: 0.9
 backpressure.disruptor.low.watermark: 0.4
+backpressure.znode.timeout.secs: 30
+backpressure.znode.update.freq.secs: 15
 
 zmq.threads: 1
 zmq.linger.millis: 5000

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -129,6 +129,23 @@ public class Config extends HashMap<String, Object> {
     public static final String BACKPRESSURE_DISRUPTOR_LOW_WATERMARK="backpressure.disruptor.low.watermark";
 
     /**
+     * How long until the backpressure znode is invalid.
+     * It's measured by the data (timestamp) of the znode, not the ctime (creation time) or mtime (modification time), etc.
+     * This must be larger than BACKPRESSURE_ZNODE_UPDATE_FREQ_SECS.
+     */
+    @isInteger
+    @isPositiveNumber
+    public static final String BACKPRESSURE_ZNODE_TIMEOUT_SECS = "backpressure.znode.timeout.secs";
+
+    /**
+     * How often will the data (timestamp) of backpressure znode be updated.
+     * But if the worker backpressure status (on/off) changes, the znode will be updated anyway.
+     */
+    @isInteger
+    @isPositiveNumber
+    public static final String BACKPRESSURE_ZNODE_UPDATE_FREQ_SECS = "backpressure.znode.update.freq.secs";
+
+    /**
      * A list of users that are allowed to interact with the topology.  To use this set
      * nimbus.authorizer to org.apache.storm.security.auth.authorizer.SimpleACLAuthorizer
      */

--- a/storm-client/src/jvm/org/apache/storm/cluster/ClusterUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/ClusterUtils.java
@@ -144,6 +144,16 @@ public class ClusterUtils {
         return backpressureStormRoot(stormId) + ZK_SEPERATOR + node + "-" + port;
     }
 
+    /**
+     * Get the backpressure znode full path.
+     * @param stormId The topology id
+     * @param shortPath A string in the form of "node-port"
+     * @return The backpressure znode path
+     */
+    public static String backpressurePath(String stormId, String shortPath) {
+        return backpressureStormRoot(stormId) + ZK_SEPERATOR + shortPath;
+    }
+
     public static String errorStormRoot(String stormId) {
         return ERRORS_SUBTREE + ZK_SEPERATOR + stormId;
     }

--- a/storm-client/src/jvm/org/apache/storm/cluster/IStormClusterState.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/IStormClusterState.java
@@ -99,7 +99,7 @@ public interface IStormClusterState {
 
     public void supervisorHeartbeat(String supervisorId, SupervisorInfo info);
 
-    public void workerBackpressure(String stormId, String node, Long port, boolean on);
+    public void workerBackpressure(String stormId, String node, Long port, long timestamp);
 
     public boolean topologyBackpressure(String stormId, Runnable callback);
 

--- a/storm-client/src/jvm/org/apache/storm/cluster/IStormClusterState.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/IStormClusterState.java
@@ -101,7 +101,7 @@ public interface IStormClusterState {
 
     public void workerBackpressure(String stormId, String node, Long port, long timestamp);
 
-    public boolean topologyBackpressure(String stormId, Runnable callback);
+    public boolean topologyBackpressure(String stormId, long timeoutMs, Runnable callback);
 
     public void setupBackpressure(String stormId);
 

--- a/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
@@ -32,6 +32,7 @@ import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -423,24 +424,26 @@ public class StormClusterStateImpl implements IStormClusterState {
     }
 
     /**
-     * if znode exists and to be not on?, delete; if exists and on?, do nothing; if not exists and to be on?, create; if not exists and not on?, do nothing;
+     * if znode exists and timestamp is 0?, delete; if exists and timestamp is larger than 0?, do nothing;
+     * if not exists and timestamp is larger than 0?, create the node and set the timestamp; if not exists and timestamp is 0?, do nothing;
      * 
      * @param stormId
      * @param node
      * @param port
-     * @param on
+     * @param timestamp
      */
     @Override
-    public void workerBackpressure(String stormId, String node, Long port, boolean on) {
+    public void workerBackpressure(String stormId, String node, Long port, long timestamp) {
         String path = ClusterUtils.backpressurePath(stormId, node, port);
         boolean existed = stateStorage.node_exists(path, false);
         if (existed) {
-            if (on == false)
+            if (timestamp == 0) {
                 stateStorage.delete_node(path);
-
+            }
         } else {
-            if (on == true) {
-                stateStorage.set_ephemeral_node(path, null, acls);
+            if (timestamp > 0) {
+                byte[] data = ByteBuffer.allocate(Long.BYTES).putLong(timestamp).array();
+                stateStorage.set_ephemeral_node(path, data, acls);
             }
         }
     }
@@ -448,7 +451,8 @@ public class StormClusterStateImpl implements IStormClusterState {
     /**
      * Check whether a topology is in throttle-on status or not:
      * if the backpresure/storm-id dir is not empty, this topology has throttle-on, otherwise throttle-off.
-     * 
+     * But if the backpresure/storm-id dir is not empty and has not been updated for more than 30s, we treat it as throttle-off.
+     * This will prevent the spouts from getting stuck indefinitely if something wrong happens.
      * @param stormId
      * @param callback
      * @return
@@ -459,14 +463,15 @@ public class StormClusterStateImpl implements IStormClusterState {
             backPressureCallback.put(stormId, callback);
         }
         String path = ClusterUtils.backpressureStormRoot(stormId);
-        List<String> childrens = null;
+        long mostRecentTimestamp = 0;
         if(stateStorage.node_exists(path, false)) {
-            childrens = stateStorage.get_children(path, callback != null);
-        } else {
-            childrens = new ArrayList<>();
+            List<String> children = stateStorage.get_children(path, callback != null);
+            mostRecentTimestamp = children.stream().map(childPath -> stateStorage.get_data(ClusterUtils.backpressurePath(stormId, childPath), false))
+                    .filter(data -> data != null).mapToLong(data -> ByteBuffer.wrap(data).getLong()).max().orElse(0);
         }
-        return childrens.size() > 0;
-
+        boolean ret =  ((System.currentTimeMillis() - mostRecentTimestamp) < 30000);
+        LOG.debug("topology backpressure is {}", ret ? "on" : "off");
+        return ret;
     }
 
     @Override

--- a/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
@@ -424,21 +424,21 @@ public class StormClusterStateImpl implements IStormClusterState {
     }
 
     /**
-     * If znode exists and timestamp is 0, delete;
+     * If znode exists and timestamp is non-positive, delete;
      * if exists and timestamp is larger than 0, update the timestamp;
      * if not exists and timestamp is larger than 0, create the znode and set the timestamp;
-     * if not exists and timestamp is 0, do nothing.
+     * if not exists and timestamp is non-positive, do nothing.
      * @param stormId The topology Id
      * @param node The node id
      * @param port The port number
-     * @param timestamp The backpressure timestamp. 0 means turning off the worker backpressure
+     * @param timestamp The backpressure timestamp. Non-positive means turning off the worker backpressure
      */
     @Override
     public void workerBackpressure(String stormId, String node, Long port, long timestamp) {
         String path = ClusterUtils.backpressurePath(stormId, node, port);
         boolean existed = stateStorage.node_exists(path, false);
         if (existed) {
-            if (timestamp == 0) {
+            if (timestamp <= 0) {
                 stateStorage.delete_node(path);
             } else {
                 byte[] data = ByteBuffer.allocate(Long.BYTES).putLong(timestamp).array();
@@ -478,7 +478,7 @@ public class StormClusterStateImpl implements IStormClusterState {
                     .max()
                     .orElse(0);
         }
-        boolean ret =  ((System.currentTimeMillis() - mostRecentTimestamp) < timeoutMs);
+        boolean ret = ((System.currentTimeMillis() - mostRecentTimestamp) < timeoutMs);
         LOG.debug("topology backpressure is {}", ret ? "on" : "off");
         return ret;
     }

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -211,8 +211,8 @@ public class WorkerState {
     final Map<String, Object> userSharedResources;
     final LoadMapping loadMapping;
     final AtomicReference<Map<String, VersionedData<Assignment>>> assignmentVersions;
-    // Whether this worker is going slow
-    final AtomicBoolean backpressure = new AtomicBoolean(false);
+    // Whether this worker is going slow. 0 indicates the backpressure is off
+    final AtomicLong backpressure = new AtomicLong(0);
     // If the transfer queue is backed-up
     final AtomicBoolean transferBackpressure = new AtomicBoolean(false);
     // a trigger for synchronization with executors

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -213,6 +213,8 @@ public class WorkerState {
     final AtomicReference<Map<String, VersionedData<Assignment>>> assignmentVersions;
     // Whether this worker is going slow. 0 indicates the backpressure is off
     final AtomicLong backpressure = new AtomicLong(0);
+    // How long until the backpressure znode is invalid.
+    final long backpressureZnodeTimeoutMs;
     // If the transfer queue is backed-up
     final AtomicBoolean transferBackpressure = new AtomicBoolean(false);
     // a trigger for synchronization with executors
@@ -298,6 +300,7 @@ public class WorkerState {
         }
         Collections.sort(taskIds);
         this.topologyConf = topologyConf;
+        this.backpressureZnodeTimeoutMs = ObjectReader.getInt(topologyConf.get(Config.BACKPRESSURE_ZNODE_TIMEOUT_SECS)) * 1000;
         this.topology = ConfigUtils.readSupervisorTopology(conf, topologyId, AdvancedFSOps.make(conf));
         this.systemTopology = StormCommon.systemTopology(topologyConf, topology);
         this.taskToComponent = StormCommon.stormTaskInfo(topology, topologyConf);
@@ -333,6 +336,7 @@ public class WorkerState {
             LOG.warn("WILL TRY TO SERIALIZE ALL TUPLES (Turn off {} for production", Config.TOPOLOGY_TESTING_ALWAYS_TRY_SERIALIZE);
         }
         this.drainer = new TransferDrainer();
+
     }
 
     public void refreshConnections() {
@@ -441,7 +445,7 @@ public class WorkerState {
     }
 
     public void refreshThrottle() {
-        boolean backpressure = stormClusterState.topologyBackpressure(topologyId, this::refreshThrottle);
+        boolean backpressure = stormClusterState.topologyBackpressure(topologyId, backpressureZnodeTimeoutMs, this::refreshThrottle);
         this.throttleOn.set(backpressure);
     }
 


### PR DESCRIPTION
[JIRA-STORM-2744](https://issues.apache.org/jira/browse/STORM-2744)

Backpressure mechanism relies on zookeeper to transfer signals. 

If at some point, the topology wants to turn off the throttle but zookeeper failed to delete the backpressure node, then the throttle will be on. And in that case, it's very likely that the znode will never be deleted and thus the throttle will always be on. The spouts will stop indefinitely. 

We want to add a restart timeout so that even the above case happens, the spouts can continue to work. 
 