### PR TITLE
STORM-2854 Expose IEventLogger to make event logging pluggable

### DIFF
--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -74,3 +74,10 @@
 #       - endpoint: "metrics-collector.mycompany.org"
 #
 # storm.cluster.metrics.consumer.publish.interval.secs: 60
+
+# Event Logger
+# topology.event.logger.register:
+#   - class: "org.apache.storm.metric.FileBasedEventLogger"
+#   - class: "org.mycompany.MyEventLogger"
+#     arguments:
+#       endpoint: "event-logger.mycompany.org"

--- a/storm-client/src/jvm/org/apache/storm/daemon/StormCommon.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/StormCommon.java
@@ -94,6 +94,9 @@ public class StormCommon {
     public static final String TOPOLOGY_METRICS_CONSUMER_EXPAND_MAP_TYPE = "expandMapType";
     public static final String TOPOLOGY_METRICS_CONSUMER_METRIC_NAME_SEPARATOR = "metricNameSeparator";
 
+    public static final String TOPOLOGY_EVENT_LOGGER_CLASS = "class";
+    public static final String TOPOLOGY_EVENT_LOGGER_ARGUMENTS = "arguments";
+
     @Deprecated
     public static String getStormId(final IStormClusterState stormClusterState, final String topologyName) {
         return stormClusterState.getTopoId(topologyName).get();

--- a/storm-client/src/jvm/org/apache/storm/metric/EventLoggerBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/EventLoggerBolt.java
@@ -15,17 +15,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.metric;
 
+import static org.apache.storm.daemon.StormCommon.TOPOLOGY_EVENT_LOGGER_ARGUMENTS;
+import static org.apache.storm.daemon.StormCommon.TOPOLOGY_EVENT_LOGGER_CLASS;
+import static org.apache.storm.metric.IEventLogger.EventInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.storm.Config;
 import org.apache.storm.task.IBolt;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
-import static org.apache.storm.metric.IEventLogger.EventInfo;
 
 public class EventLoggerBolt implements IBolt {
 
@@ -39,13 +46,19 @@ public class EventLoggerBolt implements IBolt {
     public static final String FIELD_COMPONENT_ID = "component-id";
     public static final String FIELD_MESSAGE_ID = "message-id";
 
-    private IEventLogger eventLogger;
+    private List<IEventLogger> eventLoggers;
 
     @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
         LOG.info("EventLoggerBolt prepare called");
-        eventLogger = new FileBasedEventLogger();
-        eventLogger.prepare(topoConf, context);
+
+        eventLoggers = new ArrayList<>();
+        List<Map<String, Object>> registerInfo = (List<Map<String, Object>>) topoConf.get(Config.TOPOLOGY_EVENT_LOGGER_REGISTER);
+        if (registerInfo != null && !registerInfo.isEmpty()) {
+            initializeEventLoggers(topoConf, context, registerInfo);
+        } else {
+            initializeDefaultEventLogger(topoConf, context);
+        }
     }
 
     @Override
@@ -53,15 +66,42 @@ public class EventLoggerBolt implements IBolt {
         LOG.debug("** EventLoggerBolt got tuple from sourceComponent {}, with values {}", input.getSourceComponent(), input.getValues());
 
         Object msgId = input.getValueByField(FIELD_MESSAGE_ID);
-        EventInfo eventInfo = new EventInfo(input.getValueByField(FIELD_TS).toString(), input.getSourceComponent(),
-                                            String.valueOf(input.getSourceTask()), msgId == null ? "" : msgId.toString(),
-                                            input.getValueByField(FIELD_VALUES).toString());
+        EventInfo eventInfo = new EventInfo(input.getLongByField(FIELD_TS), input.getSourceComponent(),
+                                            input.getSourceTask(), msgId, (List<Object>) input.getValueByField(FIELD_VALUES));
 
-        eventLogger.log(eventInfo);
+        for (IEventLogger eventLogger : eventLoggers) {
+            eventLogger.log(eventInfo);
+        }
     }
 
     @Override
     public void cleanup() {
-        eventLogger.close();
+        for (IEventLogger eventLogger : eventLoggers) {
+            eventLogger.close();
+        }
+    }
+
+    private void initializeEventLoggers(Map<String, Object> topoConf, TopologyContext context, List<Map<String, Object>> registerInfo) {
+        for (Map<String, Object> info : registerInfo) {
+            String className = (String) info.get(TOPOLOGY_EVENT_LOGGER_CLASS);
+            Map<String, Object> arguments = (Map<String, Object>) info.get(TOPOLOGY_EVENT_LOGGER_ARGUMENTS);
+
+            IEventLogger eventLogger;
+            try {
+                eventLogger = (IEventLogger) Class.forName(className).newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException("Could not instantiate a class listed in config under section "
+                        + Config.TOPOLOGY_EVENT_LOGGER_REGISTER + " with fully qualified name " + className, e);
+            }
+
+            eventLogger.prepare(topoConf, arguments, context);
+            eventLoggers.add(eventLogger);
+        }
+    }
+
+    private void initializeDefaultEventLogger(Map<String, Object> topoConf, TopologyContext context) {
+        FileBasedEventLogger eventLogger = new FileBasedEventLogger();
+        eventLogger.prepare(topoConf, null, context);
+        eventLoggers.add(eventLogger);
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/metric/IEventLogger.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/IEventLogger.java
@@ -20,6 +20,7 @@ package org.apache.storm.metric;
 import org.apache.storm.task.TopologyContext;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,18 +32,39 @@ public interface IEventLogger {
     /**
      * A wrapper for the fields that we would log.
      */
-    public static class EventInfo {
-        String ts;
-        String component;
-        String task;
-        String messageId;
-        String values;
-        EventInfo(String ts, String component, String task, String messageId, String values) {
+    class EventInfo {
+        private long ts;
+        private String component;
+        private int task;
+        private Object messageId;
+        private List<Object> values;
+
+        public EventInfo(long ts, String component, int task, Object messageId, List<Object> values) {
             this.ts = ts;
             this.component = component;
             this.task = task;
             this.messageId = messageId;
             this.values = values;
+        }
+
+        public long getTs() {
+            return ts;
+        }
+
+        public String getComponent() {
+            return component;
+        }
+
+        public int getTask() {
+            return task;
+        }
+
+        public Object getMessageId() {
+            return messageId;
+        }
+
+        public List<Object> getValues() {
+            return values;
         }
 
         /**
@@ -52,11 +74,12 @@ public interface IEventLogger {
          */
         @Override
         public String toString() {
-            return new Date(Long.parseLong(ts)).toString() + "," + component + "," + task + "," + messageId + "," + values;
+            return new Date(ts).toString() + "," + component + "," + String.valueOf(task) + ","
+                    + (messageId == null ? "" : messageId.toString()) + "," + values.toString();
         }
     }
 
-    void prepare(Map<String, Object> topoConf, TopologyContext context);
+    void prepare(Map<String, Object> conf, Map<String, Object> arguments, TopologyContext context);
 
     /**
      * This method would be invoked when the {@link EventLoggerBolt} receives a tuple from the spouts or bolts that has

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -501,6 +501,26 @@ public class ConfigValidation {
         }
     }
 
+    public static class EventLoggerRegistryValidator extends Validator {
+
+        @Override
+        public void validateField(String name, Object o) {
+            if(o == null) {
+                return;
+            }
+            SimpleTypeValidator.validateField(name, Map.class, o);
+            if(!((Map<?, ?>) o).containsKey("class") ) {
+                throw new IllegalArgumentException( "Field " + name + " must have map entry with key: class");
+            }
+
+            SimpleTypeValidator.validateField(name, String.class, ((Map<?, ?>) o).get("class"));
+
+            if(((Map<?, ?>) o).containsKey("arguments") ) {
+                SimpleTypeValidator.validateField(name, Map.class, ((Map<?, ?>) o).get("arguments"));
+            }
+        }
+    }
+
     public static class MapOfStringToMapOfStringToObjectValidator extends Validator {
       @Override
       public  void validateField(String name, Object o) {


### PR DESCRIPTION
* expose option to register IEventLogger similar to metrics consumer
* change the interface of IEventLogger slightly
  * allow argument
  * the change is technically not backward compatible but in real we can treat it's OK
    * cause we don't provide a chance to implement custom IEventLogger and plug to topology
* Fix EventInfo to contain origin type of values instead of String-converted values
* open possibility to extend FileBasedEventLogger and provide different format of log message
* document the change

This is in reality backward compatible change (though it is 'technically' not backward compatible), and I'd like to get it in 1.x version as well.

For 1.x-branch: #2458