### PR TITLE
STORM-2716: Fix logviewer tests on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Some storm-webapp logviewer tests require input files to have LF line endings due to byte counting.
+storm-webapp/src/test/resources/*.log.test text eol=lf

--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -106,7 +106,6 @@ public class Utils {
     public static final Logger LOG = LoggerFactory.getLogger(Utils.class);
     public static final String DEFAULT_STREAM_ID = "default";
     private static final Set<Class> defaultAllowedExceptions = new HashSet<>();
-    public static final String FILE_PATH_SEPARATOR = System.getProperty("file.separator");
     private static final List<String> LOCALHOST_ADDRESSES = Lists.newArrayList("localhost", "127.0.0.1", "0:0:0:0:0:0:0:1");
 
     private static ThreadLocal<TSerializer> threadSer = new ThreadLocal<TSerializer>();

--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -374,12 +374,12 @@
   (let [tplg-main-class (if (not-nil? tplg-config) (trim (tplg-config "topologyMainClass")))
         tplg-main-class-args (if (not-nil? tplg-config) (tplg-config "topologyMainClassArgs"))
         storm-home (System/getProperty "storm.home")
-        storm-conf-dir (str storm-home WebAppUtils/FILE_PATH_SEPARATOR "conf")
+        storm-conf-dir (str storm-home File/separator "conf")
         storm-log-dir (if (not-nil? (*STORM-CONF* "storm.log.dir")) (*STORM-CONF* "storm.log.dir")
-                                                                    (str storm-home WebAppUtils/FILE_PATH_SEPARATOR "logs"))
-        storm-libs (str storm-home WebAppUtils/FILE_PATH_SEPARATOR "lib" WebAppUtils/FILE_PATH_SEPARATOR "*")
-        java-cmd (str (System/getProperty "java.home") WebAppUtils/FILE_PATH_SEPARATOR "bin" WebAppUtils/FILE_PATH_SEPARATOR "java")
-        storm-cmd (str storm-home WebAppUtils/FILE_PATH_SEPARATOR "bin" WebAppUtils/FILE_PATH_SEPARATOR "storm")
+                                                                    (str storm-home File/separator "logs"))
+        storm-libs (str storm-home File/separator "lib" File/separator "*")
+        java-cmd (str (System/getProperty "java.home") File/separator "bin" File/separator "java")
+        storm-cmd (str storm-home File/separator "bin" File/separator "storm")
         tplg-cmd-response (apply sh
                             (flatten
                               [storm-cmd "jar" tplg-jar-file tplg-main-class

--- a/storm-core/src/jvm/org/apache/storm/utils/WebAppUtils.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/WebAppUtils.java
@@ -18,14 +18,14 @@
 
 package org.apache.storm.utils;
 
-public class WebAppUtils {
-    public static final String FILE_PATH_SEPARATOR = System.getProperty("file.separator");
+import java.io.File;
 
+public class WebAppUtils {
     public static String eventLogsFilename(String stormId, String port) {
-        return stormId + FILE_PATH_SEPARATOR + port + FILE_PATH_SEPARATOR + "events.log";
+        return stormId + File.separator + port + File.separator + "events.log";
     }
 
     public static String logsFilename(String stormId, String port) {
-        return stormId + FILE_PATH_SEPARATOR + port + FILE_PATH_SEPARATOR + "worker.log";
+        return stormId + File.separator + port + File.separator + "worker.log";
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/BasicContainer.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/BasicContainer.java
@@ -66,7 +66,7 @@ public class BasicContainer extends Container {
     private static final Logger LOG = LoggerFactory.getLogger(BasicContainer.class);
     private static final FilenameFilter jarFilter = (dir, name) -> name.endsWith(".jar");
     private static final Joiner CPJ = 
-            Joiner.on(ServerUtils.CLASS_PATH_SEPARATOR).skipNulls();
+            Joiner.on(File.pathSeparator).skipNulls();
     
     protected final LocalState _localState;
     protected final String _profileCmd;
@@ -156,7 +156,7 @@ public class BasicContainer extends Container {
         }
 
         if (profileCmd == null) {
-            profileCmd = _stormHome + Utils.FILE_PATH_SEPARATOR + "bin" + Utils.FILE_PATH_SEPARATOR
+            profileCmd = _stormHome + File.separator + "bin" + File.separator
                     + conf.get(DaemonConfig.WORKER_PROFILER_COMMAND);
         }
         _profileCmd = profileCmd;
@@ -350,10 +350,10 @@ public class BasicContainer extends Container {
      * @return the java.library.path/LD_LIBRARY_PATH to use so native libraries load correctly.
      */
     protected String javaLibraryPath(String stormRoot, Map<String, Object> conf) {
-        String resourceRoot = stormRoot + Utils.FILE_PATH_SEPARATOR + ServerConfigUtils.RESOURCES_SUBDIR;
+        String resourceRoot = stormRoot + File.separator + ServerConfigUtils.RESOURCES_SUBDIR;
         String os = System.getProperty("os.name").replaceAll("\\s+", "_");
         String arch = System.getProperty("os.arch");
-        String archResourceRoot = resourceRoot + Utils.FILE_PATH_SEPARATOR + os + "-" + arch;
+        String archResourceRoot = resourceRoot + File.separator + os + "-" + arch;
         String ret = CPJ.join(archResourceRoot, resourceRoot,
                 conf.get(DaemonConfig.JAVA_LIBRARY_PATH));
         return ret;
@@ -514,16 +514,16 @@ public class BasicContainer extends Container {
 
         if (StringUtils.isNotBlank(log4jConfigurationDir)) {
             if (!ServerUtils.isAbsolutePath(log4jConfigurationDir)) {
-                log4jConfigurationDir = _stormHome + Utils.FILE_PATH_SEPARATOR + log4jConfigurationDir;
+                log4jConfigurationDir = _stormHome + File.separator + log4jConfigurationDir;
             }
         } else {
-            log4jConfigurationDir = _stormHome + Utils.FILE_PATH_SEPARATOR + "log4j2";
+            log4jConfigurationDir = _stormHome + File.separator + "log4j2";
         }
  
         if (ServerUtils.IS_ON_WINDOWS && !log4jConfigurationDir.startsWith("file:")) {
             log4jConfigurationDir = "file:///" + log4jConfigurationDir;
         }
-        return log4jConfigurationDir + Utils.FILE_PATH_SEPARATOR + "worker.xml";
+        return log4jConfigurationDir + File.separator + "worker.xml";
     }
     
     private static class TopologyMetaData {
@@ -692,7 +692,7 @@ public class BasicContainer extends Container {
         String ret = null;
         String javaHome = System.getenv().get("JAVA_HOME");
         if (StringUtils.isNotBlank(javaHome)) {
-            ret = javaHome + Utils.FILE_PATH_SEPARATOR + "bin" + Utils.FILE_PATH_SEPARATOR + cmd;
+            ret = javaHome + File.separator + "bin" + File.separator + cmd;
         } else {
             ret = cmd;
         }

--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -318,7 +318,7 @@ public class AsyncLocalizer implements AutoCloseable {
                     }
                 }
                 boolean deleteAll = true;
-                String tmproot = ServerConfigUtils.supervisorTmpDir(conf) + Utils.FILE_PATH_SEPARATOR + Utils.uuid();
+                String tmproot = ServerConfigUtils.supervisorTmpDir(conf) + File.separator + Utils.uuid();
                 File tr = new File(tmproot);
                 try {
                     downloadBaseBlobs(tr);
@@ -379,7 +379,7 @@ public class AsyncLocalizer implements AutoCloseable {
             String resourcesJar = resourcesJar();
             URL url = classloader.getResource(ServerConfigUtils.RESOURCES_SUBDIR);
 
-            String targetDir = tmproot + Utils.FILE_PATH_SEPARATOR;
+            String targetDir = tmproot + File.separator;
             if (resourcesJar != null) {
                 LOG.info("Extracting resources from jar at {} to {}", resourcesJar, targetDir);
                 ServerUtils.extractDirFromJar(resourcesJar, ServerConfigUtils.RESOURCES_SUBDIR, new File(targetDir));

--- a/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
@@ -67,10 +67,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.zip.GZIPInputStream;
@@ -80,8 +78,6 @@ import java.util.zip.ZipFile;
 public class ServerUtils {
     public static final Logger LOG = LoggerFactory.getLogger(ServerUtils.class);
 
-    public static final String FILE_PATH_SEPARATOR = System.getProperty("file.separator");
-    public static final String CLASS_PATH_SEPARATOR = System.getProperty("path.separator");
     public static final boolean IS_ON_WINDOWS = "Windows_NT".equals(System.getenv("OS"));
     public static final String CURRENT_BLOB_SUFFIX_ID = "current";
 
@@ -282,11 +278,11 @@ public class ServerUtils {
     }
 
     public static String containerFilePath (String dir) {
-        return dir + FILE_PATH_SEPARATOR + "launch_container.sh";
+        return dir + File.separator + "launch_container.sh";
     }
 
     public static String scriptFilePath (String dir) {
-        return dir + FILE_PATH_SEPARATOR + "storm-worker-script.sh";
+        return dir + File.separator + "storm-worker-script.sh";
     }
 
     /**

--- a/storm-webapp/pom.xml
+++ b/storm-webapp/pom.xml
@@ -143,7 +143,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!--Note - the version would be inherited-->
                 <configuration>
-                    <maxAllowedViolations>8</maxAllowedViolations>
+                    <maxAllowedViolations>7</maxAllowedViolations>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandler.java
@@ -68,10 +68,10 @@ public class LogviewerProfileHandler {
      */
     public Response listDumpFiles(String topologyId, String hostPort, String user) throws IOException {
         String portStr = hostPort.split(":")[1];
-        File dir = new File(String.join(ServerUtils.FILE_PATH_SEPARATOR, logRoot, topologyId, portStr));
+        File dir = new File(String.join(File.separator, logRoot, topologyId, portStr));
 
         if (dir.exists()) {
-            String workerFileRelativePath = String.join(ServerUtils.FILE_PATH_SEPARATOR, topologyId, portStr, WORKER_LOG_FILENAME);
+            String workerFileRelativePath = String.join(File.separator, topologyId, portStr, WORKER_LOG_FILENAME);
             if (resourceAuthorizer.isUserAllowedToAccessFile(user, workerFileRelativePath)) {
                 String content = buildDumpFileListPage(topologyId, hostPort, dir);
                 return LogviewerResponseBuilder.buildSuccessHtmlResponse(content);
@@ -95,11 +95,11 @@ public class LogviewerProfileHandler {
      */
     public Response downloadDumpFile(String topologyId, String hostPort, String fileName, String user) throws IOException {
         String portStr = hostPort.split(":")[1];
-        File dir = new File(String.join(ServerUtils.FILE_PATH_SEPARATOR, logRoot, topologyId, portStr));
+        File dir = new File(String.join(File.separator, logRoot, topologyId, portStr));
         File file = new File(dir, fileName);
 
         if (dir.exists() && file.exists()) {
-            String workerFileRelativePath = String.join(ServerUtils.FILE_PATH_SEPARATOR, topologyId, portStr, WORKER_LOG_FILENAME);
+            String workerFileRelativePath = String.join(File.separator, topologyId, portStr, WORKER_LOG_FILENAME);
             if (resourceAuthorizer.isUserAllowedToAccessFile(user, workerFileRelativePath)) {
                 return LogviewerResponseBuilder.buildDownloadFile(file);
             } else {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogFileDownloader.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogFileDownloader.java
@@ -43,7 +43,7 @@ public class LogFileDownloader {
     }
 
     /**
-     * Checks authorization for the log file and download
+     * Checks authorization for the log file and download.
      *
      * @param fileName file to download
      * @param user username

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/WorkerLogs.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/WorkerLogs.java
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 
 import org.apache.storm.daemon.supervisor.ClientSupervisorUtils;
 import org.apache.storm.daemon.supervisor.SupervisorUtils;
+import org.apache.storm.daemon.utils.PathUtil;
 import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.Time;
 import org.apache.storm.utils.Utils;
@@ -207,10 +208,7 @@ public class WorkerLogs {
      */
     public static String getTopologyPortWorkerLog(File file) {
         try {
-            String[] splitted = file.getCanonicalPath().split(Utils.FILE_PATH_SEPARATOR);
-            List<String> split = takeLast(Arrays.asList(splitted), 3);
-
-            return String.join(Utils.FILE_PATH_SEPARATOR, split);
+            return PathUtil.truncatePathToLastElements(file.getCanonicalFile().toPath(), 3).toString();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/utils/PathUtil.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/utils/PathUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.daemon.utils;
+
+import java.nio.file.Path;
+
+/**
+ * Utility functions to make Path manipulation slightly less verbose.
+ */
+public class PathUtil {
+
+    /**
+     * Truncates path to the last numElements.
+     * @param path The path to truncate.
+     * @param numElements The number of elements to preserve at the end of the path.
+     * @return The truncated path.
+     */
+    public static Path truncatePathToLastElements(Path path, int numElements) {
+        if (path.getNameCount() <= numElements) {
+            return path;
+        }
+        return path.subpath(path.getNameCount() - numElements, path.getNameCount());
+    }
+    
+}

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/utils/UrlBuilder.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/utils/UrlBuilder.java
@@ -20,13 +20,16 @@ package org.apache.storm.daemon.utils;
 
 import static java.util.stream.Collectors.joining;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
  * Convenient utility class to build the URL.
  */
 public class UrlBuilder {
+
     private UrlBuilder() {
     }
 
@@ -44,8 +47,17 @@ public class UrlBuilder {
             sb.append("?");
 
             String queryParam = parameters.entrySet().stream()
-                    .map(entry -> URLEncoder.encode(entry.getKey()) + "=" + URLEncoder.encode(entry.getValue().toString()))
-                    .collect(joining("&"));
+                .map(entry -> {
+                    try {
+                        return URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.name())
+                            + "="
+                            + URLEncoder.encode(entry.getValue().toString(), StandardCharsets.UTF_8.name());
+                    } catch (UnsupportedEncodingException e) {
+                        //This can't happen, UTF-8 is always available
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(joining("&"));
             sb.append(queryParam);
         }
         return sb.toString();

--- a/storm-webapp/src/test/resources/log4j2.xml
+++ b/storm-webapp/src/test/resources/log4j2.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" charset="UTF-8"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="WARN">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="org.apache.storm.daemon.logviewer" level="INFO" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/STORM-2716.

The tests run on Windows now at least. I haven't tested Logviewer beyond checking that I can search logs on my local machine from Storm UI, so there may still be some corners of Logviewer that don't work on Windows.

I also removed some constants that were making accessing the file.separator property easy. I don't think we need them since File.separator exists.