### PR TITLE
[STORM-2873] Do not delete backpressure ephemeral node frequently

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
@@ -434,11 +434,11 @@ public class StormClusterStateImpl implements IStormClusterState {
      */
     @Override
     public void workerBackpressure(String stormId, String node, Long port, long timestamp) {
-        String path = ClusterUtils.backpressurePath(stormId, node, port);
-        boolean existed = stateStorage.node_exists(path, false);
         if (timestamp <= 0) {
             return;
         }
+        String path = ClusterUtils.backpressurePath(stormId, node, port);
+        boolean existed = stateStorage.node_exists(path, false);
         byte[] data = ByteBuffer.allocate(Long.BYTES).putLong(timestamp).array();
         if (existed) {
             stateStorage.set_data(path, data, acls);

--- a/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
@@ -438,9 +438,7 @@ public class StormClusterStateImpl implements IStormClusterState {
         String path = ClusterUtils.backpressurePath(stormId, node, port);
         boolean existed = stateStorage.node_exists(path, false);
         if (existed) {
-            if (timestamp <= 0) {
-                stateStorage.delete_node(path);
-            } else {
+            if (timestamp > 0) {
                 byte[] data = ByteBuffer.allocate(Long.BYTES).putLong(timestamp).array();
                 stateStorage.set_data(path, data, acls);
             }

--- a/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
@@ -424,10 +424,9 @@ public class StormClusterStateImpl implements IStormClusterState {
     }
 
     /**
-     * If znode exists and timestamp is non-positive, delete;
-     * if exists and timestamp is larger than 0, update the timestamp;
-     * if not exists and timestamp is larger than 0, create the znode and set the timestamp;
-     * if not exists and timestamp is non-positive, do nothing.
+     * If timestamp is non-positive, ignore;
+     * if znode exists, update the timestamp;
+     * if not exists, create the znode and set the timestamp;
      * @param stormId The topology Id
      * @param node The node id
      * @param port The port number
@@ -437,16 +436,14 @@ public class StormClusterStateImpl implements IStormClusterState {
     public void workerBackpressure(String stormId, String node, Long port, long timestamp) {
         String path = ClusterUtils.backpressurePath(stormId, node, port);
         boolean existed = stateStorage.node_exists(path, false);
+        if (timestamp <= 0) {
+            return;
+        }
+        byte[] data = ByteBuffer.allocate(Long.BYTES).putLong(timestamp).array();
         if (existed) {
-            if (timestamp > 0) {
-                byte[] data = ByteBuffer.allocate(Long.BYTES).putLong(timestamp).array();
-                stateStorage.set_data(path, data, acls);
-            }
+            stateStorage.set_data(path, data, acls);
         } else {
-            if (timestamp > 0) {
-                byte[] data = ByteBuffer.allocate(Long.BYTES).putLong(timestamp).array();
-                stateStorage.set_ephemeral_node(path, data, acls);
-            }
+            stateStorage.set_ephemeral_node(path, data, acls);
         }
     }
 


### PR DESCRIPTION
If ephemeral znode is created once, then we can leave it as is - as other workers would look at timestamp to ensure it is not stale. This avoid deletion/creation of same ephemeral znode path at very high frequency.