### PR TITLE
STORM-2855: Revert to 2017Q4 Ubuntu image in Travis to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 
 dist: trusty
 sudo: required
+group: deprecated-2017Q4
 
 language: java
 jdk:


### PR DESCRIPTION
This is just to get builds working again. I've raised https://issues.apache.org/jira/browse/STORM-2856 to figure out why it's broken on the new image.

The patch probably needs to go on master, 1.x and 1.1.x.