### PR TITLE
STORM-2779 NPE on shutting down WindowedBoltExecutor (1.x)

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
+++ b/storm-core/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
@@ -299,7 +299,9 @@ public class WindowedBoltExecutor implements IRichBolt {
 
     @Override
     public void cleanup() {
-        waterMarkEventGenerator.shutdown();
+        if (waterMarkEventGenerator != null) {
+            waterMarkEventGenerator.shutdown();
+        }
         windowManager.shutdown();
         bolt.cleanup();
     }


### PR DESCRIPTION
* waterMarkEventGenerator could be null when timestamp field is not specified