### PR TITLE
STORM-2779 NPE on shutting down WindowedBoltExecutor

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
@@ -327,7 +327,9 @@ public class WindowedBoltExecutor implements IRichBolt {
 
     @Override
     public void cleanup() {
-        waterMarkEventGenerator.shutdown();
+        if (waterMarkEventGenerator != null) {
+            waterMarkEventGenerator.shutdown();
+        }
         windowManager.shutdown();
         bolt.cleanup();
     }


### PR DESCRIPTION
* waterMarkEventGenerator could be null when timestamp field is not specified