### PR TITLE
[STORM-2998]Wrong className in LoggerFactory.getLogger method

### DIFF
--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/LoadMetricsServer.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/LoadMetricsServer.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  * A metrics server that records and reports metrics for a set of running topologies.
  */
 public class LoadMetricsServer extends HttpForwardingMetricsServer {
-    private static final Logger LOG = LoggerFactory.getLogger(HttpForwardingMetricsServer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LoadMetricsServer.class);
 
     private static class MemMeasure {
         private long mem = 0;

--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/ThroughputVsLatency.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/ThroughputVsLatency.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * proper latency statistics.
  */
 public class ThroughputVsLatency {
-    private static final Logger LOG = LoggerFactory.getLogger(GenLoad.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ThroughputVsLatency.class);
     private static final int TEST_EXECUTE_TIME_DEFAULT = 5;
     private static final long DEFAULT_RATE_PER_SECOND = 500;
     private static final String DEFAULT_TOPO_NAME = "wc-test";


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-2998](https://issues.apache.org/jira/browse/STORM-2998)
If we use LoggerFactory.getLogger method in a class,the most accurate approach is use this class as a parameter.