### PR TITLE
STORM-2971: Replace storm-kafka with storm-kafka-client in Flux examp…

### DIFF
--- a/flux/README.md
+++ b/flux/README.md
@@ -57,7 +57,7 @@ the layout and configuration of your topologies.
    in your topology code
  * Support for existing topology code (see below)
  * Define Storm Core API (Spouts/Bolts) using a flexible YAML DSL
- * YAML DSL support for most Storm components (storm-kafka, storm-hdfs, storm-hbase, etc.)
+ * YAML DSL support for most Storm components (storm-kafka-client, storm-hdfs, storm-hbase, etc.)
  * Convenient support for multi-lang components
  * External property substitution/filtering for easily switching between configurations/environments (similar to Maven-style
    `${variable.name}` substitution)
@@ -354,19 +354,20 @@ storm jar myTopology-0.1.0-SNAPSHOT.jar org.apache.storm.flux.Flux --local my_co
 With the following `dev.properties` file:
 
 ```properties
-kafka.zookeeper.hosts: localhost:2181
+kafka.bootstrap.hosts: localhost:9092
 ```
 
 You would then be able to reference those properties by key in your `.yaml` file using `${}` syntax:
 
 ```yaml
-  - id: "zkHosts"
-    className: "org.apache.storm.kafka.ZkHosts"
+  - id: "spoutConfigBuilder"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig$Builder"
     constructorArgs:
-      - "${kafka.zookeeper.hosts}"
+      - "${kafka.bootstrap.hosts}"
+      - ["myKafkaTopic"]
 ```
 
-In this case, Flux would replace `${kafka.zookeeper.hosts}` with `localhost:2181` before parsing the YAML contents.
+In this case, Flux would replace `${kafka.bootstrap.hosts}` with `localhost:9092` before parsing the YAML contents.
 
 ### Environment Variable Substitution/Filtering
 Flux also allows environment variable substitution. For example, if an environment variable named `ZK_HOSTS` if defined,
@@ -378,16 +379,16 @@ ${ENV-ZK_HOSTS}
 
 ## Components
 Components are essentially named object instances that are made available as configuration options for spouts and
-bolts. If you are familiar with the Spring framework, components are roughly analagous to Spring beans.
+bolts. If you are familiar with the Spring framework, components are roughly analogous to Spring beans.
 
 Every component is identified, at a minimum, by a unique identifier (String) and a class name (String). For example,
-the following will make an instance of the `org.apache.storm.kafka.StringScheme` class available as a reference under the key
-`"stringScheme"` . This assumes the `org.apache.storm.kafka.StringScheme` has a default constructor.
+the following will make an instance of the `org.apache.storm.flux.examples.OnlyValueRecordTranslator` class available as a reference under the key
+`"recordTranslator"` . This assumes the `org.apache.storm.flux.examples.OnlyValueRecordTranslator` has a default constructor.
 
 ```yaml
 components:
-  - id: "stringScheme"
-    className: "org.apache.storm.kafka.StringScheme"
+  - id: "recordTranslator"
+    className: "org.apache.storm.flux.examples.OnlyValueRecordTranslator"
 ```
 
 ### Contructor Arguments, References, Properties and Configuration Methods
@@ -395,32 +396,36 @@ components:
 ####Constructor Arguments
 Arguments to a class constructor can be configured by adding a `contructorArgs` element to a components.
 `constructorArgs` is a list of objects that will be passed to the class' constructor. The following example creates an
-object by calling the constructor that takes a single string as an argument:
+object by calling the constructor that takes a string and an array of strings as arguments:
 
 ```yaml
-  - id: "zkHosts"
-    className: "org.apache.storm.kafka.ZkHosts"
+  - id: "spoutConfigBuilder"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig$Builder"
     constructorArgs:
-      - "localhost:2181"
-      - true
+      - "${kafka.bootstrap.hosts}"
+      - ["myKafkaTopic"]
 ```
 
 ####References
 Each component instance is identified by a unique id that allows it to be used/reused by other components. To
 reference an existing component, you specify the id of the component with the `ref` tag.
 
-In the following example, a component with the id `"stringScheme"` is created, and later referenced, as a an argument
+In the following example, a component with the id `"recordTranslator"` is created, and later referenced, as a an argument
 to another component's constructor:
 
 ```yaml
 components:
-  - id: "stringScheme"
-    className: "org.apache.storm.kafka.StringScheme"
+  - id: "recordTranslator"
+    className: "org.apache.storm.flux.examples.OnlyValueRecordTranslator"
 
-  - id: "stringMultiScheme"
-    className: "org.apache.storm.spout.SchemeAsMultiScheme"
+    - id: "spoutConfigBuilder"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig$Builder"
     constructorArgs:
-      - ref: "stringScheme" # component with id "stringScheme" must be declared above.
+      - "localhost:9092"
+      - ["myKafkaTopic"]
+    properties:
+      - name: "recordTranslator"
+        ref: "onlyValueRecordTranslator" #Component with id "recordTranslator" must be declared above
 ```
 
 You can also reference existing components in list via specifying the id of the components with the `reflist` tag.
@@ -448,27 +453,20 @@ In addition to calling constructors with different arguments, Flux also allows y
 JavaBean-like setter methods and fields declared as `public`:
 
 ```yaml
-  - id: "spoutConfig"
-    className: "org.apache.storm.kafka.SpoutConfig"
+  - id: "spoutConfigBuilder"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig$Builder"
     constructorArgs:
-      # brokerHosts
-      - ref: "zkHosts"
-      # topic
-      - "myKafkaTopic"
-      # zkRoot
-      - "/kafkaSpout"
-      # id
-      - "myId"
+      - "localhost:9092"
+      - ["myKafkaTopic"]
     properties:
-      - name: "ignoreZkOffsets"
-        value: true
-      - name: "scheme"
-        ref: "stringMultiScheme"
+      - name: "pollTimeoutMs"
+        value: 5000
 ```
 
-In the example above, the `properties` declaration will cause Flux to look for a public method in the `SpoutConfig` with
-the signature `setForceFromStart(boolean b)` and attempt to invoke it. If a setter method is not found, Flux will then
-look for a public instance variable with the name `ignoreZkOffsets` and attempt to set its value.
+In the example above, the `properties` declaration will cause Flux to look for a public method in the `KafkaSpoutConfig$Builder` with
+the signature `setPollTimeoutMs(int i)` and attempt to invoke it. If a setter method is not found, Flux will then
+look for a public instance variable with the name `pollTimeoutMs` and attempt to set its value.
+Note that Flux will attempt to coerce actual parameter types to fit the setter parameter types, so e.g. calling `setMyFloat(float f)` with `value: 10` is possible.
 
 References may also be used as property values.
 
@@ -623,46 +621,31 @@ Kafka spout example:
 
 ```yaml
 components:
-  - id: "stringScheme"
-    className: "org.apache.storm.kafka.StringScheme"
-
-  - id: "stringMultiScheme"
-    className: "org.apache.storm.spout.SchemeAsMultiScheme"
+  - id: "onlyValueRecordTranslator"
+    className: "org.apache.storm.flux.examples.OnlyValueRecordTranslator"
+    
+  - id: "spoutConfigBuilder"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig$Builder"
     constructorArgs:
-      - ref: "stringScheme"
-
-  - id: "zkHosts"
-    className: "org.apache.storm.kafka.ZkHosts"
-    constructorArgs:
-      - "localhost:2181"
-
-# Alternative kafka config
-#  - id: "kafkaConfig"
-#    className: "org.apache.storm.kafka.KafkaConfig"
-#    constructorArgs:
-#      # brokerHosts
-#      - ref: "zkHosts"
-#      # topic
-#      - "myKafkaTopic"
-#      # clientId (optional)
-#      - "myKafkaClientId"
-
-  - id: "spoutConfig"
-    className: "org.apache.storm.kafka.SpoutConfig"
-    constructorArgs:
-      # brokerHosts
-      - ref: "zkHosts"
-      # topic
-      - "myKafkaTopic"
-      # zkRoot
-      - "/kafkaSpout"
-      # id
-      - "myId"
+      - "localhost:9092"
+      - ["myKafkaTopic"]
     properties:
-      - name: "ignoreZkOffsets"
-        value: true
-      - name: "scheme"
-        ref: "stringMultiScheme"
+      - name: "firstPollOffsetStrategy"
+        value: EARLIEST
+      - name: "recordTranslator"
+        ref: "onlyValueRecordTranslator"
+    configMethods:
+      - name: "setProp"
+        args:
+          - {
+              "key.deserializer" : "org.apache.kafka.common.serialization.StringDeserializer",
+              "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer"
+            }
+                
+  - id: "spoutConfig"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig"
+    constructorArgs:
+      - ref: "spoutConfigBuilder"
 
 config:
   topology.workers: 1
@@ -670,7 +653,7 @@ config:
 # spout definitions
 spouts:
   - id: "kafka-spout"
-    className: "org.apache.storm.kafka.KafkaSpout"
+    className: "org.apache.storm.kafka.spout.KafkaSpout"
     constructorArgs:
       - ref: "spoutConfig"
 

--- a/flux/flux-core/pom.xml
+++ b/flux/flux-core/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>
-            <artifactId>storm-kafka</artifactId>
+            <artifactId>storm-kafka-client</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/flux/flux-core/src/test/java/org/apache/storm/flux/test/OnlyValueRecordTranslator.java
+++ b/flux/flux-core/src/test/java/org/apache/storm/flux/test/OnlyValueRecordTranslator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.flux.test;
+
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.storm.kafka.spout.RecordTranslator;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+
+public class OnlyValueRecordTranslator<K, V> implements RecordTranslator<K, V> {
+
+    @Override
+    public List<Object> apply(ConsumerRecord<K, V> record) {
+        return new Values(record.value());
+    }
+
+    @Override
+    public Fields getFieldsFor(String stream) {
+        return new Fields("value");
+    }
+
+}

--- a/flux/flux-core/src/test/java/org/apache/storm/flux/test/TridentTopologySource.java
+++ b/flux/flux-core/src/test/java/org/apache/storm/flux/test/TridentTopologySource.java
@@ -21,7 +21,6 @@ import org.apache.storm.Config;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Values;
-import org.apache.storm.kafka.StringScheme;
 import org.apache.storm.trident.TridentTopology;
 import org.apache.storm.trident.operation.BaseFunction;
 import org.apache.storm.trident.operation.TridentCollector;

--- a/flux/flux-core/src/test/resources/configs/kafka_test.yaml
+++ b/flux/flux-core/src/test/resources/configs/kafka_test.yaml
@@ -25,46 +25,31 @@ name: "kafka-topology"
 #
 # for the time being, components must be declared in the order they are referenced
 components:
-  - id: "stringScheme"
-    className: "org.apache.storm.kafka.StringScheme"
-
-  - id: "stringMultiScheme"
-    className: "org.apache.storm.spout.SchemeAsMultiScheme"
+  - id: "onlyValueRecordTranslator"
+    className: "org.apache.storm.flux.test.OnlyValueRecordTranslator"
+    
+  - id: "spoutConfigBuilder"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig$Builder"
     constructorArgs:
-      - ref: "stringScheme"
-
-  - id: "zkHosts"
-    className: "org.apache.storm.kafka.ZkHosts"
-    constructorArgs:
-      - "localhost:2181"
-
-# Alternative kafka config
-#  - id: "kafkaConfig"
-#    className: "org.apache.storm.kafka.KafkaConfig"
-#    constructorArgs:
-#      # brokerHosts
-#      - ref: "zkHosts"
-#      # topic
-#      - "myKafkaTopic"
-#      # clientId (optional)
-#      - "myKafkaClientId"
-
-  - id: "spoutConfig"
-    className: "org.apache.storm.kafka.SpoutConfig"
-    constructorArgs:
-      # brokerHosts
-      - ref: "zkHosts"
-      # topic
-      - "myKafkaTopic"
-      # zkRoot
-      - "/kafkaSpout"
-      # id
-      - "myId"
+      - "localhost:9092"
+      - ["myKafkaTopic"]
     properties:
-      - name: "ignoreZkOffsets"
-        value: true
-      - name: "scheme"
-        ref: "stringMultiScheme"
+      - name: "firstPollOffsetStrategy"
+        value: EARLIEST
+      - name: "recordTranslator"
+        ref: "onlyValueRecordTranslator"
+    configMethods:
+      - name: "setProp"
+        args:
+          - {
+              "key.deserializer" : "org.apache.kafka.common.serialization.StringDeserializer",
+              "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer"
+            }
+                
+  - id: "spoutConfig"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig"
+    constructorArgs:
+      - ref: "spoutConfigBuilder"
 
 # topology configuration
 # this will be passed to the submitter as a map of config options
@@ -76,7 +61,7 @@ config:
 # spout definitions
 spouts:
   - id: "kafka-spout"
-    className: "org.apache.storm.kafka.KafkaSpout"
+    className: "org.apache.storm.kafka.spout.KafkaSpout"
     constructorArgs:
       - ref: "spoutConfig"
 

--- a/flux/flux-examples/README.md
+++ b/flux/flux-examples/README.md
@@ -40,7 +40,7 @@ written in java.
 
 ### [kafka_spout.yaml](src/main/resources/kafka_spout.yaml)
 
-This example illustrates how to configure Storm's `storm-kafka` spout using Flux YAML DSL `components`, `references`,
+This example illustrates how to configure Storm's `storm-kafka-client` spout using Flux YAML DSL `components`, `references`,
 and `constructor arguments` constructs.
 
 ### [simple_hdfs.yaml](src/main/resources/simple_hdfs.yaml)

--- a/flux/flux-examples/pom.xml
+++ b/flux/flux-examples/pom.xml
@@ -94,12 +94,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>
-            <artifactId>storm-kafka</artifactId>
+            <artifactId>storm-kafka-client</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>${storm.kafka.artifact.id}</artifactId>
         </dependency>
     </dependencies>
 

--- a/flux/flux-examples/src/main/java/org/apache/storm/flux/examples/OnlyValueRecordTranslator.java
+++ b/flux/flux-examples/src/main/java/org/apache/storm/flux/examples/OnlyValueRecordTranslator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.flux.examples;
+
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.storm.kafka.spout.RecordTranslator;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+
+public class OnlyValueRecordTranslator<K, V> implements RecordTranslator<K, V> {
+
+    @Override
+    public List<Object> apply(ConsumerRecord<K, V> record) {
+        return new Values(record.value());
+    }
+
+    @Override
+    public Fields getFieldsFor(String stream) {
+        return new Fields("value");
+    }
+
+}

--- a/flux/flux-examples/src/main/resources/kafka_spout.yaml
+++ b/flux/flux-examples/src/main/resources/kafka_spout.yaml
@@ -13,9 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-# Test ability to wire together shell spouts/bolts
 ---
 
 # topology definition
@@ -28,51 +25,31 @@ name: "kafka-topology"
 #
 # for the time being, components must be declared in the order they are referenced
 components:
-  - id: "stringScheme"
-    className: "org.apache.storm.kafka.StringScheme"
-
-  - id: "stringMultiScheme"
-    className: "org.apache.storm.spout.SchemeAsMultiScheme"
+  - id: "onlyValueRecordTranslator"
+    className: "org.apache.storm.flux.examples.OnlyValueRecordTranslator"
+    
+  - id: "spoutConfigBuilder"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig$Builder"
     constructorArgs:
-      - ref: "stringScheme"
-
-  - id: "zkHosts"
-    className: "org.apache.storm.kafka.ZkHosts"
-    constructorArgs:
-      - "localhost:2181"
-
-# Alternative kafka config
-#  - id: "kafkaConfig"
-#    className: "org.apache.storm.kafka.KafkaConfig"
-#    constructorArgs:
-#      # brokerHosts
-#      - ref: "zkHosts"
-#      # topic
-#      - "myKafkaTopic"
-#      # clientId (optional)
-#      - "myKafkaClientId"
-
-  - id: "spoutConfig"
-    className: "org.apache.storm.kafka.SpoutConfig"
-    constructorArgs:
-      # brokerHosts
-      - ref: "zkHosts"
-      # topic
-      - "myKafkaTopic"
-      # zkRoot
-      - "/kafkaSpout"
-      # id
-      - "myId"
+      - "localhost:9092"
+      - ["myKafkaTopic"]
     properties:
-      - name: "ignoreZkOffsets"
-        value: true
-      - name: "scheme"
-        ref: "stringMultiScheme"
-
-
-
-# NOTE: We may want to consider some level of spring integration. For example, allowing component references
-# to a spring `ApplicationContext`.
+      - name: "firstPollOffsetStrategy"
+        value: EARLIEST
+      - name: "recordTranslator"
+        ref: "onlyValueRecordTranslator"
+    configMethods:
+      - name: "setProp"
+        args:
+          - {
+              "key.deserializer" : "org.apache.kafka.common.serialization.StringDeserializer",
+              "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer"
+            }
+                
+  - id: "spoutConfig"
+    className: "org.apache.storm.kafka.spout.KafkaSpoutConfig"
+    constructorArgs:
+      - ref: "spoutConfigBuilder"
 
 # topology configuration
 # this will be passed to the submitter as a map of config options
@@ -84,7 +61,7 @@ config:
 # spout definitions
 spouts:
   - id: "kafka-spout"
-    className: "org.apache.storm.kafka.KafkaSpout"
+    className: "org.apache.storm.kafka.spout.KafkaSpout"
     constructorArgs:
       - ref: "spoutConfig"
 
@@ -98,7 +75,6 @@ bolts:
       # output fields
       - ["word"]
     parallelism: 1
-    # ...
 
   - id: "log"
     className: "org.apache.storm.flux.wrappers.bolts.LogInfoBolt"
@@ -108,7 +84,6 @@ bolts:
   - id: "count"
     className: "org.apache.storm.testing.TestWordCounter"
     parallelism: 1
-    # ...
 
 #stream definitions
 # stream definitions define connections between spouts and bolts.


### PR DESCRIPTION
…les, fix Flux bug where setter argument types are not checked or coerced

The change to flux is necessary to be able to call setters that take an enum value.