### PR TITLE
STORM-2799: Exclude jdk.tools for JDK 9 compatibility

### DIFF
--- a/external/storm-hbase/pom.xml
+++ b/external/storm-hbase/pom.xml
@@ -55,6 +55,11 @@
                     <groupId>org.apache.zookeeper</groupId>
                     <artifactId>zookeeper</artifactId>
                 </exclusion>
+                <exclusion>
+                    <!-- This is leaking from hadoop-annotations. -->
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -69,6 +74,11 @@
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>
                     <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- This is leaking from hadoop-annotations. -->
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/external/storm-solr/pom.xml
+++ b/external/storm-solr/pom.xml
@@ -71,6 +71,13 @@
             <artifactId>solr-core</artifactId>
             <version>${solr.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- This is leaking from hadoop-annotations. -->
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
         <hive.version>0.14.0</hive.version>
         <hadoop.version>2.6.1</hadoop.version>
         <hdfs.version>${hadoop.version}</hdfs.version>
-        <hbase.version>1.1.0</hbase.version>
+        <hbase.version>1.1.12</hbase.version>
         <kryo.version>3.0.3</kryo.version>
         <servlet.version>3.1.0</servlet.version>
         <joda-time.version>2.3</joda-time.version>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/STORM-2799.

This excludes jdk.tools from a few dependencies. I also upgraded hbase to the latest patch release of the current version, since the 1.1.0 version leaks jdk.tools https://issues.apache.org/jira/browse/HBASE-13963 and versions prior to 1.1.11 don't work with Java 9 https://issues.apache.org/jira/browse/HBASE-17944. 