### PR TITLE
[STORM-2950] Making FieldsGrouper.chooseTasks be consistent with 1.x version line

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/TupleUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/TupleUtils.java
@@ -41,7 +41,7 @@ public final class TupleUtils {
     }
 
     public static <T> int chooseTaskIndex(List<T> keys, int numTasks) {
-        return Math.abs(listHashCode(keys)) % numTasks;
+        return Math.floorMod(listHashCode(keys), numTasks);
     }
 
     private static <T> int listHashCode(List<T> alist) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2950

listHashCode(keys) might return Integer.MIN_VALUE (-2147483648). Math.abs(-2147483648) equals to -2147483648.

And as @HeartSaVioR  pointed out,  to be consistent with 1.x version:
```
 (mod listHashCode(keys) numTasks)
```
We should use
```
Math.floorMod(listHashCode(keys), numTasks) 
```
