### PR TITLE
STORM-2881: Explicitly specify the curator dependencies in storm-druid pom

### DIFF
--- a/external/storm-druid/pom.xml
+++ b/external/storm-druid/pom.xml
@@ -81,6 +81,23 @@
             <version>2.4.6</version>
         </dependency>
 
+        <!-- tranquility library depends on 2.6.0 version of curator -->
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+
         <!--test dependencies -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
https://github.com/apache/storm/pull/2498 applied to 1.x branch.