### PR TITLE
Fixing Java unit tests in storm-core to run under Windows (1.x branch)

### DIFF
--- a/storm-core/test/jvm/org/apache/storm/daemon/supervisor/BasicContainerTest.java
+++ b/storm-core/test/jvm/org/apache/storm/daemon/supervisor/BasicContainerTest.java
@@ -370,7 +370,7 @@ public class BasicContainerTest {
         final String workerConf = ContainerTest.asAbsPath(log4jdir, "worker.xml");
         final String workerRoot = ContainerTest.asAbsPath(stormLocal, "workers", workerId);
         final String workerTmpDir = ContainerTest.asAbsPath(workerRoot, "tmp");
-        
+
         final StormTopology st = new StormTopology();
         st.set_spouts(new HashMap<String, SpoutSpec>());
         st.set_bolts(new HashMap<String, Bolt>());
@@ -407,7 +407,7 @@ public class BasicContainerTest {
             assertListEquals(Arrays.asList(
                     "java",
                     "-cp",
-                    "FRAMEWORK_CP:" + stormjar.getAbsolutePath(),
+                    "FRAMEWORK_CP" + File.pathSeparator + stormjar.getAbsolutePath(),
                     "-Dlogging.sensitivity=S3",
                     "-Dlogfile.name=worker.log",
                     "-Dstorm.home=" + stormHome,
@@ -416,7 +416,7 @@ public class BasicContainerTest {
                     "-Dworker.id=" + workerId,
                     "-Dworker.port=" + port,
                     "-Dstorm.log.dir=" + stormLogDir,
-                    "-Dlog4j.configurationFile=" + workerConf,
+                    "-Dlog4j.configurationFile=" + prependFilePrefixIfOnWindows(workerConf),
                     "-DLog4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector",
                     "-Dstorm.local.dir=" + stormLocal,
                     "org.apache.storm.LogWriter",
@@ -430,7 +430,7 @@ public class BasicContainerTest {
                     "-Dworker.id=" + workerId,
                     "-Dworker.port=" + port,
                     "-Dstorm.log.dir=" + stormLogDir,
-                    "-Dlog4j.configurationFile=" + workerConf,
+                    "-Dlog4j.configurationFile=" + prependFilePrefixIfOnWindows(workerConf),
                     "-DLog4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector",
                     "-Dstorm.local.dir=" + stormLocal,
                     "-Dtesting=true",
@@ -439,7 +439,7 @@ public class BasicContainerTest {
                     "-Dstorm.options=",
                     "-Djava.io.tmpdir="+workerTmpDir,
                     "-cp",
-                    "FRAMEWORK_CP:" + stormjar.getAbsolutePath(),
+                    "FRAMEWORK_CP" + File.pathSeparator + stormjar.getAbsolutePath(),
                     "org.apache.storm.daemon.worker", 
                     topoId, 
                     "SUPERVISOR",
@@ -486,5 +486,13 @@ public class BasicContainerTest {
         
         assertListEquals(Collections.<String>emptyList(), 
                 mc.substituteChildopts(null));
+    }
+
+
+    private String prependFilePrefixIfOnWindows(String path) {
+        if(Utils.IS_ON_WINDOWS) {
+            return "file:///" + path;
+        }
+        return path;
     }
 }

--- a/storm-core/test/jvm/org/apache/storm/daemon/supervisor/ContainerTest.java
+++ b/storm-core/test/jvm/org/apache/storm/daemon/supervisor/ContainerTest.java
@@ -125,7 +125,8 @@ public class ContainerTest {
     private static final Joiner PATH_JOIN = Joiner.on(File.separator).skipNulls();
     private static final String DOUBLE_SEP = File.separator + File.separator;    
     static String asAbsPath(String ... parts) {
-        return (File.separator + PATH_JOIN.join(parts)).replace(DOUBLE_SEP, File.separator);
+        String path = (File.separator + PATH_JOIN.join(parts)).replace(DOUBLE_SEP, File.separator);
+        return new File(path).getAbsolutePath();
     }
     
     static File asAbsFile(String ... parts) {

--- a/storm-core/test/jvm/org/apache/storm/localizer/AsyncLocalizerTest.java
+++ b/storm-core/test/jvm/org/apache/storm/localizer/AsyncLocalizerTest.java
@@ -62,15 +62,15 @@ public class AsyncLocalizerTest {
         final String jarKey = topoId + "-stormjar.jar";
         final String codeKey = topoId + "-stormcode.ser";
         final String confKey = topoId + "-stormconf.ser";
-        final String stormLocal = "/tmp/storm-local/";
-        final String stormRoot = stormLocal+topoId+"/";
+        final String stormLocalAbsolutePath = new File("/tmp/storm-local/").getAbsolutePath();
+        final String stormRoot = stormLocalAbsolutePath+topoId+"/";
         final File fStormRoot = new File(stormRoot);
         ClientBlobStore blobStore = mock(ClientBlobStore.class);
         Map<String, Object> conf = new HashMap<>();
         conf.put(Config.SUPERVISOR_BLOBSTORE, ClientBlobStore.class.getName());
         conf.put(Config.STORM_PRINCIPAL_TO_LOCAL_PLUGIN, DefaultPrincipalToLocal.class.getName());
         conf.put(Config.STORM_CLUSTER_MODE, "distributed");
-        conf.put(Config.STORM_LOCAL_DIR, stormLocal);
+        conf.put(Config.STORM_LOCAL_DIR, stormLocalAbsolutePath);
         Localizer localizer = mock(Localizer.class);
         AdvancedFSOps ops = mock(AdvancedFSOps.class);
         ConfigUtils mockedCU = mock(ConfigUtils.class);
@@ -83,7 +83,7 @@ public class AsyncLocalizerTest {
         Utils origUtils = Utils.setInstance(mockedU);
         try {
             when(mockedCU.supervisorStormDistRootImpl(conf, topoId)).thenReturn(stormRoot);
-            when(mockedCU.supervisorLocalDirImpl(conf)).thenReturn(stormLocal);
+            when(mockedCU.supervisorLocalDirImpl(conf)).thenReturn(stormLocalAbsolutePath);
             when(mockedU.newInstanceImpl(ClientBlobStore.class)).thenReturn(blobStore);
             when(mockedCU.readSupervisorStormConfImpl(conf, topoId)).thenReturn(topoConf);
 
@@ -92,9 +92,9 @@ public class AsyncLocalizerTest {
             // We should be done now...
             
             verify(blobStore).prepare(conf);
-            verify(mockedU).downloadResourcesAsSupervisorImpl(eq(jarKey), startsWith(stormLocal), eq(blobStore));
-            verify(mockedU).downloadResourcesAsSupervisorImpl(eq(codeKey), startsWith(stormLocal), eq(blobStore));
-            verify(mockedU).downloadResourcesAsSupervisorImpl(eq(confKey), startsWith(stormLocal), eq(blobStore));
+            verify(mockedU).downloadResourcesAsSupervisorImpl(eq(jarKey), startsWith(stormLocalAbsolutePath), eq(blobStore));
+            verify(mockedU).downloadResourcesAsSupervisorImpl(eq(codeKey), startsWith(stormLocalAbsolutePath), eq(blobStore));
+            verify(mockedU).downloadResourcesAsSupervisorImpl(eq(confKey), startsWith(stormLocalAbsolutePath), eq(blobStore));
             verify(blobStore).shutdown();
             //Extracting the dir from the jar
             verify(mockedU).extractDirFromJarImpl(endsWith("stormjar.jar"), eq("resources"), any(File.class));


### PR DESCRIPTION
While fixing STORM-2797 I noticed a bunch of the storm-core tests didn't run under Windows.

I've fixed them up to use Windows-friendly asserts. All are done in a generic way through framework classes except one particular case where the behavior actually differs based on operating system. I only modified tests, not any actual application code. I tested this change on Windows, OS X, and Linux: all pass. On Windows, I still have to run Maven as administrator as some of the tests write to temp folders in AppData.

I'll follow up with a pull request for STORM-2797. There are still some Clojure tests failing but a lot of them are around the logviewer, which will be fixed by my next PR. 