### PR TITLE
[STORM-2814] Logviewer HTTP server should return 403 instead of 200 if the user is unauthorized

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandler.java
@@ -247,7 +247,7 @@ public class LogviewerLogPageHandler {
             if (resourceAuthorizer.getLogUserGroupWhitelist(fileName) != null) {
                 return LogviewerResponseBuilder.buildResponsePageNotFound();
             } else {
-                return LogviewerResponseBuilder.buildResponseUnautohrizedUser(user);
+                return LogviewerResponseBuilder.buildResponseUnauthorizedUser(user);
             }
         }
     }

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandler.java
@@ -76,7 +76,7 @@ public class LogviewerProfileHandler {
                 String content = buildDumpFileListPage(topologyId, hostPort, dir);
                 return LogviewerResponseBuilder.buildSuccessHtmlResponse(content);
             } else {
-                return LogviewerResponseBuilder.buildResponseUnautohrizedUser(user);
+                return LogviewerResponseBuilder.buildResponseUnauthorizedUser(user);
             }
         } else {
             return LogviewerResponseBuilder.buildResponsePageNotFound();
@@ -103,7 +103,7 @@ public class LogviewerProfileHandler {
             if (resourceAuthorizer.isUserAllowedToAccessFile(user, workerFileRelativePath)) {
                 return LogviewerResponseBuilder.buildDownloadFile(file);
             } else {
-                return LogviewerResponseBuilder.buildResponseUnautohrizedUser(user);
+                return LogviewerResponseBuilder.buildResponseUnauthorizedUser(user);
             }
         } else {
             return LogviewerResponseBuilder.buildResponsePageNotFound();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogFileDownloader.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogFileDownloader.java
@@ -57,7 +57,7 @@ public class LogFileDownloader {
             if (isDaemon || resourceAuthorizer.isUserAllowedToAccessFile(user, fileName)) {
                 return LogviewerResponseBuilder.buildDownloadFile(file);
             } else {
-                return LogviewerResponseBuilder.buildResponseUnautohrizedUser(user);
+                return LogviewerResponseBuilder.buildResponseUnauthorizedUser(user);
             }
         } else {
             return LogviewerResponseBuilder.buildResponsePageNotFound();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogviewerResponseBuilder.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogviewerResponseBuilder.java
@@ -20,6 +20,7 @@ package org.apache.storm.daemon.logviewer.utils;
 
 import static j2html.TagCreator.body;
 import static j2html.TagCreator.h2;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
 
@@ -89,9 +90,9 @@ public class LogviewerResponseBuilder {
      *
      * @param user username
      */
-    public static Response buildResponseUnautohrizedUser(String user) {
+    public static Response buildResponseUnauthorizedUser(String user) {
         String entity = buildUnauthorizedUserHtml(user);
-        return Response.status(OK)
+        return Response.status(FORBIDDEN)
                 .entity(entity)
                 .type(MediaType.TEXT_HTML_TYPE)
                 .build();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogviewerResponseBuilder.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogviewerResponseBuilder.java
@@ -116,7 +116,7 @@ public class LogviewerResponseBuilder {
      */
     public static Response buildUnauthorizedUserJsonResponse(String user, String callback) {
         return new JsonResponseBuilder().setData(UIHelpers.unauthorizedUserJson(user))
-                .setCallback(callback).setStatus(401).build();
+                .setCallback(callback).setStatus(403).build();
     }
 
     /**


### PR DESCRIPTION
A trivial fix. Change the return HTTP Code from 200 to 403.
Also fixed the typos

https://issues.apache.org/jira/browse/STORM-2814