### PR TITLE
STORM-2800: Use Maven JAXB api artifact instead of assuming it is ava…

### DIFF
--- a/external/storm-autocreds/pom.xml
+++ b/external/storm-autocreds/pom.xml
@@ -124,6 +124,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
     <plugins>

--- a/external/storm-pmml/pom.xml
+++ b/external/storm-pmml/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>pmml-evaluator</artifactId>
             <version>${jpmml.version}</version>
         </dependency>
+        <!-- JAXB api -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,7 @@
         <j2html.version>1.0.0</j2html.version>
         <jool.version>0.9.12</jool.version>
         <caffeine.version>2.3.5</caffeine.version>
+        <jaxb-version>2.3.0</jaxb-version>
 
         <!-- see intellij profile below... This fixes an annoyance with intellij -->
         <provided.scope>provided</provided.scope>
@@ -1049,6 +1050,11 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -115,6 +115,12 @@
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
         </dependency>
+        
+        <!-- JAXB -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
 
         <!-- json -->
         <dependency>


### PR DESCRIPTION
…ilable from the JDK

See https://issues.apache.org/jira/browse/STORM-2800.

jaxb-api is dual licensed under CDDL 1.1 and GPL. CDDL is a category B license, which the FAQ at https://www.apache.org/legal/resolved.html#category-b says should be labeled somewhere users will read it. Do we have a document like that already, or where do I put the notice?

The uses of JAXB are:
* Uses of DataTypeConverter in storm-client and storm-autocreds. jaxb-api includes a default implementation of this converter (https://github.com/javaee/jaxb-spec/blob/master/jaxb-api/src/main/java/javax/xml/bind/DatatypeConverterImpl.java), so we don't need to include a full JAXB implementation to use this.
* Throws declaration of JAXBException in storm-pmml, which is thrown from a class in one of the org.jpmml libraries. The org.jpmml:pmml-model library includes a JAXB implementation, so we shouldn't need to add it ourselves.