### PR TITLE
STORM-2859: Fix a number of issues with NormalizedResources, and prev…

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
@@ -196,10 +196,10 @@ public class BlobStoreUtils {
                 // Catching and logging KeyNotFoundException because, if
                 // there is a subsequent update and delete, the non-leader
                 // nimbodes might throw an exception.
-                LOG.info("KeyNotFoundException {}", knf);
+                LOG.info("KeyNotFoundException", knf);
             } catch (Exception exp) {
                 // Logging an exception while client is connecting
-                LOG.error("Exception {}", exp);
+                LOG.error("Exception", exp);
             }
         }
 

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/NormalizedResourceOffer.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/NormalizedResourceOffer.java
@@ -34,27 +34,23 @@ public class NormalizedResourceOffer extends NormalizedResources {
     private double totalMemory;
 
     /**
-     * Create a new normalized set of resources.  Note that memory is not covered here becasue it is not consistent in requests vs offers
+     * Create a new normalized set of resources.  Note that memory is not covered here because it is not consistent in requests vs offers
      * because of how on heap vs off heap is used.
      *
      * @param resources the resources to be normalized.
      */
     public NormalizedResourceOffer(Map<String, ? extends Number> resources) {
         super(resources, null);
+        totalMemory = getNormalizedResources().getOrDefault(Constants.COMMON_TOTAL_MEMORY_RESOURCE_NAME, 0.0);
     }
 
     public NormalizedResourceOffer() {
-        super(null, null);
+        this((Map<String, ? extends Number>)null);
     }
 
     public NormalizedResourceOffer(NormalizedResourceOffer other) {
         super(other);
         this.totalMemory = other.totalMemory;
-    }
-
-    @Override
-    protected void initializeMemory(Map<String, Double> normalizedResources) {
-        totalMemory = normalizedResources.getOrDefault(Constants.COMMON_TOTAL_MEMORY_RESOURCE_NAME, 0.0);
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/NormalizedResourceRequest.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/NormalizedResourceRequest.java
@@ -110,7 +110,7 @@ public class NormalizedResourceRequest extends NormalizedResources {
     private double offHeap;
 
     /**
-     * Create a new normalized set of resources.  Note that memory is not covered here becasue it is not consistent in requests vs offers
+     * Create a new normalized set of resources.  Note that memory is not covered here because it is not consistent in requests vs offers
      * because of how on heap vs off heap is used.
      *
      * @param resources the resources to be normalized.
@@ -119,6 +119,7 @@ public class NormalizedResourceRequest extends NormalizedResources {
     private NormalizedResourceRequest(Map<String, ? extends Number> resources,
                                      Map<String, Object> topologyConf) {
         super(resources, getDefaultResources(topologyConf));
+        initializeMemory(getNormalizedResources());
     }
 
     public NormalizedResourceRequest(ComponentCommon component, Map<String, Object> topoConf) {
@@ -131,6 +132,7 @@ public class NormalizedResourceRequest extends NormalizedResources {
 
     public NormalizedResourceRequest() {
         super(null, null);
+        initializeMemory(getNormalizedResources());
     }
 
     @Override
@@ -141,8 +143,7 @@ public class NormalizedResourceRequest extends NormalizedResources {
         return ret;
     }
 
-    @Override
-    protected void initializeMemory(Map<String, Double> normalizedResources) {
+    private void initializeMemory(Map<String, Double> normalizedResources) {
         onHeap = normalizedResources.getOrDefault(Constants.COMMON_ONHEAP_MEMORY_RESOURCE_NAME, 0.0);
         offHeap = normalizedResources.getOrDefault(Constants.COMMON_OFFHEAP_MEMORY_RESOURCE_NAME, 0.0);
     }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/DefaultResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/DefaultResourceAwareStrategy.java
@@ -20,11 +20,8 @@ package org.apache.storm.scheduler.resource.strategies.scheduling;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.TreeSet;
 
 import org.apache.storm.Config;
@@ -33,7 +30,6 @@ import org.apache.storm.scheduler.Component;
 import org.apache.storm.scheduler.ExecutorDetails;
 import org.apache.storm.scheduler.TopologyDetails;
 
-import org.apache.storm.scheduler.resource.ResourceUtils;
 import org.apache.storm.scheduler.resource.SchedulingResult;
 import org.apache.storm.scheduler.resource.SchedulingStatus;
 import org.slf4j.Logger;
@@ -41,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public class DefaultResourceAwareStrategy extends BaseResourceAwareStrategy implements IStrategy {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BaseResourceAwareStrategy.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultResourceAwareStrategy.class);
 
     @Override
     public SchedulingResult schedule(Cluster cluster, TopologyDetails td) {
@@ -125,10 +121,12 @@ public class DefaultResourceAwareStrategy extends BaseResourceAwareStrategy impl
     protected TreeSet<ObjectResources> sortObjectResources(
             final AllResources allResources, ExecutorDetails exec, TopologyDetails topologyDetails,
             final ExistingScheduleFunc existingScheduleFunc) {
-
+        
         for (ObjectResources objectResources : allResources.objectResources) {
             objectResources.effectiveResources =
                 allResources.availableResourcesOverall.calculateMinPercentageUsedBy(objectResources.availableResources);
+            LOG.trace("Effective resources for {} is {}, and numExistingSchedule is {}",
+                objectResources.id, objectResources.effectiveResources, existingScheduleFunc.getNumExistingSchedule(objectResources.id));
         }
 
         TreeSet<ObjectResources> sortedObjectResources =

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -27,7 +27,6 @@ import org.apache.storm.scheduler.SupervisorResources;
 import org.apache.storm.scheduler.ExecutorDetails;
 import org.apache.storm.scheduler.INimbus;
 import org.apache.storm.scheduler.SchedulerAssignment;
-import org.apache.storm.scheduler.SchedulerAssignmentImpl;
 import org.apache.storm.scheduler.SupervisorDetails;
 import org.apache.storm.scheduler.Topologies;
 import org.apache.storm.scheduler.TopologyDetails;
@@ -51,6 +50,7 @@ import static org.apache.storm.scheduler.resource.TestUtilsForResourceAwareSched
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -63,7 +63,7 @@ import java.util.TreeSet;
 public class TestDefaultResourceAwareStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(TestDefaultResourceAwareStrategy.class);
 
-    private static int currentTime = 1450418597;
+    private static final int CURRENT_TIME = 1450418597;
 
     /**
      * test if the scheduling logic for the DefaultResourceAwareStrategy is correct
@@ -99,10 +99,10 @@ public class TestDefaultResourceAwareStrategy {
         conf.put(Config.TOPOLOGY_NAME, "testTopology");
         conf.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, 2000);
         TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
-                genExecsAndComps(stormToplogy), currentTime, "user");
+                genExecsAndComps(stormToplogy), CURRENT_TIME, "user");
 
         Topologies topologies = new Topologies(topo);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, conf);
+        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, conf);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
@@ -166,10 +166,10 @@ public class TestDefaultResourceAwareStrategy {
         conf.put(Config.TOPOLOGY_SUBMITTER_USER, "user");
 
         TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
-                genExecsAndComps(stormToplogy), currentTime, "user");
+                genExecsAndComps(stormToplogy), CURRENT_TIME, "user");
 
         Topologies topologies = new Topologies(topo);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, conf);
+        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, conf);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
@@ -214,12 +214,17 @@ public class TestDefaultResourceAwareStrategy {
 
         //generate some that has alot of cpu but little of memory
         final Map<String, SupervisorDetails> supMapRack5 = genSupervisors(10, 4, 40, 400 + 200 + 10, 1000);
+        
+        //Generate some that have neither resource, to verify that the strategy will prioritize this last
+        //Also put a generic resource with 0 value in the resources list, to verify that it doesn't affect the sorting
+        final Map<String, SupervisorDetails> supMapRack6 = genSupervisors(10, 4, 50, 0.0, 0.0, Collections.singletonMap("gpu.count", 0.0));
 
         supMap.putAll(supMapRack1);
         supMap.putAll(supMapRack2);
         supMap.putAll(supMapRack3);
         supMap.putAll(supMapRack4);
         supMap.putAll(supMapRack5);
+        supMap.putAll(supMapRack6);
 
         Config config = createClusterConfig(100, 500, 500, null);
         config.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, Double.MAX_VALUE);
@@ -245,16 +250,19 @@ public class TestDefaultResourceAwareStrategy {
                 for (SupervisorDetails sup : supMapRack5.values()) {
                     ret.put(sup.getHost(), "rack-4");
                 }
+                for (SupervisorDetails sup : supMapRack6.values()) {
+                    ret.put(sup.getHost(), "rack-5");
+                }
                 return ret;
             }
         };
 
         //generate topologies
-        TopologyDetails topo1 = genTopology("topo-1", config, 8, 0, 2, 0, currentTime - 2, 10, "user");
-        TopologyDetails topo2 = genTopology("topo-2", config, 8, 0, 2, 0, currentTime - 2, 10, "user");
+        TopologyDetails topo1 = genTopology("topo-1", config, 8, 0, 2, 0, CURRENT_TIME - 2, 10, "user");
+        TopologyDetails topo2 = genTopology("topo-2", config, 8, 0, 2, 0, CURRENT_TIME - 2, 10, "user");
         
         Topologies topologies = new Topologies(topo1, topo2);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
         
         List<String> supHostnames = new LinkedList<>();
         for (SupervisorDetails sup : supMap.values()) {
@@ -280,7 +288,7 @@ public class TestDefaultResourceAwareStrategy {
         TreeSet<ObjectResources> sortedRacks = rs.sortRacks(null, topo1);
         LOG.info("Sorted Racks {}", sortedRacks);
 
-        Assert.assertEquals("# of racks sorted", 5, sortedRacks.size());
+        Assert.assertEquals("# of racks sorted", 6, sortedRacks.size());
         Iterator<ObjectResources> it = sortedRacks.iterator();
         // Ranked first since rack-0 has the most balanced set of resources
         Assert.assertEquals("rack-0 should be ordered first", "rack-0", it.next().id);
@@ -290,8 +298,10 @@ public class TestDefaultResourceAwareStrategy {
         Assert.assertEquals("rack-4 should be ordered third", "rack-4", it.next().id);
         // Ranked fourth since rack-3 has alot of memory but not cpu
         Assert.assertEquals("rack-3 should be ordered fourth", "rack-3", it.next().id);
-        //Ranked last since rack-2 has not cpu resources
+        //Ranked fifth since rack-2 has not cpu resources
         Assert.assertEquals("rack-2 should be ordered fifth", "rack-2", it.next().id);
+        //Ranked last since rack-5 has neither CPU nor memory available
+        assertEquals("Rack-5 should be ordered sixth", "rack-5", it.next().id);
 
         SchedulingResult schedulingResult = rs.schedule(cluster, topo1);
         assert(schedulingResult.isSuccess());
@@ -331,7 +341,7 @@ public class TestDefaultResourceAwareStrategy {
      */
     @Test
     public void testMultipleRacksWithFavoritism() {
-        final Map<String, SupervisorDetails> supMap = new HashMap<String, SupervisorDetails>();
+        final Map<String, SupervisorDetails> supMap = new HashMap<>();
         final Map<String, SupervisorDetails> supMapRack1 = genSupervisors(10, 4, 0, 400, 8000);
         //generate another rack of supervisors with less resources
         final Map<String, SupervisorDetails> supMapRack2 = genSupervisors(10, 4, 10, 200, 4000);
@@ -386,17 +396,17 @@ public class TestDefaultResourceAwareStrategy {
         final List<String> t1UnfavoredHostIds = Arrays.asList("host-1", "host-2", "host-3");
         t1Conf.put(Config.TOPOLOGY_SCHEDULER_UNFAVORED_NODES, t1UnfavoredHostIds);
         //generate topologies
-        TopologyDetails topo1 = genTopology("topo-1", t1Conf, 8, 0, 2, 0, currentTime - 2, 10, "user");
+        TopologyDetails topo1 = genTopology("topo-1", t1Conf, 8, 0, 2, 0, CURRENT_TIME - 2, 10, "user");
 
 
         Config t2Conf = new Config();
         t2Conf.putAll(config);
         t2Conf.put(Config.TOPOLOGY_SCHEDULER_FAVORED_NODES, Arrays.asList("host-31", "host-32", "host-33"));
         t2Conf.put(Config.TOPOLOGY_SCHEDULER_UNFAVORED_NODES, Arrays.asList("host-11", "host-12", "host-13"));
-        TopologyDetails topo2 = genTopology("topo-2", t2Conf, 8, 0, 2, 0, currentTime - 2, 10, "user");
+        TopologyDetails topo2 = genTopology("topo-2", t2Conf, 8, 0, 2, 0, CURRENT_TIME - 2, 10, "user");
 
         Topologies topologies = new Topologies(topo1, topo2);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
 
         List<String> supHostnames = new LinkedList<>();
         for (SupervisorDetails sup : supMap.values()) {
@@ -409,7 +419,7 @@ public class TestDefaultResourceAwareStrategy {
             String rack = entry.getValue();
             List<String> nodesForRack = rackToNodes.get(rack);
             if (nodesForRack == null) {
-                nodesForRack = new ArrayList<String>();
+                nodesForRack = new ArrayList<>();
                 rackToNodes.put(rack, nodesForRack);
             }
             nodesForRack.add(hostName);

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
@@ -100,7 +100,7 @@ public class TestGenericResourceAwareStrategy {
 
         Topologies topologies = new Topologies(topo);
 
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, conf);
+        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, conf);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
@@ -188,7 +188,7 @@ public class TestGenericResourceAwareStrategy {
                 genExecsAndComps(stormToplogy), currentTime, "user");
 
         Topologies topologies = new Topologies(topo);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, conf);
+        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, conf);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 


### PR DESCRIPTION
…ent it from leaking static state in tests.

This is part of making the build run on the new Travis Ubuntu image. Travis is probably running the tests in a slightly different order than before.

NormalizedResources had a static field used to track the generic resource types registered for supervisors. It was leaking from the GenericResourceAwareSchedulerTest to DefaultResourceAwareSchedulerTest, where it was causing a test failure. When the unused resource type showed up in the test, NormalizedResources would return 0.0 from calculateMinPercentageUsedBy for all racks because there was a resource type where the cluster had 0 of that resource in total. This breaks rack sorting and causes the test to fail.

I'm not entirely sure why NormalizedResources used the static field + double arrays for tracking resources, but I've replaced it with regular resourceName -> resourceValue maps. Let me know if this is a problem.

Other issues fixed:
* calculateMinPercentageUsedBy threw division by 0 error if total cpu or memory was 0.
* Removed static map between resource names and array indices. It was causing tests to leak information to each other. Rewrote parts of NormalizedResources to make this map unnecessary.
* Added check that all resources in a rack/node are also present in the total.
* calculateAvg was being inconsistent about the divisor in the average between cpu/memory and other resources. Fixed so skipped resources are never counted in the divisor. 
* calculateMin didn't handle resource totals being 0 very well. The method defined (anyNumber)/0 to result in 0, so if any resource in the total had a 0 value, all racks/nodes would be prioritized equally. Change calculateMin and calculateAvg to simply skip any resources where the total is 0 in the calculation. I think it makes sense to disregard such resources and fall back on prioritizing by any remaining non-0 resources. It was already done for CPU and memory in calculateAvg. In case there are no non-0 resources, we can just return 100% for both average and minimum to disable prioritization, since any rack/node is as good as any other.
* Fixed up NormalizedResources constructor so it doesn't call an overridable method.