### PR TITLE
STORM-2877: Add an option to configure pagination in Storm UI

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -88,6 +88,7 @@ ui.filter.params: null
 ui.users: null
 ui.header.buffer.bytes: 4096
 ui.http.creds.plugin: org.apache.storm.security.auth.DefaultHttpCredentialsPlugin
+ui.pagination: 20
 
 logviewer.port: 8000
 logviewer.childopts: "-Xmx128m"

--- a/storm-core/src/ui/public/component.html
+++ b/storm-core/src/ui/public/component.html
@@ -143,16 +143,18 @@ $(document).ready(function() {
     var url = "/api/v1/topology/"+topologyId+"/component/"+componentId+"?sys="+sys;
     if(window) url += "&window="+window;
 
-    $.extend( $.fn.dataTable.defaults, {
-      stateSave: true,
-      stateSaveCallback: function (oSettings, oData) {
-        sessionStorage.setItem( oSettings.sTableId.concat(tableStateKey), JSON.stringify(oData) );
-      },
-      stateLoadCallback: function (oSettings) {
-        return JSON.parse( sessionStorage.getItem(oSettings.sTableId.concat(tableStateKey)) );
-      },
-      lengthMenu: [[20,40,60,100,-1], [20, 40, 60, 100, "All"]],
-      pageLength: 20
+    $.getJSON("/api/v1/cluster/configuration",function(response,status,jqXHR) {
+        $.extend( $.fn.dataTable.defaults, {
+          stateSave: true,
+          stateSaveCallback: function (oSettings, oData) {
+            sessionStorage.setItem( oSettings.sTableId.concat(tableStateKey), JSON.stringify(oData) );
+          },
+          stateLoadCallback: function (oSettings) {
+            return JSON.parse( sessionStorage.getItem(oSettings.sTableId.concat(tableStateKey)) );
+          },
+          lengthMenu: [[20,40,60,100,-1], [20, 40, 60, 100, "All"]],
+          pageLength: response["ui.pagination"]
+        });
     });
 
     renderToggleSys($("#toggle-switch"));

--- a/storm-core/src/ui/public/index.html
+++ b/storm-core/src/ui/public/index.html
@@ -106,93 +106,93 @@ $(document).ajaxStart(function(){
     $.blockUI({ message: '<img src="images/spinner.gif" /> <h3>Loading summary...</h3>'});
 });
 $(document).ready(function() {
-    $.extend( $.fn.dataTable.defaults, {
-      stateSave: true,
-      lengthMenu: [[20,40,60,100,-1], [20, 40, 60, 100, "All"]],
-      pageLength: 20
-    });
-
-    $.ajaxSetup({
-        "error":function(jqXHR,textStatus,response) {
-            var errorJson = jQuery.parseJSON(jqXHR.responseText);
-            getStatic("/templates/json-error-template.html", function(template) {
-                $("#json-response-error").append(Mustache.render($(template).filter("#json-error-template").html(),errorJson));
-            });
-        }
-    });
-    var uiUser = $("#ui-user");
-    var clusterSummary = $("#cluster-summary");
-    var clusterResources = $("#cluster-resources");
-    var nimbusSummary = $("#nimbus-summary");
-    var ownerSummary = $("#owner-summary");
-    var topologySummary = $("#topology-summary");
-    var supervisorSummary = $("#supervisor-summary");
-    var config = $("#nimbus-configuration");
-
-    getStatic("/templates/index-page-template.html", function(indexTemplate) {
-        $.getJSON("/api/v1/cluster/summary",function(response,status,jqXHR) {
-            getStatic("/templates/user-template.html", function(template) {
-                uiUser.append(Mustache.render($(template).filter("#user-template").html(),response));
-                $('#ui-user [data-toggle="tooltip"]').tooltip()
-            });
-
-            clusterSummary.append(Mustache.render($(indexTemplate).filter("#cluster-summary-template").html(),response));
-            $('#cluster-summary [data-toggle="tooltip"]').tooltip();
-
-            clusterResources.append(Mustache.render($(indexTemplate).filter("#cluster-resources-template").html(),response));
-            $('#cluster-resources [data-toggle="tooltip"]').tooltip();
-
-            var displayResource = response["schedulerDisplayResource"];
-            $('#cluster-resources [data-toggle="tooltip"]').tooltip();
-            if (!displayResource){
-                $('#cluster-resources-header').hide();
-                $('#cluster-resources').hide();
-            };
+    $.getJSON("/api/v1/cluster/configuration",function(responseClusterConfig,status,jqXHR) {
+        $.extend( $.fn.dataTable.defaults, {
+          stateSave: true,
+          lengthMenu: [[20,40,60,100,-1], [20, 40, 60, 100, "All"]],
+          pageLength: responseClusterConfig["ui.pagination"]
         });
 
-        $.getJSON("/api/v1/nimbus/summary",function(response,status,jqXHR) {
-            nimbusSummary.append(Mustache.render($(indexTemplate).filter("#nimbus-summary-template").html(),response));
-            //host, port, isLeader, version, uptime
-            dtAutoPage("#nimbus-summary-table", {
-              columnDefs: [
-                {type: "num", targets: [1]},
-                {type: "time-str", targets: [4]}
-              ]
+        $.ajaxSetup({
+            "error":function(jqXHR,textStatus,response) {
+                var errorJson = jQuery.parseJSON(jqXHR.responseText);
+                getStatic("/templates/json-error-template.html", function(template) {
+                    $("#json-response-error").append(Mustache.render($(template).filter("#json-error-template").html(),errorJson));
+                });
+            }
+        });
+        var uiUser = $("#ui-user");
+        var clusterSummary = $("#cluster-summary");
+        var clusterResources = $("#cluster-resources");
+        var nimbusSummary = $("#nimbus-summary");
+        var ownerSummary = $("#owner-summary");
+        var topologySummary = $("#topology-summary");
+        var supervisorSummary = $("#supervisor-summary");
+        var config = $("#nimbus-configuration");
+
+        getStatic("/templates/index-page-template.html", function(indexTemplate) {
+            $.getJSON("/api/v1/cluster/summary",function(response,status,jqXHR) {
+                getStatic("/templates/user-template.html", function(template) {
+                    uiUser.append(Mustache.render($(template).filter("#user-template").html(),response));
+                    $('#ui-user [data-toggle="tooltip"]').tooltip()
+                });
+
+                clusterSummary.append(Mustache.render($(indexTemplate).filter("#cluster-summary-template").html(),response));
+                $('#cluster-summary [data-toggle="tooltip"]').tooltip();
+
+                clusterResources.append(Mustache.render($(indexTemplate).filter("#cluster-resources-template").html(),response));
+                $('#cluster-resources [data-toggle="tooltip"]').tooltip();
+
+                var displayResource = response["schedulerDisplayResource"];
+                $('#cluster-resources [data-toggle="tooltip"]').tooltip();
+                if (!displayResource){
+                    $('#cluster-resources-header').hide();
+                    $('#cluster-resources').hide();
+                };
             });
-            $('#nimbus-summary [data-toggle="tooltip"]').tooltip();
-        });
 
-        $.getJSON("/api/v1/owner-resources", function(response, status, jqXHR) {
-            ownerSummary.append(Mustache.render($(indexTemplate).filter("#owner-summary-template").html(), response));
-            makeOwnerSummaryTable(response, '#owner-summary-table', '#owner-summary');
-        });
-
-        $.getJSON("/api/v1/topology/summary",function(response,status,jqXHR) {
-            topologySummary.append(Mustache.render($(indexTemplate).filter("#topology-summary-template").html(),response));
-            //name, owner, status, uptime, num workers, num executors, num tasks, replication count, assigned total mem, assigned total cpu, scheduler info
-            dtAutoPage("#topology-summary-table", {
-              columnDefs: [
-                {type: "num", targets: [4, 5, 6, 7, 8, 9]},
-                {type: "time-str", targets: [3]}
-              ]
+            $.getJSON("/api/v1/nimbus/summary",function(response,status,jqXHR) {
+                nimbusSummary.append(Mustache.render($(indexTemplate).filter("#nimbus-summary-template").html(),response));
+                //host, port, isLeader, version, uptime
+                dtAutoPage("#nimbus-summary-table", {
+                  columnDefs: [
+                    {type: "num", targets: [1]},
+                    {type: "time-str", targets: [4]}
+                  ]
+                });
+                $('#nimbus-summary [data-toggle="tooltip"]').tooltip();
             });
-            $('#topology-summary [data-toggle="tooltip"]').tooltip();
-        });
 
-        $.getJSON("/api/v1/supervisor/summary",function(response,status,jqXHR) {
-            supervisorSummary.append(Mustache.render($(indexTemplate).filter("#supervisor-summary-template").html(),response));
-            //id, host, uptime, slots, used slots
-            dtAutoPage("#supervisor-summary-table", {
-              columnDefs: [
-                {type: "num", targets: [3, 4]},
-                {type: "time-str", targets: [2]}
-              ]
+            $.getJSON("/api/v1/owner-resources", function(response, status, jqXHR) {
+                ownerSummary.append(Mustache.render($(indexTemplate).filter("#owner-summary-template").html(), response));
+                makeOwnerSummaryTable(response, '#owner-summary-table', '#owner-summary');
             });
-            $('#supervisor-summary [data-toggle="tooltip"]').tooltip();
-        });
 
-        $.getJSON("/api/v1/cluster/configuration",function(response,status,jqXHR) {
-          var formattedResponse = formatConfigData(response);
+            $.getJSON("/api/v1/topology/summary",function(response,status,jqXHR) {
+                topologySummary.append(Mustache.render($(indexTemplate).filter("#topology-summary-template").html(),response));
+                //name, owner, status, uptime, num workers, num executors, num tasks, replication count, assigned total mem, assigned total cpu, scheduler info
+                dtAutoPage("#topology-summary-table", {
+                  columnDefs: [
+                    {type: "num", targets: [4, 5, 6, 7, 8, 9]},
+                    {type: "time-str", targets: [3]}
+                  ]
+                });
+                $('#topology-summary [data-toggle="tooltip"]').tooltip();
+            });
+
+            $.getJSON("/api/v1/supervisor/summary",function(response,status,jqXHR) {
+                supervisorSummary.append(Mustache.render($(indexTemplate).filter("#supervisor-summary-template").html(),response));
+                //id, host, uptime, slots, used slots
+                dtAutoPage("#supervisor-summary-table", {
+                  columnDefs: [
+                    {type: "num", targets: [3, 4]},
+                    {type: "time-str", targets: [2]}
+                  ]
+                });
+                $('#supervisor-summary [data-toggle="tooltip"]').tooltip();
+            });
+
+          var formattedResponse = formatConfigData(responseClusterConfig);
           config.append(Mustache.render($(indexTemplate).filter("#configuration-template").html(),formattedResponse));
           $('#nimbus-configuration-table td').jsonFormatter();
           //key, value

--- a/storm-core/src/ui/public/topology.html
+++ b/storm-core/src/ui/public/topology.html
@@ -251,16 +251,18 @@ $(document).ready(function() {
     var sys = $.cookies.get("sys") || "false";
     var url = "/api/v1/topology/"+topologyId+"?sys="+sys;
     if(window) url += "&window="+window;
-    $.extend( $.fn.dataTable.defaults, {
-      stateSave: true,
-      stateSaveCallback: function (oSettings, oData) {
-        sessionStorage.setItem( oSettings.sTableId.concat(tableStateKey), JSON.stringify(oData) );
-      },
-      stateLoadCallback: function (oSettings) {
-        return JSON.parse( sessionStorage.getItem(oSettings.sTableId.concat(tableStateKey)) );
-      },
-      lengthMenu: [[20,40,60,100,-1], [20, 40, 60, 100, "All"]],
-      pageLength: 20
+    $.getJSON("/api/v1/cluster/configuration",function(response,status,jqXHR) {
+        $.extend( $.fn.dataTable.defaults, {
+          stateSave: true,
+          stateSaveCallback: function (oSettings, oData) {
+            sessionStorage.setItem( oSettings.sTableId.concat(tableStateKey), JSON.stringify(oData) );
+          },
+          stateLoadCallback: function (oSettings) {
+            return JSON.parse( sessionStorage.getItem(oSettings.sTableId.concat(tableStateKey)) );
+          },
+          lengthMenu: [[20,40,60,100,-1], [20, 40, 60, 100, "All"]],
+          pageLength: response["ui.pagination"]
+        });
     });
 
     renderToggleSys($("#toggle-switch"));

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -308,6 +308,13 @@ public class DaemonConfig implements Validated {
     public static final String UI_CENTRAL_LOGGING_URL = "ui.central.logging.url";
 
     /**
+     * Storm UI drop-down pagination value. Set ui.pagination to be a positive integer
+     * or -1 (displays all entries). Valid values: -1, 10, 20, 25 etc.
+     */
+    @isInteger
+    public static final String UI_PAGINATION = "ui.pagination";
+
+    /**
      * HTTP UI port for log viewer.
      */
     @isInteger


### PR DESCRIPTION
The current pagination default value for Storm UI is hard-coded to be 20. Pagination has been introduced in `Storm 1.x`. Having 20 items in the list restricts searching through the page. It will be beneficial to have a configuration option, `ui.pagination`, which will set the pagination value when Storm UI loads. This option can be added to storm.yaml along with other configurations.

Changed the value of `ui.pagination` in `storm.yaml` to test the following cases :



| Value in `storm.yaml`        | Result    
| ------------- |:-------------:| 
|  No `ui.pagination`     | defaults to 20 entries |
|  `“All”`     | Throws error, expects integer |
|  `-10`     | List doesn't have any items in it |
|  `30`     | Populates list with 30 entries as default |
|  `10`     | Populates list with 10 entries as default|
|  `-1`      | Equivalent of All from the drop-down options|
  
  