### PR TITLE
[STORM-2977] BlowfishTupleSerializer tries to use zookeeper secret if blowfish.key is not present

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/serialization/BlowfishTupleSerializer.java
+++ b/storm-client/src/jvm/org/apache/storm/security/serialization/BlowfishTupleSerializer.java
@@ -47,18 +47,28 @@ public class BlowfishTupleSerializer extends Serializer<ListDelegate> {
      */
     public static final String SECRET_KEY = "topology.tuple.serializer.blowfish.key";
     private static final Logger LOG = LoggerFactory.getLogger(BlowfishTupleSerializer.class);
-    private BlowfishSerializer _serializer;
+    private BlowfishSerializer serializer;
 
     public BlowfishTupleSerializer(Kryo kryo, Map<String, Object> topoConf) {
-        String encryption_key;
+        String encryptionkey;
         try {
-            encryption_key = (String)topoConf.get(SECRET_KEY);
+            encryptionkey = (String) topoConf.get(SECRET_KEY);
             LOG.debug("Blowfish serializer being constructed ...");
-            if (encryption_key == null) {
-                throw new RuntimeException("Blowfish encryption key not specified");
+
+            byte[] bytes;
+            if (encryptionkey != null) {
+                bytes = Hex.decodeHex(encryptionkey.toCharArray());
+            } else {
+                // try to use zookeeper secret
+                String payload = (String) topoConf.get(Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD);
+                if (payload != null) {
+                    LOG.debug("{} is not present. Use {} as Blowfish encryption key", SECRET_KEY, Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD);
+                    bytes = payload.getBytes();
+                } else {
+                    throw new RuntimeException("Blowfish encryption key not specified");
+                }
             }
-            byte[] bytes =  Hex.decodeHex(encryption_key.toCharArray());
-            _serializer = new BlowfishSerializer(new ListDelegateSerializer(), bytes);
+            serializer = new BlowfishSerializer(new ListDelegateSerializer(), bytes);
         } catch (org.apache.commons.codec.DecoderException ex) {
             throw new RuntimeException("Blowfish encryption key invalid", ex);
         }
@@ -66,12 +76,12 @@ public class BlowfishTupleSerializer extends Serializer<ListDelegate> {
 
     @Override
     public void write(Kryo kryo, Output output, ListDelegate object) {
-        kryo.writeObject(output, object, _serializer);
+        kryo.writeObject(output, object, serializer);
     }
 
     @Override
     public ListDelegate read(Kryo kryo, Input input, Class<ListDelegate> type) {
-        return kryo.readObject(input, ListDelegate.class, _serializer);
+        return kryo.readObject(input, ListDelegate.class, serializer);
     }
 
     /**
@@ -84,7 +94,7 @@ public class BlowfishTupleSerializer extends Serializer<ListDelegate> {
             SecretKey skey = kgen.generateKey();
             byte[] raw = skey.getEncoded();
             String keyString = new String(Hex.encodeHex(raw));
-            System.out.println("storm -c "+SECRET_KEY+"="+keyString+" -c "+Config.TOPOLOGY_TUPLE_SERIALIZER+"="+BlowfishTupleSerializer.class.getName() + " ..." );
+            System.out.println("storm -c " + SECRET_KEY + "=" + keyString + " -c " + Config.TOPOLOGY_TUPLE_SERIALIZER + "=" + BlowfishTupleSerializer.class.getName() + " ..." );
         } catch (Exception ex) {
             LOG.error(ex.getMessage());
         }

--- a/storm-client/test/jvm/org/apache/storm/security/serialization/BlowfishTupleSerializerTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/serialization/BlowfishTupleSerializerTest.java
@@ -24,6 +24,8 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 
+import org.apache.storm.Config;
+import org.apache.storm.annotation.InterfaceStability.Evolving;
 import org.apache.storm.utils.ListDelegate;
 import org.junit.Assert;
 import org.junit.Test;
@@ -52,23 +54,40 @@ public class BlowfishTupleSerializerTest {
     }
 
     /**
-     * Reads a string encrypted by another instance with a shared key
+     * Test using {@link org.apache.storm.security.serialization.BlowfishTupleSerializer#SECRET_KEY}.
      */
     @Test
-    public void testEncryptsAndDecryptsMessage() {
-        String testText = "Tetraodontidae is a family of primarily marine and estuarine fish of the order" +
-                          " Tetraodontiformes. The family includes many familiar species, which are" +
-                          " variously called pufferfish, puffers, balloonfish, blowfish, bubblefish," +
-                          " globefish, swellfish, toadfish, toadies, honey toads, sugar toads, and sea" +
-                          " squab.[1] They are morphologically similar to the closely related" +
-                          " porcupinefish, which have large external spines (unlike the thinner, hidden" +
-                          " spines of Tetraodontidae, which are only visible when the fish has puffed up)." +
-                          " The scientific name refers to the four large teeth, fused into an upper and" +
-                          " lower plate, which are used for crushing the shells of crustaceans and" +
-                          " mollusks, their natural prey.";
-        Kryo kryo = new Kryo();
+    public void testUseBlowfishKey() {
         String arbitraryKey = "7dd6fb3203878381b08f9c89d25ed105";
         Map<String, Object> topoConf = ImmutableMap.of(BlowfishTupleSerializer.SECRET_KEY, arbitraryKey);
+        testEncryptsAndDecryptsMessage(topoConf);
+    }
+
+    /**
+     * Test using {@link org.apache.storm.Config#STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD}
+     * when {@link org.apache.storm.security.serialization.BlowfishTupleSerializer#SECRET_KEY} is not present.
+     */
+    @Test
+    public void testUseZookeeperSecret() {
+        Map<String, Object> topoConf = ImmutableMap.of(Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD, "user:password");
+        testEncryptsAndDecryptsMessage(topoConf);
+    }
+
+    /**
+     * Reads a string encrypted by another instance with a shared key
+     */
+    private void testEncryptsAndDecryptsMessage(Map<String, Object> topoConf) {
+        String testText = "Tetraodontidae is a family of primarily marine and estuarine fish of the order" +
+                " Tetraodontiformes. The family includes many familiar species, which are" +
+                " variously called pufferfish, puffers, balloonfish, blowfish, bubblefish," +
+                " globefish, swellfish, toadfish, toadies, honey toads, sugar toads, and sea" +
+                " squab.[1] They are morphologically similar to the closely related" +
+                " porcupinefish, which have large external spines (unlike the thinner, hidden" +
+                " spines of Tetraodontidae, which are only visible when the fish has puffed up)." +
+                " The scientific name refers to the four large teeth, fused into an upper and" +
+                " lower plate, which are used for crushing the shells of crustaceans and" +
+                " mollusks, their natural prey.";
+        Kryo kryo = new Kryo();
         BlowfishTupleSerializer writerBTS = new BlowfishTupleSerializer(kryo, topoConf);
         BlowfishTupleSerializer readerBTS = new BlowfishTupleSerializer(kryo, topoConf);
         int bufferSize = 1024;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2977

Tries to use Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD before  throwing exceptions. Making it simpler to use