### PR TITLE
STORM-2979: WorkerHooks EOFException during run_worker_shutdown_hooks

### DIFF
--- a/storm-core/src/clj/org/apache/storm/daemon/worker.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/worker.clj
@@ -566,9 +566,12 @@
         worker-topology-context (worker-context worker)
         hooks (.get_worker_hooks topology)]
     (dofor [hook hooks]
-      (let [hook-bytes (Utils/toByteArray hook)
-            deser-hook (Utils/javaDeserialize hook-bytes BaseWorkerHook)]
-        (.start deser-hook topo-conf worker-topology-context)))))
+      (let [savedposition (.position hook)
+            hook-bytes (Utils/toByteArray hook)
+            deser-hook (Utils/javaDeserialize hook-bytes BaseWorkerHook)
+            nop (.position hook savedposition)]
+        (.start deser-hook topo-conf worker-topology-context))
+      )))
 
 (defn run-worker-shutdown-hooks [worker]
   (let [topology (:topology worker)

--- a/storm-core/src/clj/org/apache/storm/daemon/worker.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/worker.clj
@@ -566,12 +566,10 @@
         worker-topology-context (worker-context worker)
         hooks (.get_worker_hooks topology)]
     (dofor [hook hooks]
-      (let [savedposition (.position hook)
-            hook-bytes (Utils/toByteArray hook)
-            deser-hook (Utils/javaDeserialize hook-bytes BaseWorkerHook)
-            nop (.position hook savedposition)]
-        (.start deser-hook topo-conf worker-topology-context))
-      )))
+      (let [duplicated-hook (.duplicate hook)
+            hook-bytes (Utils/toByteArray duplicated-hook)
+            deser-hook (Utils/javaDeserialize hook-bytes BaseWorkerHook)]
+        (.start deser-hook topo-conf worker-topology-context)))))
 
 (defn run-worker-shutdown-hooks [worker]
   (let [topology (:topology worker)

--- a/storm-core/src/clj/org/apache/storm/daemon/worker.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/worker.clj
@@ -566,12 +566,9 @@
         worker-topology-context (worker-context worker)
         hooks (.get_worker_hooks topology)]
     (dofor [hook hooks]
-      (let [savedposition (.position hook)
-            hook-bytes (Utils/toByteArray hook)
-            deser-hook (Utils/javaDeserialize hook-bytes BaseWorkerHook)
-            nop (.position hook savedposition)]
-        (.start deser-hook topo-conf worker-topology-context))
-      )))
+      (let [hook-bytes (Utils/toByteArray hook)
+            deser-hook (Utils/javaDeserialize hook-bytes BaseWorkerHook)]
+        (.start deser-hook topo-conf worker-topology-context)))))
 
 (defn run-worker-shutdown-hooks [worker]
   (let [topology (:topology worker)

--- a/storm-core/src/clj/org/apache/storm/daemon/worker.clj
+++ b/storm-core/src/clj/org/apache/storm/daemon/worker.clj
@@ -566,10 +566,12 @@
         worker-topology-context (worker-context worker)
         hooks (.get_worker_hooks topology)]
     (dofor [hook hooks]
-      (let [duplicated-hook (.duplicate hook)
-            hook-bytes (Utils/toByteArray duplicated-hook)
-            deser-hook (Utils/javaDeserialize hook-bytes BaseWorkerHook)]
-        (.start deser-hook topo-conf worker-topology-context)))))
+      (let [savedposition (.position hook)
+            hook-bytes (Utils/toByteArray hook)
+            deser-hook (Utils/javaDeserialize hook-bytes BaseWorkerHook)
+            nop (.position hook savedposition)]
+        (.start deser-hook topo-conf worker-topology-context))
+      )))
 
 (defn run-worker-shutdown-hooks [worker]
   (let [topology (:topology worker)


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2979](https://issues.apache.org/jira/browse/STORM-2979)
when using a WorkerHook, shutdown of worker throws
java.lang.RuntimeException: java.io.EOFException 

This fix is against branch 1.0.x.

I don't think that my fix is breaking the U.T like reported by continuous-integration.
I will be happy to help integrating this patch against other branches if needed.