### PR TITLE
STORM-2811: Fix NPE in Nimbus when killing the same topology multiple…

### DIFF
--- a/integration-test/src/main/java/org/apache/storm/st/utils/StringDecorator.java
+++ b/integration-test/src/main/java/org/apache/storm/st/utils/StringDecorator.java
@@ -17,7 +17,6 @@
 
 package org.apache.storm.st.utils;
 
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang.StringUtils;
 
 public class StringDecorator {

--- a/integration-test/src/test/java/org/apache/storm/st/DemoTest.java
+++ b/integration-test/src/test/java/org/apache/storm/st/DemoTest.java
@@ -80,6 +80,7 @@ public final class DemoTest extends AbstractTest {
     public void cleanup() throws Exception {
         if (topo != null) {
             topo.killOrThrow();
+            topo = null;
         }
     }
 }

--- a/integration-test/src/test/java/org/apache/storm/st/tests/window/SlidingWindowTest.java
+++ b/integration-test/src/test/java/org/apache/storm/st/tests/window/SlidingWindowTest.java
@@ -188,6 +188,7 @@ public final class SlidingWindowTest extends AbstractTest {
     public void cleanup() throws Exception {
         if (topo != null) {
             topo.killOrThrow();
+            topo = null;
         }
     }
 }

--- a/integration-test/src/test/java/org/apache/storm/st/tests/window/TumblingWindowTest.java
+++ b/integration-test/src/test/java/org/apache/storm/st/tests/window/TumblingWindowTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 
 public final class TumblingWindowTest extends AbstractTest {
     private static Logger log = LoggerFactory.getLogger(TumblingWindowTest.class);
-    TopoWrap topo;
+    private TopoWrap topo;
 
     @DataProvider
     public static Object[][] generateWindows() {
@@ -94,6 +94,7 @@ public final class TumblingWindowTest extends AbstractTest {
     public void cleanup() throws Exception {
         if (topo != null) {
             topo.killOrThrow();
+            topo = null;
         }
     }
 }

--- a/integration-test/src/test/java/org/apache/storm/st/wrapper/StormCluster.java
+++ b/integration-test/src/test/java/org/apache/storm/st/wrapper/StormCluster.java
@@ -93,7 +93,7 @@ public class StormCluster {
                 client.killTopologyWithOpts(topologyName, killOptions);
                 log.info("Topology killed: " + topologyName);
                 return;
-            } catch (Throwable e) {
+            } catch (TException e) {
                 log.warn("Couldn't kill topology: " + topologyName + ", going to retry soon. Exception: " + ExceptionUtils.getFullStackTrace(e));
                 Thread.sleep(TimeUnit.SECONDS.toMillis(2));
             }

--- a/storm-client/src/jvm/org/apache/storm/cluster/IStormClusterState.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/IStormClusterState.java
@@ -168,8 +168,8 @@ public interface IStormClusterState {
     default Optional<String> getTopoId(final String topologyName) {
         String ret = null;
         for (String topoId: activeStorms()) {
-            String name = stormBase(topoId, null).get_name();
-            if (topologyName.equals(name)) {
+            StormBase base = stormBase(topoId, null);
+            if(base != null && topologyName.equals(base.get_name())) {
                 ret = topoId;
                 break;
             }


### PR DESCRIPTION
… times, fix integration test killing the same topology multiple times

https://issues.apache.org/jira/browse/STORM-2811

Some of the integration tests don't create a TopoWrap, which causes the cleanup code to kill the same topology multiple times.

The Nimbus client's behavior when the server throws exceptions was a little surprising to me. It looks like the client lost connection to the server after the NPE was thrown, so the subsequent atttempts to kill the topology just got TTransportException (I'm guessing the socket was closed). I'm not sure if this is expected behavior?