### PR TITLE
STORM-2924 Fix intermittent test failure in org.apache.storm.TickTupl…

### DIFF
--- a/storm-server/src/test/java/org/apache/storm/TickTupleTest.java
+++ b/storm-server/src/test/java/org/apache/storm/TickTupleTest.java
@@ -55,8 +55,9 @@ public class TickTupleTest {
             try (ILocalTopology topo = cluster.submitTopology("test", topoConf,  topology)) {
                 //Give the topology some time to come up
                 long time = 0;
+                int timeout = Math.max(Testing.TEST_TIMEOUT_MS, 100_000);
                 while (tickTupleTimes.size() <= 0) {
-                    assert time <= 100_000 : "took over " + time + " ms of simulated time to get a message back...";
+                    assert time <= timeout : "took over " + time + " ms of simulated time to get a message back...";
                     cluster.advanceClusterTime(10);
                     time += 10_000;
                 }


### PR DESCRIPTION
…eTest

* leverages STORM_TEST_TIMEOUT_MS to make timeout being flexible

This change effectively increase test timeout to 150_000 ms described in `travis-script.sh`.