### PR TITLE
[STORM-2838] Replace log4j-over-slf4j with log4j-1.2-api

### DIFF
--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -85,8 +85,8 @@
             <artifactId>java-hamcrest</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
         <auto-service.version>1.0-rc3</auto-service.version>
         <netty.version>3.9.0.Final</netty.version>
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
-        <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
+        <slf4j-log4j12.version>1.6.6</slf4j-log4j12.version>
         <log4j.version>2.8.2</log4j.version>
         <slf4j.version>1.7.21</slf4j.version>
         <metrics.version>3.1.0</metrics.version>
@@ -896,6 +896,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
@@ -912,12 +917,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>${log4j-over-slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>${log4j-over-slf4j.version}</version>
+                <version>${slf4j-log4j12.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -63,8 +63,8 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
         </dependency>
 
         <!-- guava -->

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -247,8 +247,8 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2838

To let storm work with HDFS, we need to replace log4j-over-slf4j with log4j-1.2-api. Otherwise we will get an error: 
```
Detected both log4j-over-slf4j.jar AND slf4j-log4j12.jar on the class path, preempting StackOverflowError.
```
