### PR TITLE
[STORM-2690] resurrect invocation of ISupervisor.assigned() & make Supervisor.launchDaemon() accessible

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
@@ -137,6 +137,7 @@ public class ReadClusterState implements Runnable, AutoCloseable {
                 }
             }
             HashSet<Integer> allPorts = new HashSet<>(assignedPorts);
+            iSuper.assigned(allPorts);
             allPorts.addAll(slots.keySet());
             
             Map<Integer, Set<TopoProfileAction>> filtered = new HashMap<>();

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -211,7 +211,7 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
     /**
      * start distribute supervisor
      */
-    private void launchDaemon() {
+    public void launchDaemon() {
         LOG.info("Starting supervisor for storm version '{}'.", VersionInfo.getVersion());
         try {
             Map<String, Object> conf = getConf();


### PR DESCRIPTION
This commit fixes the storm-mesos integration for the interaction between the Storm core's Supervisor daemon and the MesosSupervisor that implements the ISupervisor interface.