### PR TITLE
[STORM-2769] Fast-fail if output streamId is null

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/topology/OutputFieldsGetter.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/OutputFieldsGetter.java
@@ -39,6 +39,9 @@ public class OutputFieldsGetter implements OutputFieldsDeclarer {
     }
 
     public void declareStream(String streamId, boolean direct, Fields fields) {
+        if (null == streamId) {
+            throw new IllegalArgumentException("streamId can't be null");
+        }
         if(_fields.containsKey(streamId)) {
             throw new IllegalArgumentException("Fields for " + streamId + " already set");
         }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/STORM-2769

If streamId is null, we should throw an exception because thrift doesn't support null in map keys.

A test:

![image](https://user-images.githubusercontent.com/14900612/31143518-188d8a32-a843-11e7-800d-045219948008.png)

