### PR TITLE
STORM-2864: Minor optimisation about trident kafka state

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaState.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaState.java
@@ -29,7 +29,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.storm.kafka.trident.mapper.TridentTupleToKafkaMapper;
 import org.apache.storm.kafka.trident.selector.KafkaTopicSelector;
-import org.apache.storm.task.OutputCollector;
 import org.apache.storm.topology.FailedException;
 import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.state.State;
@@ -37,21 +36,20 @@ import org.apache.storm.trident.tuple.TridentTuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TridentKafkaState implements State {
+public class TridentKafkaState<K, V> implements State {
     private static final Logger LOG = LoggerFactory.getLogger(TridentKafkaState.class);
 
-    private KafkaProducer producer;
-    private OutputCollector collector;
+    private KafkaProducer<K, V> producer;
 
-    private TridentTupleToKafkaMapper mapper;
+    private TridentTupleToKafkaMapper<K, V> mapper;
     private KafkaTopicSelector topicSelector;
 
-    public TridentKafkaState withTridentTupleToKafkaMapper(TridentTupleToKafkaMapper mapper) {
+    public TridentKafkaState<K, V> withTridentTupleToKafkaMapper(TridentTupleToKafkaMapper<K, V> mapper) {
         this.mapper = mapper;
         return this;
     }
 
-    public TridentKafkaState withKafkaTopicSelector(KafkaTopicSelector selector) {
+    public TridentKafkaState<K, V> withKafkaTopicSelector(KafkaTopicSelector selector) {
         this.topicSelector = selector;
         return this;
     }
@@ -73,7 +71,7 @@ public class TridentKafkaState implements State {
     public void prepare(Properties options) {
         Objects.requireNonNull(mapper, "mapper can not be null");
         Objects.requireNonNull(topicSelector, "topicSelector can not be null");
-        producer = new KafkaProducer(options);
+        producer = new KafkaProducer<>(options);
     }
 
     /**
@@ -89,19 +87,19 @@ public class TridentKafkaState implements State {
             List<Future<RecordMetadata>> futures = new ArrayList<>(numberOfRecords);
             for (TridentTuple tuple : tuples) {
                 topic = topicSelector.getTopic(tuple);
-                Object messageFromTuple = mapper.getMessageFromTuple(tuple);
-                Object keyFromTuple = mapper.getKeyFromTuple(tuple);
+                V messageFromTuple = mapper.getMessageFromTuple(tuple);
+                K keyFromTuple = mapper.getKeyFromTuple(tuple);
 
                 if (topic != null) {
                     if (messageFromTuple != null) {
-                        Future<RecordMetadata> result = producer.send(new ProducerRecord(topic, keyFromTuple, messageFromTuple));
+                        Future<RecordMetadata> result = producer.send(new ProducerRecord<>(topic, keyFromTuple, messageFromTuple));
                         futures.add(result);
                     } else {
-                        LOG.warn("skipping Message with Key " + keyFromTuple + " as message was null");
+                        LOG.warn("skipping Message with Key {} as message was null", keyFromTuple);
                     }
 
                 } else {
-                    LOG.warn("skipping key = " + keyFromTuple + ", topic selector returned null.");
+                    LOG.warn("skipping key = {}, topic selector returned null.", keyFromTuple);
                 }
             }
 
@@ -116,11 +114,12 @@ public class TridentKafkaState implements State {
             }
 
             if (exceptions.size() > 0) {
-                StringBuilder errorMsg = new StringBuilder("Could not retrieve result for messages " + tuples + " from topic = " + topic
-                    + " because of the following exceptions:" + System.lineSeparator());
+                StringBuilder errorMsg = new StringBuilder("Could not retrieve result for messages ");
+                errorMsg.append(tuples).append(" from topic = ").append(topic)
+                        .append(" because of the following exceptions:").append(System.lineSeparator());
 
                 for (ExecutionException exception : exceptions) {
-                    errorMsg = errorMsg.append(exception.getMessage()).append(System.lineSeparator());;
+                    errorMsg = errorMsg.append(exception.getMessage()).append(System.lineSeparator());
                 }
                 String message = errorMsg.toString();
                 LOG.error(message);

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaStateFactory.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaStateFactory.java
@@ -28,25 +28,26 @@ import org.apache.storm.trident.state.StateFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TridentKafkaStateFactory implements StateFactory {
+public class TridentKafkaStateFactory<K, V> implements StateFactory {
 
+    private static final long serialVersionUID = -3613240970062343385L;
     private static final Logger LOG = LoggerFactory.getLogger(TridentKafkaStateFactory.class);
 
-    private TridentTupleToKafkaMapper mapper;
+    private TridentTupleToKafkaMapper<K, V> mapper;
     private KafkaTopicSelector topicSelector;
     private Properties producerProperties = new Properties();
 
-    public TridentKafkaStateFactory withTridentTupleToKafkaMapper(TridentTupleToKafkaMapper mapper) {
+    public TridentKafkaStateFactory<K, V> withTridentTupleToKafkaMapper(TridentTupleToKafkaMapper<K, V> mapper) {
         this.mapper = mapper;
         return this;
     }
 
-    public TridentKafkaStateFactory withKafkaTopicSelector(KafkaTopicSelector selector) {
+    public TridentKafkaStateFactory<K, V> withKafkaTopicSelector(KafkaTopicSelector selector) {
         this.topicSelector = selector;
         return this;
     }
 
-    public TridentKafkaStateFactory withProducerProperties(Properties props) {
+    public TridentKafkaStateFactory<K, V> withProducerProperties(Properties props) {
         this.producerProperties = props;
         return this;
     }
@@ -54,9 +55,9 @@ public class TridentKafkaStateFactory implements StateFactory {
     @Override
     public State makeState(Map<String, Object> conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
         LOG.info("makeState(partitonIndex={}, numpartitions={}", partitionIndex, numPartitions);
-        TridentKafkaState state = new TridentKafkaState()
-                .withKafkaTopicSelector(this.topicSelector)
-                .withTridentTupleToKafkaMapper(this.mapper);
+        TridentKafkaState<K, V> state = new TridentKafkaState<>();
+        state.withKafkaTopicSelector(this.topicSelector)
+            .withTridentTupleToKafkaMapper(this.mapper);
         state.prepare(producerProperties);
         return state;
     }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaStateUpdater.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaStateUpdater.java
@@ -23,10 +23,12 @@ import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.state.BaseStateUpdater;
 import org.apache.storm.trident.tuple.TridentTuple;
 
-public class TridentKafkaStateUpdater extends BaseStateUpdater<TridentKafkaState> {
+public class TridentKafkaStateUpdater<K, V> extends BaseStateUpdater<TridentKafkaState<K, V>> {
+
+    private static final long serialVersionUID = 3352659585225274402L;
 
     @Override
-    public void updateState(TridentKafkaState state, List<TridentTuple> tuples, TridentCollector collector) {
+    public void updateState(TridentKafkaState<K, V> state, List<TridentTuple> tuples, TridentCollector collector) {
         state.updateState(tuples, collector);
     }
 }


### PR DESCRIPTION
Make TridentKafkaState a template class to eliminate warning messages in eclipse, and a minor optimisation that use StringBuilder.append instead of string concat operation.