### PR TITLE
[STORM-2777] The number of ackers should default to the number of workers

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2673,7 +2673,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             }
             Map<String, Object> otherConf = Utils.getConfigFromClasspath(cp, conf);
             Map<String, Object> totalConfToSave = Utils.merge(otherConf, topoConf);
-            Map<String, Object> totalConf = Utils.merge(totalConfToSave, conf);
+            Map<String, Object> totalConf = Utils.merge(conf, totalConfToSave);
             //When reading the conf in nimbus we want to fall back to our own settings
             // if the other config does not have it set.
             topology = normalizeTopology(totalConf, topology);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/STORM-2777

https://github.com/apache/storm/pull/2325 introduced a bug that  the number of ackers doesn't default to the number of workers in non-RAS cases.

Manually tested on both non-RAS case and RAS case.
