### PR TITLE
STORM-3005-Removed deprecation from LinearDRPCTopologyBuilder.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/drpc/LinearDRPCTopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/LinearDRPCTopologyBuilder.java
@@ -50,9 +50,7 @@ import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.tuple.Fields;
 
 
-// Trident subsumes the functionality provided by this class, so it's deprecated
-@Deprecated
-public class LinearDRPCTopologyBuilder {    
+public class LinearDRPCTopologyBuilder {
     String function;
     List<Component> components = new ArrayList<>();
     


### PR DESCRIPTION
Users may still want to use LinearDRPCTopologyBuilder even though they don't use Trident.