### PR TITLE
STORM-2939 add WorkerMetricsProcessor interface

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -296,6 +296,7 @@ storm.daemon.metrics.reporter.plugins:
      - "org.apache.storm.daemon.metrics.reporters.JmxPreparableReporter"
 
 storm.metricstore.class: "org.apache.storm.metricstore.rocksdb.RocksDbStore"
+storm.metricprocessor.class: "org.apache.storm.metricstore.NimbusMetricProcessor"
 storm.metricstore.rocksdb.location: "storm_rocks"
 storm.metricstore.rocksdb.create_if_missing: true
 storm.metricstore.rocksdb.metadata_string_cache_capacity: 4000

--- a/docs/storm-metricstore.md
+++ b/docs/storm-metricstore.md
@@ -23,6 +23,7 @@ The following configuation options exist:
 
 ```yaml
 storm.metricstore.class: "org.apache.storm.metricstore.rocksdb.RocksDbStore"
+storm.metricprocessor.class: "org.apache.storm.metricstore.NimbusMetricProcessor"
 storm.metricstore.rocksdb.location: "storm_rocks"
 storm.metricstore.rocksdb.create_if_missing: true
 storm.metricstore.rocksdb.metadata_string_cache_capacity: 4000
@@ -31,6 +32,8 @@ storm.metricstore.rocksdb.retention_hours: 240
 
 * storm.metricstore.class is the class that implements the 
 ([`MetricStore`]({{page.git-blob-base}}/storm-server/src/main/java/org/apache/storm/metricstore/MetricStore.java)).
+* storm.metricprocessor.class is the class that implements the 
+([`WorkerMetricsProcessor`]({{page.git-blob-base}}/storm-server/src/main/java/org/apache/storm/metricstore/WorkerMetricsProcessor.java)).
 * storm.metricstore.rocksdb.location provides to location of the RocksDB database on Nimbus
 * storm.metricstore.rocksdb.create_if_missing permits creating a RocksDB database if missing
 * storm.metricstore.rocksdb.metadata_string_cache_capacity controls the number of metadata strings cached in memory.

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -1031,7 +1031,7 @@ public class DaemonConfig implements Validated {
         "storm.supervisor.medium.memory.grace.period.ms";
 
     /**
-     * Class implementing MetricStore.
+     * Class implementing MetricStore.  Runs on Nimbus.
      */
     @NotNull
     @isString
@@ -1040,7 +1040,7 @@ public class DaemonConfig implements Validated {
     public static final String STORM_METRIC_STORE_CLASS = "storm.metricstore.class";
 
     /**
-     * Class implementing WorkerMetricsProcessor.
+     * Class implementing WorkerMetricsProcessor.  Runs on Supervisors.
      */
     @NotNull
     @isString

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -33,7 +33,6 @@ import static org.apache.storm.validation.ConfigValidationAnnotations.isNoDuplic
 import static org.apache.storm.validation.ConfigValidationAnnotations.isMapEntryCustom;
 
 import org.apache.storm.container.ResourceIsolationInterface;
-import org.apache.storm.metricstore.MetricStore;
 import org.apache.storm.nimbus.ITopologyActionNotifierPlugin;
 import org.apache.storm.scheduler.blacklist.reporters.IReporter;
 import org.apache.storm.scheduler.blacklist.strategies.IBlacklistStrategy;
@@ -1039,6 +1038,13 @@ public class DaemonConfig implements Validated {
     // Validating class implementation could fail on non-Nimbus Daemons.  Nimbus will catch the class not found on startup
     // and log an error message, so just validating this as a String for now.
     public static final String STORM_METRIC_STORE_CLASS = "storm.metricstore.class";
+
+    /**
+     * Class implementing WorkerMetricsProcessor.
+     */
+    @NotNull
+    @isString
+    public static final String STORM_METRIC_PROCESSOR_CLASS = "storm.metricprocessor.class";
 
     /**
      * RocksDB file location. This setting is specific to the org.apache.storm.metricstore.rocksdb.RocksDbStore

--- a/storm-server/src/main/java/org/apache/storm/metricstore/MetricStoreConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/MetricStoreConfig.java
@@ -25,7 +25,7 @@ import org.apache.storm.DaemonConfig;
 public class MetricStoreConfig {
 
     /**
-     * Configures metrics store to use the class specified in the conf.
+     * Configures metrics store (running on Nimbus) to use the class specified in the conf.
      * @param conf Storm config map
      * @return MetricStore prepared store
      * @throws MetricException  on misconfiguration
@@ -37,14 +37,14 @@ public class MetricStoreConfig {
             MetricStore store = (MetricStore) (Class.forName(storeClass)).newInstance();
             store.prepare(conf);
             return store;
-        } catch (Throwable t) {
-            throw new MetricException("Failed to create metric store", t);
+        } catch (Exception e) {
+            throw new MetricException("Failed to create metric store", e);
         }
     }
 
     /**
-     * Configures metric processor to use the class specified in the conf.
-     * @param conf Storm config map
+     * Configures metric processor (running on supervisor) to use the class specified in the conf.
+     * @param conf  the supervisor config
      * @return WorkerMetricsProcessor prepared processor
      * @throws MetricException  on misconfiguration
      */
@@ -55,8 +55,8 @@ public class MetricStoreConfig {
             WorkerMetricsProcessor processor = (WorkerMetricsProcessor) (Class.forName(processorClass)).newInstance();
             processor.prepare(conf);
             return processor;
-        } catch (Throwable t) {
-            throw new MetricException("Failed to create metric processor", t);
+        } catch (Exception e) {
+            throw new MetricException("Failed to create metric processor", e);
         }
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/metricstore/MetricStoreConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/MetricStoreConfig.java
@@ -41,5 +41,23 @@ public class MetricStoreConfig {
             throw new MetricException("Failed to create metric store", t);
         }
     }
+
+    /**
+     * Configures metric processor to use the class specified in the conf.
+     * @param conf Storm config map
+     * @return WorkerMetricsProcessor prepared processor
+     * @throws MetricException  on misconfiguration
+     */
+    public static WorkerMetricsProcessor configureMetricProcessor(Map conf) throws MetricException {
+
+        try {
+            String processorClass = (String)conf.get(DaemonConfig.STORM_METRIC_PROCESSOR_CLASS);
+            WorkerMetricsProcessor processor = (WorkerMetricsProcessor) (Class.forName(processorClass)).newInstance();
+            processor.prepare(conf);
+            return processor;
+        } catch (Throwable t) {
+            throw new MetricException("Failed to create metric processor", t);
+        }
+    }
 }
 

--- a/storm-server/src/main/java/org/apache/storm/metricstore/NimbusMetricProcessor.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/NimbusMetricProcessor.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.storm.metricstore;
+
+import java.util.Map;
+import org.apache.storm.generated.WorkerMetrics;
+import org.apache.storm.utils.NimbusClient;
+import org.apache.thrift.TException;
+
+/**
+ * Implementation of WorkerMetricsProcessor that sends metric data to Nimbus for processing.
+ */
+public class NimbusMetricProcessor implements  WorkerMetricsProcessor {
+    @Override
+    public void processWorkerMetrics(Map<String, Object> conf, WorkerMetrics metrics) throws MetricException {
+        try (NimbusClient client = NimbusClient.getConfiguredClient(conf)) {
+            client.getClient().processWorkerMetrics(metrics);
+        } catch (TException e) {
+            throw new MetricException("Failed to process metrics", e);
+        }
+    }
+
+    @Override
+    public void prepare(Map config) throws MetricException {}
+}

--- a/storm-server/src/main/java/org/apache/storm/metricstore/WorkerMetricsProcessor.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/WorkerMetricsProcessor.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.storm.metricstore;
+
+import java.util.Map;
+import org.apache.storm.generated.WorkerMetrics;
+
+public interface WorkerMetricsProcessor {
+
+    /**
+     * Process insertion of worker metrics.
+     * @param conf Storm config map
+     * @param metrics  the metrics to process
+     * @throws MetricException  on error
+     */
+    void processWorkerMetrics(Map<String, Object> conf, WorkerMetrics metrics) throws MetricException;
+
+    /**
+     * Prepares the metric processor.
+     * @param config Storm config map
+     * @throws MetricException  on error
+     */
+    void prepare(Map config) throws MetricException;
+}

--- a/storm-server/src/main/java/org/apache/storm/metricstore/WorkerMetricsProcessor.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/WorkerMetricsProcessor.java
@@ -24,8 +24,8 @@ import org.apache.storm.generated.WorkerMetrics;
 public interface WorkerMetricsProcessor {
 
     /**
-     * Process insertion of worker metrics.
-     * @param conf Storm config map
+     * Process insertion of worker metrics.  The implementation should be thread-safe.
+     * @param conf the supervisor config
      * @param metrics  the metrics to process
      * @throws MetricException  on error
      */

--- a/storm-server/src/test/java/org/apache/storm/daemon/supervisor/SlotTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/supervisor/SlotTest.java
@@ -149,7 +149,7 @@ public class SlotTest {
             ContainerLauncher containerLauncher = mock(ContainerLauncher.class);
             ISupervisor iSuper = mock(ISupervisor.class);
             StaticState staticState = new StaticState(localizer, 1000, 1000, 1000, 1000,
-                    containerLauncher, "localhost", 8080, iSuper, state, cb, null);
+                    containerLauncher, "localhost", 8080, iSuper, state, cb, null, null);
             DynamicState dynamicState = new DynamicState(null, null, null);
             DynamicState nextState = Slot.handleEmpty(dynamicState, staticState);
             assertEquals(MachineState.EMPTY, nextState.state);
@@ -181,7 +181,7 @@ public class SlotTest {
             
             ISupervisor iSuper = mock(ISupervisor.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                    containerLauncher, "localhost", port, iSuper, state, cb, null);
+                    containerLauncher, "localhost", port, iSuper, state, cb, null, null);
             DynamicState dynamicState = new DynamicState(null, null, null)
                     .withNewAssignment(newAssignment);
 
@@ -250,7 +250,7 @@ public class SlotTest {
             ISupervisor iSuper = mock(ISupervisor.class);
             LocalState state = mock(LocalState.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                    containerLauncher, "localhost", port, iSuper, state, cb, null);
+                    containerLauncher, "localhost", port, iSuper, state, cb, null, null);
             DynamicState dynamicState = new DynamicState(assignment, container, assignment);
             
             DynamicState nextState = Slot.stateMachineStep(dynamicState, staticState);
@@ -311,7 +311,7 @@ public class SlotTest {
             
             ISupervisor iSuper = mock(ISupervisor.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                    containerLauncher, "localhost", port, iSuper, state, cb, null);
+                    containerLauncher, "localhost", port, iSuper, state, cb, null, null);
             DynamicState dynamicState = new DynamicState(cAssignment, cContainer, nAssignment);
             
             DynamicState nextState = Slot.stateMachineStep(dynamicState, staticState);
@@ -392,7 +392,7 @@ public class SlotTest {
             ISupervisor iSuper = mock(ISupervisor.class);
             LocalState state = mock(LocalState.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                    containerLauncher, "localhost", port, iSuper, state, cb, null);
+                    containerLauncher, "localhost", port, iSuper, state, cb, null, null);
             DynamicState dynamicState = new DynamicState(cAssignment, cContainer, null);
             
             DynamicState nextState = Slot.stateMachineStep(dynamicState, staticState);
@@ -453,7 +453,7 @@ public class SlotTest {
             ISupervisor iSuper = mock(ISupervisor.class);
             LocalState state = mock(LocalState.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                    containerLauncher, "localhost", port, iSuper, state, cb, null);
+                    containerLauncher, "localhost", port, iSuper, state, cb, null, null);
             Set<TopoProfileAction> profileActions = new HashSet<>();
             ProfileRequest request = new ProfileRequest();
             request.set_action(ProfileAction.JPROFILE_STOP);
@@ -531,7 +531,7 @@ public class SlotTest {
             ISupervisor iSuper = mock(ISupervisor.class);
             long heartbeatTimeoutMs = 5000;
             StaticState staticState = new StaticState(localizer, heartbeatTimeoutMs, 120_000, 1000, 1000,
-                containerLauncher, "localhost", port, iSuper, state, cb, null);
+                containerLauncher, "localhost", port, iSuper, state, cb, null, null);
 
             Set<Slot.BlobChanging> changing = new HashSet<>();
             LocallyCachedBlob stormJar = mock(LocallyCachedBlob.class);


### PR DESCRIPTION
This adds the WorkerMetricsProcessor interface.  The default implementation executes the current code that sends metric data to Nimbus for insertion, now done by NimbusMetricProcessor.

The intent is that we can replace this class for other metricstore implementations (HBase is what I am currently working on) that can instead do insertion directly.

