### PR TITLE
STORM-2756: Make KafkaSpoutConfig.Builder constructors set key/value …

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
@@ -250,6 +250,19 @@ public class KafkaSpoutConfig<K, V> implements Serializable {
             this.valueDesClazz = valDesClazz;
             this.subscription = subscription;
             this.translator = new DefaultRecordTranslator<>();
+            
+            if (keyDesClazz != null) {
+                this.kafkaProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDesClazz);
+            }
+            if (keyDes != null) {
+                this.kafkaProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDes.getClass());
+            }
+            if (valueDesClazz != null) {
+                this.kafkaProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDesClazz);
+            }
+            if (valueDes != null) {
+                this.kafkaProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDes.getClass());
+            }
         }
 
         private Builder(Builder<?, ?> builder, SerializableDeserializer<K> keyDes, Class<? extends Deserializer<K>> keyDesClazz,
@@ -266,6 +279,20 @@ public class KafkaSpoutConfig<K, V> implements Serializable {
             // when they change the key/value types.
             this.translator = (RecordTranslator<K, V>) builder.translator;
             this.retryService = builder.retryService;
+            
+            if (keyDesClazz != null) {
+                this.kafkaProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDesClazz);
+            }
+            if (keyDes != null) {
+                this.kafkaProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDes.getClass());
+            }
+            if (valueDesClazz != null) {
+                this.kafkaProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDesClazz);
+            }
+            if (valueDes != null) {
+                this.kafkaProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDes.getClass());
+            }
+            
             this.keyDes = keyDes;
             this.keyDesClazz = keyDesClazz;
             this.valueDes = valueDes;


### PR DESCRIPTION
…deserializers in kafkaProps, so they are used when building a consumer

See https://issues.apache.org/jira/browse/STORM-2756. 