### PR TITLE
[STORM-2846] Add extra classpath for nimbus and supervisor separately

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -104,6 +104,8 @@ JAVA_CMD = get_java_cmd();
 if JAVA_HOME and not os.path.exists(JAVA_CMD):
     print("ERROR:  JAVA_HOME is invalid.  Could not find bin/java at %s." % JAVA_HOME)
     sys.exit(1)
+NIMBUS_EXTRA_CLASSPATHS = os.getenv('NIMBUS_EXTRA_CLASSPATHS', None)
+SUPERVISOR_EXTRA_CLASSPATHS = os.getenv('SUPERVISOR_EXTRA_CLASSPATHS', None)
 STORM_EXT_CLASSPATH = os.getenv('STORM_EXT_CLASSPATH', None)
 STORM_EXT_CLASSPATH_DAEMON = os.getenv('STORM_EXT_CLASSPATH_DAEMON', None)
 DEP_JARS_OPTS = []
@@ -694,7 +696,10 @@ def nimbus(klass="org.apache.storm.daemon.nimbus.Nimbus"):
     See Setting up a Storm cluster for more information.
     (http://storm.apache.org/documentation/Setting-up-a-Storm-cluster)
     """
-    cppaths = [CLUSTER_CONF_DIR]
+    if NIMBUS_EXTRA_CLASSPATHS != None:
+        cppaths = [CLUSTER_CONF_DIR, NIMBUS_EXTRA_CLASSPATHS]
+    else:
+        cppaths = [CLUSTER_CONF_DIR]
     jvmopts = parse_args(confvalue("nimbus.childopts", cppaths)) + [
         "-Dlogfile.name=nimbus.log",
         "-DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector",
@@ -737,7 +742,10 @@ def supervisor(klass="org.apache.storm.daemon.supervisor.Supervisor"):
     See Setting up a Storm cluster for more information.
     (http://storm.apache.org/documentation/Setting-up-a-Storm-cluster)
     """
-    cppaths = [CLUSTER_CONF_DIR]
+    if SUPERVISOR_EXTRA_CLASSPATHS != None:
+        cppaths = [CLUSTER_CONF_DIR, SUPERVISOR_EXTRA_CLASSPATHS]
+    else:
+        cppaths = [CLUSTER_CONF_DIR]
     jvmopts = parse_args(confvalue("supervisor.childopts", cppaths)) + [
         "-Dlogfile.name=" + STORM_SUPERVISOR_LOG_FILE,
         "-Dlog4j.configurationFile=" + os.path.join(get_log4j2_conf_dir(), "cluster.xml"),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2846

Currently we have STORM_EXT_CLASSPATH_DAEMON and STORM_EXT_CLASSPATH for extra classpath. We might want to have extra classpath for nimbus and supervisor specifically. One of the issue I am facing with is about setting up HdfsBlobstore. I point STORM_EXT_CLASSPATH_DAEMON to the classpath of existing hadoop cluster. But because the hadoop classpath includes jersey-core-1.9, storm logviewer and drpc server failed to run (since storm uses jersey-2.x).

```
java.lang.Error: java.lang.NoSuchMethodError: javax.ws.rs.core.Application.getProperties()Ljava/util/Map;
        at org.apache.storm.utils.Utils.handleUncaughtException(Utils.java:568) ~[storm-client-2.0.0.y.jar:2.0.0.y]
        at org.apache.storm.utils.Utils.handleUncaughtException(Utils.java:547) ~[storm-client-2.0.0.y.jar:2.0.0.y]
        at org.apache.storm.utils.Utils$5.uncaughtException(Utils.java:877) ~[storm-client-2.0.0.y.jar:2.0.0.y]
        at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:1057) ~[?:1.8.0_131]
        at java.lang.ThreadGroup.uncaughtException(ThreadGroup.java:1052) ~[?:1.8.0_131]
        at java.lang.Thread.dispatchUncaughtException(Thread.java:1959) [?:1.8.0_131]
Caused by: java.lang.NoSuchMethodError: javax.ws.rs.core.Application.getProperties()Ljava/util/Map;
        at org.glassfish.jersey.server.ApplicationHandler.<init>(ApplicationHandler.java:331) ~[jersey-server-2.24.1.jar:?]
        at org.glassfish.jersey.servlet.WebComponent.<init>(WebComponent.java:392) ~[jersey-container-servlet-core-2.24.1.jar:?]
        at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:177) ~[jersey-container-servlet-core-2.24.1.jar:?]
        at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:369) ~[jersey-container-servlet-core-2.24.1.jar:?]
        at javax.servlet.GenericServlet.init(GenericServlet.java:244) ~[javax.servlet-api-3.1.0.jar:3.1.0]
        at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:637) ~[jetty-servlet-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:421) ~[jetty-servlet-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:760) ~[jetty-servlet-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:348) ~[jetty-servlet-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:785) ~[jetty-server-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:261) ~[jetty-servlet-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) ~[jetty-util-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131) ~[jetty-util-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.server.Server.start(Server.java:449) ~[jetty-server-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:105) ~[jetty-util-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:113) ~[jetty-server-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.server.Server.doStart(Server.java:416) ~[jetty-server-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) ~[jetty-util-9.4.7.v20170914.jar:9.4.7.v20170914]
        at org.apache.storm.daemon.logviewer.LogviewerServer.start(LogviewerServer.java:129) ~[storm-webapp-2.0.0.y.jar:2.0.0.y]
        at org.apache.storm.daemon.logviewer.LogviewerServer.main(LogviewerServer.java:170) ~[storm-webapp-2.0.0.y.jar:2.0.0.y]
```

Adding the jvm option -verbose:class, we have the following message:
```
[Loaded javax.ws.rs.core.Application from file:/home/gs/gridre/yroot.openqe74blue/share/hadoop-2.8.1.7.1709112043/share/hadoop/common/lib/jersey-core-1.9.jar]
```
It means that the javax.ws.rs.core.Application is loaded from jersey-core-1.9.
So adding separate classpath for nimbus/supervisor can solve this problem.

This might seem like not a clean solution. But I think it makes sense to have separate extra classpath for nimbus or supervisor since other daemons shouldn't have to care about extra classpaths nimbus/supervisor requires.