### PR TITLE
[STORM-2948] add -XX:+HeapDumpOnOutOfMemoryError for maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1100,7 +1100,7 @@
                         <includes>
                             <include>${java.unit.test.include}</include>
                         </includes>
-                        <argLine>-Xmx3g</argLine>
+                        <argLine>-Xmx3g -XX:+HeapDumpOnOutOfMemoryError</argLine>
                         <trimStackTrace>false</trimStackTrace>
                         <forkCount>1.0C</forkCount>
                         <reuseForks>true</reuseForks>


### PR DESCRIPTION
Pretty minor change. 