### PR TITLE
STORM-2853 Initialize tick tuple after initializing spouts/bolts

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/Executor.java
@@ -251,7 +251,6 @@ public abstract class Executor implements Callable, EventHandler<Object> {
         String handlerName = componentId + "-executor" + executorId;
         Utils.SmartThread handlers =
                 Utils.asyncLoop(this, false, reportErrorDie, Thread.NORM_PRIORITY, true, true, handlerName);
-        setupTicks(StatsUtil.SPOUT.equals(type));
 
         LOG.info("Finished loading executor " + componentId + ":" + executorId);
         return new ExecutorShutdown(this, Lists.newArrayList(systemThreads, handlers), idToTask, receiveQueue, sendQueue);

--- a/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
@@ -87,6 +87,7 @@ public class BoltExecutor extends Executor {
         }
         openOrPrepareWasCalled.set(true);
         LOG.info("Prepared bolt {}:{}", componentId, idToTask.keySet());
+        setupTicks(false);
         setupMetrics();
     }
 

--- a/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
@@ -128,6 +128,7 @@ public class SpoutExecutor extends Executor {
         }
         openOrPrepareWasCalled.set(true);
         LOG.info("Opened spout {}:{}", componentId, idToTask.keySet());
+        setupTicks(true);
         setupMetrics();
     }
 


### PR DESCRIPTION
* this prevents newly-initializing executor in deactivated topology to show high CPU usage

Please refer https://issues.apache.org/jira/browse/STORM-2853 for more details.

Please also note that we assume all the tasks in executor are for same component.