### PR TITLE
[STORM-2893] fix storm distribution build by using POSIX tar

### DIFF
--- a/storm-dist/binary/final-package/pom.xml
+++ b/storm-dist/binary/final-package/pom.xml
@@ -54,6 +54,7 @@
                 </executions>
                 <configuration>
                     <attach>true</attach>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <runOnlyAtExecutionRoot>false</runOnlyAtExecutionRoot>
                     <descriptors>
                         <descriptor>${project.basedir}/src/main/assembly/binary.xml</descriptor>


### PR DESCRIPTION
There is a known issue with the maven-assembly-plugin version 2.5+ where it fails with errors like the following:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single (default) on project final-package: Execution default of goal org.apache.maven.plugins:maven-assembly-plugin:2.6:single failed: group id '906175167' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]
```

This became an issue with change 84a4314d96b9e4e377a3d5d81d0a042d96a0625e when the maven-assembly-plugin
was upgraded from version 2.2.2 to 2.6, as inherited from the apache pom version 18.

To fix this we set the assembly plugin's `tarLongFileMode` configuration setting to `posix`.