### PR TITLE
[STORM-2961] Refactor addResource and addResources Methods in BaseConfigurationDeclarer

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/coordination/BatchSubtopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/coordination/BatchSubtopologyBuilder.java
@@ -450,17 +450,7 @@ public class BatchSubtopologyBuilder {
         @Override
         public BoltDeclarer addConfigurations(Map<String, Object> conf) {
             if (conf != null) {
-                component.componentConf.putAll(conf);
-            }
-            return this;
-        }
-
-        @Override
-        public BoltDeclarer addResources(Map<String, Double> resources) {
-            if (resources != null) {
-                Map<String, Double> currentResources = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                    Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-                currentResources.putAll(resources);
+                getComponentConfiguration().putAll(conf);
             }
             return this;
         }
@@ -471,14 +461,9 @@ public class BatchSubtopologyBuilder {
             return this;
         }
 
-        @SuppressWarnings("unchecked")
         @Override
-        public BoltDeclarer addResource(String resourceName, Number resourceValue) {
-            Map<String, Double> resourcesMap = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-
-            resourcesMap.put(resourceName, resourceValue.doubleValue());
-            return this;
+        public Map<String, Object> getComponentConfiguration() {
+            return component.componentConf;
         }
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/drpc/LinearDRPCTopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/LinearDRPCTopologyBuilder.java
@@ -407,24 +407,14 @@ public class LinearDRPCTopologyBuilder {
             return this;
         }
 
+        /**
+         * return the current component configuration.
+         *
+         * @return the current configuration.
+         */
         @Override
-        public LinearDRPCInputDeclarer addResources(Map<String, Double> resources) {
-            if (resources != null) {
-                Map<String, Double> currentResources = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                    Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-                currentResources.putAll(resources);
-            }
-            return this;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public LinearDRPCInputDeclarer addResource(String resourceName, Number resourceValue) {
-            Map<String, Double> resourcesMap = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-
-            resourcesMap.put(resourceName, resourceValue.doubleValue());
-            return this;
+        public Map<String, Object> getComponentConfiguration() {
+            return component.componentConf;
         }
 
         @Override

--- a/storm-client/src/jvm/org/apache/storm/topology/BaseConfigurationDeclarer.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/BaseConfigurationDeclarer.java
@@ -86,4 +86,30 @@ public abstract class BaseConfigurationDeclarer<T extends ComponentConfiguration
         }
         return (T) this;
     }
+
+    @SuppressWarnings("unchecked")
+    public T addResource(String resourceName, Number resourceValue) {
+        Map<String, Double> resourcesMap = (Map<String, Double>) getComponentConfiguration().computeIfAbsent(Config.TOPOLOGY_COMPONENT_RESOURCES_MAP,
+            (x) -> new HashMap<String, Double>());
+        resourcesMap.put(resourceName, resourceValue.doubleValue());
+
+        return (T) this;
+    }
+
+    /**
+     * Add generic resources for this component.
+     *
+     * @param resources
+     */
+    @Override
+    public T addResources(Map<String, Double> resources) {
+        if (resources != null) {
+            Map<String, Double> currentResources = (Map<String, Double>) getComponentConfiguration().computeIfAbsent(
+                Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
+            currentResources.putAll(resources);
+        }
+        return (T) this;
+    }
+
+
 }

--- a/storm-client/src/jvm/org/apache/storm/topology/ComponentConfigurationDeclarer.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/ComponentConfigurationDeclarer.java
@@ -29,6 +29,13 @@ public interface ComponentConfigurationDeclarer<T extends ComponentConfiguration
     T addConfigurations(Map<String, Object> conf);
 
     /**
+     * return the current component configuration.
+     *
+     * @return the current configuration.
+     */
+    Map<String, Object> getComponentConfiguration();
+
+    /**
      * Add in a single config.
      * @param config the key for the config
      * @param value the value of the config

--- a/storm-client/src/jvm/org/apache/storm/topology/TopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/TopologyBuilder.java
@@ -585,6 +585,16 @@ public class TopologyBuilder {
             return (T) this;
         }
 
+        /**
+         * return the current component configuration.
+         *
+         * @return the current configuration.
+         */
+        @Override
+        public Map<String, Object> getComponentConfiguration() {
+            return parseJson(commons.get(id).get_json_conf());
+        }
+
         @Override
         public T addResources(Map<String, Double> resources) {
             if (resources != null && !resources.isEmpty()) {

--- a/storm-client/src/jvm/org/apache/storm/transactional/TransactionalTopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/transactional/TransactionalTopologyBuilder.java
@@ -230,29 +230,19 @@ public class TransactionalTopologyBuilder {
             return this;
         }
 
+        /**
+         * return the current component configuration.
+         *
+         * @return the current configuration.
+         */
         @Override
-        public SpoutDeclarerImpl addResources(Map<String, Double> resources) {
-            if (resources != null) {
-                Map<String, Double> currentResources = (Map<String, Double>) spoutConf.computeIfAbsent(
-                    Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-                currentResources.putAll(resources);
-            }
-            return this;
+        public Map<String, Object> getComponentConfiguration() {
+            return spoutConf;
         }
 
         @Override
         public SpoutDeclarer addSharedMemory(SharedMemory request) {
             spoutSharedMemory.add(request);
-            return this;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public SpoutDeclarer addResource(String resourceName, Number resourceValue) {
-            Map<String, Double> resourcesMap = (Map<String, Double>) spoutConf.computeIfAbsent(Config.TOPOLOGY_COMPONENT_RESOURCES_MAP,
-                (k) -> new HashMap<>());
-
-            resourcesMap.put(resourceName, resourceValue.doubleValue());
             return this;
         }
     }
@@ -553,33 +543,24 @@ public class TransactionalTopologyBuilder {
         @Override
         public BoltDeclarer addConfigurations(Map<String, Object> conf) {
             if (conf != null) {
-                component.componentConf.putAll(conf);
+                getComponentConfiguration().putAll(conf);
             }
             return this;
         }
 
+        /**
+         * return the current component configuration.
+         *
+         * @return the current configuration.
+         */
         @Override
-        public BoltDeclarer addResources(Map<String, Double> resources) {
-            if (resources != null) {
-                Map<String, Double> currentResources = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                    Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-                currentResources.putAll(resources);
-            }
-            return this;
+        public Map<String, Object> getComponentConfiguration() {
+            return component.componentConf;
         }
+
         @Override
         public BoltDeclarer addSharedMemory(SharedMemory request) {
             component.sharedMemory.add(request);
-            return this;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public BoltDeclarer addResource(String resourceName, Number resourceValue) {
-            Map<String, Double> resourcesMap = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-
-            resourcesMap.put(resourceName, resourceValue.doubleValue());
             return this;
         }
     }

--- a/storm-client/src/jvm/org/apache/storm/trident/topology/TridentTopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/topology/TridentTopologyBuilder.java
@@ -779,7 +779,7 @@ public class TridentTopologyBuilder {
             return component.componentConf;
         }
 
-       @Override
+        @Override
         public BoltDeclarer addSharedMemory(SharedMemory request) {
             component.sharedMemory.add(request);
             return this;

--- a/storm-client/src/jvm/org/apache/storm/trident/topology/TridentTopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/topology/TridentTopologyBuilder.java
@@ -366,24 +366,14 @@ public class TridentTopologyBuilder {
             return this;
         }
 
+        /**
+         * return the current component configuration.
+         *
+         * @return the current configuration.
+         */
         @Override
-        public SpoutDeclarer addResources(Map<String, Double> resources) {
-            if (resources != null) {
-                Map<String, Double> currentResources = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                    Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-                currentResources.putAll(resources);
-            }
-            return this;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public SpoutDeclarer addResource(String resourceName, Number resourceValue) {
-            Map<String, Double> resourcesMap = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-
-            resourcesMap.put(resourceName, resourceValue.doubleValue());
-            return this;
+        public Map<String, Object> getComponentConfiguration() {
+            return component.componentConf;
         }
 
         @Override
@@ -779,29 +769,19 @@ public class TridentTopologyBuilder {
             return this;
         }
 
+        /**
+         * return the current component configuration.
+         *
+         * @return the current configuration.
+         */
         @Override
-        public BoltDeclarer addResources(Map<String, Double> resources) {
-            if (resources != null) {
-                Map<String, Double> currentResources = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                    Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-                currentResources.putAll(resources);
-            }
-            return this;
+        public Map<String, Object> getComponentConfiguration() {
+            return component.componentConf;
         }
 
-        @Override
+       @Override
         public BoltDeclarer addSharedMemory(SharedMemory request) {
             component.sharedMemory.add(request);
-            return this;
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public BoltDeclarer addResource(String resourceName, Number resourceValue) {
-            Map<String, Double> resourcesMap = (Map<String, Double>) component.componentConf.computeIfAbsent(
-                Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, (k) -> new HashMap<>());
-
-            resourcesMap.put(resourceName, resourceValue.doubleValue());
             return this;
         }
     }    


### PR DESCRIPTION
In duplicated code, `TransactionalTopologyBuilder.addResource` method implementation caused NPEs, motivating this cleanup.