### PR TITLE
[STORM-2829] fix logviewer deepSearch direct self-reference leading to cycle exception

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
@@ -414,7 +414,7 @@ public class LogviewerLogSearchHandler {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            currentFileMatch.put("port", truncatePathToLastElements(firstLogAbsPath, 2).getName(0));
+            currentFileMatch.put("port", truncatePathToLastElements(firstLogAbsPath, 2).getName(0).toString());
             newMatches.add(currentFileMatch);
 
             int newCount = matchCount + ((List<?>)theseMatches.get("matches")).size();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2829

```
2017-11-21 21:06:19.369 o.e.j.s.HttpChannel qtp1471948789-17 [WARN] /api/v1/deepSearch/wc-1-1511188542
javax.servlet.ServletException: java.lang.RuntimeException: com.fasterxml.jackson.databind.JsonMappingException: Direct self-reference leading to cycle (through reference chain: org.apache.storm.daemon.logviewer.handler.Matched["matches"]->java.util.ArrayList[0]->java.util.HashMap["port"]->sun.nio.fs.UnixPath["fileSystem"]->sun.nio.fs.LinuxFileSystem["rootDirectories"]->sun.nio.fs.UnixPath["root"])
```

We are having the above exception because 
`truncatePathToLastElements(firstLogAbsPath, 2).getName(0)` returns a Path object. Then `OBJECT_MAPPER.writeValueAsString()` (in `Matched` `toJSONString()`) somehow interprets the path to `sun.nio.fs.UnixPath["fileSystem"]` and etc... which causes the exception. 

Tested it manually. With this patch, the deepSearch should works fine.
 

![image](https://user-images.githubusercontent.com/14900612/33098514-44daacee-ced3-11e7-99cb-6905c29e79e1.png)
