### PR TITLE
(1.x) STORM-2854 Expose IEventLogger to make event logging pluggable

### DIFF
--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -73,3 +73,10 @@
 #       - endpoint: "metrics-collector.mycompany.org"
 #
 # storm.cluster.metrics.consumer.publish.interval.secs: 60
+
+# Event Logger
+# topology.event.logger.register:
+#   - class: "org.apache.storm.metric.FileBasedEventLogger"
+#   - class: "org.mycompany.MyEventLogger"
+#     arguments:
+#       endpoint: "event-logger.mycompany.org"

--- a/storm-core/src/jvm/org/apache/storm/Config.java
+++ b/storm-core/src/jvm/org/apache/storm/Config.java
@@ -20,6 +20,7 @@ package org.apache.storm;
 import org.apache.storm.scheduler.resource.strategies.eviction.IEvictionStrategy;
 import org.apache.storm.scheduler.resource.strategies.priority.ISchedulingPriorityStrategy;
 import org.apache.storm.scheduler.resource.strategies.scheduling.IStrategy;
+import org.apache.storm.metric.IEventLogger;
 import org.apache.storm.serialization.IKryoDecorator;
 import org.apache.storm.serialization.IKryoFactory;
 import org.apache.storm.validation.ConfigValidationAnnotations.*;
@@ -324,7 +325,6 @@ public class Config extends HashMap<String, Object> {
      * to false, then Storm will use a pure-Java messaging system. The purpose
      * of this flag is to make it easy to run Storm in local mode by eliminating
      * the need for native dependencies, which can be difficult to install.
-     *
      * Defaults to false.
      */
     @isBoolean
@@ -1704,6 +1704,18 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_ACKER_EXECUTORS = "topology.acker.executors";
 
     /**
+     * A list of classes implementing IEventLogger (See storm.yaml.example for exact config format).
+     * Each listed class will be routed all the events sampled from emitting tuples.
+     * If there's no class provided to the option, default event logger will be initialized and used
+     * unless you disable event logger executor.
+     *
+     * Note that EventLoggerBolt takes care of all the implementations of IEventLogger, hence registering
+     * many implementations (especially they're implemented as 'blocking' manner) would slow down overall topology.
+     */
+    @isListEntryCustom(entryValidatorClasses={EventLoggerRegistryValidator.class})
+    public static final String TOPOLOGY_EVENT_LOGGER_REGISTER = "topology.event.logger.register";
+
+    /**
      * How many executors to spawn for event logger.
      *
      * <p>By not setting this variable or setting it as null, Storm will set the number of eventlogger executors
@@ -2360,6 +2372,32 @@ public class Config extends HashMap<String, Object> {
 
     public void registerSerialization(Class klass, Class<? extends Serializer> serializerClass) {
         registerSerialization(this, klass, serializerClass);
+    }
+
+    public void registerEventLogger(Class<? extends IEventLogger> klass, Map<String, Object> argument) {
+        registerEventLogger(this, klass, argument);
+    }
+
+    public void registerEventLogger(Class<? extends IEventLogger> klass) {
+        registerEventLogger(this, klass, null);
+    }
+
+    public static void registerEventLogger(Map<String, Object> conf, Class<? extends IEventLogger> klass, Map<String, Object> argument) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("class", klass.getCanonicalName());
+        m.put("arguments", argument);
+
+        List<Map<String, Object>> l = (List<Map<String, Object>>)conf.get(TOPOLOGY_EVENT_LOGGER_REGISTER);
+        if (l == null) {
+            l = new ArrayList<>();
+        }
+        l.add(m);
+
+        conf.put(TOPOLOGY_EVENT_LOGGER_REGISTER, l);
+    }
+
+    public static void registerEventLogger(Map<String, Object> conf, Class<? extends IEventLogger> klass) {
+        registerEventLogger(conf, klass, null);
     }
 
     public static void registerMetricsConsumer(Map conf, Class klass, Object argument, long parallelismHint) {

--- a/storm-core/src/jvm/org/apache/storm/metric/FileBasedEventLogger.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/FileBasedEventLogger.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.metric;
 
 import org.apache.commons.lang.StringUtils;
@@ -64,7 +65,7 @@ public class FileBasedEventLogger implements IEventLogger {
             @Override
             public void run() {
                 try {
-                    if(dirty) {
+                    if (dirty) {
                         eventLogWriter.flush();
                         dirty = false;
                     }
@@ -101,7 +102,7 @@ public class FileBasedEventLogger implements IEventLogger {
     }
 
     @Override
-    public void prepare(Map stormConf, TopologyContext context) {
+    public void prepare(Map<String, Object> stormConf, Map<String, Object> arguments, TopologyContext context) {
         String workersArtifactDir; // workers artifact directory
         String stormId = context.getStormId();
         int port = context.getThisWorkerPort();
@@ -129,13 +130,17 @@ public class FileBasedEventLogger implements IEventLogger {
     public void log(EventInfo event) {
         try {
             //TODO: file rotation
-            eventLogWriter.write(event.toString());
+            eventLogWriter.write(buildLogMessage(event));
             eventLogWriter.newLine();
             dirty = true;
         } catch (IOException ex) {
             LOG.error("Error logging event {}", event, ex);
             throw new RuntimeException(ex);
         }
+    }
+
+    protected String buildLogMessage(EventInfo event) {
+        return event.toString();
     }
 
     @Override

--- a/storm-core/src/jvm/org/apache/storm/metric/IEventLogger.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/IEventLogger.java
@@ -20,6 +20,7 @@ package org.apache.storm.metric;
 import org.apache.storm.task.TopologyContext;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,18 +32,39 @@ public interface IEventLogger {
     /**
      * A wrapper for the fields that we would log.
      */
-    public static class EventInfo {
-        String ts;
-        String component;
-        String task;
-        String messageId;
-        String values;
-        EventInfo(String ts, String component, String task, String messageId, String values) {
+    class EventInfo {
+        private long ts;
+        private String component;
+        private int task;
+        private Object messageId;
+        private List<Object> values;
+
+        public EventInfo(long ts, String component, int task, Object messageId, List<Object> values) {
             this.ts = ts;
             this.component = component;
             this.task = task;
             this.messageId = messageId;
             this.values = values;
+        }
+
+        public long getTs() {
+            return ts;
+        }
+
+        public String getComponent() {
+            return component;
+        }
+
+        public int getTask() {
+            return task;
+        }
+
+        public Object getMessageId() {
+            return messageId;
+        }
+
+        public List<Object> getValues() {
+            return values;
         }
 
         /**
@@ -52,11 +74,12 @@ public interface IEventLogger {
          */
         @Override
         public String toString() {
-            return new Date(Long.parseLong(ts)).toString() + "," + component + "," + task + "," + messageId + "," + values;
+            return new Date(ts).toString() + "," + component + "," + String.valueOf(task) + ","
+                    + (messageId == null ? "" : messageId.toString()) + "," + values.toString();
         }
     }
 
-    void prepare(Map stormConf, TopologyContext context);
+    void prepare(Map<String, Object> conf, Map<String, Object> arguments, TopologyContext context);
 
     /**
      * This method would be invoked when the {@link EventLoggerBolt} receives a tuple from the spouts or bolts that has

--- a/storm-core/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-core/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -493,6 +493,26 @@ public class ConfigValidation {
         }
     }
 
+    public static class EventLoggerRegistryValidator extends Validator {
+
+        @Override
+        public void validateField(String name, Object o) {
+            if(o == null) {
+                return;
+            }
+            SimpleTypeValidator.validateField(name, Map.class, o);
+            if(!((Map<?, ?>) o).containsKey("class") ) {
+                throw new IllegalArgumentException( "Field " + name + " must have map entry with key: class");
+            }
+
+            SimpleTypeValidator.validateField(name, String.class, ((Map<?, ?>) o).get("class"));
+
+            if(((Map<?, ?>) o).containsKey("arguments") ) {
+                SimpleTypeValidator.validateField(name, Map.class, ((Map<?, ?>) o).get("arguments"));
+            }
+        }
+    }
+
     public static class MapOfStringToMapOfStringToObjectValidator extends Validator {
       @Override
       public  void validateField(String name, Object o) {


### PR DESCRIPTION
* expose option to register IEventLogger similar to metrics consumer
* change the interface of IEventLogger slightly
  * allow argument
  * the change is technically not backward compatible but in real we can treat it's OK
    * cause we don't provide a chance to implement custom IEventLogger and plug to topology
* open possibility to extend FileBasedEventLogger and provide different format of log message
* document the change

For master branch: #2457
