### PR TITLE
STORM-2803: Fix leaking threads from Nimbus/TimeCacheMap, slightly refactor Time to use more final fields, replaced uses of deprecated classes/methods and added a few tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_install:
 install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
 script:
   - /bin/bash ./dev-tools/travis/travis-script.sh `pwd` $MODULES
-sudo: true
 cache:
   directories:
     - "$HOME/.m2/repository"

--- a/examples/storm-starter/test/jvm/org/apache/storm/starter/tools/NthLastModifiedTimeTrackerTest.java
+++ b/examples/storm-starter/test/jvm/org/apache/storm/starter/tools/NthLastModifiedTimeTrackerTest.java
@@ -23,6 +23,8 @@ import org.testng.annotations.Test;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
+import org.apache.storm.utils.Time.SimulatedTime;
+
 public class NthLastModifiedTimeTrackerTest {
 
   private static final int ANY_NUM_TIMES_TO_TRACK = 3;
@@ -55,19 +57,17 @@ public class NthLastModifiedTimeTrackerTest {
 
   @Test(dataProvider = "whenNotYetMarkedAsModifiedData")
   public void shouldReturnCorrectModifiedTimeEvenWhenNotYetMarkedAsModified(int secondsToAdvance) {
-    // given
-    Time.startSimulating();
-    NthLastModifiedTimeTracker tracker = new NthLastModifiedTimeTracker(ANY_NUM_TIMES_TO_TRACK);
+      // given
+      try (SimulatedTime t = new SimulatedTime()) {
+          NthLastModifiedTimeTracker tracker = new NthLastModifiedTimeTracker(ANY_NUM_TIMES_TO_TRACK);
 
-    // when
-    advanceSimulatedTimeBy(secondsToAdvance);
-    int seconds = tracker.secondsSinceOldestModification();
+          // when
+          Time.advanceTimeSecs(secondsToAdvance);
+          int seconds = tracker.secondsSinceOldestModification();
 
-    // then
-    assertThat(seconds).isEqualTo(secondsToAdvance);
-
-    // cleanup
-    Time.stopSimulating();
+          // then
+          assertThat(seconds).isEqualTo(secondsToAdvance);
+      }
   }
 
   @DataProvider
@@ -94,32 +94,26 @@ public class NthLastModifiedTimeTrackerTest {
         { 3, new int[]{ 1, 2, 3 }, new int[]{ 1, 3, 5 } } };
   }
 
-  @Test(dataProvider = "simulatedTrackerIterations")
-  public void shouldReturnCorrectModifiedTimeWhenMarkedAsModified(int numTimesToTrack,
-      int[] secondsToAdvancePerIteration, int[] expLastModifiedTimes) {
-    // given
-    Time.startSimulating();
-    NthLastModifiedTimeTracker tracker = new NthLastModifiedTimeTracker(numTimesToTrack);
+    @Test(dataProvider = "simulatedTrackerIterations")
+    public void shouldReturnCorrectModifiedTimeWhenMarkedAsModified(int numTimesToTrack,
+        int[] secondsToAdvancePerIteration, int[] expLastModifiedTimes) {
+        // given
+        try (SimulatedTime t = new SimulatedTime()) {
+            NthLastModifiedTimeTracker tracker = new NthLastModifiedTimeTracker(numTimesToTrack);
 
-    int[] modifiedTimes = new int[expLastModifiedTimes.length];
+            int[] modifiedTimes = new int[expLastModifiedTimes.length];
 
-    // when
-    int i = 0;
-    for (int secondsToAdvance : secondsToAdvancePerIteration) {
-      advanceSimulatedTimeBy(secondsToAdvance);
-      tracker.markAsModified();
-      modifiedTimes[i] = tracker.secondsSinceOldestModification();
-      i++;
+            // when
+            int i = 0;
+            for (int secondsToAdvance : secondsToAdvancePerIteration) {
+                Time.advanceTimeSecs(secondsToAdvance);
+                tracker.markAsModified();
+                modifiedTimes[i] = tracker.secondsSinceOldestModification();
+                i++;
+            }
+
+            // then
+            assertThat(modifiedTimes).isEqualTo(expLastModifiedTimes);
+        }
     }
-
-    // then
-    assertThat(modifiedTimes).isEqualTo(expLastModifiedTimes);
-
-    // cleanup
-    Time.stopSimulating();
-  }
-
-  private void advanceSimulatedTimeBy(int seconds) {
-    Time.advanceTime(seconds * MILLIS_IN_SEC);
-  }
 }

--- a/storm-client/src/jvm/org/apache/storm/utils/RotatingMap.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/RotatingMap.java
@@ -67,7 +67,7 @@ public class RotatingMap<K, V> {
 
     public RotatingMap(int numBuckets) {
         this(numBuckets, null);
-    }   
+    }
     
     public Map<K, V> rotate() {
         Map<K, V> dead = _buckets.removeLast();

--- a/storm-client/src/jvm/org/apache/storm/utils/ShellCommandRunner.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ShellCommandRunner.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.utils;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Contains convenience functions for running shell commands for cases that are too simple to need a full {@link ShellUtils} implementation.
+ */
+public interface ShellCommandRunner {
+    
+    /**
+     * Method to execute a shell command.
+     * Covers most of the simple cases without requiring the user to implement
+     * the {@link ShellUtils} interface.
+     * @param cmd shell command to execute.
+     * @return the output of the executed command.
+     */
+    String execCommand(String ... cmd) throws IOException;
+
+    /**
+     * Method to execute a shell command.
+     * Covers most of the simple cases without requiring the user to implement
+     * the {@link ShellUtils} interface.
+     * @param env the map of environment key=value
+     * @param cmd shell command to execute.
+     * @param timeout time in milliseconds after which script should be marked timeout
+     * @return the output of the executed command.
+     */
+
+    String execCommand(Map<String, String> env, String[] cmd,
+                                     long timeout) throws IOException;
+
+    /**
+     * Method to execute a shell command.
+     * Covers most of the simple cases without requiring the user to implement
+     * the {@link ShellUtils} interface.
+     * @param env the map of environment key=value
+     * @param cmd shell command to execute.
+     * @return the output of the executed command.
+     */
+    String execCommand(Map<String,String> env, String ... cmd)
+        throws IOException;
+    
+    /** Token separator regex used to parse Shell tool outputs */
+    String getTokenSeparatorRegex();
+
+}

--- a/storm-client/src/jvm/org/apache/storm/utils/ShellCommandRunnerImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ShellCommandRunnerImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.utils;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class ShellCommandRunnerImpl implements ShellCommandRunner {
+
+    @Override
+    public String execCommand(String... cmd) throws IOException {
+        return execCommand(null, cmd, 0L);
+    }
+
+    @Override
+    public String execCommand(Map<String, String> env, String[] cmd, long timeout) throws IOException {
+        ShellUtils.ShellCommandExecutor exec = new ShellUtils.ShellCommandExecutor(cmd, null, env,
+                                                             timeout);
+        exec.execute();
+        return exec.getOutput();
+    }
+
+    @Override
+    public String execCommand(Map<String, String> env, String... cmd) throws IOException {
+        return execCommand(env, cmd, 0L);
+    }
+
+    @Override
+    public String getTokenSeparatorRegex() {
+        return ShellUtils.TOKEN_SEPARATOR_REGEX;
+    }
+}

--- a/storm-client/src/jvm/org/apache/storm/utils/ShellUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ShellUtils.java
@@ -135,8 +135,10 @@ abstract public class ShellUtils {
 
     /** a Unix command to get the current user's groups list */
     public static String[] getGroupsCommand() {
-        return (WINDOWS)? new String[]{"cmd", "/c", "groups"}
-        : new String[]{"bash", "-c", "groups"};
+        if (WINDOWS) {
+            throw new UnsupportedOperationException("Getting user groups is not supported on Windows");
+        }
+        return new String[]{"bash", "-c", "groups"};
     }
 
     /**
@@ -146,6 +148,9 @@ abstract public class ShellUtils {
      * i.e. the user's primary group will be included twice.
      */
     public static String[] getGroupsForUserCommand(final String user) {
+        if (WINDOWS) {
+            throw new UnsupportedOperationException("Getting user groups is not supported on Windows");
+        }
         //'groups username' command return is non-consistent across different unixes
         return new String [] {"bash", "-c", "id -gn " + user
                          + "&& id -Gn " + user};
@@ -429,49 +434,6 @@ abstract public class ShellUtils {
      */
     private void setTimedOut() {
         this.timedOut.set(true);
-    }
-
-
-    /**
-     * Static method to execute a shell command.
-     * Covers most of the simple cases without requiring the user to implement
-     * the <code>Shell</code> interface.
-     * @param cmd shell command to execute.
-     * @return the output of the executed command.
-     */
-    public static String execCommand(String ... cmd) throws IOException {
-        return execCommand(null, cmd, 0L);
-    }
-
-    /**
-     * Static method to execute a shell command.
-     * Covers most of the simple cases without requiring the user to implement
-     * the <code>Shell</code> interface.
-     * @param env the map of environment key=value
-     * @param cmd shell command to execute.
-     * @param timeout time in milliseconds after which script should be marked timeout
-     * @return the output of the executed command.o
-     */
-
-    public static String execCommand(Map<String, String> env, String[] cmd,
-                                     long timeout) throws IOException {
-        ShellCommandExecutor exec = new ShellCommandExecutor(cmd, null, env,
-                                                             timeout);
-        exec.execute();
-        return exec.getOutput();
-    }
-
-    /**
-     * Static method to execute a shell command.
-     * Covers most of the simple cases without requiring the user to implement
-     * the <code>Shell</code> interface.
-     * @param env the map of environment key=value
-     * @param cmd shell command to execute.
-     * @return the output of the executed command.
-     */
-    public static String execCommand(Map<String,String> env, String ... cmd)
-        throws IOException {
-        return execCommand(env, cmd, 0L);
     }
 
     /**

--- a/storm-client/test/jvm/org/apache/storm/security/auth/ShellBasedGroupsMappingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/ShellBasedGroupsMappingTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.security.auth;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.storm.Config;
+import org.apache.storm.utils.ShellCommandRunner;
+import org.apache.storm.utils.ShellUtils;
+import org.apache.storm.utils.Time;
+import org.apache.storm.utils.Time.SimulatedTime;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShellBasedGroupsMappingTest {
+
+    private static final String TEST_TWO_GROUPS = "group1 group2";
+    private static final String TEST_NO_GROUPS = "";
+    private static final String TEST_USER_1 = "TestUserOne";
+    private static final String GROUP_SEPARATOR_REGEX = "\\s";
+    private static final int CACHE_EXPIRATION_SECS = 10;
+    
+    private ShellCommandRunner mockShell;
+    private ShellBasedGroupsMapping groupsMapping;
+    private Map<String, Object> topoConf;
+
+    @Before
+    public void setUp() {
+        mockShell = mock(ShellCommandRunner.class);
+        groupsMapping = new ShellBasedGroupsMapping(mockShell);
+        topoConf = new HashMap<>();
+        topoConf.put(Config.STORM_GROUP_MAPPING_SERVICE_CACHE_DURATION_SECS, 10);
+        when(mockShell.getTokenSeparatorRegex()).thenReturn(GROUP_SEPARATOR_REGEX);
+    }
+    
+    @Test
+    public void testCanGetGroups() throws Exception {
+        try (SimulatedTime t = new SimulatedTime()) {
+            groupsMapping.prepare(topoConf);
+            when(mockShell.execCommand(ShellUtils.getGroupsForUserCommand(TEST_USER_1))).thenReturn(TEST_TWO_GROUPS);
+            
+            Set<String> groups = groupsMapping.getGroups(TEST_USER_1);
+            
+            assertThat(groups, containsInAnyOrder(TEST_TWO_GROUPS.split(GROUP_SEPARATOR_REGEX)));
+        }
+    }
+    
+    @Test
+    public void testWillCacheGroups() throws Exception {
+        try(SimulatedTime t = new SimulatedTime()) {
+            groupsMapping.prepare(topoConf);
+            when(mockShell.execCommand(ShellUtils.getGroupsForUserCommand(TEST_USER_1))).thenReturn(TEST_TWO_GROUPS, TEST_NO_GROUPS);
+            
+            Set<String> firstGroups = groupsMapping.getGroups(TEST_USER_1);
+            Set<String> secondGroups = groupsMapping.getGroups(TEST_USER_1);
+            
+            assertThat(firstGroups, is(secondGroups));
+        }
+    }
+    
+    @Test
+    public void testWillExpireCache() throws Exception {
+        try(SimulatedTime t = new SimulatedTime()) {
+            groupsMapping.prepare(topoConf);
+            when(mockShell.execCommand(ShellUtils.getGroupsForUserCommand(TEST_USER_1))).thenReturn(TEST_TWO_GROUPS, TEST_NO_GROUPS);
+            
+            Set<String> firstGroups = groupsMapping.getGroups(TEST_USER_1);
+            Time.advanceTimeSecs(CACHE_EXPIRATION_SECS * 2);
+            Set<String> secondGroups = groupsMapping.getGroups(TEST_USER_1);
+            
+            assertThat(firstGroups, not(secondGroups));
+            assertThat(secondGroups, contains(TEST_NO_GROUPS));
+        }
+    }
+
+}

--- a/storm-core/src/jvm/org/apache/storm/utils/TopologySpoutLag.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/TopologySpoutLag.java
@@ -162,7 +162,7 @@ public class TopologySpoutLag {
 
             // if commands contains one or more null value, spout is compiled with lower version of storm-kafka / storm-kafka-client
             if (!commands.contains(null)) {
-                String resultFromMonitor = ShellUtils.execCommand(commands.toArray(new String[0]));
+                String resultFromMonitor = new ShellCommandRunnerImpl().execCommand(commands.toArray(new String[0]));
 
                 try {
                     result = (Map<String, Object>) JSONValue.parseWithException(resultFromMonitor);

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -4132,6 +4132,9 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             stormClusterState.disconnect();
             downloaders.cleanup();
             uploaders.cleanup();
+            blobDownloaders.cleanup();
+            blobUploaders.cleanup();
+            blobListers.cleanup();
             blobStore.shutdown();
             leaderElector.close();
             ITopologyActionNotifierPlugin actionNotifier = nimbusTopologyActionNotifier;

--- a/storm-server/src/test/java/org/apache/storm/scheduler/utils/ArtifactoryConfigLoaderTest.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/utils/ArtifactoryConfigLoaderTest.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.storm.utils.Time.SimulatedTime;
 
 public class ArtifactoryConfigLoaderTest {
 
@@ -125,9 +126,7 @@ public class ArtifactoryConfigLoaderTest {
         conf.put(DaemonConfig.SCHEDULER_CONFIG_LOADER_URI,  ARTIFACTORY_HTTP_SCHEME_PREFIX + "bogushost.yahoo.com:9999/location/of/test/dir");
         conf.put(Config.STORM_LOCAL_DIR, tmpDirPath.toString());
 
-        Time.startSimulating();
-
-        try {
+        try (SimulatedTime t = new SimulatedTime()) {
             ArtifactoryConfigLoaderMock loaderMock = new ArtifactoryConfigLoaderMock(conf);
 
             loaderMock.setData("Anything", "/location/of/test/dir",
@@ -186,8 +185,6 @@ public class ArtifactoryConfigLoaderTest {
             Assert.assertEquals(2, ret2.get("two"));
             Assert.assertEquals(3, ret2.get("three"));
             Assert.assertEquals(4, ret2.get("four"));
-        } finally {
-            Time.stopSimulating();
         }
     }
 


### PR DESCRIPTION
I'll squash once review is done. Ran this a few times on Travis, and it looks like SlotTest is stable now. The integration test is still failing occasionally. 

The flaky SlotTest was caused by Nimbus not cleaning up 3 TimeCacheMap instances, which have threads that occasionally call Time.sleep. SlotTest depends on the simulated time having certain values, so when the leaked threads slept the tests broke.

Changes: 
* TimeCacheMap threads were leaking from Nimbus, which caused time simulation to be unreliable in later tests, because the leaked threads call Time.sleep. Made sure to kill the threads.
* Replaced TimeCacheMap with RotatingMap in ShellBasedGroupsMapping, since that class has the same problem as Nimbus but also can't be cleaned up. Also added some tests for this class.
* As part of adding tests for ShellBasedGroupsMapping, moved some static functions from ShellUtils to an interface so they can be stubbed in tests.
* Removed uses of deprecated Time.startSimulating/stopSimulating in storm-server.
* Removed duplicate sudo in travis.yml
* Slightly refactored Time so all fields are final, and field resetting happens in the constructor. It seems easier to me to reason about thread safety this way.
* Add check to SlotTest.testResourcesChanged to ensure that the worker heartbeat hasn't expired in the step from WAITING_FOR_WORKER_START to RUNNING. It's a little weird that the test is reusing the original worker heartbeat in that step, so maybe changing the test to create a second heartbeat would be better. Let me know what you think.
* Removed non-functional (as far as I could tell) Windows groups command from ShellUtils and replaced it with an exception. Running "groups" on Windows doesn't do anything to my knowledge.