### PR TITLE
STORM-2985: Explicitly add jackson-annotations dependency in pom dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -685,6 +685,11 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-smile</artifactId>
                 <version>${jackson.version}</version>


### PR DESCRIPTION
This is taken care of in master via jackson-bom dependency.