### PR TITLE
[STORM-2686] Add locality awareness to LoadAwareShuffleGrouping

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -261,6 +261,8 @@ topology.disruptor.batch.size: 100
 topology.disruptor.batch.timeout.millis: 1
 topology.disable.loadaware.messaging: false
 topology.state.checkpoint.interval.ms: 1000
+topology.localityaware.higher.bound.percent: 0.8
+topology.localityaware.lower.bound.percent: 0.2
 
 # Configs for Resource Aware Scheduler
 # topology priority describing the importance of the topology in decreasing importance starting from 0 (i.e. 0 is the highest priority and the priority importance decreases as the priority number increases).

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -65,6 +65,24 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_DISABLE_LOADAWARE_MESSAGING = "topology.disable.loadaware.messaging";
 
     /**
+     * This signifies the load congestion among target tasks in scope. Currently it's only used in LoadAwareShuffleGrouping.
+     * When the average load is higher than the higher bound, the executor should choose target tasks in a higher scope,
+     * The scopes and their orders are: EVERYTHING > RACK_LOCAL > HOST_LOCAL > WORKER_LOCAL
+     */
+    @isPositiveNumber
+    @NotNull
+    public static final String TOPOLOGY_LOCALITYAWARE_HIGHER_BOUND_PERCENT = "topology.localityaware.higher.bound.percent";
+
+    /**
+     * This signifies the load congestion among target tasks in scope. Currently it's only used in LoadAwareShuffleGrouping.
+     * When the average load is lower than the lower bound, the executor should choose target tasks in a lower scope.
+     * The scopes and their orders are: EVERYTHING > RACK_LOCAL > HOST_LOCAL > WORKER_LOCAL
+     */
+    @isPositiveNumber
+    @NotNull
+    public static final String TOPOLOGY_LOCALITYAWARE_LOWER_BOUND_PERCENT = "topology.localityaware.lower.bound.percent";
+
+    /**
      * Try to serialize all tuples, even for local transfers.  This should only be used
      * for testing, as a sanity check that all of your tuples are setup properly.
      */

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -585,7 +585,7 @@ public class WorkerState {
             return new WorkerTopologyContext(systemTopology, topologyConf, taskToComponent, componentToSortedTasks,
                 componentToStreamToFields, topologyId, codeDir, pidDir, port, taskIds,
                 defaultSharedResources,
-                userSharedResources);
+                userSharedResources, cachedTaskToNodePort, assignmentId);
         } catch (IOException e) {
             throw Utils.wrapInRuntime(e);
         }

--- a/storm-client/src/jvm/org/apache/storm/task/GeneralTopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/GeneralTopologyContext.java
@@ -199,4 +199,8 @@ public class GeneralTopologyContext implements JSONAware {
         }
         return max;
     }
+
+    public Map<String, Object> getConf() {
+        return _topoConf;
+    }
 }


### PR DESCRIPTION
A redesign of https://github.com/apache/storm/pull/2270 . This adds the locality awareness to LoadAwareShuffleGrouping. It applies the concept of Bang–bang control (credit to @revans2 ).

I didn't change the critical function like chooseTasks(). So the performance should be good. 

I am doing some performance testing. Hope to get some feedback first. Thanks.