### PR TITLE
[STORM-2976] Fix Supervisor HealthCheck validations

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -209,7 +209,7 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
             eventTimer.scheduleRecurring(0, 10, new EventManagerPushCallback(readState, eventManager));
 
             // supervisor health check
-            eventTimer.scheduleRecurring(300, 300, new SupervisorHealthCheck(this));
+            eventTimer.scheduleRecurring(30, 30, new SupervisorHealthCheck(this));
         }
         LOG.info("Starting supervisor with id {} at host {}.", getId(), getHostName());
     }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/timer/SupervisorHealthCheck.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/timer/SupervisorHealthCheck.java
@@ -22,8 +22,11 @@ import java.util.Map;
 
 import org.apache.storm.daemon.supervisor.Supervisor;
 import org.apache.storm.healthcheck.HealthChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SupervisorHealthCheck implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(SupervisorHealthCheck.class);
     private final Supervisor supervisor;
 
     public SupervisorHealthCheck(Supervisor supervisor) {
@@ -33,9 +36,12 @@ public class SupervisorHealthCheck implements Runnable {
     @Override
     public void run() {
         Map<String, Object> conf = supervisor.getConf();
+        LOG.info("Running supervisor healthchecks...");
         int healthCode = HealthChecker.healthCheck(conf);
         if (healthCode != 0) {
+            LOG.info("The supervisor healthchecks FAILED...");
             supervisor.shutdownAllWorkers(null, null);
+            throw new RuntimeException("Supervisor failed health check. Exiting.");
         }
     }
 }


### PR DESCRIPTION
The couple of issues with Supervisor HealthCheck functionality.
1. `ClassCastException` while reading configuration.
2.  The supervisor should die if healthchecks fail.