### PR TITLE
Add anchor links to the README

### DIFF
--- a/external/storm-hdfs/README.md
+++ b/external/storm-hdfs/README.md
@@ -1,8 +1,8 @@
 # Storm HDFS
 
 Storm components for interacting with HDFS file systems
- - HDFS Bolt 
- - HDFS Spout
+ - [HDFS Bolt](#hdfs-bolt)
+ - [HDFS Spout](#hdfs-spout)
 
 ---
 


### PR DESCRIPTION
Makes it easier to jump to the HDFS Spout documentation. The HDFS Bolt link isn't really needed but is done for consistency's sake.