### PR TITLE
[STORM-2932] the naming of topology localityaware configs are confusing

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -258,8 +258,8 @@ topology.disruptor.batch.size: 100
 topology.disruptor.batch.timeout.millis: 1
 topology.disable.loadaware.messaging: false
 topology.state.checkpoint.interval.ms: 1000
-topology.localityaware.higher.bound.percent: 0.8
-topology.localityaware.lower.bound.percent: 0.2
+topology.localityaware.higher.bound: 0.8
+topology.localityaware.lower.bound: 0.2
 topology.serialized.message.size.metrics: false
 
 # Configs for Resource Aware Scheduler

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -73,7 +73,7 @@ public class Config extends HashMap<String, Object> {
      */
     @isPositiveNumber
     @NotNull
-    public static final String TOPOLOGY_LOCALITYAWARE_HIGHER_BOUND_PERCENT = "topology.localityaware.higher.bound.percent";
+    public static final String TOPOLOGY_LOCALITYAWARE_HIGHER_BOUND = "topology.localityaware.higher.bound";
 
     /**
      * This signifies the load congestion among target tasks in scope. Currently it's only used in LoadAwareShuffleGrouping.
@@ -82,7 +82,7 @@ public class Config extends HashMap<String, Object> {
      */
     @isPositiveNumber
     @NotNull
-    public static final String TOPOLOGY_LOCALITYAWARE_LOWER_BOUND_PERCENT = "topology.localityaware.lower.bound.percent";
+    public static final String TOPOLOGY_LOCALITYAWARE_LOWER_BOUND = "topology.localityaware.lower.bound";
 
     /**
      * Try to serialize all tuples, even for local transfers.  This should only be used

--- a/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareShuffleGrouping.java
+++ b/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareShuffleGrouping.java
@@ -89,8 +89,8 @@ public class LoadAwareShuffleGrouping implements LoadAwareCustomStreamGrouping, 
         dnsToSwitchMapping = ReflectionUtils.newInstance((String) conf.get(Config.STORM_NETWORK_TOPOGRAPHY_PLUGIN));
         localityGroup = new HashMap<>();
         currentScope = Scope.WORKER_LOCAL;
-        higherBound = ObjectReader.getDouble(conf.get(Config.TOPOLOGY_LOCALITYAWARE_HIGHER_BOUND_PERCENT));
-        lowerBound = ObjectReader.getDouble(conf.get(Config.TOPOLOGY_LOCALITYAWARE_LOWER_BOUND_PERCENT));
+        higherBound = ObjectReader.getDouble(conf.get(Config.TOPOLOGY_LOCALITYAWARE_HIGHER_BOUND));
+        lowerBound = ObjectReader.getDouble(conf.get(Config.TOPOLOGY_LOCALITYAWARE_LOWER_BOUND));
 
         rets = (List<Integer>[]) new List<?>[targetTasks.size()];
         int i = 0;

--- a/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
@@ -65,8 +65,8 @@ public class LoadAwareShuffleGroupingTest {
     private WorkerTopologyContext mockContext(List<Integer> availableTaskIds) {
         Map<String, Object> conf = new HashMap<>();
         conf.put(Config.STORM_NETWORK_TOPOGRAPHY_PLUGIN, "org.apache.storm.networktopography.DefaultRackDNSToSwitchMapping");
-        conf.put(Config.TOPOLOGY_LOCALITYAWARE_HIGHER_BOUND_PERCENT, 0.8);
-        conf.put(Config.TOPOLOGY_LOCALITYAWARE_LOWER_BOUND_PERCENT, 0.2);
+        conf.put(Config.TOPOLOGY_LOCALITYAWARE_HIGHER_BOUND, 0.8);
+        conf.put(Config.TOPOLOGY_LOCALITYAWARE_LOWER_BOUND, 0.2);
 
         WorkerTopologyContext context = mock(WorkerTopologyContext.class);
         when(context.getConf()).thenReturn(conf);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2932

The names are confusing. I think we should delete "percent"