### PR TITLE
[STORM-2983] fix the issue that the inter-worker transfer thread is not spun up on some cases on RAS cluster

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -718,6 +718,10 @@ public class WorkerState {
         return outboundTasks;
     }
 
+    public Set<Integer> getOutboundTasks() {
+        return this.outboundTasks;
+    }
+
     public void haltWorkerTransfer() {
         workerTransfer.haltTransferThd();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2983

Because the number of workers are dynamically calculated on RAS and is not populated to SupervisorStormConf, by default `topologyConf.get(Config.TOPOLOGY_WORKERS)`  returns 1 and the transferThread is not launched. Some topologies like 
```
bin/storm jar storm-loadgen-*.jar org.apache.storm.loadgen.ThroughputVsLatency --spouts 1 --splitters 2 --counters 1 -c topology.debug=true
```
on RAS cluster are not working properly.