### PR TITLE
STORM-2791: Add Fields constructor to FixedTupleSpout for multiple output field support.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/testing/FixedTupleSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/FixedTupleSpout.java
@@ -60,13 +60,21 @@ public class FixedTupleSpout implements IRichSpout, CompletableSpout {
     private Map<String, FixedTuple> _pending;
 
     private String _id;
-    private String _fieldName;
+    private Fields _fields;
 
     public FixedTupleSpout(List tuples) {
-        this(tuples, null);
+        this(tuples, (Fields) null);
     }
 
+    /**
+     * @deprecated please use {@link #FixedTupleSpout(List, Fields)}
+     */
+    @Deprecated
     public FixedTupleSpout(List tuples, String fieldName) {
+        this(tuples, new Fields(fieldName));
+    }
+
+    public FixedTupleSpout(List tuples, Fields fields) {
         _id = UUID.randomUUID().toString();
         synchronized(acked) {
             acked.put(_id, 0);
@@ -84,7 +92,7 @@ public class FixedTupleSpout implements IRichSpout, CompletableSpout {
             }
             _tuples.add(ft);
         }
-        _fieldName = fieldName;
+        _fields = fields;
     }
 
     public List<FixedTuple> getSourceTuples() {
@@ -168,8 +176,8 @@ public class FixedTupleSpout implements IRichSpout, CompletableSpout {
 
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) { 
-        if (_fieldName != null) {
-            declarer.declare(new Fields(_fieldName));
+        if (_fields != null) {
+            declarer.declare(_fields);
         }
     }
 


### PR DESCRIPTION
[JIRA - STORM 2791](https://issues.apache.org/jira/browse/STORM-2791)
Also deprecated existing constructor that accepts a `String`.