### PR TITLE
[STORM-2901] Reuse ZK connection for getKeySequenceNumber

### DIFF
--- a/storm-core/src/clj/org/apache/storm/command/shell_submission.clj
+++ b/storm-core/src/clj/org/apache/storm/command/shell_submission.clj
@@ -14,19 +14,24 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns org.apache.storm.command.shell-submission
-  (:import [org.apache.storm StormSubmitter]
+  (:import [org.apache.storm Config StormSubmitter]
            [org.apache.storm.utils ServerUtils]
            [org.apache.storm.zookeeper Zookeeper])
   (:use [org.apache.storm util config log])
   (:require [clojure.string :as str])
-  (:import [org.apache.storm.utils ConfigUtils])
+  (:import [org.apache.storm.callback DefaultWatcherCallBack]
+           [org.apache.storm.utils ConfigUtils]
+           [org.apache.storm.zookeeper Zookeeper ClientZookeeper])
   (:gen-class))
 
 
 (defn -main [^String tmpjarpath & args]
   (let [conf (clojurify-structure (ConfigUtils/readStormConfig))
+        servers (.get conf Config/STORM_ZOOKEEPER_SERVERS)
+        port (.get conf Config/STORM_ZOOKEEPER_PORT)
+        zk (ClientZookeeper/mkClient conf servers port "" (DefaultWatcherCallBack.) conf)
         ; since this is not a purpose to add to leader lock queue, passing nil as blob-store and topo cache is ok
-        zk-leader-elector (Zookeeper/zkLeaderElector conf nil nil)
+        zk-leader-elector (Zookeeper/zkLeaderElector conf zk nil nil)
         leader-nimbus (.getLeader zk-leader-elector)
         host (.getHost leader-nimbus)
         port (.getPort leader-nimbus)

--- a/storm-core/src/jvm/org/apache/storm/command/AdminCommands.java
+++ b/storm-core/src/jvm/org/apache/storm/command/AdminCommands.java
@@ -24,12 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.storm.Config;
 import org.apache.storm.blobstore.BlobStore;
 import org.apache.storm.blobstore.KeyFilter;
 import org.apache.storm.blobstore.LocalFsBlobStore;
-import org.apache.storm.callback.DefaultWatcherCallBack;
 import org.apache.storm.cluster.ClusterStateContext;
 import org.apache.storm.cluster.ClusterUtils;
 import org.apache.storm.cluster.DaemonType;
@@ -38,7 +35,6 @@ import org.apache.storm.nimbus.NimbusInfo;
 import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.utils.ServerUtils;
 import org.apache.storm.utils.Utils;
-import org.apache.storm.zookeeper.ClientZookeeper;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
@@ -75,8 +71,6 @@ public class AdminCommands {
     private static void initialize() {
         conf = Utils.readStormConfig();
         nimbusBlobStore = ServerUtils.getNimbusBlobStore (conf, NimbusInfo.fromConf(conf));
-        List<String> servers = (List<String>) conf.get(Config.STORM_ZOOKEEPER_SERVERS);
-        Object port = conf.get(Config.STORM_ZOOKEEPER_PORT);
         List<ACL> acls = null;
         if (Utils.isZkAuthenticationConfiguredStormServer(conf)) {
             acls = adminZkAcls();
@@ -87,7 +81,6 @@ public class AdminCommands {
             LOG.error("admin can't create stormClusterState");
             new RuntimeException(e);
         }
-        CuratorFramework zk = ClientZookeeper.mkClient(conf, servers, port, "", new DefaultWatcherCallBack(),conf);
     }
 
     // we might think of moving this method in Utils class

--- a/storm-core/test/clj/org/apache/storm/nimbus_test.clj
+++ b/storm-core/test/clj/org/apache/storm/nimbus_test.clj
@@ -1311,7 +1311,7 @@
   (with-open [zk (InProcessZookeeper. )]
     (with-open [tmp-nimbus-dir (TmpPath.)
                 _ (MockedZookeeper. (proxy [Zookeeper] []
-                      (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. ))))]
+                      (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. ))))]
       (let [nimbus-dir (.getPath tmp-nimbus-dir)]
         (letlocals
           (bind conf (merge (clojurify-structure (ConfigUtils/readStormConfig))
@@ -1328,7 +1328,7 @@
                            {}))
 
           (with-open [_ (MockedZookeeper. (proxy [Zookeeper] []
-                          (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. false))))]
+                          (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. false))))]
 
             (letlocals
               (bind non-leader-cluster-state (ClusterUtils/mkStormClusterState conf nil (ClusterStateContext.)))
@@ -1635,7 +1635,7 @@
                   _ (UtilsInstaller. fake-utils)
                   - (StormCommonInstaller. fake-common)
                   zk-le (MockedZookeeper. (proxy [Zookeeper] []
-                          (zkLeaderElectorImpl [conf blob-store tc] nil)))
+                          (zkLeaderElectorImpl [conf zk blob-store tc] nil)))
                   mocked-cluster (MockedCluster. cluster-utils)]
           (mk-nimbus auth-conf fake-inimbus)
           (.mkStormClusterStateImpl (Mockito/verify cluster-utils (Mockito/times 1)) (Mockito/any) (Mockito/eq expected-acls) (Mockito/any))
@@ -1706,7 +1706,7 @@
   (with-open [zk (InProcessZookeeper. )]
     (with-open [tmp-nimbus-dir (TmpPath.)
                 _ (MockedZookeeper. (proxy [Zookeeper] []
-                    (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. ))))]
+                    (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. ))))]
       (let [nimbus-dir (.getPath tmp-nimbus-dir)]
         (letlocals
           (bind conf (merge (clojurify-structure (ConfigUtils/readStormConfig))
@@ -1899,7 +1899,7 @@
         mock-blob-store (Mockito/mock BlobStore)
         conf {NIMBUS-MONITOR-FREQ-SECS 10}]
     (with-open [_ (MockedZookeeper. (proxy [Zookeeper] []
-                    (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. ))))]
+                    (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. ))))]
       (let [nimbus (Mockito/spy (Nimbus. conf nil mock-state nil mock-blob-store nil nil))]
         (.set (.getHeartbeatsCache nimbus) hb-cache)
         (.thenReturn (Mockito/when (.storedTopoIds mock-blob-store)) (HashSet. inactive-topos))
@@ -1944,7 +1944,7 @@
         mock-blob-store (Mockito/mock BlobStore)
         conf {NIMBUS-MONITOR-FREQ-SECS 10}]
     (with-open [_ (MockedZookeeper. (proxy [Zookeeper] []
-                    (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. ))))]
+                    (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. ))))]
       (let [nimbus (Mockito/spy (Nimbus. conf nil mock-state nil mock-blob-store nil nil))]
         (.set (.getHeartbeatsCache nimbus) hb-cache)
         (.thenReturn (Mockito/when (.storedTopoIds mock-blob-store)) (set inactive-topos))

--- a/storm-core/test/clj/org/apache/storm/security/auth/auth_test.clj
+++ b/storm-core/test/clj/org/apache/storm/security/auth/auth_test.clj
@@ -62,7 +62,7 @@
 
 (defn nimbus-data [storm-conf inimbus]
   (with-open [_ (MockedZookeeper. (proxy [Zookeeper] []
-                  (zkLeaderElectorImpl [conf blob-store tc] (Mockito/mock ILeaderElector))))]
+                  (zkLeaderElectorImpl [conf zk blob-store tc] (Mockito/mock ILeaderElector))))]
     (org.apache.storm.daemon.nimbus.Nimbus. storm-conf inimbus (Mockito/mock IStormClusterState) nil (Mockito/mock BlobStore) nil nil)))
 
 (defn dummy-service-handler

--- a/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
@@ -48,6 +48,10 @@ public class BlobStoreUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(BlobStoreUtils.class);
 
+    public static String getBlobStoreRoot(Map<String, Object> conf) {
+        return conf.get(Config.STORM_ZOOKEEPER_ROOT) + BLOBSTORE_SUBTREE;
+    }
+
     public static CuratorFramework createZKClient(Map<String, Object> conf) {
         @SuppressWarnings("unchecked")
         List<String> zkServers = (List<String>) conf.get(Config.STORM_ZOOKEEPER_SERVERS);

--- a/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
@@ -17,7 +17,6 @@
  */
 package org.apache.storm.blobstore;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -55,7 +54,6 @@ public class BlobStoreUtils {
         ZookeeperAuthInfo zkAuthInfo = new ZookeeperAuthInfo(conf);
         CuratorFramework zkClient = CuratorUtils.newCurator(conf, zkServers, port, (String) conf.get(Config.STORM_ZOOKEEPER_ROOT), zkAuthInfo);
         zkClient.start();
-
         return zkClient;
     }
 
@@ -270,5 +268,4 @@ public class BlobStoreUtils {
             throw new RuntimeException(exp);
         }
     }
-
 }

--- a/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 public class BlobStoreUtils {
     private static final String BLOBSTORE_SUBTREE="/blobstore";
+
     private static final Logger LOG = LoggerFactory.getLogger(BlobStoreUtils.class);
 
     public static CuratorFramework createZKClient(Map<String, Object> conf) {

--- a/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.blobstore;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -54,6 +55,7 @@ public class BlobStoreUtils {
         ZookeeperAuthInfo zkAuthInfo = new ZookeeperAuthInfo(conf);
         CuratorFramework zkClient = CuratorUtils.newCurator(conf, zkServers, port, (String) conf.get(Config.STORM_ZOOKEEPER_ROOT), zkAuthInfo);
         zkClient.start();
+
         return zkClient;
     }
 
@@ -268,6 +270,5 @@ public class BlobStoreUtils {
             throw new RuntimeException(exp);
         }
     }
-
 
 }

--- a/storm-server/src/main/java/org/apache/storm/blobstore/BlobSynchronizer.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/BlobSynchronizer.java
@@ -17,16 +17,16 @@
  */
 package org.apache.storm.blobstore;
 
-import org.apache.storm.generated.KeyNotFoundException;
-import org.apache.storm.nimbus.NimbusInfo;
-import org.apache.curator.framework.CuratorFramework;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.nio.channels.ClosedByInterruptException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.storm.generated.KeyNotFoundException;
+import org.apache.storm.nimbus.NimbusInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Is called periodically and updates the nimbus with blobs based on the state stored inside the zookeeper

--- a/storm-server/src/main/java/org/apache/storm/blobstore/BlobSynchronizer.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/BlobSynchronizer.java
@@ -58,6 +58,10 @@ public class BlobSynchronizer {
         this.blobStoreKeySet = blobStoreKeySet;
     }
 
+    public void setZkClient(CuratorFramework zkClient) {
+        this.zkClient = zkClient;
+    }
+
     public Set<String> getBlobStoreKeySet() {
         Set<String> keySet = new HashSet<String>();
         keySet.addAll(blobStoreKeySet);
@@ -73,7 +77,6 @@ public class BlobSynchronizer {
     public synchronized void syncBlobs() {
         try {
             LOG.debug("Sync blobs - blobstore keys {}, zookeeper keys {}",getBlobStoreKeySet(), getZookeeperKeySet());
-            zkClient = BlobStoreUtils.createZKClient(conf);
             deleteKeySetFromBlobStoreNotOnZookeeper(getBlobStoreKeySet(), getZookeeperKeySet());
             updateKeySetForBlobStore(getBlobStoreKeySet());
             Set<String> keySetToDownload = getKeySetToDownload(getBlobStoreKeySet(), getZookeeperKeySet());
@@ -89,9 +92,6 @@ public class BlobSynchronizer {
                 } catch (KeyNotFoundException e) {
                     LOG.debug("Detected deletion for the key {} while downloading - skipping download", key);
                 }
-            }
-            if (zkClient !=null) {
-                zkClient.close();
             }
         } catch(InterruptedException | ClosedByInterruptException exp) {
             LOG.error("Interrupt Exception {}", exp);

--- a/storm-server/src/main/java/org/apache/storm/blobstore/KeySequenceNumber.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/KeySequenceNumber.java
@@ -131,9 +131,8 @@ public class KeySequenceNumber {
         this.nimbusInfo = nimbusInfo;
     }
 
-    public synchronized int getKeySequenceNumber(Map<String, Object> conf) throws KeyNotFoundException {
+    public synchronized int getKeySequenceNumber(CuratorFramework zkClient) throws KeyNotFoundException {
         TreeSet<Integer> sequenceNumbers = new TreeSet<Integer>();
-        CuratorFramework zkClient = BlobStoreUtils.createZKClient(conf);
         try {
             // Key has not been created yet and it is the first time it is being created
             if (zkClient.checkExists().forPath(BLOBSTORE_SUBTREE + "/" + key) == null) {

--- a/storm-server/src/main/java/org/apache/storm/blobstore/KeySequenceNumber.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/KeySequenceNumber.java
@@ -18,19 +18,18 @@
 
 package org.apache.storm.blobstore;
 
+import java.nio.ByteBuffer;
+import java.util.TreeSet;
+import java.util.List;
+
+import org.apache.curator.framework.CuratorFramework;
 import org.apache.storm.generated.KeyNotFoundException;
 import org.apache.storm.nimbus.NimbusInfo;
-import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.ByteBuffer;
-import java.util.TreeSet;
-import java.util.Map;
-import java.util.List;
 
 /**
  * Class hands over the key sequence number which implies the number of updates made to a blob.

--- a/storm-server/src/main/java/org/apache/storm/blobstore/KeySequenceNumber.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/KeySequenceNumber.java
@@ -206,10 +206,6 @@ public class KeySequenceNumber {
             // in other case, just set this to 0 to trigger re-sync later
             LOG.error("Exception {}", e);
             return INITIAL_SEQUENCE_NUMBER - 1;
-        } finally {
-            if (zkClient != null) {
-                zkClient.close();
-            }
         }
     }
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1029,7 +1029,6 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     private final AtomicLong submittedCount;
     //Cached CuratorFramework, mainly used for BlobStore.
     private CuratorFramework zkClient;
-    private final Object zkClientCreateLock = new Object();
     private final IStormClusterState stormClusterState;
     private final Object submitLock = new Object();
     private final Object schedLock = new Object();

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -62,11 +62,11 @@ import org.apache.storm.StormTimer;
 import org.apache.storm.blobstore.AtomicOutputStream;
 import org.apache.storm.blobstore.BlobStore;
 import org.apache.storm.blobstore.BlobStoreAclHandler;
-import org.apache.storm.blobstore.BlobStoreUtils;
 import org.apache.storm.blobstore.BlobSynchronizer;
 import org.apache.storm.blobstore.InputStreamWithMeta;
 import org.apache.storm.blobstore.KeySequenceNumber;
 import org.apache.storm.blobstore.LocalFsBlobStore;
+import org.apache.storm.callback.DefaultWatcherCallBack;
 import org.apache.storm.cluster.ClusterStateContext;
 import org.apache.storm.cluster.ClusterUtils;
 import org.apache.storm.cluster.DaemonType;
@@ -180,6 +180,7 @@ import org.apache.storm.utils.Utils;
 import org.apache.storm.utils.Utils.UptimeComputer;
 import org.apache.storm.utils.VersionInfo;
 import org.apache.storm.validation.ConfigValidation;
+import org.apache.storm.zookeeper.ClientZookeeper;
 import org.apache.storm.zookeeper.Zookeeper;
 import org.apache.thrift.TException;
 import org.apache.zookeeper.ZooDefs;
@@ -1064,6 +1065,17 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     private final List<ClusterMetricsConsumerExecutor> clusterConsumerExceutors;
     private final IGroupMappingServiceProvider groupMapper;
     private final IPrincipalToLocal principalToLocal;
+
+    private static CuratorFramework makeZKClient(Map<String, Object> conf) {
+        List<String> servers = (List<String>)conf.get(Config.STORM_ZOOKEEPER_SERVERS);
+        Object port = conf.get(Config.STORM_ZOOKEEPER_PORT);
+
+        CuratorFramework ret = null;
+        if (servers != null && port != null) {
+            ret = ClientZookeeper.mkClient(conf,servers,port,"", new DefaultWatcherCallBack(),conf);
+        }
+        return ret;
+    }
     
     private static IStormClusterState makeStormClusterState(Map<String, Object> conf) throws Exception {
         List<ACL> acls = null;
@@ -1124,8 +1136,9 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         });
         this.underlyingScheduler = makeScheduler(conf, inimbus);
         this.scheduler = wrapAsBlacklistScheduler(conf, underlyingScheduler);
+        this.zkClient = makeZKClient(conf);
         if (leaderElector == null) {
-            leaderElector = Zookeeper.zkLeaderElector(conf, blobStore, topoCache);
+            leaderElector = Zookeeper.zkLeaderElector(conf, zkClient, blobStore, topoCache);
         }
         this.leaderElector = leaderElector;
         this.idToSchedStatus = new AtomicReference<>(new HashMap<>());
@@ -1153,18 +1166,6 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     @VisibleForTesting
     public void setAuthorizationHandler(IAuthorizer authorizationHandler) {
         this.authorizationHandler = authorizationHandler;
-    }
-
-    private CuratorFramework getOrCreateZkClient() {
-        if (this.zkClient == null) {
-            synchronized (zkClientCreateLock) {
-                if (zkClient == null) {
-                    this.zkClient = BlobStoreUtils.createZKClient(conf);
-                }
-            }
-        }
-
-        return this.zkClient;
     }
 
     private IStormClusterState getStormClusterState() {
@@ -1287,17 +1288,17 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             try (FileInputStream fin = new FileInputStream(tmpJarLocation)) {
                 store.createBlob(jarKey, fin, new SettableBlobMeta(BlobStoreAclHandler.DEFAULT), subject);
             }
-        }
-
-        topoCache.addTopoConf(topoId, subject, topoConf);
-        topoCache.addTopology(topoId, subject, topology);
-
-        if (store instanceof LocalFsBlobStore) {
-            if (tmpJarLocation != null) {
-                clusterState.setupBlobstore(jarKey, hostPortInfo, getVersionForKey(jarKey, hostPortInfo, getOrCreateZkClient()));
+            if (store instanceof LocalFsBlobStore) {
+                clusterState.setupBlobstore(jarKey, hostPortInfo, getVersionForKey(jarKey, hostPortInfo, zkClient));
             }
-            clusterState.setupBlobstore(confKey, hostPortInfo, getVersionForKey(confKey, hostPortInfo, getOrCreateZkClient()));
-            clusterState.setupBlobstore(codeKey, hostPortInfo, getVersionForKey(codeKey, hostPortInfo, getOrCreateZkClient()));
+        }
+        topoCache.addTopoConf(topoId, subject, topoConf);
+        if (store instanceof LocalFsBlobStore) {
+            clusterState.setupBlobstore(confKey, hostPortInfo, getVersionForKey(confKey, hostPortInfo, zkClient));
+        }
+        topoCache.addTopology(topoId, subject, topology);
+        if (store instanceof LocalFsBlobStore) {
+            clusterState.setupBlobstore(codeKey, hostPortInfo, getVersionForKey(codeKey, hostPortInfo, zkClient));
         }
     }
 
@@ -2170,7 +2171,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         LOG.debug("Creating list of key entries for blobstore inside zookeeper {} local {}", activeKeys, activeLocalKeys);
         for (String key: activeLocalKeys) {
             try {
-                state.setupBlobstore(key, nimbusInfo, getVersionForKey(key, nimbusInfo, getOrCreateZkClient()));
+                state.setupBlobstore(key, nimbusInfo, getVersionForKey(key, nimbusInfo, zkClient));
             } catch (KeyNotFoundException e) {
                 // invalid key, remove it from blobstore
                 store.deleteBlob(key, NIMBUS_SUBJECT);
@@ -2278,7 +2279,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 }));
                 LOG.debug("blob-sync blob-store-keys {} zookeeper-keys {}", allKeys, zkKeys);
                 BlobSynchronizer sync = new BlobSynchronizer(store, conf);
-                sync.setZkClient(getOrCreateZkClient());
+                sync.setZkClient(zkClient);
                 sync.setNimbusInfo(nimbusInfo);
                 sync.setBlobStoreKeySet(allKeys);
                 sync.setZookeeperKeySet(zkKeys);
@@ -3368,7 +3369,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             BlobStore store = blobStore;
             NimbusInfo ni = nimbusHostPortInfo;
             if (store instanceof LocalFsBlobStore) {
-                state.setupBlobstore(key, ni, getVersionForKey(key, ni, getOrCreateZkClient()));
+                state.setupBlobstore(key, ni, getVersionForKey(key, ni, zkClient));
             }
             LOG.debug("Created state in zookeeper {} {} {}", state, store, ni);
         } catch (Exception e) {

--- a/storm-server/src/main/java/org/apache/storm/zookeeper/LeaderElectorImp.java
+++ b/storm-server/src/main/java/org/apache/storm/zookeeper/LeaderElectorImp.java
@@ -121,7 +121,6 @@ public class LeaderElectorImp implements ILeaderElector {
 
     @Override
     public void close() {
-        LOG.info("closing zookeeper connection of leader elector.");
-        zk.close();
+        //Do nothing now.
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/zookeeper/Zookeeper.java
+++ b/storm-server/src/main/java/org/apache/storm/zookeeper/Zookeeper.java
@@ -29,7 +29,6 @@ import org.apache.curator.framework.recipes.leader.Participant;
 import org.apache.storm.Config;
 import org.apache.storm.blobstore.BlobStore;
 import org.apache.storm.blobstore.InputStreamWithMeta;
-import org.apache.storm.callback.DefaultWatcherCallBack;
 import org.apache.storm.cluster.ClusterUtils;
 import org.apache.storm.daemon.nimbus.TopoCache;
 import org.apache.storm.generated.AuthorizationException;
@@ -250,16 +249,14 @@ public class Zookeeper {
         };
     }
 
-    public static ILeaderElector zkLeaderElector(Map<String, Object> conf, BlobStore blobStore, final TopoCache tc)
-        throws UnknownHostException {
-        return _instance.zkLeaderElectorImpl(conf, blobStore, tc);
+    public static ILeaderElector zkLeaderElector(Map<String, Object> conf, CuratorFramework zk, BlobStore blobStore,
+        final TopoCache tc) throws UnknownHostException {
+        return _instance.zkLeaderElectorImpl(conf, zk, blobStore, tc);
     }
 
-    protected ILeaderElector zkLeaderElectorImpl(Map<String, Object> conf, BlobStore blobStore, final TopoCache tc)
-        throws UnknownHostException {
+    protected ILeaderElector zkLeaderElectorImpl(Map<String, Object> conf, CuratorFramework zk, BlobStore blobStore,
+        final TopoCache tc) throws UnknownHostException {
         List<String> servers = (List<String>) conf.get(Config.STORM_ZOOKEEPER_SERVERS);
-        Object port = conf.get(Config.STORM_ZOOKEEPER_PORT);
-        CuratorFramework zk = ClientZookeeper.mkClient(conf, servers, port, "", new DefaultWatcherCallBack(), conf);
         String leaderLockPath = conf.get(Config.STORM_ZOOKEEPER_ROOT) + "/leader-lock";
         String id = NimbusInfo.fromConf(conf).toHostPortString();
         AtomicReference<LeaderLatch> leaderLatchAtomicReference = new AtomicReference<>(new LeaderLatch(zk, leaderLockPath, id));


### PR DESCRIPTION
Reuse connections for nimbus blob-store keys registration when restarting.

Also for storm-code setup.

This is the JIRA: [#STORM-2901](https://issues.apache.org/jira/browse/STORM-2901)