### PR TITLE
STORM-2856: Make Storm build work on post-2017Q4 Travis Trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,15 @@ env:
 
 dist: trusty
 sudo: required
-group: deprecated-2017Q4
 
 language: java
 jdk:
   - oraclejdk8
 before_install:
-  - rvm use 2.1.5 --install
-  - nvm install 0.12.2
-  - nvm use 0.12.2
+  - rvm reload
+  - rvm use 2.4.2 --install
+  - nvm install 8.9.3
+  - nvm use 8.9.3
 install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
 script:
   - /bin/bash ./dev-tools/travis/travis-script.sh `pwd` $MODULES

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -239,19 +239,19 @@ To pull in a merge request you should generally follow the command line instruct
 # Build the code and run the tests
 
 ## Prerequisites
-Firt of all you need to make sure you are using maven 3.2.5 or below.  There is a bug in later versions of maven as linked to from https://issues.apache.org/jira/browse/MSHADE-206 that
+First of all you need to make sure you are using maven 3.2.5 or below.  There is a bug in later versions of maven as linked to from https://issues.apache.org/jira/browse/MSHADE-206 that
 cause shaded dependencies to not be packaged correctly.  Also please be aware that because we are shading dependencies mvn dependency:tree will not always show the dependencies correctly. 
 
-In order to build `storm` you need `python`, `ruby` and `nodejs`. In order to avoid an overful page we don't provide platform/OS specific installation instructions for those here. Please refer to you platform's/OS' documentation for support.
+In order to build `storm` you need `python`, `ruby` and `nodejs`. In order to avoid an overfull page we don't provide platform/OS specific installation instructions for those here. Please refer to you platform's/OS' documentation for support.
 
 The `ruby` package manager `rvm` and `nodejs` package manager `nvm` are for convenience and are used in the tests which run on [travis](https://travis-ci.org/apache/storm). They can be installed using `curl -L https://get.rvm.io | bash -s stable --autolibs=enabled && source ~/.profile` (see the [rvm installation instructions](https://github.com/rvm/rvm) for details) and `wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.26.1/install.sh | bash && source ~/.bashrc` (see the [nvm installation instructions](https://github.com/creationix/nvm) for details).
 
 With `rvm` and `nvm` installed you can run
 
 ```sh
-rvm use 2.1.5 --install
-nvm install 0.12.2
-nvm use 0.12.2
+rvm use 2.4.2 --install
+nvm install 8.9.3
+nvm use 8.9.3
 ```
 
 in order to get started as fast as possible. Users can still install a specific version of `ruby` and/or `node` manually.


### PR DESCRIPTION
Since the issues breaking the build have been fixed, we should switch to using the new Ubuntu image on Travis.