### PR TITLE
[STORM-2940] Dynamically set the CAPACITY value of LoadAwareShuffleGrouping

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareShuffleGrouping.java
+++ b/storm-client/src/jvm/org/apache/storm/grouping/LoadAwareShuffleGrouping.java
@@ -85,7 +85,7 @@ public class LoadAwareShuffleGrouping implements LoadAwareCustomStreamGrouping, 
         sourceNodeInfo = new NodeInfo(context.getThisWorkerHost(), Sets.newHashSet((long) context.getThisWorkerPort()));
         taskToNodePort = context.getTaskToNodePort();
         this.targetTasks = targetTasks;
-        capacity = targetTasks.size() == 1 ? 1 : targetTasks.size() * MAX_WEIGHT;
+        capacity = targetTasks.size() == 1 ? 1 : Math.max(1000, targetTasks.size() * 5);
         conf = context.getConf();
         dnsToSwitchMapping = ReflectionUtils.newInstance((String) conf.get(Config.STORM_NETWORK_TOPOGRAPHY_PLUGIN));
         localityGroup = new HashMap<>();

--- a/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
@@ -101,10 +101,10 @@ public class LoadAwareShuffleGroupingTest {
             double expectedOnePercentage = expectedOneWeight / (expectedOneWeight + expectedTwoWeight);
             double expectedTwoPercentage = expectedTwoWeight / (expectedOneWeight + expectedTwoWeight);
             assertEquals("i = " + i,
-                expectedOnePercentage, countByType.getOrDefault(1, 0.0) / grouping.getCAPACITY(),
+                expectedOnePercentage, countByType.getOrDefault(1, 0.0) / grouping.getCapacity(),
                 0.01);
             assertEquals("i = " + i,
-                expectedTwoPercentage, countByType.getOrDefault(2, 0.0) / grouping.getCAPACITY(),
+                expectedTwoPercentage, countByType.getOrDefault(2, 0.0) / grouping.getCapacity(),
                 0.01);
         }
 
@@ -121,9 +121,9 @@ public class LoadAwareShuffleGroupingTest {
             LOG.info("contByType = {}", countByType);
             double expectedOnePercentage = expectedOneWeight / (expectedOneWeight + expectedTwoWeight);
             double expectedTwoPercentage = expectedTwoWeight / (expectedOneWeight + expectedTwoWeight);
-            assertEquals(expectedOnePercentage, countByType.getOrDefault(1, 0.0) / grouping.getCAPACITY(),
+            assertEquals(expectedOnePercentage, countByType.getOrDefault(1, 0.0) / grouping.getCapacity(),
                 0.01);
-            assertEquals(expectedTwoPercentage, countByType.getOrDefault(2, 0.0) / grouping.getCAPACITY(),
+            assertEquals(expectedTwoPercentage, countByType.getOrDefault(2, 0.0) / grouping.getCapacity(),
                 0.01);
         }
     }

--- a/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
@@ -101,10 +101,10 @@ public class LoadAwareShuffleGroupingTest {
             double expectedOnePercentage = expectedOneWeight / (expectedOneWeight + expectedTwoWeight);
             double expectedTwoPercentage = expectedTwoWeight / (expectedOneWeight + expectedTwoWeight);
             assertEquals("i = " + i,
-                expectedOnePercentage, countByType.getOrDefault(1, 0.0) / LoadAwareShuffleGrouping.CAPACITY,
+                expectedOnePercentage, countByType.getOrDefault(1, 0.0) / grouping.getCAPACITY(),
                 0.01);
             assertEquals("i = " + i,
-                expectedTwoPercentage, countByType.getOrDefault(2, 0.0) / LoadAwareShuffleGrouping.CAPACITY,
+                expectedTwoPercentage, countByType.getOrDefault(2, 0.0) / grouping.getCAPACITY(),
                 0.01);
         }
 
@@ -121,9 +121,9 @@ public class LoadAwareShuffleGroupingTest {
             LOG.info("contByType = {}", countByType);
             double expectedOnePercentage = expectedOneWeight / (expectedOneWeight + expectedTwoWeight);
             double expectedTwoPercentage = expectedTwoWeight / (expectedOneWeight + expectedTwoWeight);
-            assertEquals(expectedOnePercentage, countByType.getOrDefault(1, 0.0) / LoadAwareShuffleGrouping.CAPACITY,
+            assertEquals(expectedOnePercentage, countByType.getOrDefault(1, 0.0) / grouping.getCAPACITY(),
                 0.01);
-            assertEquals(expectedTwoPercentage, countByType.getOrDefault(2, 0.0) / LoadAwareShuffleGrouping.CAPACITY,
+            assertEquals(expectedTwoPercentage, countByType.getOrDefault(2, 0.0) / grouping.getCAPACITY(),
                 0.01);
         }
     }

--- a/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
@@ -138,9 +138,16 @@ public class LoadAwareShuffleGroupingTest {
     }
 
     @Test
-    public void testLoadAwareShuffleGroupingWithEvenLoad() {
-        // just pick arbitrary number
-        final int numTasks = 7;
+    public void testLoadAwareShuffleGroupingWithEvenLoadWithManyTargets() {
+        testLoadAwareShuffleGroupingWithEvenLoad(1000);
+    }
+
+    @Test
+    public void testLoadAwareShuffleGroupingWithEvenLoadWithLessTargets() {
+        testLoadAwareShuffleGroupingWithEvenLoad(7);
+    }
+
+    private void testLoadAwareShuffleGroupingWithEvenLoad(int numTasks) {
         final LoadAwareShuffleGrouping grouper = new LoadAwareShuffleGrouping();
 
         // Define our taskIds and loads
@@ -166,8 +173,16 @@ public class LoadAwareShuffleGroupingTest {
     }
 
     @Test
-    public void testLoadAwareShuffleGroupingWithEvenLoadMultiThreaded() throws InterruptedException, ExecutionException {
-        final int numTasks = 7;
+    public void testLoadAwareShuffleGroupingWithEvenLoadMultiThreadedWithManyTargets() throws ExecutionException, InterruptedException {
+        testLoadAwareShuffleGroupingWithEvenLoadMultiThreaded(1000);
+    }
+
+    @Test
+    public void testLoadAwareShuffleGroupingWithEvenLoadMultiThreadedWithLessTargets() throws ExecutionException, InterruptedException {
+        testLoadAwareShuffleGroupingWithEvenLoadMultiThreaded(7);
+    }
+
+    private void testLoadAwareShuffleGroupingWithEvenLoadMultiThreaded(int numTasks) throws InterruptedException, ExecutionException {
 
         final LoadAwareShuffleGrouping grouper = new LoadAwareShuffleGrouping();
 


### PR DESCRIPTION
Explained in https://issues.apache.org/jira/browse/STORM-2940.

This is to fix the problem thatin some extreme cases where random.nextInt will receive currentIdx=0 and throws `java.lang.IllegalArgumentException: bound must be positive` exception