### PR TITLE
[STORM-2794] Translate backtype to org.apache for topology.scheduler.strategy if scheduling older version topologies

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceAwareScheduler.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceAwareScheduler.java
@@ -109,7 +109,14 @@ public class ResourceAwareScheduler implements IScheduler {
         IStrategy rasStrategy = null;
         String strategyConf = (String) td.getConf().get(Config.TOPOLOGY_SCHEDULER_STRATEGY);
         try {
-            rasStrategy = ReflectionUtils.newSchedulerStrategyInstance((String) td.getConf().get(Config.TOPOLOGY_SCHEDULER_STRATEGY), conf);
+            String strategy = (String) td.getConf().get(Config.TOPOLOGY_SCHEDULER_STRATEGY);
+            if (strategy.startsWith("backtype.storm")) {
+                // Storm supports to launch workers of older version.
+                // If the config of TOPOLOGY_SCHEDULER_STRATEGY comes from the older version, replace the package name.
+                strategy = strategy.replace("backtype.storm", "org.apache.storm");
+                LOG.debug("Replace backtype.storm with org.apache.storm for Config.TOPOLOGY_SCHEDULER_STRATEGY");
+            }
+            rasStrategy = ReflectionUtils.newSchedulerStrategyInstance(strategy, conf);
             rasStrategy.prepare(conf);
         } catch (DisallowedStrategyException e) {
             markFailedTopology(topologySubmitter, cluster, td,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2794

In order to support running workers of older version, when we schedule a topology of older version, the confs in TopologyDetails could be "backtype.storm". To make scheduler work, we need to translate "backtype.storm" to "org.storm" for Config.TOPOLOGY_SCHEDULER_STRATEGY

Tested it manually.