### PR TITLE
[STORM-2757] Fix broken log links when HTTPS is in use

### DIFF
--- a/storm-core/src/ui/public/deep_search_result.html
+++ b/storm-core/src/ui/public/deep_search_result.html
@@ -91,11 +91,12 @@ $(document).ready(function() {
             $('#search-form [data-toggle="tooltip"]').tooltip();
         });
 
-        function render_file(file, host, logviewerPort, count, template) {
+        function render_file(file, host, logviewerPort, logviewerScheme, count, template) {
             file.host = host;
             file.id = id;
             file.count = count;
             file.logviewerPort = logviewerPort;
+            file.logviewerScheme = logviewerScheme;
             file.search_archived = search_archived;
             if (file.matches == 0) {
                file.resultNotFound = true;
@@ -131,6 +132,7 @@ $(document).ready(function() {
                 result.append(Mustache.render($(template).filter("#search-result-files-template").html(),response));
 
                 var logviewerPort = response.logviewerPort;
+                var logviewerScheme = response.logviewerScheme;
                 var distinct_hosts = {};
                 for (var index in response.supervisors) {
                     distinct_hosts[response.supervisors[index].host] = true;
@@ -138,7 +140,7 @@ $(document).ready(function() {
 
 
                 for (var host in distinct_hosts) {
-                    var searchURL = "http://"+host+":"+logviewerPort+"/api/v1/deepSearch/"+id+"?search-string="+search+"&num-matches="+count+"&port="+port;
+                    var searchURL = logviewerScheme + "://"+host+":"+logviewerPort+"/api/v1/deepSearch/"+id+"?search-string="+search+"&num-matches="+count+"&port="+port;
                     if(search_archived)
                         searchURL += "&search-archived=" + search_archived;
                     
@@ -152,13 +154,13 @@ $(document).ready(function() {
                                 if(port == "*") {
                                     for(var by_port in data) {
                                         for(var i in data[by_port].matches) {
-                                            render_file(data[by_port].matches[i], this.host, logviewerPort, count, template);
+                                            render_file(data[by_port].matches[i], this.host, logviewerPort, logviewerScheme, count, template);
                                         }
                                     }
                                 }
                                 else {
                                     for(var i in data.matches) {
-                                        render_file(data.matches[i], this.host, logviewerPort, count, template);
+                                        render_file(data.matches[i], this.host, logviewerPort, logviewerScheme, count, template);
                                     }
                                 }
                             }, {host: host, id: id})

--- a/storm-core/src/ui/public/search_result.html
+++ b/storm-core/src/ui/public/search_result.html
@@ -66,14 +66,15 @@ $(document).ready(function() {
            result.append(Mustache.render($(template).filter("#search-result-files-template").html(),response));
 
            var logviewerPort = response.logviewerPort;
+           var logviewerScheme = response.logviewerScheme;
            for (var index in response.hostPortList) {
              var host = response.hostPortList[index].host;
              var port = response.hostPortList[index].port;
              var elemId = response.hostPortList[index].elemId;
              var file = id+"/"+port+"/worker.log";
-             var searchURL = "http://"+host+":"+logviewerPort+"/api/v1/search?file="+encodeURIComponent(file)+"&search-string="+search+"&num-matches="+count;
+             var searchURL = logviewerScheme + "://"+host+":"+logviewerPort+"/api/v1/search?file="+encodeURIComponent(file)+"&search-string="+search+"&num-matches="+count;
              if (searchArchived != "") {
-               searchURL = "http://"+host+":"+logviewerPort+"/api/v1/deepSearch/"+id+"?search-string="+search+"&num-matches="+count+"&search-archived=true&port="+port;
+               searchURL = logviewerScheme + "://"+host+":"+logviewerPort+"/api/v1/deepSearch/"+id+"?search-string="+search+"&num-matches="+count+"&search-archived=true&port="+port;
              }
 
              $.ajax({dataType: "json",
@@ -87,6 +88,7 @@ $(document).ready(function() {
                                   data.port = this.port;
                                   data.id = id;
                                   data.logviewerPort = logviewerPort;
+                                  data.logviewerScheme = logviewerScheme;
                                   var searchTemp = $(template).filter("#search-result-identified-template").html();
                                   if (searchArchived != "") {
                                     searchTemp = $(template).filter("#deepsearch-result-identified-template").html();

--- a/storm-core/src/ui/public/templates/deep-search-result-page-template.html
+++ b/storm-core/src/ui/public/templates/deep-search-result-page-template.html
@@ -30,7 +30,7 @@
 <script id="search-result-identified-template" type="text/html">
     {{#matches}}
     <tr id="aResult">
-      <td><a href="http://{{host}}:{{logviewerPort}}/logviewer_search.html?file={{fileName}}&search={{searchString}}">{{host}}:{{port}}</a></td>
+      <td><a href="{{logviewerScheme}}://{{host}}:{{logviewerPort}}/logviewer_search.html?file={{fileName}}&search={{searchString}}">{{host}}:{{port}}</a></td>
       <td><pre>{{beforeString}}<b><a href="{{logviewerURL}}">{{matchString}}</a></b>{{afterString}}</pre></td>
     </tr>
     {{/matches}}

--- a/storm-core/src/ui/public/templates/search-result-page-template.html
+++ b/storm-core/src/ui/public/templates/search-result-page-template.html
@@ -30,7 +30,7 @@
 <script id="search-result-identified-template" type="text/html">
     {{#matches}}
     <tr>
-      <td><a href="http://{{host}}:{{logviewerPort}}/logviewer_search.html?file={{file}}&search={{searchString}}">{{host}}:{{port}}</a></td>
+      <td><a href="{{logviewerScheme}}://{{host}}:{{logviewerPort}}/logviewer_search.html?file={{file}}&search={{searchString}}">{{host}}:{{port}}</a></td>
       <td><pre>{{beforeString}}<b><a href="{{logviewerURL}}">{{matchString}}</a></b>{{afterString}}</pre></td>
     </tr>
     {{/matches}}
@@ -39,7 +39,7 @@
     {{#matches}}
     {{#matches}}
     <tr>
-      <td><a href="http://{{host}}:{{logviewerPort}}/logviewer_search.html?file={{fileName}}&search={{searchString}}">{{host}}:{{port}}</a></td>
+      <td><a href="{{logviewerScheme}}://{{host}}:{{logviewerPort}}/logviewer_search.html?file={{fileName}}&search={{searchString}}">{{host}}:{{port}}</a></td>
       <td><pre>{{beforeString}}<b><a href="{{logviewerURL}}">{{matchString}}</a></b>{{afterString}}</pre></td>
     </tr>
     {{/matches}}

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -310,7 +310,7 @@ public class DaemonConfig implements Validated {
     public static final String LOGVIEWER_MAX_PER_WORKER_LOGS_SIZE_MB = "logviewer.max.per.worker.logs.size.mb";
 
     /**
-     * Storm Logviewer HTTPS port.
+     * Storm Logviewer HTTPS port. Logviewer must use HTTPS if Storm UI is using HTTPS.
      */
     @isInteger
     @isPositiveNumber
@@ -413,7 +413,7 @@ public class DaemonConfig implements Validated {
     public static final String UI_HEADER_BUFFER_BYTES = "ui.header.buffer.bytes";
 
     /**
-     * This port is used by Storm DRPC for receiving HTTPS (SSL) DPRC requests from clients.
+     * This port is used by Storm UI for receiving HTTPS (SSL) requests from clients.
      */
     @isInteger
     @isPositiveNumber


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/STORM-2757

We have HTTPS configs for UI and Logviewer. But it's not working properly.  

We should expect: 

| UI        | LogViewer           | scheme of log links  | port of log links
| ------------- |:-------------:| -----:|-----:|
|HTTP | HTTP | http | logviewer.port
|HTTP | HTTPS| https | logviewer.https.port
|HTTPS | HTTPS| https|  logviewer.https.port
|HTTPS | HTTP| should not work | should not work
