### PR TITLE
STORM-2809:  Always create the resources directory so we can check for it

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedTopologyBlob.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedTopologyBlob.java
@@ -217,6 +217,10 @@ public class LocallyCachedTopologyBlob extends LocallyCachedBlob {
 
     protected void extractDirFromJar(String jarpath, String dir, Path dest) throws IOException {
         LOG.debug("EXTRACTING {} from {} and placing it at {}", dir, jarpath, dest);
+        if (!Files.exists(dest)) {
+            //Create the directory no matter what. This is so we can check if it was downloaded in the future.
+            Files.createDirectories(dest);
+        }
         try (JarFile jarFile = new JarFile(jarpath)) {
             String toRemove = dir + '/';
             Enumeration<JarEntry> jarEnums = jarFile.entries();


### PR DESCRIPTION
The issue was actually a few lines below this.  In the isFullyDownloaded function.  It would check if we wanted to extract things, like with the resources jar, that the destination directory existed.  But that directory would only be created if there was something to extract.  Some topology jars didn't have anything to extract so the directory would never be created and the worker would be relaunched every 30 seconds.