### PR TITLE
STORM-2858 1.x

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -31,6 +31,7 @@
 
     <properties>
         <worker-launcher.conf.dir>/etc/storm</worker-launcher.conf.dir>
+        <worker-launcher.build.dir>${project.build.directory}/native/worker-launcher</worker-launcher.build.dir>
         <worker-launcher.additional_cflags />
         <argLine />
     </properties>
@@ -144,7 +145,7 @@
           <artifactId>java.jmx</artifactId>
           <version>${java_jmx.version}</version>
         </dependency>
-        
+
         <!--java-->
         <dependency>
             <groupId>commons-io</groupId>
@@ -343,7 +344,7 @@
     </dependencies>
     <build>
         <sourceDirectory>src/jvm</sourceDirectory>
-         <testSourceDirectory>test/jvm</testSourceDirectory>
+        <testSourceDirectory>test/jvm</testSourceDirectory>
         <resources>
             <resource>
                 <directory>../conf</directory>
@@ -1028,13 +1029,11 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.2.1</version>
+                        <version>1.6.0</version>
                         <executions>
                             <execution>
                                 <phase>generate-sources</phase>
                                 <goals><goal>exec</goal></goals>
-                            </execution>
-                        </executions>
                         <configuration>
                             <executable>sh</executable>
                             <arguments>
@@ -1042,50 +1041,62 @@
                                 <argument>mkdir -p ${project.build.directory}/; cp -rufv ${basedir}/src/native/ ${project.build.directory}/</argument>
                             </arguments>
                         </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>make-maven-plugin</artifactId>
-                        <version>1.0-beta-1</version>
-                        <executions>
+                            </execution>
                             <execution>
                                 <id>compile</id>
                                 <phase>compile</phase>
                                 <goals>
-                                    <goal>autoreconf</goal>
-                                    <goal>configure</goal>
-                                    <goal>make-install</goal>
+                                    <goal>exec</goal>
                                 </goals>
+                                <configuration>
+                                    <executable>sh</executable>
+                                    <arguments>
+                                        <argument>compile-worker-launcher.sh</argument>
+                                    </arguments>
+                                    <workingDirectory>${worker-launcher.build.dir}</workingDirectory>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>test</id>
                                 <phase>test</phase>
                                 <goals>
-                                    <goal>test</goal>
+                                    <goal>exec</goal>
                                 </goals>
+                        <configuration>
+                                    <executable>make</executable>
+                            <arguments>
+                                        <argument>check</argument>
+                            </arguments>
+                                    <workingDirectory>${worker-launcher.build.dir}</workingDirectory>
+                        </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <!-- autoreconf settings -->
-                            <workDir>${project.build.directory}/native/worker-launcher</workDir>
-                            <arguments>
-                                <argument>-i</argument>
-                            </arguments>
-
-                            <!-- configure settings -->
-                            <configureEnvironment>
-                                <property>
-                                    <name>CFLAGS</name>
-                                    <value>-DEXEC_CONF_DIR=${worker-launcher.conf.dir} ${worker-launcher.additional_cflags}</value>
-                                </property>
-                            </configureEnvironment>
-                            <configureWorkDir>${project.build.directory}/native/worker-launcher</configureWorkDir>
-                            <prefix>/usr/local</prefix>
-
-                            <!-- configure & make settings -->
-                            <destDir>${project.build.directory}/native/target</destDir>
-
-                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.0.2</version>
+                        <executions>
+                            <execution>
+                                <id>copy-build-scripts</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/resources</directory>
+                                            <includes>
+                                                <include>compile-worker-launcher.sh</include>
+                                            </includes>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>${worker-launcher.build.dir}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/storm-core/src/resources/compile-worker-launcher.sh
+++ b/storm-core/src/resources/compile-worker-launcher.sh
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+autoreconf -i
+export CFLAGS=-DEXEC_CONF_DIR=${worker-launcher.conf.dir} ${worker-launcher.additional_cflags}
+./configure --prefix=/usr/local
+export DESTDIR=${project.build.directory}/native/target
+make install


### PR DESCRIPTION
1.x version of https://github.com/apache/storm/pull/2462

I didn't think we needed this initially since asprintf isn't used in 1.x, but it looks like the build is failing on 1.x after upgrading to the newest Travis image (e.g. https://travis-ci.org/apache/storm/builds/324620269).

This only contains the replacement of make-maven-plugin. Make-maven-plugin fails to run autoreconf on Travis. The error log is
```
[DEBUG] Executing: /bin/sh -l -c cd /home/travis/build/srdo/storm/storm-core/target/native/worker-launcher && autoreconf -i
[DEBUG] /bin/sh: 14: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 21: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 28: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 35: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 42: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 49: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 56: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 62: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 62: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 62: /opt/jdk_switcher/jdk_switcher.sh: [[: not found
[DEBUG] /bin/sh: 109: /opt/jdk_switcher/jdk_switcher.sh: Syntax error: "(" unexpected (expecting "fi")
```
Googling it leads to https://github.com/travis-ci/travis-cookbooks/issues/964. Sounds like jdk_switcher isn't expecting to be called with a non-bash shell, and it gets called that way when opening sh as a login shell.
  