### PR TITLE
[STORM-2868] Address handling activate/deactivate in multilang module files

### DIFF
--- a/examples/storm-starter/multilang/resources/randomsentence.js
+++ b/examples/storm-starter/multilang/resources/randomsentence.js
@@ -62,6 +62,14 @@ RandomSentenceSpout.prototype.nextTuple = function(done) {
     },100);
 }
 
+RandomSentenceSpout.prototype.activate = function(done) {
+    done();
+}
+
+RandomSentenceSpout.prototype.deactivate = function(done) {
+    done();
+}
+
 RandomSentenceSpout.prototype.createNextTupleId = function() {
     var id = this.runningTupleId;
     this.runningTupleId++;

--- a/flux/flux-wrappers/src/main/resources/resources/randomsentence.js
+++ b/flux/flux-wrappers/src/main/resources/resources/randomsentence.js
@@ -62,6 +62,14 @@ RandomSentenceSpout.prototype.nextTuple = function(done) {
     },100);
 }
 
+RandomSentenceSpout.prototype.activate = function(done) {
+    done();
+}
+
+RandomSentenceSpout.prototype.deactivate = function(done) {
+    done();
+}
+
 RandomSentenceSpout.prototype.createNextTupleId = function() {
     var id = this.runningTupleId;
     this.runningTupleId++;

--- a/storm-core/src/dev/resources/tester_spout.js
+++ b/storm-core/src/dev/resources/tester_spout.js
@@ -44,6 +44,14 @@ TesterSpout.prototype.nextTuple = function(done) {
     done();
 }
 
+TesterSpout.prototype.activate = function(done) {
+    done();
+}
+
+TesterSpout.prototype.deactivate = function(done) {
+    done();
+}
+
 TesterSpout.prototype.createNextTupleId = function() {
     var id = this.runningTupleId;
     this.runningTupleId++;

--- a/storm-multilang/javascript/src/main/resources/resources/storm.js
+++ b/storm-multilang/javascript/src/main/resources/resources/storm.js
@@ -354,6 +354,18 @@ Spout.prototype = Object.create(Storm.prototype);
 Spout.prototype.constructor = Spout;
 
 /**
+ * This method will be called when a spout has been activated out of a deactivated mode.
+ * @param done Call this method when finished and ready to receive tuples.
+ */
+Spout.prototype.activate = function(done) {};
+
+/**
+ * This method will be called when a spout has been deactivated.
+ * @param done Call this method when finished.
+ */
+Spout.prototype.deactivate = function(done) {};
+
+/**
  * This method will be called when an ack is received for preciously sent tuple. One may implement it.
  * @param id The id of the tuple.
  * @param done Call this method when finished and ready to receive more tuples.
@@ -378,6 +390,14 @@ Spout.prototype.handleNewCommand = function(command) {
     var self = this;
     var callback = function() {
         self.sync();
+    }
+
+    if (command['command'] === 'activate') {
+        this.activate(callback);
+    }
+
+    if (command['command'] === 'deactivate') {
+        this.deactivate(callback);
     }
 
     if (command['command'] === 'next') {

--- a/storm-multilang/python/src/main/resources/resources/storm.py
+++ b/storm-multilang/python/src/main/resources/resources/storm.py
@@ -232,6 +232,12 @@ class Spout(object):
     def initialize(self, conf, context):
         pass
 
+    def activate(self):
+        pass
+
+    def deactivate(self):
+        pass
+
     def ack(self, id):
         pass
 
@@ -249,6 +255,10 @@ class Spout(object):
             self.initialize(conf, context)
             while True:
                 msg = readCommand()
+                if msg["command"] == "activate":
+                    self.activate()
+                if msg["command"] == "deactivate":
+                    self.deactivate()
                 if msg["command"] == "next":
                     self.nextTuple()
                 if msg["command"] == "ack":

--- a/storm-multilang/ruby/src/main/resources/resources/storm.rb
+++ b/storm-multilang/ruby/src/main/resources/resources/storm.rb
@@ -205,6 +205,10 @@ module Storm
 
     def open(conf, context); end
 
+    def activate; end
+
+    def deactivate; end
+
     def nextTuple; end
 
     def ack(id); end
@@ -219,6 +223,10 @@ module Storm
         while true
           msg = read_command
           case msg['command']
+            when 'activate'
+              activate
+            when 'deactivate'
+              deactivate
             when 'next'
               nextTuple
             when 'ack'


### PR DESCRIPTION
As it is now required to answer to the activation and deactivation, I added those to the javascript files because the examples stopped working.

I updated ruby and python as well, but they don't have that issue because they always send sync without waiting for a callback.

But now you should be able to implement those as well in your code depending on those libs.