### PR TITLE
STORM-2811: Fix integration test killing the same topology multiple t…

### DIFF
--- a/integration-test/src/test/java/org/apache/storm/st/DemoTest.java
+++ b/integration-test/src/test/java/org/apache/storm/st/DemoTest.java
@@ -80,6 +80,7 @@ public final class DemoTest extends AbstractTest {
     public void cleanup() throws Exception {
         if (topo != null) {
             topo.killOrThrow();
+            topo = null;
         }
     }
 }

--- a/integration-test/src/test/java/org/apache/storm/st/tests/window/SlidingWindowTest.java
+++ b/integration-test/src/test/java/org/apache/storm/st/tests/window/SlidingWindowTest.java
@@ -188,6 +188,7 @@ public final class SlidingWindowTest extends AbstractTest {
     public void cleanup() throws Exception {
         if (topo != null) {
             topo.killOrThrow();
+            topo = null;
         }
     }
 }

--- a/integration-test/src/test/java/org/apache/storm/st/tests/window/TumblingWindowTest.java
+++ b/integration-test/src/test/java/org/apache/storm/st/tests/window/TumblingWindowTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 
 public final class TumblingWindowTest extends AbstractTest {
     private static Logger log = LoggerFactory.getLogger(TumblingWindowTest.class);
-    TopoWrap topo;
+    private TopoWrap topo;
 
     @DataProvider
     public static Object[][] generateWindows() {
@@ -94,6 +94,7 @@ public final class TumblingWindowTest extends AbstractTest {
     public void cleanup() throws Exception {
         if (topo != null) {
             topo.killOrThrow();
+            topo = null;
         }
     }
 }

--- a/integration-test/src/test/java/org/apache/storm/st/wrapper/StormCluster.java
+++ b/integration-test/src/test/java/org/apache/storm/st/wrapper/StormCluster.java
@@ -93,7 +93,7 @@ public class StormCluster {
                 client.killTopologyWithOpts(topologyName, killOptions);
                 log.info("Topology killed: " + topologyName);
                 return;
-            } catch (Throwable e) {
+            } catch (TException e) {
                 log.warn("Couldn't kill topology: " + topologyName + ", going to retry soon. Exception: " + ExceptionUtils.getFullStackTrace(e));
                 Thread.sleep(TimeUnit.SECONDS.toMillis(2));
             }


### PR DESCRIPTION
…imes

1.x version of https://github.com/apache/storm/pull/2415. The clojure code equivalent to IStormClusterState.getTopoId (daemon/common.clj:get-storm-id) doesn't have an NPE bug, so that fix isn't necessary here.