### PR TITLE
(1.x) STORM-2870 Properly shutdown ExecutorService in FileBasedEventLogger

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/metric/FileBasedEventLogger.java
+++ b/storm-core/src/jvm/org/apache/storm/metric/FileBasedEventLogger.java
@@ -35,7 +35,10 @@ import java.nio.file.StandardOpenOption;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 public class FileBasedEventLogger implements IEventLogger {
     private static final Logger LOG = LoggerFactory.getLogger(FileBasedEventLogger.class);
@@ -44,6 +47,7 @@ public class FileBasedEventLogger implements IEventLogger {
 
     private Path eventLogPath;
     private BufferedWriter eventLogWriter;
+    private ScheduledExecutorService flushScheduler;
     private volatile boolean dirty = false;
 
     private void initLogWriter(Path logFilePath) {
@@ -60,8 +64,13 @@ public class FileBasedEventLogger implements IEventLogger {
 
 
     private void setUpFlushTask() {
-        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-        Runnable task = new Runnable() {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("event-logger-flush-%d")
+                .setDaemon(true)
+                .build();
+
+        flushScheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
+        Runnable runnable = new Runnable() {
             @Override
             public void run() {
                 try {
@@ -76,7 +85,7 @@ public class FileBasedEventLogger implements IEventLogger {
             }
         };
 
-        scheduler.scheduleAtFixedRate(task, FLUSH_INTERVAL_MILLIS, FLUSH_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
+        flushScheduler.scheduleAtFixedRate(runnable, FLUSH_INTERVAL_MILLIS, FLUSH_INTERVAL_MILLIS, TimeUnit.MILLISECONDS);
     }
 
     private String getFirstNonNull(String... strings) {
@@ -147,8 +156,27 @@ public class FileBasedEventLogger implements IEventLogger {
     public void close() {
         try {
             eventLogWriter.close();
+
         } catch (IOException ex) {
             LOG.error("Error closing event log.", ex);
+        }
+
+        closeFlushScheduler();
+    }
+
+    private void closeFlushScheduler() {
+        if (flushScheduler != null) {
+            flushScheduler.shutdown();
+            try {
+                if (!flushScheduler.awaitTermination(2, TimeUnit.SECONDS)) {
+                    flushScheduler.shutdownNow();
+                }
+            } catch (InterruptedException ie) {
+                // (Re-)Cancel if current thread also interrupted
+                flushScheduler.shutdownNow();
+                // Preserve interrupt status
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }


### PR DESCRIPTION
* extract local variable 'scheduler' to one of fields
* gracefully shutdown the scheduler

PR for master branch: #2482 
I think this can be easily cherry-picked to 1.1.x-branch and 1.0.x-branch.