### PR TITLE
[STORM-2857] Loosen some constraints to support running topologies of older version

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -562,14 +562,24 @@ public class ConfigValidation {
                 return;
             }
             SimpleTypeValidator.validateField(name, String.class, o);
+            String className = (String) o;
             try {
-                Class<?> objectClass = Class.forName((String) o);
+                Class<?> objectClass = Class.forName(className);
                 if (!this.classImplements.isAssignableFrom(objectClass)) {
                     throw new IllegalArgumentException("Field " + name + " with value " + o
                             + " does not implement " + this.classImplements.getName());
                 }
             } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
+                //To support topologies of older version to run, we might have to loose the constraints so that
+                //the configs of older version can pass the validation.
+                if (className.startsWith("backtype.storm")) {
+                    LOG.error("ClassNotFoundException: {}", className);
+                    LOG.warn("Replace backtype.storm with org.apache.storm and try to validate again");
+                    LOG.warn("We loosen some constraints here to support topologies of older version running on the current version");
+                    validateField(name, className.replace("backtype.storm", "org.apache.storm"));
+                } else {
+                    throw new RuntimeException(e);
+                }
             }
         }
     }


### PR DESCRIPTION
Some explanation in https://issues.apache.org/jira/browse/STORM-2857

I have been thinking about some solutions for this problem. For example, the customized classLoader for version specific classpath; or translate the configs before validation. But I think the simplest way that I can come up with is to loosen some constraints for the `@isImplementationOfClass`.


 When users submit a topology with older version configs (containing `backtype.storm.XXX` ), if the newest version of the class (ie `org.apache.XXX`) is found, we let the validation pass. And we replace the class name with `org.apache` when we use it if needed, for example, https://github.com/apache/storm/pull/2397 .

 For now it's really just about `TOPOLOGY_SCHEDULER_STRATEGY` config. This is not really elegant but as discussed in  https://github.com/apache/storm/pull/2397, this serves as a short term solution and should be manageable. 
