### PR TITLE
storm-kafka: added ExponentialBackoffMsgRetryManagerSpoutConfig

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/ExponentialBackoffMsgRetryManagerSpoutConfig.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/ExponentialBackoffMsgRetryManagerSpoutConfig.java
@@ -1,0 +1,237 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.kafka;
+
+/**
+ * A spout config for {@link ExponentialBackoffMsgRetryManager}.
+ * @author richter
+ */
+public class ExponentialBackoffMsgRetryManagerSpoutConfig extends SpoutConfig {
+    private static final long serialVersionUID = 1L;
+    /**
+     * The initial retry delay in milliseconds default.
+     */
+    private static final long RETRY_INITIAL_DELAY_MS_DEFAULT = 0;
+    /**
+     * The retry delay multiplier default.
+     */
+    private static final double RETRY_DELAY_MULTIPLIER_DEFAULT = 1.0;
+    /**
+     * The maximum retry delay default.
+     */
+    private static final long RETRY_DELAY_MAX_MS_DEFAULT = 60000;
+    /**
+     * The retry limit default.
+     */
+    private static final int RETRY_LIMIT_DEFAULT = -1;
+    /**
+     * The initial retry delay in milliseconds.
+     */
+    private final long retryInitialDelayMs;
+    /**
+     * The retry delay multiplier.
+     */
+    private final double retryDelayMultiplier;
+    /**
+     * The maximum retry delay.
+     */
+    private final long retryDelayMaxMs;
+    /**
+     * The retry limit.
+     */
+    private final int retryLimit;
+
+    /**
+     * Creates a new spout config.
+     * @param hosts the hosts
+     * @param topic the topic
+     * @param zkRoot the Zookeeper root
+     * @param id the id
+     */
+    public ExponentialBackoffMsgRetryManagerSpoutConfig(final BrokerHosts hosts,
+            final String topic,
+            final String zkRoot,
+            final String id) {
+//        this(RETRY_INITIAL_DELAY_MS_DEFAULT,
+//                RETRY_DELAY_MULTIPLIER_DEFAULT,
+//                RETRY_DELAY_MAX_MS_DEFAULT,
+//                RETRY_LIMIT_DEFAULT,
+//                hosts,
+//                topic,
+//                zkRoot,
+//                id);
+        super(hosts,
+                topic,
+                zkRoot,
+                id);
+        this.retryInitialDelayMs = RETRY_INITIAL_DELAY_MS_DEFAULT;
+        this.retryDelayMultiplier = RETRY_DELAY_MULTIPLIER_DEFAULT;
+        this.retryDelayMaxMs = RETRY_DELAY_MAX_MS_DEFAULT;
+        this.retryLimit = RETRY_LIMIT_DEFAULT;
+    }
+
+    /**
+     * Creates a new spout config.
+     * @param hosts the hosts
+     * @param topic the topic
+     * @param clientId the client id
+     * @param zkRoot the Zookeeper root
+     * @param id the id
+     */
+    public ExponentialBackoffMsgRetryManagerSpoutConfig(final BrokerHosts hosts,
+            final String topic,
+            final String clientId,
+            final String zkRoot,
+            final String id) {
+//        this(RETRY_INITIAL_DELAY_MS_DEFAULT,
+//                RETRY_DELAY_MULTIPLIER_DEFAULT,
+//                RETRY_DELAY_MAX_MS_DEFAULT,
+//                RETRY_LIMIT_DEFAULT,
+//                hosts,
+//                topic,
+//                clientId,
+//                zkRoot,
+//                id);
+        super(hosts,
+                topic,
+                clientId,
+                zkRoot,
+                id);
+        this.retryInitialDelayMs = RETRY_INITIAL_DELAY_MS_DEFAULT;
+        this.retryDelayMultiplier = RETRY_DELAY_MULTIPLIER_DEFAULT;
+        this.retryDelayMaxMs = RETRY_DELAY_MAX_MS_DEFAULT;
+        this.retryLimit = RETRY_LIMIT_DEFAULT;
+    }
+
+    /**
+     * Creates a new spout config.
+     * @param retryInitialDelayMsArg the initial retry delay in milliseconds
+     * @param retryDelayMultiplierArg the retry delay multiplier
+     * @param retryDelayMaxMsArg the maximum retry delay
+     * @param retryLimitArg the retry limit
+     */
+    public ExponentialBackoffMsgRetryManagerSpoutConfig(
+            final long retryInitialDelayMsArg,
+            final double retryDelayMultiplierArg,
+            final long retryDelayMaxMsArg,
+            final int retryLimitArg) {
+        super(null,
+                null,
+                null,
+                null);
+        this.retryInitialDelayMs = retryInitialDelayMsArg;
+        this.retryDelayMultiplier = retryDelayMultiplierArg;
+        this.retryDelayMaxMs = retryDelayMaxMsArg;
+        this.retryLimit = retryLimitArg;
+    }
+
+//    /**
+//     * Creates a new spout config.
+//     * @param retryInitialDelayMsArg the initial retry delay in milliseconds
+//     * @param retryDelayMultiplierArg the retry delay multiplier
+//     * @param retryDelayMaxMsArg the maximum retry delay
+//     * @param retryLimitArg the retry limit
+//     * @param hosts the hosts
+//     * @param topic the topic
+//     * @param zkRoot the Zookeeper root
+//     * @param id the id
+//     */
+//    public ExponentialBackoffMsgRetryManagerSpoutConfig(
+//            final long retryInitialDelayMsArg,
+//            final double retryDelayMultiplierArg,
+//            final long retryDelayMaxMsArg,
+//            final int retryLimitArg,
+//            final BrokerHosts hosts,
+//            final String topic,
+//            final String zkRoot,
+//            final String id) {
+//        super(hosts,
+//                topic,
+//                zkRoot,
+//                id);
+//        this.retryInitialDelayMs = retryInitialDelayMsArg;
+//        this.retryDelayMultiplier = retryDelayMultiplierArg;
+//        this.retryDelayMaxMs = retryDelayMaxMsArg;
+//        this.retryLimit = retryLimitArg;
+//    }
+//
+//    /**
+//     * Creates a new spout config.
+//     * @param retryInitialDelayMsArg the initial retry delay in milliseconds
+//     * @param retryDelayMultiplierArg the retry delay multiplier
+//     * @param retryDelayMaxMsArg the maximum retry delay
+//     * @param retryLimitArg the retry limit
+//     * @param hosts the hosts
+//     * @param topic the topic
+//     * @param clientId the client id
+//     * @param zkRoot the Zookeeper root
+//     * @param id the id
+//     */
+//    public ExponentialBackoffMsgRetryManagerSpoutConfig(
+//            final long retryInitialDelayMsArg,
+//            final double retryDelayMultiplierArg,
+//            final long retryDelayMaxMsArg,
+//            final int retryLimitArg,
+//            final BrokerHosts hosts,
+//            final String topic,
+//            final String clientId,
+//            final String zkRoot,
+//            final String id) {
+//        super(hosts,
+//                topic,
+//                clientId,
+//                zkRoot,
+//                id);
+//        this.retryInitialDelayMs = retryInitialDelayMsArg;
+//        this.retryDelayMultiplier = retryDelayMultiplierArg;
+//        this.retryDelayMaxMs = retryDelayMaxMsArg;
+//        this.retryLimit = retryLimitArg;
+//    }
+
+    /**
+     * Gets the initial retry delay in milliseconds.
+     * @return the retryInitialDelayMs
+     */
+    public long getRetryInitialDelayMs() {
+        return retryInitialDelayMs;
+    }
+
+    /**
+     * Gets the retry delay multiplier.
+     * @return the retryDelayMultiplier
+     */
+    public double getRetryDelayMultiplier() {
+        return retryDelayMultiplier;
+    }
+
+    /**
+     * Gets the maximum retry delay in milliseconds.
+     * @return the retryDelayMaxMs
+     */
+    public long getRetryDelayMaxMs() {
+        return retryDelayMaxMs;
+    }
+
+    /**
+     * Gets the retry limit.
+     * @return the retryLimit
+     */
+    public int getRetryLimit() {
+        return retryLimit;
+    }
+}

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/FailedMsgRetryManager.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/FailedMsgRetryManager.java
@@ -21,12 +21,20 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 
-public interface FailedMsgRetryManager extends Serializable {
+/**
+ * Manages retrying of sending failed messages.
+ * @author unknown
+ * @param <S> the type of spout config to use
+ */
+public interface FailedMsgRetryManager<S extends SpoutConfig>
+        extends Serializable {
 
     /**
-     * Initialization
+     * Initialization.
+     * @param spoutConfig the spout configuration to use
+     * @param topoConf the topology configuration to use
      */
-    void prepare(SpoutConfig spoutConfig, Map<String, Object> topoConf);
+    void prepare(S spoutConfig, Map<String, Object> topoConf);
 
     /**
      * Message corresponding to the offset failed in kafka spout.

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaSpout.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaSpout.java
@@ -43,7 +43,7 @@ public class KafkaSpout extends BaseRichSpout {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSpout.class);
 
-    SpoutConfig _spoutConfig;
+    ExponentialBackoffMsgRetryManagerSpoutConfig _spoutConfig;
     SpoutOutputCollector _collector;
     PartitionCoordinator _coordinator;
     DynamicPartitionConnections _connections;
@@ -53,7 +53,7 @@ public class KafkaSpout extends BaseRichSpout {
 
     int _currPartitionIndex = 0;
 
-    public KafkaSpout(SpoutConfig spoutConf) {
+    public KafkaSpout(ExponentialBackoffMsgRetryManagerSpoutConfig spoutConf) {
         _spoutConfig = spoutConf;
     }
 

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
@@ -38,7 +38,15 @@ import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.MessageAndOffset;
 
-public class PartitionManager {
+/**
+ * Manages partitions.
+ * @author unknown
+ * @param <S> the type of spout config required by the
+ * {@link FailedMsgRetryManager}
+ * @param <F> the type of {@link FailedMsgRetryManager}
+ */
+public class PartitionManager<S extends SpoutConfig,
+        F extends FailedMsgRetryManager<S>> {
     private static final Logger LOG = LoggerFactory.getLogger(PartitionManager.class);
 
     private final CombinedMetric _fetchAPILatencyMax;
@@ -50,78 +58,142 @@ public class PartitionManager {
     // Count of messages which were not retried because failedMsgRetryManager didn't consider offset eligible for
     // retry
     private final CountMetric _messageIneligibleForRetryCount;
-    Long _emittedToOffset;
+    Long emittedToOffset;
     // _pending key = Kafka offset, value = time at which the message was first submitted to the topology
-    private SortedMap<Long,Long> _pending = new TreeMap<Long,Long>();
-    private final FailedMsgRetryManager _failedMsgRetryManager;
+    private SortedMap<Long,Long> pending = new TreeMap<Long,Long>();
+    private final F failedMsgRetryManager;
 
     // retryRecords key = Kafka offset, value = retry info for the given message
-    Long _committedTo;
-    LinkedList<MessageAndOffset> _waitingToEmit = new LinkedList<MessageAndOffset>();
+    Long committedTo;
+    LinkedList<MessageAndOffset> waitingToEmit = new LinkedList<MessageAndOffset>();
     Partition _partition;
-    SpoutConfig _spoutConfig;
+    S spoutConfig;
     String _topologyInstanceId;
     SimpleConsumer _consumer;
-    DynamicPartitionConnections _connections;
-    ZkState _state;
-    Map _topoConf;
+    DynamicPartitionConnections connections;
+    ZkState state;
+    Map topoConf;
     long numberFailed, numberAcked;
 
+    /**
+     * Creates a new partition manager.
+     * @param connectionsArg the connections to use
+     * @param topologyInstanceIdArg the topology id
+     * @param stateArg the initial state
+     * @param topoConfArg the topology configuration
+     * @param spoutConfigArg the spout configuration
+     * @param idArg the id to use
+     * @param previousManager previous partition manager if manager for
+     * partition is being recreated
+     */
     public PartitionManager(
-            DynamicPartitionConnections connections,
-            String topologyInstanceId,
-            ZkState state,
-            Map<String, Object> topoConf,
-            SpoutConfig spoutConfig,
-            Partition id)
+            final DynamicPartitionConnections connectionsArg,
+            final String topologyInstanceIdArg,
+            final ZkState stateArg,
+            final Map<String, Object> topoConfArg,
+            final S spoutConfigArg,
+            final Partition idArg,
+            final PartitionManager<S, F> previousManager)
     {
-        this(connections, topologyInstanceId, state, topoConf, spoutConfig, id, null);
+        this(connectionsArg,
+                topologyInstanceIdArg,
+                stateArg,
+                topoConfArg,
+                spoutConfigArg,
+                idArg,
+                previousManager.failedMsgRetryManager,
+                previousManager.committedTo,
+                previousManager.emittedToOffset,
+                previousManager.waitingToEmit,
+                previousManager.pending,
+                false //init
+        );
     }
 
     /**
-     * @param previousManager previous partition manager if manager for partition is being recreated
+     * Creates a new partition manager.
+     * @param connectionsArg the connections to use
+     * @param topologyInstanceIdArg the topology id
+     * @param stateArg the initial state
+     * @param topoConfArg the topology configuration
+     * @param spoutConfigArg the spout configuration
+     * @param idArg the id to use
+     * @param failedMsgRetryManagerArg the failed message retry manager
      */
     public PartitionManager(
-            DynamicPartitionConnections connections,
-            String topologyInstanceId,
-            ZkState state,
-            Map<String, Object> topoConf,
-            SpoutConfig spoutConfig,
-            Partition id,
-            PartitionManager previousManager) {
+            final DynamicPartitionConnections connectionsArg,
+            final String topologyInstanceIdArg,
+            final ZkState stateArg,
+            final Map<String, Object> topoConfArg,
+            final S spoutConfigArg,
+            final Partition idArg,
+            final F failedMsgRetryManagerArg) {
+        this(connectionsArg,
+                topologyInstanceIdArg,
+                stateArg,
+                topoConfArg,
+                spoutConfigArg,
+                idArg,
+                failedMsgRetryManagerArg,
+                0l,
+                0l,
+                new LinkedList<>(),
+                new TreeMap<>(),
+                true);
+    }
+
+    /**
+     * Creates a new partition manager.
+     * @param connectionsArg the connections to use
+     * @param topologyInstanceIdArg the topology id
+     * @param stateArg the initial state
+     * @param topoConfArg the topology configuration
+     * @param spoutConfigArg the spout configuration
+     * @param idArg the id to use
+     * @param failedMsgRetryManagerArg the failed message retry manager
+     * @param committedTo the committed
+     * @param emittedToOffset the emitted offset
+     * @param waitingToEmit the initial waiting to emit queue
+     * @param pending the initial pending queue
+     * @param init flag to run the init routine
+     */
+    public PartitionManager(
+            final DynamicPartitionConnections connections,
+            final String topologyInstanceId,
+            final ZkState state,
+            final Map<String, Object> topoConf,
+            final S spoutConfig,
+            final Partition id,
+            final F failedMsgRetryManager,
+            final Long committedTo,
+            final Long emittedToOffset,
+            final LinkedList<MessageAndOffset> waitingToEmit,
+            final SortedMap<Long,Long> pending,
+            final boolean init) {
         _partition = id;
-        _connections = connections;
-        _spoutConfig = spoutConfig;
+        this.connections = connections;
+        this.spoutConfig = spoutConfig;
         _topologyInstanceId = topologyInstanceId;
         _consumer = connections.register(id.host, id.topic, id.partition);
-        _state = state;
-        _topoConf = topoConf;
+        this.state = state;
+        this.topoConf = topoConf;
         numberAcked = numberFailed = 0;
-
-        if (previousManager != null) {
-            _failedMsgRetryManager = previousManager._failedMsgRetryManager;
-            _committedTo = previousManager._committedTo;
-            _emittedToOffset = previousManager._emittedToOffset;
-            _waitingToEmit = previousManager._waitingToEmit;
-            _pending = previousManager._pending;
-            LOG.info("Recreating PartitionManager based on previous manager, _waitingToEmit size: {}, _pending size: {}",
-                    _waitingToEmit.size(),
-                    _pending.size());
-        } else {
-            try {
-                _failedMsgRetryManager = (FailedMsgRetryManager) Class.forName(spoutConfig.failedMsgRetryManagerClass).newInstance();
-                _failedMsgRetryManager.prepare(spoutConfig, _topoConf);
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-                throw new IllegalArgumentException(String.format("Failed to create an instance of <%s> from: <%s>",
-                        FailedMsgRetryManager.class,
-                        spoutConfig.failedMsgRetryManagerClass), e);
-            }
+        this.failedMsgRetryManager = failedMsgRetryManager;
+        this.committedTo = committedTo;
+        this.emittedToOffset = emittedToOffset;
+        this.waitingToEmit = waitingToEmit;
+        this.pending = pending;
+        LOG.info("Recreating PartitionManager based on previous manager, _waitingToEmit size: {}, _pending size: {}",
+                waitingToEmit.size(),
+                pending.size());
+        if (init) {
+            failedMsgRetryManager.prepare(spoutConfig, this.topoConf);
 
             String jsonTopologyId = null;
             Long jsonOffset = null;
             String path = committedPath();
             try {
-                Map<Object, Object> json = _state.readJSON(path);
+                Map<Object, Object> json = this.state.readJSON(path);
                 LOG.info("Read partition information from: " + path + "  --> " + json);
                 if (json != null) {
                     jsonTopologyId = (String) ((Map<Object, Object>) json.get("topology")).get("id");
@@ -135,26 +207,26 @@ public class PartitionManager {
             Long currentOffset = KafkaUtils.getOffset(_consumer, topic, id.partition, spoutConfig);
 
             if (jsonTopologyId == null || jsonOffset == null) { // failed to parse JSON?
-                _committedTo = currentOffset;
+                this.committedTo = currentOffset;
                 LOG.info("No partition information found, using configuration to determine offset");
             } else if (!topologyInstanceId.equals(jsonTopologyId) && spoutConfig.ignoreZkOffsets) {
-                _committedTo = KafkaUtils.getOffset(_consumer, topic, id.partition, spoutConfig.startOffsetTime);
+                this.committedTo = KafkaUtils.getOffset(_consumer, topic, id.partition, spoutConfig.startOffsetTime);
                 LOG.info("Topology change detected and ignore zookeeper offsets set to true, using configuration to determine offset");
             } else {
-                _committedTo = jsonOffset;
-                LOG.info("Read last commit offset from zookeeper: " + _committedTo + "; old topology_id: " + jsonTopologyId + " - new topology_id: " + topologyInstanceId);
+                this.committedTo = jsonOffset;
+                LOG.info("Read last commit offset from zookeeper: " + this.committedTo + "; old topology_id: " + jsonTopologyId + " - new topology_id: " + topologyInstanceId);
             }
 
-            if (currentOffset - _committedTo > spoutConfig.maxOffsetBehind || _committedTo <= 0) {
-                LOG.info("Last commit offset from zookeeper: " + _committedTo);
-                Long lastCommittedOffset = _committedTo;
-                _committedTo = currentOffset;
+            if (currentOffset - this.committedTo > spoutConfig.maxOffsetBehind || this.committedTo <= 0) {
+                LOG.info("Last commit offset from zookeeper: " + this.committedTo);
+                Long lastCommittedOffset = this.committedTo;
+                this.committedTo = currentOffset;
                 LOG.info("Commit offset " + lastCommittedOffset + " is more than " +
                         spoutConfig.maxOffsetBehind + " behind latest offset " + currentOffset + ", resetting to startOffsetTime=" + spoutConfig.startOffsetTime);
             }
 
-            LOG.info("Starting Kafka " + _consumer.host() + " " + id + " from offset " + _committedTo);
-            _emittedToOffset = _committedTo;
+            LOG.info("Starting Kafka " + _consumer.host() + " " + id + " from offset " + this.committedTo);
+            this.emittedToOffset = this.committedTo;
         }
 
         _fetchAPILatencyMax = new CombinedMetric(new MaxMetric());
@@ -180,26 +252,26 @@ public class PartitionManager {
 
     //returns false if it's reached the end of current batch
     public EmitState next(SpoutOutputCollector collector) {
-        if (_waitingToEmit.isEmpty()) {
+        if (waitingToEmit.isEmpty()) {
             fill();
         }
         while (true) {
-            MessageAndOffset toEmit = _waitingToEmit.pollFirst();
+            MessageAndOffset toEmit = waitingToEmit.pollFirst();
             if (toEmit == null) {
                 return EmitState.NO_EMITTED;
             }
 
             Iterable<List<Object>> tups;
-            if (_spoutConfig.scheme instanceof MessageMetadataSchemeAsMultiScheme) {
-                tups = KafkaUtils.generateTuples((MessageMetadataSchemeAsMultiScheme) _spoutConfig.scheme, toEmit.message(), _partition, toEmit.offset());
+            if (spoutConfig.scheme instanceof MessageMetadataSchemeAsMultiScheme) {
+                tups = KafkaUtils.generateTuples((MessageMetadataSchemeAsMultiScheme) spoutConfig.scheme, toEmit.message(), _partition, toEmit.offset());
             } else {
-                tups = KafkaUtils.generateTuples(_spoutConfig, toEmit.message(), _partition.topic);
+                tups = KafkaUtils.generateTuples(spoutConfig, toEmit.message(), _partition.topic);
             }
 
             if ((tups != null) && tups.iterator().hasNext()) {
-               if (!Strings.isNullOrEmpty(_spoutConfig.outputStreamId)) {
+               if (!Strings.isNullOrEmpty(spoutConfig.outputStreamId)) {
                     for (List<Object> tup : tups) {
-                        collector.emit(_spoutConfig.outputStreamId, tup, new KafkaMessageId(_partition, toEmit.offset()));
+                        collector.emit(spoutConfig.outputStreamId, tup, new KafkaMessageId(_partition, toEmit.offset()));
                     }
                 } else {
                     for (List<Object> tup : tups) {
@@ -211,7 +283,7 @@ public class PartitionManager {
                 ack(toEmit.offset());
             }
         }
-        if (!_waitingToEmit.isEmpty()) {
+        if (!waitingToEmit.isEmpty()) {
             return EmitState.EMITTED_MORE_LEFT;
         } else {
             return EmitState.EMITTED_END;
@@ -224,15 +296,15 @@ public class PartitionManager {
         Long offset;
 
         // Are there failed tuples? If so, fetch those first.
-        offset = this._failedMsgRetryManager.nextFailedMessageToRetry();
+        offset = this.failedMsgRetryManager.nextFailedMessageToRetry();
         final boolean processingNewTuples = (offset == null);
         if (processingNewTuples) {
-            offset = _emittedToOffset;
+            offset = emittedToOffset;
         }
 
         ByteBufferMessageSet msgs = null;
         try {
-            msgs = KafkaUtils.fetchMessages(_spoutConfig, _consumer, _partition, offset);
+            msgs = KafkaUtils.fetchMessages(spoutConfig, _consumer, _partition, offset);
         } catch (TopicOffsetOutOfRangeException e) {
             offset = KafkaUtils.getOffset(_consumer, _partition.topic, _partition.partition, kafka.api.OffsetRequest.EarliestTime());
             // fetch failed, so don't update the fetch metrics
@@ -243,22 +315,22 @@ public class PartitionManager {
                 // all the failed offsets, that are earlier than actual EarliestTime
                 // offset, since they are anyway not there.
                 // These calls to broker API will be then saved.
-                Set<Long> omitted = this._failedMsgRetryManager.clearOffsetsBefore(offset);
+                Set<Long> omitted = this.failedMsgRetryManager.clearOffsetsBefore(offset);
 
                 // Omitted messages have not been acked and may be lost
                 if (null != omitted) {
                     _lostMessageCount.incrBy(omitted.size());
                 }
 
-                _pending.headMap(offset).clear();
+                pending.headMap(offset).clear();
 
                 LOG.warn("Removing the failed offsets for {} that are out of range: {}", _partition, omitted);
             }
 
-            if (offset > _emittedToOffset) {
-                _lostMessageCount.incrBy(offset - _emittedToOffset);
-                _emittedToOffset = offset;
-                LOG.warn("{} Using new offset: {}", _partition, _emittedToOffset);
+            if (offset > emittedToOffset) {
+                _lostMessageCount.incrBy(offset - emittedToOffset);
+                emittedToOffset = offset;
+                LOG.warn("{} Using new offset: {}", _partition, emittedToOffset);
             }
 
             return;
@@ -276,15 +348,15 @@ public class PartitionManager {
                     // Skip any old offsets.
                     continue;
                 }
-                if (processingNewTuples || this._failedMsgRetryManager.shouldReEmitMsg(cur_offset)) {
+                if (processingNewTuples || this.failedMsgRetryManager.shouldReEmitMsg(cur_offset)) {
                     numMessages += 1;
-                    if (!_pending.containsKey(cur_offset)) {
-                        _pending.put(cur_offset, System.currentTimeMillis());
+                    if (!pending.containsKey(cur_offset)) {
+                        pending.put(cur_offset, System.currentTimeMillis());
                     }
-                    _waitingToEmit.add(msg);
-                    _emittedToOffset = Math.max(msg.nextOffset(), _emittedToOffset);
-                    if (_failedMsgRetryManager.shouldReEmitMsg(cur_offset)) {
-                        this._failedMsgRetryManager.retryStarted(cur_offset);
+                    waitingToEmit.add(msg);
+                    emittedToOffset = Math.max(msg.nextOffset(), emittedToOffset);
+                    if (failedMsgRetryManager.shouldReEmitMsg(cur_offset)) {
+                        this.failedMsgRetryManager.retryStarted(cur_offset);
                     }
                 }
             }
@@ -293,62 +365,61 @@ public class PartitionManager {
     }
 
     public void ack(Long offset) {
-        if (!_pending.isEmpty() && _pending.firstKey() < offset - _spoutConfig.maxOffsetBehind) {
+        if (!pending.isEmpty() && pending.firstKey() < offset - spoutConfig.maxOffsetBehind) {
             // Too many things pending!
-            _pending.headMap(offset - _spoutConfig.maxOffsetBehind).clear();
+            pending.headMap(offset - spoutConfig.maxOffsetBehind).clear();
         }
-        _pending.remove(offset);
-        this._failedMsgRetryManager.acked(offset);
+        pending.remove(offset);
+        this.failedMsgRetryManager.acked(offset);
         numberAcked++;
     }
 
     public void fail(Long offset) {
-        if (offset < _emittedToOffset - _spoutConfig.maxOffsetBehind) {
-            LOG.info(
-                    "Skipping failed tuple at offset={}" +
+        if (offset < emittedToOffset - spoutConfig.maxOffsetBehind) {
+            LOG.info("Skipping failed tuple at offset={}" +
                         " because it's more than maxOffsetBehind={}" +
                         " behind _emittedToOffset={} for {}",
                 offset,
-                _spoutConfig.maxOffsetBehind,
-                _emittedToOffset,
+                spoutConfig.maxOffsetBehind,
+                emittedToOffset,
                 _partition
             );
         } else {
-            LOG.debug("Failing at offset={} with _pending.size()={} pending and _emittedToOffset={} for {}", offset, _pending.size(), _emittedToOffset, _partition);
+            LOG.debug("Failing at offset={} with _pending.size()={} pending and _emittedToOffset={} for {}", offset, pending.size(), emittedToOffset, _partition);
             numberFailed++;
-            if (numberAcked == 0 && numberFailed > _spoutConfig.maxOffsetBehind) {
+            if (numberAcked == 0 && numberFailed > spoutConfig.maxOffsetBehind) {
                 throw new RuntimeException("Too many tuple failures");
             }
 
             // Offset may not be considered for retry by failedMsgRetryManager
-            if (this._failedMsgRetryManager.retryFurther(offset)) {
-                this._failedMsgRetryManager.failed(offset);
+            if (this.failedMsgRetryManager.retryFurther(offset)) {
+                this.failedMsgRetryManager.failed(offset);
             } else {
                 // state for the offset should be cleaned up
                 LOG.warn("Will not retry failed kafka offset {} further", offset);
                 _messageIneligibleForRetryCount.incr();
-                this._failedMsgRetryManager.cleanOffsetAfterRetries(_partition, offset);
-                _pending.remove(offset);
-                this._failedMsgRetryManager.acked(offset);
+                this.failedMsgRetryManager.cleanOffsetAfterRetries(_partition, offset);
+                pending.remove(offset);
+                this.failedMsgRetryManager.acked(offset);
             }
         }
     }
 
     public void commit() {
         long lastCompletedOffset = lastCompletedOffset();
-        if (_committedTo != lastCompletedOffset) {
+        if (committedTo != lastCompletedOffset) {
             LOG.debug("Writing last completed offset ({}) to ZK for {} for topology: {}", lastCompletedOffset, _partition, _topologyInstanceId);
             Map<Object, Object> data = (Map<Object, Object>) ImmutableMap.builder()
                     .put("topology", ImmutableMap.of("id", _topologyInstanceId,
-                            "name", _topoConf.get(Config.TOPOLOGY_NAME)))
+                            "name", topoConf.get(Config.TOPOLOGY_NAME)))
                     .put("offset", lastCompletedOffset)
                     .put("partition", _partition.partition)
                     .put("broker", ImmutableMap.of("host", _partition.host.host,
                             "port", _partition.host.port))
                     .put("topic", _partition.topic).build();
-            _state.writeJSON(committedPath(), data);
+            state.writeJSON(committedPath(), data);
 
-            _committedTo = lastCompletedOffset;
+            committedTo = lastCompletedOffset;
             LOG.debug("Wrote last completed offset ({}) to ZK for {} for topology: {}", lastCompletedOffset, _partition, _topologyInstanceId);
         } else {
             LOG.debug("No new offset for {} for topology: {}", _partition, _topologyInstanceId);
@@ -356,19 +427,19 @@ public class PartitionManager {
     }
 
     protected String committedPath() {
-        return _spoutConfig.zkRoot + "/" + _spoutConfig.id + "/" + _partition.getId();
+        return spoutConfig.zkRoot + "/" + spoutConfig.id + "/" + _partition.getId();
     }
 
     public long lastCompletedOffset() {
-        if (_pending.isEmpty()) {
-            return _emittedToOffset;
+        if (pending.isEmpty()) {
+            return emittedToOffset;
         } else {
-            return _pending.firstKey();
+            return pending.firstKey();
         }
     }
 
     public OffsetData getOffsetData() {
-        return new OffsetData(_emittedToOffset, lastCompletedOffset());
+        return new OffsetData(emittedToOffset, lastCompletedOffset());
     }
 
     public Partition getPartition() {
@@ -377,7 +448,7 @@ public class PartitionManager {
 
     public void close() {
         commit();
-        _connections.unregister(_partition.host, _partition.topic , _partition.partition);
+        connections.unregister(_partition.host, _partition.topic , _partition.partition);
     }
 
     static class KafkaMessageId implements Serializable {

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/SpoutConfig.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/SpoutConfig.java
@@ -36,13 +36,6 @@ public class SpoutConfig extends KafkaConfig implements Serializable {
     // Retry strategy for failed messages
     public String failedMsgRetryManagerClass = ExponentialBackoffMsgRetryManager.class.getName();
 
-    // Exponential back-off retry settings.  These are used by ExponentialBackoffMsgRetryManager for retrying messages after a bolt
-    // calls OutputCollector.fail(). These come into effect only if ExponentialBackoffMsgRetryManager is being used.
-    public long retryInitialDelayMs = 0;
-    public double retryDelayMultiplier = 1.0;
-    public long retryDelayMaxMs = 60 * 1000;
-    public int retryLimit = -1;
-
     /**
      * Create a SpoutConfig without setting client.id, which can make the source application ambiguous when tracing Kafka calls.
      */

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/StaticCoordinator.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/StaticCoordinator.java
@@ -26,14 +26,28 @@ public class StaticCoordinator implements PartitionCoordinator {
     Map<Partition, PartitionManager> _managers = new HashMap<Partition, PartitionManager>();
     List<PartitionManager> _allManagers = new ArrayList<>();
 
-    public StaticCoordinator(DynamicPartitionConnections connections, Map<String, Object> topoConf, SpoutConfig config, ZkState state,
-            int taskIndex, int totalTasks, int taskId, String topologyInstanceId) {
+    public StaticCoordinator(DynamicPartitionConnections connections,
+            Map<String, Object> topoConf,
+            SpoutConfig config,
+            ZkState state,
+            int taskIndex,
+            int totalTasks,
+            int taskId,
+            String topologyInstanceId) {
         StaticHosts hosts = (StaticHosts) config.hosts;
         List<GlobalPartitionInformation> partitions = new ArrayList<GlobalPartitionInformation>();
         partitions.add(hosts.getPartitionInformation());
         List<Partition> myPartitions = KafkaUtils.calculatePartitionsForTask(partitions, totalTasks, taskIndex, taskId);
         for (Partition myPartition : myPartitions) {
-            _managers.put(myPartition, new PartitionManager(connections, topologyInstanceId, state, topoConf, config, myPartition));
+            FailedMsgRetryManager failedMsgRetryManager = new ExponentialBackoffMsgRetryManager();
+            _managers.put(myPartition, new PartitionManager(connections,
+                    topologyInstanceId,
+                    state,
+                    topoConf,
+                    config,
+                    myPartition,
+                    failedMsgRetryManager
+            ));
         }
         _allManagers = new ArrayList<>(_managers.values());
     }

--- a/external/storm-kafka/src/test/org/apache/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/ExponentialBackoffMsgRetryManagerTest.java
@@ -267,17 +267,29 @@ public class ExponentialBackoffMsgRetryManagerTest {
 
         assertFalse(manager.retryFurther(TEST_OFFSET));
     }
-    
-    private ExponentialBackoffMsgRetryManager buildExponentialBackoffMsgRetryManager(long retryInitialDelayMs, 
-                                                                                     double retryDelayMultiplier,
-                                                                                     long retryDelayMaxMs,
-                                                                                     int retryLimit) {
-        SpoutConfig spoutConfig = new SpoutConfig(null, null, null, null);
-        spoutConfig.retryInitialDelayMs = retryInitialDelayMs;
-        spoutConfig.retryDelayMultiplier = retryDelayMultiplier;
-        spoutConfig.retryDelayMaxMs = retryDelayMaxMs;
-        spoutConfig.retryLimit = retryLimit; 
-        ExponentialBackoffMsgRetryManager exponentialBackoffMsgRetryManager = new ExponentialBackoffMsgRetryManager();
+
+    /**
+     * Creates a {@link ExponentialBackoffMsgRetryManager} with the specified
+     * values.
+     * @param retryInitialDelayMs the initial retry delay in milliseconds
+     * @param retryDelayMultiplier the retry delay multiplier
+     * @param retryDelayMaxMs the maximum retry delay
+     * @param retryLimit the retry limit
+     * @return the created retry manager
+     */
+    private ExponentialBackoffMsgRetryManager
+        buildExponentialBackoffMsgRetryManager(final long retryInitialDelayMs,
+                final double retryDelayMultiplier,
+                final long retryDelayMaxMs,
+                final int retryLimit) {
+        ExponentialBackoffMsgRetryManagerSpoutConfig spoutConfig =
+                new ExponentialBackoffMsgRetryManagerSpoutConfig(
+                        retryInitialDelayMs,
+                        retryDelayMultiplier,
+                        retryDelayMaxMs,
+                        retryLimit);
+        ExponentialBackoffMsgRetryManager exponentialBackoffMsgRetryManager =
+                new ExponentialBackoffMsgRetryManager();
         exponentialBackoffMsgRetryManager.prepare(spoutConfig, null);
         return exponentialBackoffMsgRetryManager;
     }

--- a/external/storm-kafka/src/test/org/apache/storm/kafka/PartitionManagerTest.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/PartitionManagerTest.java
@@ -76,7 +76,7 @@ public class PartitionManagerTest {
 
         ZkHosts zkHosts = new ZkHosts(broker.getZookeeperConnectionString());
 
-        SpoutConfig spoutConfig = new SpoutConfig(zkHosts, TOPIC_NAME, "/test", "id");
+        ExponentialBackoffMsgRetryManagerSpoutConfig spoutConfig = new ExponentialBackoffMsgRetryManagerSpoutConfig(zkHosts, TOPIC_NAME, "/test", "id");
 
         coordinator = new ZkCoordinator(
             new DynamicPartitionConnections(spoutConfig, new ZkBrokerReader(conf, TOPIC_NAME, zkHosts)),

--- a/external/storm-kafka/src/test/org/apache/storm/kafka/ZkCoordinatorTest.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/ZkCoordinatorTest.java
@@ -45,7 +45,7 @@ public class ZkCoordinatorTest {
     private KafkaTestBroker broker = new KafkaTestBroker();
     private TestingServer server;
     private Map<String, Object> topoConf = new HashMap();
-    private SpoutConfig spoutConfig;
+    private ExponentialBackoffMsgRetryManagerSpoutConfig spoutConfig;
     private ZkState state;
     private SimpleConsumer simpleConsumer;
 
@@ -56,7 +56,7 @@ public class ZkCoordinatorTest {
         String connectionString = server.getConnectString();
         ZkHosts hosts = new ZkHosts(connectionString);
         hosts.refreshFreqSecs = 1;
-        spoutConfig = new SpoutConfig(hosts, "topic", "/test", "id");
+        spoutConfig = new ExponentialBackoffMsgRetryManagerSpoutConfig(hosts, "topic", "/test", "id");
         Map<String, Object> conf = buildZookeeperConfig(server);
         state = new ZkState(conf);
         simpleConsumer = new SimpleConsumer("localhost", broker.getPort(), 60000, 1024, "testClient");
@@ -145,9 +145,9 @@ public class ZkCoordinatorTest {
         assertNotNull(managerBefore);
         assertNotNull(managerAfter);
         assertNotSame(managerBefore, managerAfter);
-        assertSame(managerBefore._waitingToEmit, managerAfter._waitingToEmit);
-        assertSame(managerBefore._emittedToOffset, managerAfter._emittedToOffset);
-        assertSame(managerBefore._committedTo, managerAfter._committedTo);
+        assertSame(managerBefore.waitingToEmit, managerAfter.waitingToEmit);
+        assertSame(managerBefore.emittedToOffset, managerAfter.emittedToOffset);
+        assertSame(managerBefore.committedTo, managerAfter.committedTo);
     }
 
     private void assertPartitionsAreDifferent(List<PartitionManager> partitionManagersBefore, List<PartitionManager> partitionManagersAfter, int partitionsPerTask) {


### PR DESCRIPTION
Only `ExponentialBackoffMsgRetryManager` uses `SpoutConfig.retryInitialDelayMs`, `retryDelayMultiplier`, `retryDelayMaxMs` and `retryLimit` which means that those properties should be moved to a subclass `ExponentialBackoffMsgRetryManagerSpoutConfig` and the type be enforced through class parameters. Since `ExponentialBackoffMsgRetryManager` is the only `FailedMsgRetryManager` is the only implementation there's no need to make excessive use of class parameter since that flexibility is YAGNI.

Furthermore the properties are declared redundantly in `ExponentialBackoffMsgRetryManager` and `SpoutConfig`.

I don't seem to figure out how to find which new checkstyle violations the PR introduces, so I had to guess which changes caused the temporary increase in violations.

The larger portion of commented out code is left there since checkstyle value for NumberParameter of 7 seems overkill and at least constructors should be allowed to be much longer, we should talk about that on the mailing list.

The initialization of `FailedMsgRetryManager` through reflection in undocumented and seem unnecessary.

I got the note that apache-kafka might be removed from the project. I'm working with this code and want to share my work. I'd be happy if you take the time for review.