### PR TITLE
STORM-2907: Exclude curator dependencies from storm-core in storm-autocreds pom

### DIFF
--- a/external/storm-autocreds/pom.xml
+++ b/external/storm-autocreds/pom.xml
@@ -40,6 +40,18 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>log4j-over-slf4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-recipes</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.curator</groupId>
+                    <artifactId>curator-framework</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
storm-autocreds brings in the curator 4.0 jars via transitive dependency of storm-core. Even though storm-core is listed as provided scope, the app assembler plugin puts the dependency (curator 4.0) into external/storm-autocreds directory. This conflicts with the storm-druid tranquility library which depends on curator 2.6.0. 

There could be other conflicts if storm-autocreds is included in class path. 

Excluding curator dependency from storm-core resolves this.