### PR TITLE
[STORM-2765] Disallow colons in blobstore key name

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class BlobStore implements Shutdownable {
     private static final Logger LOG = LoggerFactory.getLogger(BlobStore.class);
-    private static final Pattern KEY_PATTERN = Pattern.compile("^[\\w \\t\\.:_-]+$", Pattern.UNICODE_CHARACTER_CLASS);
+    private static final Pattern KEY_PATTERN = Pattern.compile("^[\\w \\t\\._-]+$", Pattern.UNICODE_CHARACTER_CLASS);
     protected static final String BASE_BLOBS_DIR_NAME = "blobs";
 
     /**
@@ -193,10 +193,10 @@ public abstract class BlobStore implements Shutdownable {
      * Validates key checking for potentially harmful patterns
      * @param key Key for the blob.
      */
-    public static final void validateKey(String key) throws AuthorizationException {
+    public static final void validateKey(String key) throws IllegalArgumentException {
         if (StringUtils.isEmpty(key) || "..".equals(key) || ".".equals(key) || !KEY_PATTERN.matcher(key).matches()) {
-            LOG.error("'{}' does not appear to be valid {}", key, KEY_PATTERN);
-            throw new AuthorizationException(key+" does not appear to be a valid blob key");
+            LOG.error("'{}' does not appear to be valid. It must match {}. And it can't be \".\", \"..\", null or empty string.", key, KEY_PATTERN);
+            throw new IllegalArgumentException(key+" does not appear to be a valid blob key");
         }
     }
 

--- a/storm-client/test/jvm/org/apache/storm/blobstore/ClientBlobStoreTest.java
+++ b/storm-client/test/jvm/org/apache/storm/blobstore/ClientBlobStoreTest.java
@@ -166,8 +166,8 @@ public class ClientBlobStoreTest {
 
   @Test
   public void testBloblStoreKeyWithUnicodesValidation() throws Exception {
-    BlobStore.validateKey("msg:kafka-unicodewriter䶵-11-1483434711-stormconf.ser");
-    BlobStore.validateKey("msg:kafka-ascii-11-148343436363-stormconf.ser");
+    BlobStore.validateKey("msg-kafka-unicodewriter䶵-11-1483434711-stormconf.ser");
+    BlobStore.validateKey("msg-kafka-ascii-11-148343436363-stormconf.ser");
   }
 
   private void createTestBlob(String testKey, SettableBlobMeta meta) throws AuthorizationException, KeyAlreadyExistsException {

--- a/storm-core/src/jvm/org/apache/storm/command/Blobstore.java
+++ b/storm-core/src/jvm/org/apache/storm/command/Blobstore.java
@@ -19,10 +19,7 @@ package org.apache.storm.command;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.storm.blobstore.AtomicOutputStream;
-import org.apache.storm.blobstore.BlobStoreAclHandler;
-import org.apache.storm.blobstore.ClientBlobStore;
-import org.apache.storm.blobstore.InputStreamWithMeta;
+import org.apache.storm.blobstore.*;
 import org.apache.storm.generated.AccessControl;
 import org.apache.storm.generated.AuthorizationException;
 import org.apache.storm.generated.KeyNotFoundException;
@@ -122,7 +119,7 @@ public class Blobstore {
         SettableBlobMeta meta = new SettableBlobMeta(acl);
         meta.set_replication_factor(replicationFactor);
 
-        ServerUtils.validateKeyName(key);
+        BlobStore.validateKey(key);
 
         LOG.info("Creating {} with ACL {}", key, generateAccessControlsInfo(acl));
 

--- a/storm-core/test/clj/org/apache/storm/nimbus_test.clj
+++ b/storm-core/test/clj/org/apache/storm/nimbus_test.clj
@@ -1646,9 +1646,9 @@
                           (doto (LocalCluster$Builder. )
                             (.withDaemonConf {SUPERVISOR-ENABLE false TOPOLOGY-ACKER-EXECUTORS 0 TOPOLOGY-EVENTLOGGER-EXECUTORS 0})))]
     (let [nimbus (.getNimbus cluster)]
-      (is (thrown-cause? AuthorizationException (.beginFileDownload nimbus nil)))
-      (is (thrown-cause? AuthorizationException (.beginFileDownload nimbus "")))
-      (is (thrown-cause? AuthorizationException (.beginFileDownload nimbus "/bogus-path/foo")))
+      (is (thrown-cause? IllegalArgumentException (.beginFileDownload nimbus nil)))
+      (is (thrown-cause? IllegalArgumentException (.beginFileDownload nimbus "")))
+      (is (thrown-cause? IllegalArgumentException (.beginFileDownload nimbus "/bogus-path/foo")))
       )))
 
 (deftest test-validate-topo-config-on-submit

--- a/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
@@ -89,12 +89,6 @@ public class ServerUtils {
     public static final String DEFAULT_BLOB_VERSION_SUFFIX = ".version";
     public static final int SIGKILL = 9;
     public static final int SIGTERM = 15;
-    /**
-     * Make sure a given key name is valid for the storm config.
-     * Throw RuntimeException if the key isn't valid.
-     * @param name The name of the config key to check.
-     */
-    private static final Set<String> disallowedKeys = new HashSet<>(Arrays.asList(new String[] {"/", ".", ":", "\\"}));
 
     // A singleton instance allows us to mock delegated static methods in our
     // tests by subclassing.
@@ -634,18 +628,6 @@ public class ServerUtils {
             }
         } finally {
             zipFile.close();
-        }
-    }
-
-    public static void validateKeyName(String name) {
-
-        for(String key : disallowedKeys) {
-            if( name.contains(key) ) {
-                throw new RuntimeException("Key name cannot contain any of the following: " + disallowedKeys.toString());
-            }
-        }
-        if(name.trim().isEmpty()) {
-            throw new RuntimeException("Key name cannot be blank");
         }
     }
 


### PR DESCRIPTION
We should disallow colons in blobstore key name.  HDFS prohibits the use of ":" in path name. 

![image](https://user-images.githubusercontent.com/14900612/30991627-6552b530-a46b-11e7-98dc-e261af791988.png)


[ Related code is here](https://github.com/apache/hadoop/blob/branch-2.6.1/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/DFSUtil.java#L237)

Secondly, the original code uses two different functions to validate key names in different places. We probably just want to use one to avoid confusion. 
