### PR TITLE
Updated how to get the storm-starter code

### DIFF
--- a/examples/storm-starter/README.markdown
+++ b/examples/storm-starter/README.markdown
@@ -22,9 +22,9 @@ Table of Contents
 First, you need `java` and `git` installed and in your user's `PATH`.  Also, two of the examples in storm-starter
 require Python and Ruby.
 
-Next, make sure you have the storm-starter code available on your machine.  Git/GitHub beginners may want to use the
+Next, make sure you have the storm-starter code available on your machine. If you have already downloaded storm from http://storm.apache.org/downloads.html then you will find the storm-starter code under your `apache-storm-<version>/examples/` directory. Alternatively, Git/GitHub beginners may want to use the
 following command to download the latest storm-starter code and change to the new directory that contains the downloaded
-code.
+code, but make sure you have the same version of `storm` running.
 
     $ git clone git://github.com/apache/storm.git && cd storm/examples/storm-starter
 


### PR DESCRIPTION
A typical use case for somebody trying this is, first setting up a working storm installation and then running the example. If the storm-starter code is cloned from github directly, it may not match the version of storm they just installed, and giving rise to an error like `Error: Could not find or load main class org.apache.storm.starter.ExclamationTopology` when the topology is submitted.

The README doesn't make it clear that the storm-starter code is also available inside the version they had downloaded from http://storm.apache.org/downloads.html

Hopefully this edit will bring more clarity.