### PR TITLE
STORM-3005-1.1.x-removed-deprecation-LinearDRPCTopologyBuilder

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/drpc/LinearDRPCTopologyBuilder.java
+++ b/storm-core/src/jvm/org/apache/storm/drpc/LinearDRPCTopologyBuilder.java
@@ -44,9 +44,7 @@ import java.util.List;
 import java.util.Map;
 
 
-// Trident subsumes the functionality provided by this class, so it's deprecated
-@Deprecated
-public class LinearDRPCTopologyBuilder {    
+public class LinearDRPCTopologyBuilder {
     String _function;
     List<Component> _components = new ArrayList<Component>();
     


### PR DESCRIPTION
Removed deprecation from LinearDRPCTopologyBuilder.