### PR TITLE
[STORM-2892] fix PATH substitution in flux tests

### DIFF
--- a/flux/flux-core/src/test/resources/configs/substitution-test.yaml
+++ b/flux/flux-core/src/test/resources/configs/substitution-test.yaml
@@ -22,7 +22,7 @@
 name: "${topology.name}"
 
 # Components
-# Components are analagous to Spring beans. They are meant to be used as constructor,
+# Components are analogous to Spring beans. They are meant to be used as constructor,
 # property(setter), and builder arguments.
 #components:
 #  - id: "myComponent"
@@ -41,8 +41,8 @@ name: "${topology.name}"
 #
 config:
   topology.workers: 1
-  # test environent variable substitution
-  test.env.value: ${ENV-PATH}
+  # test environment variable substitution
+  test.env.value: "${ENV-PATH}"
   # test variable substitution for list type
   list.property.target: ${a.list.property}
 


### PR DESCRIPTION
The tests fail when the PATH environment variable has a trailing colon, despite that being a valid PATH.
This happens because it is substituted directly into the resultant YAML file, which results in invalid
YAML (since you cannot end a map's value with ":" in the raw text).

So the solution is to wrap the map value with double-quotes.

Also fix 2 typos in comments in this file.