### PR TITLE
[STORM-2820] fix validateTopologyWorkerMaxHeapSizeConfigs function never picks up the value set by nimbus problem

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2546,10 +2546,10 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
 
     @VisibleForTesting
     static void validateTopologyWorkerMaxHeapSizeConfigs(
-        Map<String, Object> stormConf, StormTopology topology) {
+        Map<String, Object> stormConf, StormTopology topology, double defaultWorkerMaxHeapSizeMB) {
         double largestMemReq = getMaxExecutorMemoryUsageForTopo(topology, stormConf);
         double topologyWorkerMaxHeapSize =
-            ObjectReader.getDouble(stormConf.get(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB), 768.0);
+            ObjectReader.getDouble(stormConf.get(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB), defaultWorkerMaxHeapSizeMB);
         if (topologyWorkerMaxHeapSize < largestMemReq) {
             throw new IllegalArgumentException(
                 "Topology will not be able to be successfully scheduled: Config "
@@ -2626,7 +2626,8 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                   Config.TOPOLOGY_BLOBSTORE_MAP + " = " + blobMap);
                 }
             }
-            validateTopologyWorkerMaxHeapSizeConfigs(topoConf, topology);
+            validateTopologyWorkerMaxHeapSizeConfigs(topoConf, topology,
+                    ObjectReader.getDouble(conf.get(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB)));
             Utils.validateTopologyBlobStoreMap(topoConf, blobStore);
             long uniqueNum = submittedCount.incrementAndGet();
             String topoId = topoName + "-" + uniqueNum + "-" + Time.currentTimeSecs();

--- a/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
@@ -48,7 +48,7 @@ public class NimbusTest {
         config1.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, 128.0);
         config1.put(Config.TOPOLOGY_COMPONENT_RESOURCES_ONHEAP_MEMORY_MB, 129.0);
         try {
-            Nimbus.validateTopologyWorkerMaxHeapSizeConfigs(config1, stormTopology1);
+            Nimbus.validateTopologyWorkerMaxHeapSizeConfigs(config1, stormTopology1, 768.0);
             fail("Expected exception not thrown");
         } catch (IllegalArgumentException e) {
             //Expected...


### PR DESCRIPTION
As stated in https://issues.apache.org/jira/browse/STORM-2820, the validateTopologyWorkerMaxHeapSizeConfigs use either the value from topology configuration (set by the topology) or 768.0. It never picks up the value set by nimbus.

Tested it manually.