### PR TITLE
STORM-2858: Fix worker-launcher build by erroring out if asprintf fai…

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -31,6 +31,7 @@
 
     <properties>
         <worker-launcher.conf.dir>/etc/storm</worker-launcher.conf.dir>
+        <worker-launcher.build.dir>${project.build.directory}/native/worker-launcher</worker-launcher.build.dir>
         <worker-launcher.additional_cflags></worker-launcher.additional_cflags>
         <argLine></argLine>
     </properties>
@@ -661,64 +662,74 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.2.1</version>
+                        <version>1.6.0</version>
                         <executions>
                             <execution>
                                 <phase>generate-sources</phase>
                                 <goals><goal>exec</goal></goals>
+                                <configuration>
+                                    <executable>sh</executable>
+                                    <arguments>
+                                        <argument>-c</argument>
+                                        <argument>mkdir -p ${project.build.directory}/; cp -rufv ${basedir}/src/native/ ${project.build.directory}/</argument>
+                                    </arguments>
+                                </configuration>
                             </execution>
-                        </executions>
-                        <configuration>
-                            <executable>sh</executable>
-                            <arguments>
-                                <argument>-c</argument>
-                                <argument>mkdir -p ${project.build.directory}/; cp -rufv ${basedir}/src/native/ ${project.build.directory}/</argument>
-                            </arguments>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>make-maven-plugin</artifactId>
-                        <version>1.0-beta-1</version>
-                        <executions>
                             <execution>
                                 <id>compile</id>
                                 <phase>compile</phase>
                                 <goals>
-                                    <goal>autoreconf</goal>
-                                    <goal>configure</goal>
-                                    <goal>make-install</goal>
+                                    <goal>exec</goal>
                                 </goals>
+                                <configuration>
+                                    <executable>sh</executable>
+                                    <arguments>
+                                        <argument>compile-worker-launcher.sh</argument>
+                                    </arguments>
+                                    <workingDirectory>${worker-launcher.build.dir}</workingDirectory>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>test</id>
                                 <phase>test</phase>
                                 <goals>
-                                    <goal>test</goal>
+                                    <goal>exec</goal>
                                 </goals>
+                                <configuration>
+                                    <executable>make</executable>
+                                    <arguments>
+                                        <argument>check</argument>
+                                    </arguments>
+                                    <workingDirectory>${worker-launcher.build.dir}</workingDirectory>
+                                </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <!-- autoreconf settings -->
-                            <workDir>${project.build.directory}/native/worker-launcher</workDir>
-                            <arguments>
-                                <argument>-i</argument>
-                            </arguments>
-
-                            <!-- configure settings -->
-                            <configureEnvironment>
-                                <property>
-                                    <name>CFLAGS</name>
-                                    <value>-DEXEC_CONF_DIR=${worker-launcher.conf.dir} ${worker-launcher.additional_cflags}</value>
-                                </property>
-                            </configureEnvironment>
-                            <configureWorkDir>${project.build.directory}/native/worker-launcher</configureWorkDir>
-                            <prefix>/usr/local</prefix>
-
-                            <!-- configure & make settings -->
-                            <destDir>${project.build.directory}/native/target</destDir>
-
-                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.0.2</version>
+                        <executions>
+                            <execution>
+                                <id>copy-build-scripts</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/resources</directory>
+                                            <includes>
+                                                <include>compile-worker-launcher.sh</include>
+                                            </includes>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>${worker-launcher.build.dir}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/storm-core/src/native/worker-launcher/impl/worker-launcher.c
+++ b/storm-core/src/native/worker-launcher/impl/worker-launcher.c
@@ -185,7 +185,11 @@ int change_user(uid_t user, gid_t group) {
 
 char *get_container_launcher_file(const char* work_dir) {
   char *ret;
-  asprintf(&ret, "%s/%s", work_dir, CONTAINER_SCRIPT);
+  int bytesPrinted = asprintf(&ret, "%s/%s", work_dir, CONTAINER_SCRIPT);
+  if (bytesPrinted == -1) {
+    //asprintf failed, stop the process
+    exit(EXIT_FAILURE);
+  }
   return ret;
 }
 
@@ -563,7 +567,11 @@ static int remove_files_from_dir(const char *path) {
           continue;
       }
       char *newpath;
-      asprintf(&newpath, "%s/%s", path, entry->d_name);
+      int bytesPrinted = asprintf(&newpath, "%s/%s", path, entry->d_name);
+      if (bytesPrinted == -1) {
+        //asprintf failed, stop the process
+        exit(EXIT_FAILURE);
+      }
       if(newpath) {
         // Recur on anything in the directory.
         int new_exit = recursive_delete(newpath, 0);

--- a/storm-core/src/resources/compile-worker-launcher.sh
+++ b/storm-core/src/resources/compile-worker-launcher.sh
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+autoreconf -i
+export CFLAGS=-DEXEC_CONF_DIR=${worker-launcher.conf.dir} ${worker-launcher.additional_cflags}
+./configure --prefix=/usr/local
+export DESTDIR=${project.build.directory}/native/target
+make install


### PR DESCRIPTION
…ls to allocate memory. Replace make-maven-plugin with a build shell script.

This is part of making the build run on the new Travis Ubuntu image. 

I got an error when building storm-core with -Pnative because GCC has marked asprintf as a function where you shouldn't ignore the return value. I've put in return value handling that exits the worker-launcher process if asprintf fails to allocate memory. As part of this I replaced make-maven-plugin, because it's fairly old (last release in 2009, there doesn't seem to be a page for the plugin anymore) and opaque (had to decompile the jar to figure out what it was doing). I think a build script + exec-maven-plugin is less magical. The make process output now also goes in the terminal when building, which it didn't with make-maven-plugin.