### PR TITLE
STORM-2934 - fix startup ClassNotFoundException when missing RocksDB jar

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -1035,7 +1035,9 @@ public class DaemonConfig implements Validated {
      * Class implementing MetricStore.
      */
     @NotNull
-    @isImplementationOfClass(implementsClass = MetricStore.class)
+    @isString
+    // Validating class implementation could fail on non-Nimbus Daemons.  Nimbus will catch the class not found on startup
+    // and log an error message, so just validating this as a String for now.
     public static final String STORM_METRIC_STORE_CLASS = "storm.metricstore.class";
 
     /**


### PR DESCRIPTION
Currently, only Nimbus uses STORM_METRIC_STORE_CLASS.  

If the RocksDB jar is missing on Daemons other than Nimbus, they should be able to startup successfully.  

If the jar is missing on Nimbus, the metricStore will fail to initialize, and an ERROR will be logged. Nimbus will still be able to run; it just ignores using the metricStore.

