### PR TITLE
[STORM-2753] Avoid shutting down netty server on netty exception

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/NettyUncaughtExceptionHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/NettyUncaughtExceptionHandler.java
@@ -33,10 +33,9 @@ public class NettyUncaughtExceptionHandler implements Thread.UncaughtExceptionHa
 
         try {
             Utils.handleUncaughtException(e);
-        } catch (Throwable throwable) {
-            LOG.error("Exception thrown while handling uncaught exception " + throwable.getCause());
+        } catch (Error error) {
+            LOG.error("Exception thrown while handling uncaught exception " + error.getCause());
+            Runtime.getRuntime().exit(1);
         }
-        LOG.info("Received error in netty thread.. terminating server...");
-        Runtime.getRuntime().exit(1);
     }
 }


### PR DESCRIPTION
[JIRA-STORM-2753](https://issues.apache.org/jira/browse/STORM-2753)

`NettyUncaughtExceptionHandler` should only exit if there is an `Error`