### PR TITLE
[STORM-2690] resurrect invocation of ISupervisor.assigned() & make Supervisor.launchDaemon() accessible

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/ReadClusterState.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/ReadClusterState.java
@@ -145,6 +145,7 @@ public class ReadClusterState implements Runnable, AutoCloseable {
                 }
             }
             HashSet<Integer> allPorts = new HashSet<>(assignedPorts);
+            iSuper.assigned(allPorts);
             allPorts.addAll(slots.keySet());
             
             Map<Integer, Set<TopoProfileAction>> filtered = new HashMap<>();

--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -245,7 +245,7 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
     /**
      * start distribute supervisor
      */
-    private void launchDaemon() {
+    public void launchDaemon() {
         LOG.info("Starting supervisor for storm version '{}'.", VersionInfo.getVersion());
         try {
             Map<String, Object> conf = getConf();


### PR DESCRIPTION
This commit fixes the storm-mesos integration for the interaction between the Storm core's Supervisor daemon and the MesosSupervisor that implements the ISupervisor interface.

_(Backport of #2468 to `1.1.x-branch`.)_