### PR TITLE
STORM-3009: Upgrade to Dropwizard 1.3.0, and ensure storm-webapp has …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <wagonVersion>1.0</wagonVersion>
         <azure-eventhubs.version>0.13.1</azure-eventhubs.version>
         <jersey.version>2.24.1</jersey.version>
-        <dropwizard.version>1.1.2</dropwizard.version>
+        <dropwizard.version>1.3.0</dropwizard.version>
         <j2html.version>1.0.0</j2html.version>
         <jool.version>0.9.12</jool.version>
         <caffeine.version>2.3.5</caffeine.version>

--- a/storm-webapp/pom.xml
+++ b/storm-webapp/pom.xml
@@ -43,12 +43,6 @@
             <scope>compile</scope>
         </dependency> 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>compile</scope>
@@ -56,6 +50,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
+            <!-- This is present in the Storm /lib directory, and should not also be present in /lib-webapp since both are on the classpath -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
@@ -88,16 +88,16 @@
             <version>${dropwizard.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>log4j-over-slf4j</artifactId>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jcl-over-slf4j</artifactId>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-access</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
…only one SLF4j binding on the classpath

https://issues.apache.org/jira/browse/STORM-3009

Verified that the logviewer still works after this change. While the Dropwizard documentation (https://github.com/dropwizard/dropwizard/pull/1900) mentions that we should add a configuration parameter to make this work, I can't find anywhere in storm-webapp where Dropwizard is actually started, nor do we seem to have a Dropwizard configuration file, so I suspect it's not necessary.