### PR TITLE
STORM-2993: Storm HDFS bolt throws ClosedChannelException when Timed rotation policy is used

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -273,14 +273,16 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
         TimerTask task = new TimerTask() {
             @Override
             public void run() {
-                for (final Writer writer : writers.values()) {
-                    try {
-                        rotateOutputFile(writer);
-                    } catch (IOException e) {
-                        LOG.warn("IOException during scheduled file rotation.", e);
+                synchronized (writeLock) {
+                    for (final Writer writer : writers.values()) {
+                        try {
+                            rotateOutputFile(writer);
+                        } catch (IOException e) {
+                            LOG.warn("IOException during scheduled file rotation.", e);
+                        }
                     }
+                    writers.clear();
                 }
-                writers.clear();
             }
         };
         this.rotationTimer.scheduleAtFixedRate(task, interval, interval);


### PR DESCRIPTION
The TimedRotation should synchronize so that the bolt does not attempt to write to a stale writer.