### PR TITLE
[STORM-2773]If a drpcserver node in cluster is down,drpc cluster won't work if we don't modify the drpc.server configuration and restart the cluster

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/drpc/DRPCInvocationsClient.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/DRPCInvocationsClient.java
@@ -43,16 +43,16 @@ public class DRPCInvocationsClient extends ThriftClient implements DistributedRP
         this.host = host;
         this.port = port;
         if (isConnected() != true) {
-            for (int i=0; i < connectRetry; i++) {
+            for (int i = 0; i < connectRetry; i++) {
                 try {
                     this.reconnectClient();
                 } catch (Exception e) {
-                    LOG.warn("Can't connect to drpcServer "+host+",will attempt to retry.");
+                    LOG.warn("Can't connect to drpcServer " + host + ",will attempt to retry.");
                 }
                 if (isConnected() == true) {
                     break;
                 } else if (i == connectRetry) {
-                    LOG.warn("Can't connect to drpcServer "+host+" after "+connectRetry+" attempts,will ignore it.");
+                    LOG.warn("Can't connect to drpcServer " + host + " after " + connectRetry + " attempts,will ignore it.");
                 }
             }
         }

--- a/storm-client/src/jvm/org/apache/storm/drpc/DRPCSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/DRPCSpout.java
@@ -105,9 +105,14 @@ public class DRPCSpout extends BaseRichSpout {
 
         @Override
         public Void call() throws Exception {
-            DRPCInvocationsClient c = new DRPCInvocationsClient(conf, server, port);
-            synchronized (_clients) {
-                _clients.add(c);
+            try {
+                DRPCInvocationsClient c = new DRPCInvocationsClient(conf, server, port);
+
+                synchronized (_clients) {
+                    _clients.add(c);
+                }
+            } catch (Exception e) {
+                LOG.warn("Can't connect to drpcserver "+server+" when init drpcspout,please check your cluster");
             }
             return null;
         }

--- a/storm-client/src/jvm/org/apache/storm/drpc/ReturnResults.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/ReturnResults.java
@@ -85,7 +85,7 @@ public class ReturnResults extends BaseRichBolt {
                 if(!_clients.containsKey(server)) {
                     try {
                         _clients.put(server, new DRPCInvocationsClient(_conf, host, port));
-                    } catch (TTransportException ex) {
+                    } catch (Exception ex) {
                         throw new RuntimeException(ex);
                     }
                 }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/ThriftClient.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/ThriftClient.java
@@ -46,7 +46,7 @@ public class ThriftClient implements AutoCloseable {
         this(topoConf, type, host, port, timeout, null, true);
     }
 
-    public ThriftClient(Map<String, Object> topoConf, ThriftConnectionType type, String host, Integer port, Integer timeout, String asUser,Boolean toReconnect) {
+    public ThriftClient(Map<String, Object> topoConf, ThriftConnectionType type, String host, Integer port, Integer timeout, String asUser, Boolean toReconnect) {
         //create a socket with server
         if (host==null) {
             throw new IllegalArgumentException("host is not set");
@@ -62,7 +62,7 @@ public class ThriftClient implements AutoCloseable {
 
         if (port<=0 && !type.isFake()) {
             throw new IllegalArgumentException("invalid port: "+port);
-        }          
+        }
 
         _host = host;
         _port = port;
@@ -80,7 +80,7 @@ public class ThriftClient implements AutoCloseable {
     public synchronized TTransport transport() {
         return _transport;
     }
-    
+
     public synchronized void reconnect() {
         close();
         TSocket socket = null;
@@ -99,7 +99,7 @@ public class ThriftClient implements AutoCloseable {
             //TODO get this from type instead of hardcoding to Nimbus.
             //establish client-server transport via plugin
             //do retries if the connect fails
-            TBackoffConnect connectionRetry 
+            TBackoffConnect connectionRetry
                 = new TBackoffConnect(
                                       ObjectReader.getInt(_conf.get(Config.STORM_NIMBUS_RETRY_TIMES)),
                                       ObjectReader.getInt(_conf.get(Config.STORM_NIMBUS_RETRY_INTERVAL)),

--- a/storm-client/src/jvm/org/apache/storm/security/auth/ThriftClient.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/ThriftClient.java
@@ -39,14 +39,14 @@ public class ThriftClient implements AutoCloseable {
     protected boolean _retryForever = false;
 
     public ThriftClient(Map<String, Object> topoConf, ThriftConnectionType type, String host) {
-        this(topoConf, type, host, null, null, null);
+        this(topoConf, type, host, null, null, null, true);
     }
 
     public ThriftClient(Map<String, Object> topoConf, ThriftConnectionType type, String host, Integer port, Integer timeout){
-        this(topoConf, type, host, port, timeout, null);
+        this(topoConf, type, host, port, timeout, null, true);
     }
 
-    public ThriftClient(Map<String, Object> topoConf, ThriftConnectionType type, String host, Integer port, Integer timeout, String asUser) {
+    public ThriftClient(Map<String, Object> topoConf, ThriftConnectionType type, String host, Integer port, Integer timeout, String asUser,Boolean toReconnect) {
         //create a socket with server
         if (host==null) {
             throw new IllegalArgumentException("host is not set");
@@ -70,8 +70,10 @@ public class ThriftClient implements AutoCloseable {
         _conf = topoConf;
         _type = type;
         _asUser = asUser;
-        if (!type.isFake()) {
-            reconnect();
+        if (toReconnect == true) {
+            if (!type.isFake()) {
+                reconnect();
+            }
         }
     }
 

--- a/storm-client/src/jvm/org/apache/storm/trident/drpc/ReturnResultsReducer.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/drpc/ReturnResultsReducer.java
@@ -102,7 +102,7 @@ public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
                 if(!_clients.containsKey(server)) {
                     try {
                         _clients.put(server, new DRPCInvocationsClient(conf, host, port));
-                    } catch (TTransportException ex) {
+                    } catch (Exception ex) {
                         throw new RuntimeException(ex);
                     }
                 }

--- a/storm-client/src/jvm/org/apache/storm/utils/DRPCClient.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/DRPCClient.java
@@ -106,7 +106,7 @@ public class DRPCClient extends ThriftClient implements DistributedRPC.Iface {
 
     private DRPCClient(DistributedRPC.Iface override) {
         super(new HashMap<>(), ThriftConnectionType.LOCAL_FAKE,
-                "localhost", 1234, null, null);
+                "localhost", 1234, null, null, true);
         this.host = "localhost";
         this.port = 1234;
         this.client = override;
@@ -119,7 +119,7 @@ public class DRPCClient extends ThriftClient implements DistributedRPC.Iface {
 
     public DRPCClient(Map<String, Object> conf, String host, int port, Integer timeout) throws TTransportException {
         super(conf, _localOverrideClient != null ? ThriftConnectionType.LOCAL_FAKE : ThriftConnectionType.DRPC,
-                host, port, timeout, null);
+                host, port, timeout, null, true);
         this.host = host;
         this.port = port;
         if (_localOverrideClient != null) {

--- a/storm-client/src/jvm/org/apache/storm/utils/NimbusClient.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/NimbusClient.java
@@ -161,25 +161,25 @@ public class NimbusClient extends ThriftClient {
     }
 
     public NimbusClient(Map<String, Object> conf, String host, int port, Integer timeout) throws TTransportException {
-        super(conf, ThriftConnectionType.NIMBUS, host, port, timeout, null);
+        super(conf, ThriftConnectionType.NIMBUS, host, port, timeout, null, true);
         _client = new Nimbus.Client(_protocol);
         _isLocal = false;
     }
 
     public NimbusClient(Map<String, Object> conf, String host, Integer port, Integer timeout, String asUser) throws TTransportException {
-        super(conf, ThriftConnectionType.NIMBUS, host, port, timeout, asUser);
+        super(conf, ThriftConnectionType.NIMBUS, host, port, timeout, asUser, true);
         _client = new Nimbus.Client(_protocol);
         _isLocal = false;
     }
 
     public NimbusClient(Map<String, Object> conf, String host) throws TTransportException {
-        super(conf, ThriftConnectionType.NIMBUS, host, null, null, null);
+        super(conf, ThriftConnectionType.NIMBUS, host, null, null, null, true);
         _client = new Nimbus.Client(_protocol);
         _isLocal = false;
     }
     
     private NimbusClient(Nimbus.Iface client) {
-        super(new HashMap<>(), ThriftConnectionType.LOCAL_FAKE, "localhost", null, null, null);
+        super(new HashMap<>(), ThriftConnectionType.LOCAL_FAKE, "localhost", null, null, null, true);
         _client = client;
         _isLocal = true;
     }


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2773](https://issues.apache.org/jira/browse/STORM-2773)

There is a cluster which includes three nodes named storm1,storm2,storm3.And there is a drpcserver in every node,a worker which has been started on strom1.When strom1 was down with hardware failure,my drpc topology won't work,when I send request from drpcclient.
As storm1 was down,so the worker will be restarted on another node,but it can't Initialize successfully because the call method of Adder will throw a RuntimeException,when drpcspout try to connect to storm1,so the worker will restart again.
In conclusion,If a drpcserver node in cluster is down,drpc cluster won't work until we modify the drpc.server configuration and restart the cluster,but in production,it's difficult to restart whole cluster.
So I think we should catch the RuntimeException and log it,and the drpc topology will work normally.