### PR TITLE
[STORM-2901] Reuse ZK connection for getKeySequenceNumber [for 2.0.0 storm]

### DIFF
--- a/storm-core/src/clj/org/apache/storm/command/shell_submission.clj
+++ b/storm-core/src/clj/org/apache/storm/command/shell_submission.clj
@@ -14,19 +14,25 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 (ns org.apache.storm.command.shell-submission
-  (:import [org.apache.storm StormSubmitter]
+  (:import [org.apache.storm Config StormSubmitter]
            [org.apache.storm.utils ServerUtils]
            [org.apache.storm.zookeeper Zookeeper])
   (:use [org.apache.storm util config log])
   (:require [clojure.string :as str])
-  (:import [org.apache.storm.utils ConfigUtils])
+  (:import [org.apache.storm.callback DefaultWatcherCallBack]
+           [org.apache.storm.utils ConfigUtils]
+           [org.apache.storm.zookeeper Zookeeper ClientZookeeper])
   (:gen-class))
 
 
 (defn -main [^String tmpjarpath & args]
   (let [conf (clojurify-structure (ConfigUtils/readStormConfig))
+        servers (.get conf Config/STORM_ZOOKEEPER_SERVERS)
+        port (.get conf Config/STORM_ZOOKEEPER_PORT)
+        root (.get conf Config/STORM_ZOOKEEPER_ROOT)
+        zk (ClientZookeeper/mkClient conf servers port root (DefaultWatcherCallBack.) conf)
         ; since this is not a purpose to add to leader lock queue, passing nil as blob-store and topo cache is ok
-        zk-leader-elector (Zookeeper/zkLeaderElector conf nil nil)
+        zk-leader-elector (Zookeeper/zkLeaderElector conf zk nil nil)
         leader-nimbus (.getLeader zk-leader-elector)
         host (.getHost leader-nimbus)
         port (.getPort leader-nimbus)

--- a/storm-core/src/jvm/org/apache/storm/command/AdminCommands.java
+++ b/storm-core/src/jvm/org/apache/storm/command/AdminCommands.java
@@ -24,12 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.storm.Config;
 import org.apache.storm.blobstore.BlobStore;
 import org.apache.storm.blobstore.KeyFilter;
 import org.apache.storm.blobstore.LocalFsBlobStore;
-import org.apache.storm.callback.DefaultWatcherCallBack;
 import org.apache.storm.cluster.ClusterStateContext;
 import org.apache.storm.cluster.ClusterUtils;
 import org.apache.storm.cluster.DaemonType;
@@ -38,7 +35,6 @@ import org.apache.storm.nimbus.NimbusInfo;
 import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.utils.ServerUtils;
 import org.apache.storm.utils.Utils;
-import org.apache.storm.zookeeper.ClientZookeeper;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
@@ -75,8 +71,6 @@ public class AdminCommands {
     private static void initialize() {
         conf = Utils.readStormConfig();
         nimbusBlobStore = ServerUtils.getNimbusBlobStore (conf, NimbusInfo.fromConf(conf));
-        List<String> servers = (List<String>) conf.get(Config.STORM_ZOOKEEPER_SERVERS);
-        Object port = conf.get(Config.STORM_ZOOKEEPER_PORT);
         List<ACL> acls = null;
         if (Utils.isZkAuthenticationConfiguredStormServer(conf)) {
             acls = adminZkAcls();
@@ -87,7 +81,6 @@ public class AdminCommands {
             LOG.error("admin can't create stormClusterState");
             new RuntimeException(e);
         }
-        CuratorFramework zk = ClientZookeeper.mkClient(conf, servers, port, "", new DefaultWatcherCallBack(),conf);
     }
 
     // we might think of moving this method in Utils class

--- a/storm-core/test/clj/org/apache/storm/nimbus_test.clj
+++ b/storm-core/test/clj/org/apache/storm/nimbus_test.clj
@@ -1311,7 +1311,7 @@
   (with-open [zk (InProcessZookeeper. )]
     (with-open [tmp-nimbus-dir (TmpPath.)
                 _ (MockedZookeeper. (proxy [Zookeeper] []
-                      (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. ))))]
+                      (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. ))))]
       (let [nimbus-dir (.getPath tmp-nimbus-dir)]
         (letlocals
           (bind conf (merge (clojurify-structure (ConfigUtils/readStormConfig))
@@ -1328,7 +1328,7 @@
                            {}))
 
           (with-open [_ (MockedZookeeper. (proxy [Zookeeper] []
-                          (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. false))))]
+                          (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. false))))]
 
             (letlocals
               (bind non-leader-cluster-state (ClusterUtils/mkStormClusterState conf nil (ClusterStateContext.)))
@@ -1635,7 +1635,7 @@
                   _ (UtilsInstaller. fake-utils)
                   - (StormCommonInstaller. fake-common)
                   zk-le (MockedZookeeper. (proxy [Zookeeper] []
-                          (zkLeaderElectorImpl [conf blob-store tc] nil)))
+                          (zkLeaderElectorImpl [conf zk blob-store tc] nil)))
                   mocked-cluster (MockedCluster. cluster-utils)]
           (mk-nimbus auth-conf fake-inimbus)
           (.mkStormClusterStateImpl (Mockito/verify cluster-utils (Mockito/times 1)) (Mockito/any) (Mockito/eq expected-acls) (Mockito/any))
@@ -1706,7 +1706,7 @@
   (with-open [zk (InProcessZookeeper. )]
     (with-open [tmp-nimbus-dir (TmpPath.)
                 _ (MockedZookeeper. (proxy [Zookeeper] []
-                    (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. ))))]
+                    (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. ))))]
       (let [nimbus-dir (.getPath tmp-nimbus-dir)]
         (letlocals
           (bind conf (merge (clojurify-structure (ConfigUtils/readStormConfig))
@@ -1899,7 +1899,7 @@
         mock-blob-store (Mockito/mock BlobStore)
         conf {NIMBUS-MONITOR-FREQ-SECS 10}]
     (with-open [_ (MockedZookeeper. (proxy [Zookeeper] []
-                    (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. ))))]
+                    (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. ))))]
       (let [nimbus (Mockito/spy (Nimbus. conf nil mock-state nil mock-blob-store nil nil))]
         (.set (.getHeartbeatsCache nimbus) hb-cache)
         (.thenReturn (Mockito/when (.storedTopoIds mock-blob-store)) (HashSet. inactive-topos))
@@ -1944,7 +1944,7 @@
         mock-blob-store (Mockito/mock BlobStore)
         conf {NIMBUS-MONITOR-FREQ-SECS 10}]
     (with-open [_ (MockedZookeeper. (proxy [Zookeeper] []
-                    (zkLeaderElectorImpl [conf blob-store tc] (MockLeaderElector. ))))]
+                    (zkLeaderElectorImpl [conf zk blob-store tc] (MockLeaderElector. ))))]
       (let [nimbus (Mockito/spy (Nimbus. conf nil mock-state nil mock-blob-store nil nil))]
         (.set (.getHeartbeatsCache nimbus) hb-cache)
         (.thenReturn (Mockito/when (.storedTopoIds mock-blob-store)) (set inactive-topos))

--- a/storm-core/test/clj/org/apache/storm/security/auth/auth_test.clj
+++ b/storm-core/test/clj/org/apache/storm/security/auth/auth_test.clj
@@ -62,7 +62,7 @@
 
 (defn nimbus-data [storm-conf inimbus]
   (with-open [_ (MockedZookeeper. (proxy [Zookeeper] []
-                  (zkLeaderElectorImpl [conf blob-store tc] (Mockito/mock ILeaderElector))))]
+                  (zkLeaderElectorImpl [conf zk blob-store tc] (Mockito/mock ILeaderElector))))]
     (org.apache.storm.daemon.nimbus.Nimbus. storm-conf inimbus (Mockito/mock IStormClusterState) nil (Mockito/mock BlobStore) nil nil)))
 
 (defn dummy-service-handler

--- a/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/BlobStoreUtils.java
@@ -45,7 +45,12 @@ import org.slf4j.LoggerFactory;
 
 public class BlobStoreUtils {
     private static final String BLOBSTORE_SUBTREE="/blobstore";
+
     private static final Logger LOG = LoggerFactory.getLogger(BlobStoreUtils.class);
+
+    public static String getBlobStoreSubtree() {
+        return BLOBSTORE_SUBTREE;
+    }
 
     public static CuratorFramework createZKClient(Map<String, Object> conf) {
         @SuppressWarnings("unchecked")
@@ -268,6 +273,4 @@ public class BlobStoreUtils {
             throw new RuntimeException(exp);
         }
     }
-
-
 }

--- a/storm-server/src/main/java/org/apache/storm/blobstore/BlobSynchronizer.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/BlobSynchronizer.java
@@ -17,16 +17,16 @@
  */
 package org.apache.storm.blobstore;
 
+import java.nio.channels.ClosedByInterruptException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.storm.generated.KeyNotFoundException;
 import org.apache.storm.nimbus.NimbusInfo;
 import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.channels.ClosedByInterruptException;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Is called periodically and updates the nimbus with blobs based on the state stored inside the zookeeper
@@ -58,6 +58,10 @@ public class BlobSynchronizer {
         this.blobStoreKeySet = blobStoreKeySet;
     }
 
+    public void setZkClient(CuratorFramework zkClient) {
+        this.zkClient = zkClient;
+    }
+
     public Set<String> getBlobStoreKeySet() {
         Set<String> keySet = new HashSet<String>();
         keySet.addAll(blobStoreKeySet);
@@ -73,7 +77,6 @@ public class BlobSynchronizer {
     public synchronized void syncBlobs() {
         try {
             LOG.debug("Sync blobs - blobstore keys {}, zookeeper keys {}",getBlobStoreKeySet(), getZookeeperKeySet());
-            zkClient = BlobStoreUtils.createZKClient(conf);
             deleteKeySetFromBlobStoreNotOnZookeeper(getBlobStoreKeySet(), getZookeeperKeySet());
             updateKeySetForBlobStore(getBlobStoreKeySet());
             Set<String> keySetToDownload = getKeySetToDownload(getBlobStoreKeySet(), getZookeeperKeySet());
@@ -89,9 +92,6 @@ public class BlobSynchronizer {
                 } catch (KeyNotFoundException e) {
                     LOG.debug("Detected deletion for the key {} while downloading - skipping download", key);
                 }
-            }
-            if (zkClient !=null) {
-                zkClient.close();
             }
         } catch(InterruptedException | ClosedByInterruptException exp) {
             LOG.error("Interrupt Exception {}", exp);

--- a/storm-server/src/main/java/org/apache/storm/zookeeper/LeaderElectorImp.java
+++ b/storm-server/src/main/java/org/apache/storm/zookeeper/LeaderElectorImp.java
@@ -121,7 +121,6 @@ public class LeaderElectorImp implements ILeaderElector {
 
     @Override
     public void close() {
-        LOG.info("closing zookeeper connection of leader elector.");
-        zk.close();
+        //Do nothing now.
     }
 }


### PR DESCRIPTION
Reuse connections for nimbus blob-store keys registration when restarting.

Also for storm-code setup.

This is the JIRA: [#STORM-2901](https://issues.apache.org/jira/browse/STORM-2901)