### PR TITLE
STORM-2876: Work around memory leak, and try to speed up tests

### DIFF
--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -223,6 +223,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+		<configuration>
+                    <reuseForks>false</reuseForks>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.2</version>
                 <executions>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -157,6 +157,14 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <reuseForks>true</reuseForks>
+          <forkCount>1</forkCount>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-clean-plugin</artifactId>
         <version>2.5</version>
         <executions>

--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -135,6 +135,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>true</reuseForks>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.5</version>
                 <executions>

--- a/external/storm-mqtt/pom.xml
+++ b/external/storm-mqtt/pom.xml
@@ -92,7 +92,6 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkMode>perTest</forkMode>
                     <enableAssertions>false</enableAssertions>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <excludedGroups>${java.unit.test.exclude}</excludedGroups>
@@ -106,7 +105,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <forkMode>perTest</forkMode>
                     <enableAssertions>false</enableAssertions>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <includes>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -111,6 +111,8 @@
                             <value>org.apache.storm.st.meta.TestngListener</value>
                         </property>
                     </properties>
+                    <reuseForks>true</reuseForks>
+                    <forkCount>1</forkCount>
                     <systemPropertyVariables>
                         <regression.downloadWorkerLogs>${regression.downloadWorkerLogs}</regression.downloadWorkerLogs>
                     </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -1089,6 +1089,8 @@
                         </includes>
                         <argLine>-Xmx1536m</argLine>
                         <trimStackTrace>false</trimStackTrace>
+                        <forkCount>1.0C</forkCount>
+                        <reuseForks>true</reuseForks>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
The actual fix is just the changes in storm-hdfs/pom.xml  But this added 1 min to the build time on a decently powerful box.  So to combat that I made as many of the test run in parallel.  Some of the tests didn't work well in this mode, so I disabled the parallelism for storm-hive, storm-kafka-client, and integration-test.  Storm-hdfs and storm-hive have some issues with where data is stored, and we could probably make it work with the right settings.  storm-kafka-client mostly works, but occasionally I would see a test hang and I didn't have time to debug it.