### PR TITLE
STORM-2918 Update Netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>16.0.1</guava.version>
         <auto-service.version>1.0-rc3</auto-service.version>
-        <netty.version>3.9.0.Final</netty.version>
+        <netty.version>3.9.9.Final</netty.version>
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
         <log4j.version>2.8.2</log4j.version>


### PR DESCRIPTION
Ran `mvn clean install -DskipTests` on the parent project
ran `mvn clean install` on storm-core

got the following error, is the test flaky? Build ran successfully

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.apache.storm.serialization.SerializationTest
Running org.apache.storm.command.TestCLI
Running org.apache.storm.command.RebalanceTest
Running org.apache.storm.command.SetLogLevelTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.apache.storm.command.RebalanceTest
Running org.apache.storm.stats.TestStatsUtil
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.056 sec - in org.apache.storm.command.SetLogLevelTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.634 sec - in org.apache.storm.command.TestCLI
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.723 sec - in org.apache.storm.stats.TestStatsUtil
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.888 sec - in org.apache.storm.serialization.SerializationTest

Results :

Tests run: 15, Failures: 0, Errors: 0, Skipped: 0

[INFO]
[INFO] --- clojure-maven-plugin:1.7.1:test (test-clojure) @ storm-core ---
3784 [main] WARN  o.a.s.v.ConfigValidation - storm.messaging.netty.max_retries is a deprecated config please see class org.apache.storm.Config.STORM_MESSAGING_NETTY_MAX_RETRIES for more information.
Running org.apache.storm.drpc-test
Tests run: 7, Passed: 14, Failures: 0, Errors: 0
Running org.apache.storm.transactional-test
Tests run: 6, Passed: 108, Failures: 0, Errors: 0
Running org.apache.storm.scheduler-test
Tests run: 4, Passed: 64, Failures: 0, Errors: 0
Running org.apache.storm.messaging.netty-unit-test
Tests run: 5, Passed: 24, Failures: 0, Errors: 0
Running org.apache.storm.trident.tuple-test
Tests run: 6, Passed: 36, Failures: 0, Errors: 0
Running org.apache.storm.serialization-test
Tests run: 1, Passed: 0, Failures: 0, Errors: 0
Running org.apache.storm.security.auth.nimbus-auth-test
Tests run: 5, Passed: 39, Failures: 0, Errors: 0
Running org.apache.storm.security.auth.auth-test
Tests run: 14, Passed: 100, Failures: 0, Errors: 0
Running org.apache.storm.nimbus-test
162903 [main-SendThread(localhost:2181)] WARN  o.a.z.ClientCnxn - Session 0x0 for server null, unexpected error, closing socket connection and attempting reconnect
java.net.ConnectException: Connection refused
	at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method) ~[?:1.8.0_162]
	at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:717) ~[?:1.8.0_162]
	at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:361) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
	at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1081) [zookeeper-3.4.6.jar:3.4.6-1569965]
Tests run: 41, Passed: 773, Failures: 0, Errors: 0
Running org.apache.storm.trident.state-test
Tests run: 5, Passed: 37, Failures: 0, Errors: 0
Running org.apache.storm.submitter-test
Tests run: 1, Passed: 13, Failures: 0, Errors: 0
Running org.apache.storm.grouping-test
Tests run: 3, Passed: 7, Failures: 0, Errors: 0
Running org.apache.storm.scheduler.multitenant-scheduler-test
Tests run: 17, Passed: 233, Failures: 0, Errors: 0
Running org.apache.storm.security.auth.auto-login-module-test
Tests run: 6, Passed: 22, Failures: 0, Errors: 0
Running org.apache.storm.versioned-store-test
Tests run: 2, Passed: 5, Failures: 0, Errors: 0
Running org.apache.storm.messaging.netty-integration-test
Tests run: 1, Passed: 1, Failures: 0, Errors: 0
Running org.apache.storm.metrics-test
Tests run: 8, Passed: 66, Failures: 0, Errors: 0
Running org.apache.storm.cluster-test
Tests run: 10, Passed: 92, Failures: 0, Errors: 0
```