### PR TITLE
[STORM-2905] Fix KeyNotFoundException when kill a storm and add isRem…

### DIFF
--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsClientBlobStore.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsClientBlobStore.java
@@ -17,6 +17,9 @@
  */
 package org.apache.storm.hdfs.blobstore;
 
+import java.util.Iterator;
+import java.util.Map;
+
 import org.apache.storm.blobstore.AtomicOutputStream;
 import org.apache.storm.blobstore.ClientBlobStore;
 import org.apache.storm.blobstore.InputStreamWithMeta;
@@ -28,9 +31,6 @@ import org.apache.storm.generated.SettableBlobMeta;
 import org.apache.storm.utils.NimbusClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Iterator;
-import java.util.Map;
 
 /**
  *  Client to access the HDFS blobStore. At this point, this is meant to only be used by the
@@ -52,6 +52,16 @@ public class HdfsClientBlobStore extends ClientBlobStore {
         this._conf = conf;
         _blobStore = new HdfsBlobStore();
         _blobStore.prepare(conf, null, null);
+    }
+
+    @Override
+    public boolean isRemoteBlobExists(String blobKey) throws AuthorizationException {
+        try {
+            _blobStore.getBlob(blobKey, null);
+        } catch (KeyNotFoundException e) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
@@ -18,6 +18,9 @@
 
 package org.apache.storm.blobstore;
 
+import java.util.Iterator;
+import java.util.Map;
+
 import org.apache.storm.daemon.Shutdownable;
 import org.apache.storm.generated.AuthorizationException;
 import org.apache.storm.generated.ReadableBlobMeta;
@@ -27,9 +30,6 @@ import org.apache.storm.generated.KeyNotFoundException;
 import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.utils.NimbusClient;
-
-import java.util.Iterator;
-import java.util.Map;
 
 /**
  * The ClientBlobStore has two concrete implementations
@@ -66,6 +66,12 @@ public abstract class ClientBlobStore implements Shutdownable, AutoCloseable {
      * @param conf The storm conf containing the config details.
      */
     public abstract void prepare(Map<String, Object> conf);
+
+    /**
+     * Decide if the blob is deleted from cluster.
+     * @param blobKey blob key
+     */
+    public abstract boolean isRemoteBlobExists(String blobKey) throws AuthorizationException;
 
     /**
      * Client facing API to create a blob.

--- a/storm-client/src/jvm/org/apache/storm/blobstore/LocalModeClientBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/LocalModeClientBlobStore.java
@@ -48,6 +48,16 @@ public class LocalModeClientBlobStore extends ClientBlobStore {
     }
 
     @Override
+    public boolean isRemoteBlobExists(String blobKey) throws AuthorizationException {
+        try {
+            wrapped.getBlob(blobKey, null);
+        } catch (KeyNotFoundException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     protected AtomicOutputStream createBlobToExtend(String key, SettableBlobMeta meta) throws AuthorizationException, KeyAlreadyExistsException {
         return wrapped.createBlob(key, meta, null);
     }

--- a/storm-client/src/jvm/org/apache/storm/blobstore/NimbusBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/NimbusBlobStore.java
@@ -272,6 +272,18 @@ public class NimbusBlobStore extends ClientBlobStore implements AutoCloseable {
     }
 
     @Override
+    public boolean isRemoteBlobExists(String blobKey) throws AuthorizationException {
+        try {
+            return client.getClient().isRemoteBlobExists(blobKey);
+
+        } catch (AuthorizationException aze) {
+            throw aze;
+        } catch (TException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     protected AtomicOutputStream createBlobToExtend(String key, SettableBlobMeta meta)
             throws AuthorizationException, KeyAlreadyExistsException {
         try {

--- a/storm-client/src/jvm/org/apache/storm/generated/Nimbus.java
+++ b/storm-client/src/jvm/org/apache/storm/generated/Nimbus.java
@@ -189,9 +189,16 @@ public class Nimbus {
      * 
      * @param heatbeat
      */
-    public void sendSupervisorWorkerHeartbeat(SupervisorWorkerHeartbeat heatbeat) throws AuthorizationException, org.apache.thrift.TException;
+    public void sendSupervisorWorkerHeartbeat(SupervisorWorkerHeartbeat heatbeat) throws AuthorizationException, NotAliveException, org.apache.thrift.TException;
 
     public void processWorkerMetrics(WorkerMetrics metrics) throws org.apache.thrift.TException;
+
+    /**
+     * Decide if the blob is removed from cluster.
+     * 
+     * @param blobKey
+     */
+    public boolean isRemoteBlobExists(String blobKey) throws AuthorizationException, org.apache.thrift.TException;
 
   }
 
@@ -296,6 +303,8 @@ public class Nimbus {
     public void sendSupervisorWorkerHeartbeat(SupervisorWorkerHeartbeat heatbeat, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
 
     public void processWorkerMetrics(WorkerMetrics metrics, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
+
+    public void isRemoteBlobExists(String blobKey, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
 
   }
 
@@ -1602,7 +1611,7 @@ public class Nimbus {
       return;
     }
 
-    public void sendSupervisorWorkerHeartbeat(SupervisorWorkerHeartbeat heatbeat) throws AuthorizationException, org.apache.thrift.TException
+    public void sendSupervisorWorkerHeartbeat(SupervisorWorkerHeartbeat heatbeat) throws AuthorizationException, NotAliveException, org.apache.thrift.TException
     {
       send_sendSupervisorWorkerHeartbeat(heatbeat);
       recv_sendSupervisorWorkerHeartbeat();
@@ -1615,12 +1624,15 @@ public class Nimbus {
       sendBase("sendSupervisorWorkerHeartbeat", args);
     }
 
-    public void recv_sendSupervisorWorkerHeartbeat() throws AuthorizationException, org.apache.thrift.TException
+    public void recv_sendSupervisorWorkerHeartbeat() throws AuthorizationException, NotAliveException, org.apache.thrift.TException
     {
       sendSupervisorWorkerHeartbeat_result result = new sendSupervisorWorkerHeartbeat_result();
       receiveBase(result, "sendSupervisorWorkerHeartbeat");
       if (result.aze != null) {
         throw result.aze;
+      }
+      if (result.e != null) {
+        throw result.e;
       }
       return;
     }
@@ -1643,6 +1655,32 @@ public class Nimbus {
       processWorkerMetrics_result result = new processWorkerMetrics_result();
       receiveBase(result, "processWorkerMetrics");
       return;
+    }
+
+    public boolean isRemoteBlobExists(String blobKey) throws AuthorizationException, org.apache.thrift.TException
+    {
+      send_isRemoteBlobExists(blobKey);
+      return recv_isRemoteBlobExists();
+    }
+
+    public void send_isRemoteBlobExists(String blobKey) throws org.apache.thrift.TException
+    {
+      isRemoteBlobExists_args args = new isRemoteBlobExists_args();
+      args.set_blobKey(blobKey);
+      sendBase("isRemoteBlobExists", args);
+    }
+
+    public boolean recv_isRemoteBlobExists() throws AuthorizationException, org.apache.thrift.TException
+    {
+      isRemoteBlobExists_result result = new isRemoteBlobExists_result();
+      receiveBase(result, "isRemoteBlobExists");
+      if (result.is_set_success()) {
+        return result.success;
+      }
+      if (result.aze != null) {
+        throw result.aze;
+      }
+      throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "isRemoteBlobExists failed: unknown result");
     }
 
   }
@@ -3299,7 +3337,7 @@ public class Nimbus {
         prot.writeMessageEnd();
       }
 
-      public void getResult() throws AuthorizationException, org.apache.thrift.TException {
+      public void getResult() throws AuthorizationException, NotAliveException, org.apache.thrift.TException {
         if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
           throw new IllegalStateException("Method call not finished!");
         }
@@ -3338,6 +3376,38 @@ public class Nimbus {
         org.apache.thrift.transport.TMemoryInputTransport memoryTransport = new org.apache.thrift.transport.TMemoryInputTransport(getFrameBuffer().array());
         org.apache.thrift.protocol.TProtocol prot = client.getProtocolFactory().getProtocol(memoryTransport);
         (new Client(prot)).recv_processWorkerMetrics();
+      }
+    }
+
+    public void isRemoteBlobExists(String blobKey, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException {
+      checkReady();
+      isRemoteBlobExists_call method_call = new isRemoteBlobExists_call(blobKey, resultHandler, this, ___protocolFactory, ___transport);
+      this.___currentMethod = method_call;
+      ___manager.call(method_call);
+    }
+
+    public static class isRemoteBlobExists_call extends org.apache.thrift.async.TAsyncMethodCall {
+      private String blobKey;
+      public isRemoteBlobExists_call(String blobKey, org.apache.thrift.async.AsyncMethodCallback resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+        super(client, protocolFactory, transport, resultHandler, false);
+        this.blobKey = blobKey;
+      }
+
+      public void write_args(org.apache.thrift.protocol.TProtocol prot) throws org.apache.thrift.TException {
+        prot.writeMessageBegin(new org.apache.thrift.protocol.TMessage("isRemoteBlobExists", org.apache.thrift.protocol.TMessageType.CALL, 0));
+        isRemoteBlobExists_args args = new isRemoteBlobExists_args();
+        args.set_blobKey(blobKey);
+        args.write(prot);
+        prot.writeMessageEnd();
+      }
+
+      public boolean getResult() throws AuthorizationException, org.apache.thrift.TException {
+        if (getState() != org.apache.thrift.async.TAsyncMethodCall.State.RESPONSE_READ) {
+          throw new IllegalStateException("Method call not finished!");
+        }
+        org.apache.thrift.transport.TMemoryInputTransport memoryTransport = new org.apache.thrift.transport.TMemoryInputTransport(getFrameBuffer().array());
+        org.apache.thrift.protocol.TProtocol prot = client.getProtocolFactory().getProtocol(memoryTransport);
+        return (new Client(prot)).recv_isRemoteBlobExists();
       }
     }
 
@@ -3404,6 +3474,7 @@ public class Nimbus {
       processMap.put("sendSupervisorWorkerHeartbeats", new sendSupervisorWorkerHeartbeats());
       processMap.put("sendSupervisorWorkerHeartbeat", new sendSupervisorWorkerHeartbeat());
       processMap.put("processWorkerMetrics", new processWorkerMetrics());
+      processMap.put("isRemoteBlobExists", new isRemoteBlobExists());
       return processMap;
     }
 
@@ -4615,6 +4686,8 @@ public class Nimbus {
           iface.sendSupervisorWorkerHeartbeat(args.heatbeat);
         } catch (AuthorizationException aze) {
           result.aze = aze;
+        } catch (NotAliveException e) {
+          result.e = e;
         }
         return result;
       }
@@ -4636,6 +4709,31 @@ public class Nimbus {
       public processWorkerMetrics_result getResult(I iface, processWorkerMetrics_args args) throws org.apache.thrift.TException {
         processWorkerMetrics_result result = new processWorkerMetrics_result();
         iface.processWorkerMetrics(args.metrics);
+        return result;
+      }
+    }
+
+    public static class isRemoteBlobExists<I extends Iface> extends org.apache.thrift.ProcessFunction<I, isRemoteBlobExists_args> {
+      public isRemoteBlobExists() {
+        super("isRemoteBlobExists");
+      }
+
+      public isRemoteBlobExists_args getEmptyArgsInstance() {
+        return new isRemoteBlobExists_args();
+      }
+
+      protected boolean isOneway() {
+        return false;
+      }
+
+      public isRemoteBlobExists_result getResult(I iface, isRemoteBlobExists_args args) throws org.apache.thrift.TException {
+        isRemoteBlobExists_result result = new isRemoteBlobExists_result();
+        try {
+          result.success = iface.isRemoteBlobExists(args.blobKey);
+          result.set_success_isSet(true);
+        } catch (AuthorizationException aze) {
+          result.aze = aze;
+        }
         return result;
       }
     }
@@ -4703,6 +4801,7 @@ public class Nimbus {
       processMap.put("sendSupervisorWorkerHeartbeats", new sendSupervisorWorkerHeartbeats());
       processMap.put("sendSupervisorWorkerHeartbeat", new sendSupervisorWorkerHeartbeat());
       processMap.put("processWorkerMetrics", new processWorkerMetrics());
+      processMap.put("isRemoteBlobExists", new isRemoteBlobExists());
       return processMap;
     }
 
@@ -7565,6 +7664,11 @@ public class Nimbus {
                         result.set_aze_isSet(true);
                         msg = result;
             }
+            else             if (e instanceof NotAliveException) {
+                        result.e = (NotAliveException) e;
+                        result.set_e_isSet(true);
+                        msg = result;
+            }
              else 
             {
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
@@ -7637,6 +7741,64 @@ public class Nimbus {
 
       public void start(I iface, processWorkerMetrics_args args, org.apache.thrift.async.AsyncMethodCallback<Void> resultHandler) throws TException {
         iface.processWorkerMetrics(args.metrics,resultHandler);
+      }
+    }
+
+    public static class isRemoteBlobExists<I extends AsyncIface> extends org.apache.thrift.AsyncProcessFunction<I, isRemoteBlobExists_args, Boolean> {
+      public isRemoteBlobExists() {
+        super("isRemoteBlobExists");
+      }
+
+      public isRemoteBlobExists_args getEmptyArgsInstance() {
+        return new isRemoteBlobExists_args();
+      }
+
+      public AsyncMethodCallback<Boolean> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
+        final org.apache.thrift.AsyncProcessFunction fcall = this;
+        return new AsyncMethodCallback<Boolean>() { 
+          public void onComplete(Boolean o) {
+            isRemoteBlobExists_result result = new isRemoteBlobExists_result();
+            result.success = o;
+            result.set_success_isSet(true);
+            try {
+              fcall.sendResponse(fb,result, org.apache.thrift.protocol.TMessageType.REPLY,seqid);
+              return;
+            } catch (Exception e) {
+              LOGGER.error("Exception writing to internal frame buffer", e);
+            }
+            fb.close();
+          }
+          public void onError(Exception e) {
+            byte msgType = org.apache.thrift.protocol.TMessageType.REPLY;
+            org.apache.thrift.TBase msg;
+            isRemoteBlobExists_result result = new isRemoteBlobExists_result();
+            if (e instanceof AuthorizationException) {
+                        result.aze = (AuthorizationException) e;
+                        result.set_aze_isSet(true);
+                        msg = result;
+            }
+             else 
+            {
+              msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
+              msg = (org.apache.thrift.TBase)new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
+            }
+            try {
+              fcall.sendResponse(fb,msg,msgType,seqid);
+              return;
+            } catch (Exception ex) {
+              LOGGER.error("Exception writing to internal frame buffer", ex);
+            }
+            fb.close();
+          }
+        };
+      }
+
+      protected boolean isOneway() {
+        return false;
+      }
+
+      public void start(I iface, isRemoteBlobExists_args args, org.apache.thrift.async.AsyncMethodCallback<Boolean> resultHandler) throws TException {
+        iface.isRemoteBlobExists(args.blobKey,resultHandler);
       }
     }
 
@@ -50746,6 +50908,7 @@ public class Nimbus {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("sendSupervisorWorkerHeartbeat_result");
 
     private static final org.apache.thrift.protocol.TField AZE_FIELD_DESC = new org.apache.thrift.protocol.TField("aze", org.apache.thrift.protocol.TType.STRUCT, (short)1);
+    private static final org.apache.thrift.protocol.TField E_FIELD_DESC = new org.apache.thrift.protocol.TField("e", org.apache.thrift.protocol.TType.STRUCT, (short)2);
 
     private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
     static {
@@ -50754,10 +50917,12 @@ public class Nimbus {
     }
 
     private AuthorizationException aze; // required
+    private NotAliveException e; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-      AZE((short)1, "aze");
+      AZE((short)1, "aze"),
+      E((short)2, "e");
 
       private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -50774,6 +50939,8 @@ public class Nimbus {
         switch(fieldId) {
           case 1: // AZE
             return AZE;
+          case 2: // E
+            return E;
           default:
             return null;
         }
@@ -50819,6 +50986,8 @@ public class Nimbus {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
       tmpMap.put(_Fields.AZE, new org.apache.thrift.meta_data.FieldMetaData("aze", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
+      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(sendSupervisorWorkerHeartbeat_result.class, metaDataMap);
     }
@@ -50827,10 +50996,12 @@ public class Nimbus {
     }
 
     public sendSupervisorWorkerHeartbeat_result(
-      AuthorizationException aze)
+      AuthorizationException aze,
+      NotAliveException e)
     {
       this();
       this.aze = aze;
+      this.e = e;
     }
 
     /**
@@ -50839,6 +51010,9 @@ public class Nimbus {
     public sendSupervisorWorkerHeartbeat_result(sendSupervisorWorkerHeartbeat_result other) {
       if (other.is_set_aze()) {
         this.aze = new AuthorizationException(other.aze);
+      }
+      if (other.is_set_e()) {
+        this.e = new NotAliveException(other.e);
       }
     }
 
@@ -50849,6 +51023,7 @@ public class Nimbus {
     @Override
     public void clear() {
       this.aze = null;
+      this.e = null;
     }
 
     public AuthorizationException get_aze() {
@@ -50874,6 +51049,29 @@ public class Nimbus {
       }
     }
 
+    public NotAliveException get_e() {
+      return this.e;
+    }
+
+    public void set_e(NotAliveException e) {
+      this.e = e;
+    }
+
+    public void unset_e() {
+      this.e = null;
+    }
+
+    /** Returns true if field e is set (has been assigned a value) and false otherwise */
+    public boolean is_set_e() {
+      return this.e != null;
+    }
+
+    public void set_e_isSet(boolean value) {
+      if (!value) {
+        this.e = null;
+      }
+    }
+
     public void setFieldValue(_Fields field, Object value) {
       switch (field) {
       case AZE:
@@ -50884,6 +51082,14 @@ public class Nimbus {
         }
         break;
 
+      case E:
+        if (value == null) {
+          unset_e();
+        } else {
+          set_e((NotAliveException)value);
+        }
+        break;
+
       }
     }
 
@@ -50891,6 +51097,9 @@ public class Nimbus {
       switch (field) {
       case AZE:
         return get_aze();
+
+      case E:
+        return get_e();
 
       }
       throw new IllegalStateException();
@@ -50905,6 +51114,8 @@ public class Nimbus {
       switch (field) {
       case AZE:
         return is_set_aze();
+      case E:
+        return is_set_e();
       }
       throw new IllegalStateException();
     }
@@ -50931,6 +51142,15 @@ public class Nimbus {
           return false;
       }
 
+      boolean this_present_e = true && this.is_set_e();
+      boolean that_present_e = true && that.is_set_e();
+      if (this_present_e || that_present_e) {
+        if (!(this_present_e && that_present_e))
+          return false;
+        if (!this.e.equals(that.e))
+          return false;
+      }
+
       return true;
     }
 
@@ -50942,6 +51162,11 @@ public class Nimbus {
       list.add(present_aze);
       if (present_aze)
         list.add(aze);
+
+      boolean present_e = true && (is_set_e());
+      list.add(present_e);
+      if (present_e)
+        list.add(e);
 
       return list.hashCode();
     }
@@ -50960,6 +51185,16 @@ public class Nimbus {
       }
       if (is_set_aze()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.aze, other.aze);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = Boolean.valueOf(is_set_e()).compareTo(other.is_set_e());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (is_set_e()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.e, other.e);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -50989,6 +51224,14 @@ public class Nimbus {
         sb.append("null");
       } else {
         sb.append(this.aze);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("e:");
+      if (this.e == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.e);
       }
       first = false;
       sb.append(")");
@@ -51043,6 +51286,15 @@ public class Nimbus {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
+            case 2: // E
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.e = new NotAliveException();
+                struct.e.read(iprot);
+                struct.set_e_isSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
             default:
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
           }
@@ -51059,6 +51311,11 @@ public class Nimbus {
         if (struct.aze != null) {
           oprot.writeFieldBegin(AZE_FIELD_DESC);
           struct.aze.write(oprot);
+          oprot.writeFieldEnd();
+        }
+        if (struct.e != null) {
+          oprot.writeFieldBegin(E_FIELD_DESC);
+          struct.e.write(oprot);
           oprot.writeFieldEnd();
         }
         oprot.writeFieldStop();
@@ -51082,20 +51339,31 @@ public class Nimbus {
         if (struct.is_set_aze()) {
           optionals.set(0);
         }
-        oprot.writeBitSet(optionals, 1);
+        if (struct.is_set_e()) {
+          optionals.set(1);
+        }
+        oprot.writeBitSet(optionals, 2);
         if (struct.is_set_aze()) {
           struct.aze.write(oprot);
+        }
+        if (struct.is_set_e()) {
+          struct.e.write(oprot);
         }
       }
 
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, sendSupervisorWorkerHeartbeat_result struct) throws org.apache.thrift.TException {
         TTupleProtocol iprot = (TTupleProtocol) prot;
-        BitSet incoming = iprot.readBitSet(1);
+        BitSet incoming = iprot.readBitSet(2);
         if (incoming.get(0)) {
           struct.aze = new AuthorizationException();
           struct.aze.read(iprot);
           struct.set_aze_isSet(true);
+        }
+        if (incoming.get(1)) {
+          struct.e = new NotAliveException();
+          struct.e.read(iprot);
+          struct.set_e_isSet(true);
         }
       }
     }
@@ -51706,6 +51974,828 @@ public class Nimbus {
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, processWorkerMetrics_result struct) throws org.apache.thrift.TException {
         TTupleProtocol iprot = (TTupleProtocol) prot;
+      }
+    }
+
+  }
+
+  public static class isRemoteBlobExists_args implements org.apache.thrift.TBase<isRemoteBlobExists_args, isRemoteBlobExists_args._Fields>, java.io.Serializable, Cloneable, Comparable<isRemoteBlobExists_args>   {
+    private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("isRemoteBlobExists_args");
+
+    private static final org.apache.thrift.protocol.TField BLOB_KEY_FIELD_DESC = new org.apache.thrift.protocol.TField("blobKey", org.apache.thrift.protocol.TType.STRING, (short)1);
+
+    private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
+    static {
+      schemes.put(StandardScheme.class, new isRemoteBlobExists_argsStandardSchemeFactory());
+      schemes.put(TupleScheme.class, new isRemoteBlobExists_argsTupleSchemeFactory());
+    }
+
+    private String blobKey; // required
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift.TFieldIdEnum {
+      BLOB_KEY((short)1, "blobKey");
+
+      private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+
+      static {
+        for (_Fields field : EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          case 1: // BLOB_KEY
+            return BLOB_KEY;
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      public static _Fields findByName(String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final String _fieldName;
+
+      _Fields(short thriftId, String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      public String getFieldName() {
+        return _fieldName;
+      }
+    }
+
+    // isset id assignments
+    public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
+    static {
+      Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.BLOB_KEY, new org.apache.thrift.meta_data.FieldMetaData("blobKey", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+      metaDataMap = Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(isRemoteBlobExists_args.class, metaDataMap);
+    }
+
+    public isRemoteBlobExists_args() {
+    }
+
+    public isRemoteBlobExists_args(
+      String blobKey)
+    {
+      this();
+      this.blobKey = blobKey;
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public isRemoteBlobExists_args(isRemoteBlobExists_args other) {
+      if (other.is_set_blobKey()) {
+        this.blobKey = other.blobKey;
+      }
+    }
+
+    public isRemoteBlobExists_args deepCopy() {
+      return new isRemoteBlobExists_args(this);
+    }
+
+    @Override
+    public void clear() {
+      this.blobKey = null;
+    }
+
+    public String get_blobKey() {
+      return this.blobKey;
+    }
+
+    public void set_blobKey(String blobKey) {
+      this.blobKey = blobKey;
+    }
+
+    public void unset_blobKey() {
+      this.blobKey = null;
+    }
+
+    /** Returns true if field blobKey is set (has been assigned a value) and false otherwise */
+    public boolean is_set_blobKey() {
+      return this.blobKey != null;
+    }
+
+    public void set_blobKey_isSet(boolean value) {
+      if (!value) {
+        this.blobKey = null;
+      }
+    }
+
+    public void setFieldValue(_Fields field, Object value) {
+      switch (field) {
+      case BLOB_KEY:
+        if (value == null) {
+          unset_blobKey();
+        } else {
+          set_blobKey((String)value);
+        }
+        break;
+
+      }
+    }
+
+    public Object getFieldValue(_Fields field) {
+      switch (field) {
+      case BLOB_KEY:
+        return get_blobKey();
+
+      }
+      throw new IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new IllegalArgumentException();
+      }
+
+      switch (field) {
+      case BLOB_KEY:
+        return is_set_blobKey();
+      }
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+      if (that == null)
+        return false;
+      if (that instanceof isRemoteBlobExists_args)
+        return this.equals((isRemoteBlobExists_args)that);
+      return false;
+    }
+
+    public boolean equals(isRemoteBlobExists_args that) {
+      if (that == null)
+        return false;
+
+      boolean this_present_blobKey = true && this.is_set_blobKey();
+      boolean that_present_blobKey = true && that.is_set_blobKey();
+      if (this_present_blobKey || that_present_blobKey) {
+        if (!(this_present_blobKey && that_present_blobKey))
+          return false;
+        if (!this.blobKey.equals(that.blobKey))
+          return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      List<Object> list = new ArrayList<Object>();
+
+      boolean present_blobKey = true && (is_set_blobKey());
+      list.add(present_blobKey);
+      if (present_blobKey)
+        list.add(blobKey);
+
+      return list.hashCode();
+    }
+
+    @Override
+    public int compareTo(isRemoteBlobExists_args other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+
+      lastComparison = Boolean.valueOf(is_set_blobKey()).compareTo(other.is_set_blobKey());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (is_set_blobKey()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.blobKey, other.blobKey);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      return 0;
+    }
+
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    public void read(org.apache.thrift.protocol.TProtocol iprot) throws org.apache.thrift.TException {
+      schemes.get(iprot.getScheme()).getScheme().read(iprot, this);
+    }
+
+    public void write(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {
+      schemes.get(oprot.getScheme()).getScheme().write(oprot, this);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("isRemoteBlobExists_args(");
+      boolean first = true;
+
+      sb.append("blobKey:");
+      if (this.blobKey == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.blobKey);
+      }
+      first = false;
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift.TException {
+      // check for required fields
+      // check for sub-struct validity
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+      try {
+        read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private static class isRemoteBlobExists_argsStandardSchemeFactory implements SchemeFactory {
+      public isRemoteBlobExists_argsStandardScheme getScheme() {
+        return new isRemoteBlobExists_argsStandardScheme();
+      }
+    }
+
+    private static class isRemoteBlobExists_argsStandardScheme extends StandardScheme<isRemoteBlobExists_args> {
+
+      public void read(org.apache.thrift.protocol.TProtocol iprot, isRemoteBlobExists_args struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TField schemeField;
+        iprot.readStructBegin();
+        while (true)
+        {
+          schemeField = iprot.readFieldBegin();
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+            break;
+          }
+          switch (schemeField.id) {
+            case 1: // BLOB_KEY
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+                struct.blobKey = iprot.readString();
+                struct.set_blobKey_isSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            default:
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+          }
+          iprot.readFieldEnd();
+        }
+        iprot.readStructEnd();
+        struct.validate();
+      }
+
+      public void write(org.apache.thrift.protocol.TProtocol oprot, isRemoteBlobExists_args struct) throws org.apache.thrift.TException {
+        struct.validate();
+
+        oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.blobKey != null) {
+          oprot.writeFieldBegin(BLOB_KEY_FIELD_DESC);
+          oprot.writeString(struct.blobKey);
+          oprot.writeFieldEnd();
+        }
+        oprot.writeFieldStop();
+        oprot.writeStructEnd();
+      }
+
+    }
+
+    private static class isRemoteBlobExists_argsTupleSchemeFactory implements SchemeFactory {
+      public isRemoteBlobExists_argsTupleScheme getScheme() {
+        return new isRemoteBlobExists_argsTupleScheme();
+      }
+    }
+
+    private static class isRemoteBlobExists_argsTupleScheme extends TupleScheme<isRemoteBlobExists_args> {
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol prot, isRemoteBlobExists_args struct) throws org.apache.thrift.TException {
+        TTupleProtocol oprot = (TTupleProtocol) prot;
+        BitSet optionals = new BitSet();
+        if (struct.is_set_blobKey()) {
+          optionals.set(0);
+        }
+        oprot.writeBitSet(optionals, 1);
+        if (struct.is_set_blobKey()) {
+          oprot.writeString(struct.blobKey);
+        }
+      }
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol prot, isRemoteBlobExists_args struct) throws org.apache.thrift.TException {
+        TTupleProtocol iprot = (TTupleProtocol) prot;
+        BitSet incoming = iprot.readBitSet(1);
+        if (incoming.get(0)) {
+          struct.blobKey = iprot.readString();
+          struct.set_blobKey_isSet(true);
+        }
+      }
+    }
+
+  }
+
+  public static class isRemoteBlobExists_result implements org.apache.thrift.TBase<isRemoteBlobExists_result, isRemoteBlobExists_result._Fields>, java.io.Serializable, Cloneable, Comparable<isRemoteBlobExists_result>   {
+    private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("isRemoteBlobExists_result");
+
+    private static final org.apache.thrift.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift.protocol.TField("success", org.apache.thrift.protocol.TType.BOOL, (short)0);
+    private static final org.apache.thrift.protocol.TField AZE_FIELD_DESC = new org.apache.thrift.protocol.TField("aze", org.apache.thrift.protocol.TType.STRUCT, (short)1);
+
+    private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
+    static {
+      schemes.put(StandardScheme.class, new isRemoteBlobExists_resultStandardSchemeFactory());
+      schemes.put(TupleScheme.class, new isRemoteBlobExists_resultTupleSchemeFactory());
+    }
+
+    private boolean success; // required
+    private AuthorizationException aze; // required
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift.TFieldIdEnum {
+      SUCCESS((short)0, "success"),
+      AZE((short)1, "aze");
+
+      private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+
+      static {
+        for (_Fields field : EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          case 0: // SUCCESS
+            return SUCCESS;
+          case 1: // AZE
+            return AZE;
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      public static _Fields findByName(String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final String _fieldName;
+
+      _Fields(short thriftId, String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      public String getFieldName() {
+        return _fieldName;
+      }
+    }
+
+    // isset id assignments
+    private static final int __SUCCESS_ISSET_ID = 0;
+    private byte __isset_bitfield = 0;
+    public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
+    static {
+      Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+      tmpMap.put(_Fields.AZE, new org.apache.thrift.meta_data.FieldMetaData("aze", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
+      metaDataMap = Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(isRemoteBlobExists_result.class, metaDataMap);
+    }
+
+    public isRemoteBlobExists_result() {
+    }
+
+    public isRemoteBlobExists_result(
+      boolean success,
+      AuthorizationException aze)
+    {
+      this();
+      this.success = success;
+      set_success_isSet(true);
+      this.aze = aze;
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public isRemoteBlobExists_result(isRemoteBlobExists_result other) {
+      __isset_bitfield = other.__isset_bitfield;
+      this.success = other.success;
+      if (other.is_set_aze()) {
+        this.aze = new AuthorizationException(other.aze);
+      }
+    }
+
+    public isRemoteBlobExists_result deepCopy() {
+      return new isRemoteBlobExists_result(this);
+    }
+
+    @Override
+    public void clear() {
+      set_success_isSet(false);
+      this.success = false;
+      this.aze = null;
+    }
+
+    public boolean is_success() {
+      return this.success;
+    }
+
+    public void set_success(boolean success) {
+      this.success = success;
+      set_success_isSet(true);
+    }
+
+    public void unset_success() {
+      __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __SUCCESS_ISSET_ID);
+    }
+
+    /** Returns true if field success is set (has been assigned a value) and false otherwise */
+    public boolean is_set_success() {
+      return EncodingUtils.testBit(__isset_bitfield, __SUCCESS_ISSET_ID);
+    }
+
+    public void set_success_isSet(boolean value) {
+      __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __SUCCESS_ISSET_ID, value);
+    }
+
+    public AuthorizationException get_aze() {
+      return this.aze;
+    }
+
+    public void set_aze(AuthorizationException aze) {
+      this.aze = aze;
+    }
+
+    public void unset_aze() {
+      this.aze = null;
+    }
+
+    /** Returns true if field aze is set (has been assigned a value) and false otherwise */
+    public boolean is_set_aze() {
+      return this.aze != null;
+    }
+
+    public void set_aze_isSet(boolean value) {
+      if (!value) {
+        this.aze = null;
+      }
+    }
+
+    public void setFieldValue(_Fields field, Object value) {
+      switch (field) {
+      case SUCCESS:
+        if (value == null) {
+          unset_success();
+        } else {
+          set_success((Boolean)value);
+        }
+        break;
+
+      case AZE:
+        if (value == null) {
+          unset_aze();
+        } else {
+          set_aze((AuthorizationException)value);
+        }
+        break;
+
+      }
+    }
+
+    public Object getFieldValue(_Fields field) {
+      switch (field) {
+      case SUCCESS:
+        return is_success();
+
+      case AZE:
+        return get_aze();
+
+      }
+      throw new IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new IllegalArgumentException();
+      }
+
+      switch (field) {
+      case SUCCESS:
+        return is_set_success();
+      case AZE:
+        return is_set_aze();
+      }
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+      if (that == null)
+        return false;
+      if (that instanceof isRemoteBlobExists_result)
+        return this.equals((isRemoteBlobExists_result)that);
+      return false;
+    }
+
+    public boolean equals(isRemoteBlobExists_result that) {
+      if (that == null)
+        return false;
+
+      boolean this_present_success = true;
+      boolean that_present_success = true;
+      if (this_present_success || that_present_success) {
+        if (!(this_present_success && that_present_success))
+          return false;
+        if (this.success != that.success)
+          return false;
+      }
+
+      boolean this_present_aze = true && this.is_set_aze();
+      boolean that_present_aze = true && that.is_set_aze();
+      if (this_present_aze || that_present_aze) {
+        if (!(this_present_aze && that_present_aze))
+          return false;
+        if (!this.aze.equals(that.aze))
+          return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      List<Object> list = new ArrayList<Object>();
+
+      boolean present_success = true;
+      list.add(present_success);
+      if (present_success)
+        list.add(success);
+
+      boolean present_aze = true && (is_set_aze());
+      list.add(present_aze);
+      if (present_aze)
+        list.add(aze);
+
+      return list.hashCode();
+    }
+
+    @Override
+    public int compareTo(isRemoteBlobExists_result other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+
+      lastComparison = Boolean.valueOf(is_set_success()).compareTo(other.is_set_success());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (is_set_success()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.success, other.success);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = Boolean.valueOf(is_set_aze()).compareTo(other.is_set_aze());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (is_set_aze()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.aze, other.aze);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      return 0;
+    }
+
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    public void read(org.apache.thrift.protocol.TProtocol iprot) throws org.apache.thrift.TException {
+      schemes.get(iprot.getScheme()).getScheme().read(iprot, this);
+    }
+
+    public void write(org.apache.thrift.protocol.TProtocol oprot) throws org.apache.thrift.TException {
+      schemes.get(oprot.getScheme()).getScheme().write(oprot, this);
+      }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("isRemoteBlobExists_result(");
+      boolean first = true;
+
+      sb.append("success:");
+      sb.append(this.success);
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("aze:");
+      if (this.aze == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.aze);
+      }
+      first = false;
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift.TException {
+      // check for required fields
+      // check for sub-struct validity
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+      try {
+        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
+        __isset_bitfield = 0;
+        read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private static class isRemoteBlobExists_resultStandardSchemeFactory implements SchemeFactory {
+      public isRemoteBlobExists_resultStandardScheme getScheme() {
+        return new isRemoteBlobExists_resultStandardScheme();
+      }
+    }
+
+    private static class isRemoteBlobExists_resultStandardScheme extends StandardScheme<isRemoteBlobExists_result> {
+
+      public void read(org.apache.thrift.protocol.TProtocol iprot, isRemoteBlobExists_result struct) throws org.apache.thrift.TException {
+        org.apache.thrift.protocol.TField schemeField;
+        iprot.readStructBegin();
+        while (true)
+        {
+          schemeField = iprot.readFieldBegin();
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+            break;
+          }
+          switch (schemeField.id) {
+            case 0: // SUCCESS
+              if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
+                struct.success = iprot.readBool();
+                struct.set_success_isSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            case 1: // AZE
+              if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+                struct.aze = new AuthorizationException();
+                struct.aze.read(iprot);
+                struct.set_aze_isSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            default:
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+          }
+          iprot.readFieldEnd();
+        }
+        iprot.readStructEnd();
+        struct.validate();
+      }
+
+      public void write(org.apache.thrift.protocol.TProtocol oprot, isRemoteBlobExists_result struct) throws org.apache.thrift.TException {
+        struct.validate();
+
+        oprot.writeStructBegin(STRUCT_DESC);
+        if (struct.is_set_success()) {
+          oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
+          oprot.writeBool(struct.success);
+          oprot.writeFieldEnd();
+        }
+        if (struct.aze != null) {
+          oprot.writeFieldBegin(AZE_FIELD_DESC);
+          struct.aze.write(oprot);
+          oprot.writeFieldEnd();
+        }
+        oprot.writeFieldStop();
+        oprot.writeStructEnd();
+      }
+
+    }
+
+    private static class isRemoteBlobExists_resultTupleSchemeFactory implements SchemeFactory {
+      public isRemoteBlobExists_resultTupleScheme getScheme() {
+        return new isRemoteBlobExists_resultTupleScheme();
+      }
+    }
+
+    private static class isRemoteBlobExists_resultTupleScheme extends TupleScheme<isRemoteBlobExists_result> {
+
+      @Override
+      public void write(org.apache.thrift.protocol.TProtocol prot, isRemoteBlobExists_result struct) throws org.apache.thrift.TException {
+        TTupleProtocol oprot = (TTupleProtocol) prot;
+        BitSet optionals = new BitSet();
+        if (struct.is_set_success()) {
+          optionals.set(0);
+        }
+        if (struct.is_set_aze()) {
+          optionals.set(1);
+        }
+        oprot.writeBitSet(optionals, 2);
+        if (struct.is_set_success()) {
+          oprot.writeBool(struct.success);
+        }
+        if (struct.is_set_aze()) {
+          struct.aze.write(oprot);
+        }
+      }
+
+      @Override
+      public void read(org.apache.thrift.protocol.TProtocol prot, isRemoteBlobExists_result struct) throws org.apache.thrift.TException {
+        TTupleProtocol iprot = (TTupleProtocol) prot;
+        BitSet incoming = iprot.readBitSet(2);
+        if (incoming.get(0)) {
+          struct.success = iprot.readBool();
+          struct.set_success_isSet(true);
+        }
+        if (incoming.get(1)) {
+          struct.aze = new AuthorizationException();
+          struct.aze.read(iprot);
+          struct.set_aze_isSet(true);
+        }
       }
     }
 

--- a/storm-client/src/jvm/org/apache/storm/generated/SupervisorInfo.java
+++ b/storm-client/src/jvm/org/apache/storm/generated/SupervisorInfo.java
@@ -58,13 +58,13 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
   private static final org.apache.thrift.protocol.TField TIME_SECS_FIELD_DESC = new org.apache.thrift.protocol.TField("time_secs", org.apache.thrift.protocol.TType.I64, (short)1);
   private static final org.apache.thrift.protocol.TField HOSTNAME_FIELD_DESC = new org.apache.thrift.protocol.TField("hostname", org.apache.thrift.protocol.TType.STRING, (short)2);
   private static final org.apache.thrift.protocol.TField ASSIGNMENT_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("assignment_id", org.apache.thrift.protocol.TType.STRING, (short)3);
-  private static final org.apache.thrift.protocol.TField SERVER_PORT_FIELD_DESC = new org.apache.thrift.protocol.TField("server_port", org.apache.thrift.protocol.TType.I32, (short)4);
-  private static final org.apache.thrift.protocol.TField USED_PORTS_FIELD_DESC = new org.apache.thrift.protocol.TField("used_ports", org.apache.thrift.protocol.TType.LIST, (short)5);
-  private static final org.apache.thrift.protocol.TField META_FIELD_DESC = new org.apache.thrift.protocol.TField("meta", org.apache.thrift.protocol.TType.LIST, (short)6);
-  private static final org.apache.thrift.protocol.TField SCHEDULER_META_FIELD_DESC = new org.apache.thrift.protocol.TField("scheduler_meta", org.apache.thrift.protocol.TType.MAP, (short)7);
-  private static final org.apache.thrift.protocol.TField UPTIME_SECS_FIELD_DESC = new org.apache.thrift.protocol.TField("uptime_secs", org.apache.thrift.protocol.TType.I64, (short)8);
-  private static final org.apache.thrift.protocol.TField VERSION_FIELD_DESC = new org.apache.thrift.protocol.TField("version", org.apache.thrift.protocol.TType.STRING, (short)9);
-  private static final org.apache.thrift.protocol.TField RESOURCES_MAP_FIELD_DESC = new org.apache.thrift.protocol.TField("resources_map", org.apache.thrift.protocol.TType.MAP, (short)10);
+  private static final org.apache.thrift.protocol.TField USED_PORTS_FIELD_DESC = new org.apache.thrift.protocol.TField("used_ports", org.apache.thrift.protocol.TType.LIST, (short)4);
+  private static final org.apache.thrift.protocol.TField META_FIELD_DESC = new org.apache.thrift.protocol.TField("meta", org.apache.thrift.protocol.TType.LIST, (short)5);
+  private static final org.apache.thrift.protocol.TField SCHEDULER_META_FIELD_DESC = new org.apache.thrift.protocol.TField("scheduler_meta", org.apache.thrift.protocol.TType.MAP, (short)6);
+  private static final org.apache.thrift.protocol.TField UPTIME_SECS_FIELD_DESC = new org.apache.thrift.protocol.TField("uptime_secs", org.apache.thrift.protocol.TType.I64, (short)7);
+  private static final org.apache.thrift.protocol.TField VERSION_FIELD_DESC = new org.apache.thrift.protocol.TField("version", org.apache.thrift.protocol.TType.STRING, (short)8);
+  private static final org.apache.thrift.protocol.TField RESOURCES_MAP_FIELD_DESC = new org.apache.thrift.protocol.TField("resources_map", org.apache.thrift.protocol.TType.MAP, (short)9);
+  private static final org.apache.thrift.protocol.TField SERVER_PORT_FIELD_DESC = new org.apache.thrift.protocol.TField("server_port", org.apache.thrift.protocol.TType.I32, (short)10);
 
   private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
   static {
@@ -75,26 +75,26 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
   private long time_secs; // required
   private String hostname; // required
   private String assignment_id; // optional
-  private int server_port; // optional
   private List<Long> used_ports; // optional
   private List<Long> meta; // optional
   private Map<String,String> scheduler_meta; // optional
   private long uptime_secs; // optional
   private String version; // optional
   private Map<String,Double> resources_map; // optional
+  private int server_port; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
     TIME_SECS((short)1, "time_secs"),
     HOSTNAME((short)2, "hostname"),
     ASSIGNMENT_ID((short)3, "assignment_id"),
-    SERVER_PORT((short)4, "server_port"),
-    USED_PORTS((short)5, "used_ports"),
-    META((short)6, "meta"),
-    SCHEDULER_META((short)7, "scheduler_meta"),
-    UPTIME_SECS((short)8, "uptime_secs"),
-    VERSION((short)9, "version"),
-    RESOURCES_MAP((short)10, "resources_map");
+    USED_PORTS((short)4, "used_ports"),
+    META((short)5, "meta"),
+    SCHEDULER_META((short)6, "scheduler_meta"),
+    UPTIME_SECS((short)7, "uptime_secs"),
+    VERSION((short)8, "version"),
+    RESOURCES_MAP((short)9, "resources_map"),
+    SERVER_PORT((short)10, "server_port");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -115,20 +115,20 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           return HOSTNAME;
         case 3: // ASSIGNMENT_ID
           return ASSIGNMENT_ID;
-        case 4: // SERVER_PORT
-          return SERVER_PORT;
-        case 5: // USED_PORTS
+        case 4: // USED_PORTS
           return USED_PORTS;
-        case 6: // META
+        case 5: // META
           return META;
-        case 7: // SCHEDULER_META
+        case 6: // SCHEDULER_META
           return SCHEDULER_META;
-        case 8: // UPTIME_SECS
+        case 7: // UPTIME_SECS
           return UPTIME_SECS;
-        case 9: // VERSION
+        case 8: // VERSION
           return VERSION;
-        case 10: // RESOURCES_MAP
+        case 9: // RESOURCES_MAP
           return RESOURCES_MAP;
+        case 10: // SERVER_PORT
+          return SERVER_PORT;
         default:
           return null;
       }
@@ -170,10 +170,10 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
 
   // isset id assignments
   private static final int __TIME_SECS_ISSET_ID = 0;
-  private static final int __SERVER_PORT_ISSET_ID = 1;
-  private static final int __UPTIME_SECS_ISSET_ID = 2;
+  private static final int __UPTIME_SECS_ISSET_ID = 1;
+  private static final int __SERVER_PORT_ISSET_ID = 2;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.ASSIGNMENT_ID,_Fields.SERVER_PORT,_Fields.USED_PORTS,_Fields.META,_Fields.SCHEDULER_META,_Fields.UPTIME_SECS,_Fields.VERSION,_Fields.RESOURCES_MAP};
+  private static final _Fields optionals[] = {_Fields.ASSIGNMENT_ID,_Fields.USED_PORTS,_Fields.META,_Fields.SCHEDULER_META,_Fields.UPTIME_SECS,_Fields.VERSION,_Fields.RESOURCES_MAP,_Fields.SERVER_PORT};
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -183,8 +183,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.ASSIGNMENT_ID, new org.apache.thrift.meta_data.FieldMetaData("assignment_id", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
-    tmpMap.put(_Fields.SERVER_PORT, new org.apache.thrift.meta_data.FieldMetaData("server_port", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
-        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
     tmpMap.put(_Fields.USED_PORTS, new org.apache.thrift.meta_data.FieldMetaData("used_ports", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
             new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64))));
@@ -203,6 +201,8 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
         new org.apache.thrift.meta_data.MapMetaData(org.apache.thrift.protocol.TType.MAP, 
             new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING), 
             new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE))));
+    tmpMap.put(_Fields.SERVER_PORT, new org.apache.thrift.meta_data.FieldMetaData("server_port", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(SupervisorInfo.class, metaDataMap);
   }
@@ -232,7 +232,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
     if (other.is_set_assignment_id()) {
       this.assignment_id = other.assignment_id;
     }
-    this.server_port = other.server_port;
     if (other.is_set_used_ports()) {
       List<Long> __this__used_ports = new ArrayList<Long>(other.used_ports);
       this.used_ports = __this__used_ports;
@@ -253,6 +252,7 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       Map<String,Double> __this__resources_map = new HashMap<String,Double>(other.resources_map);
       this.resources_map = __this__resources_map;
     }
+    this.server_port = other.server_port;
   }
 
   public SupervisorInfo deepCopy() {
@@ -265,8 +265,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
     this.time_secs = 0;
     this.hostname = null;
     this.assignment_id = null;
-    set_server_port_isSet(false);
-    this.server_port = 0;
     this.used_ports = null;
     this.meta = null;
     this.scheduler_meta = null;
@@ -274,6 +272,8 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
     this.uptime_secs = 0;
     this.version = null;
     this.resources_map = null;
+    set_server_port_isSet(false);
+    this.server_port = 0;
   }
 
   public long get_time_secs() {
@@ -342,28 +342,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
     if (!value) {
       this.assignment_id = null;
     }
-  }
-
-  public int get_server_port() {
-    return this.server_port;
-  }
-
-  public void set_server_port(int server_port) {
-    this.server_port = server_port;
-    set_server_port_isSet(true);
-  }
-
-  public void unset_server_port() {
-    __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __SERVER_PORT_ISSET_ID);
-  }
-
-  /** Returns true if field server_port is set (has been assigned a value) and false otherwise */
-  public boolean is_set_server_port() {
-    return EncodingUtils.testBit(__isset_bitfield, __SERVER_PORT_ISSET_ID);
-  }
-
-  public void set_server_port_isSet(boolean value) {
-    __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __SERVER_PORT_ISSET_ID, value);
   }
 
   public int get_used_ports_size() {
@@ -555,6 +533,28 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
     }
   }
 
+  public int get_server_port() {
+    return this.server_port;
+  }
+
+  public void set_server_port(int server_port) {
+    this.server_port = server_port;
+    set_server_port_isSet(true);
+  }
+
+  public void unset_server_port() {
+    __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __SERVER_PORT_ISSET_ID);
+  }
+
+  /** Returns true if field server_port is set (has been assigned a value) and false otherwise */
+  public boolean is_set_server_port() {
+    return EncodingUtils.testBit(__isset_bitfield, __SERVER_PORT_ISSET_ID);
+  }
+
+  public void set_server_port_isSet(boolean value) {
+    __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __SERVER_PORT_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, Object value) {
     switch (field) {
     case TIME_SECS:
@@ -578,14 +578,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
         unset_assignment_id();
       } else {
         set_assignment_id((String)value);
-      }
-      break;
-
-    case SERVER_PORT:
-      if (value == null) {
-        unset_server_port();
-      } else {
-        set_server_port((Integer)value);
       }
       break;
 
@@ -637,6 +629,14 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       }
       break;
 
+    case SERVER_PORT:
+      if (value == null) {
+        unset_server_port();
+      } else {
+        set_server_port((Integer)value);
+      }
+      break;
+
     }
   }
 
@@ -650,9 +650,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
 
     case ASSIGNMENT_ID:
       return get_assignment_id();
-
-    case SERVER_PORT:
-      return get_server_port();
 
     case USED_PORTS:
       return get_used_ports();
@@ -672,6 +669,9 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
     case RESOURCES_MAP:
       return get_resources_map();
 
+    case SERVER_PORT:
+      return get_server_port();
+
     }
     throw new IllegalStateException();
   }
@@ -689,8 +689,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       return is_set_hostname();
     case ASSIGNMENT_ID:
       return is_set_assignment_id();
-    case SERVER_PORT:
-      return is_set_server_port();
     case USED_PORTS:
       return is_set_used_ports();
     case META:
@@ -703,6 +701,8 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       return is_set_version();
     case RESOURCES_MAP:
       return is_set_resources_map();
+    case SERVER_PORT:
+      return is_set_server_port();
     }
     throw new IllegalStateException();
   }
@@ -744,15 +744,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       if (!(this_present_assignment_id && that_present_assignment_id))
         return false;
       if (!this.assignment_id.equals(that.assignment_id))
-        return false;
-    }
-
-    boolean this_present_server_port = true && this.is_set_server_port();
-    boolean that_present_server_port = true && that.is_set_server_port();
-    if (this_present_server_port || that_present_server_port) {
-      if (!(this_present_server_port && that_present_server_port))
-        return false;
-      if (this.server_port != that.server_port)
         return false;
     }
 
@@ -810,6 +801,15 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
         return false;
     }
 
+    boolean this_present_server_port = true && this.is_set_server_port();
+    boolean that_present_server_port = true && that.is_set_server_port();
+    if (this_present_server_port || that_present_server_port) {
+      if (!(this_present_server_port && that_present_server_port))
+        return false;
+      if (this.server_port != that.server_port)
+        return false;
+    }
+
     return true;
   }
 
@@ -831,11 +831,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
     list.add(present_assignment_id);
     if (present_assignment_id)
       list.add(assignment_id);
-
-    boolean present_server_port = true && (is_set_server_port());
-    list.add(present_server_port);
-    if (present_server_port)
-      list.add(server_port);
 
     boolean present_used_ports = true && (is_set_used_ports());
     list.add(present_used_ports);
@@ -866,6 +861,11 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
     list.add(present_resources_map);
     if (present_resources_map)
       list.add(resources_map);
+
+    boolean present_server_port = true && (is_set_server_port());
+    list.add(present_server_port);
+    if (present_server_port)
+      list.add(server_port);
 
     return list.hashCode();
   }
@@ -904,16 +904,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
     }
     if (is_set_assignment_id()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.assignment_id, other.assignment_id);
-      if (lastComparison != 0) {
-        return lastComparison;
-      }
-    }
-    lastComparison = Boolean.valueOf(is_set_server_port()).compareTo(other.is_set_server_port());
-    if (lastComparison != 0) {
-      return lastComparison;
-    }
-    if (is_set_server_port()) {
-      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.server_port, other.server_port);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -978,6 +968,16 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
         return lastComparison;
       }
     }
+    lastComparison = Boolean.valueOf(is_set_server_port()).compareTo(other.is_set_server_port());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (is_set_server_port()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.server_port, other.server_port);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -1017,12 +1017,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       } else {
         sb.append(this.assignment_id);
       }
-      first = false;
-    }
-    if (is_set_server_port()) {
-      if (!first) sb.append(", ");
-      sb.append("server_port:");
-      sb.append(this.server_port);
       first = false;
     }
     if (is_set_used_ports()) {
@@ -1079,6 +1073,12 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       } else {
         sb.append(this.resources_map);
       }
+      first = false;
+    }
+    if (is_set_server_port()) {
+      if (!first) sb.append(", ");
+      sb.append("server_port:");
+      sb.append(this.server_port);
       first = false;
     }
     sb.append(")");
@@ -1158,15 +1158,7 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
-          case 4: // SERVER_PORT
-            if (schemeField.type == org.apache.thrift.protocol.TType.I32) {
-              struct.server_port = iprot.readI32();
-              struct.set_server_port_isSet(true);
-            } else { 
-              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
-            }
-            break;
-          case 5: // USED_PORTS
+          case 4: // USED_PORTS
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
                 org.apache.thrift.protocol.TList _list622 = iprot.readListBegin();
@@ -1184,7 +1176,7 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
-          case 6: // META
+          case 5: // META
             if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
               {
                 org.apache.thrift.protocol.TList _list625 = iprot.readListBegin();
@@ -1202,7 +1194,7 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
-          case 7: // SCHEDULER_META
+          case 6: // SCHEDULER_META
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
                 org.apache.thrift.protocol.TMap _map628 = iprot.readMapBegin();
@@ -1222,7 +1214,7 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
-          case 8: // UPTIME_SECS
+          case 7: // UPTIME_SECS
             if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
               struct.uptime_secs = iprot.readI64();
               struct.set_uptime_secs_isSet(true);
@@ -1230,7 +1222,7 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
-          case 9: // VERSION
+          case 8: // VERSION
             if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
               struct.version = iprot.readString();
               struct.set_version_isSet(true);
@@ -1238,7 +1230,7 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
-          case 10: // RESOURCES_MAP
+          case 9: // RESOURCES_MAP
             if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
               {
                 org.apache.thrift.protocol.TMap _map632 = iprot.readMapBegin();
@@ -1254,6 +1246,14 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
                 iprot.readMapEnd();
               }
               struct.set_resources_map_isSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
+          case 10: // SERVER_PORT
+            if (schemeField.type == org.apache.thrift.protocol.TType.I32) {
+              struct.server_port = iprot.readI32();
+              struct.set_server_port_isSet(true);
             } else { 
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
@@ -1285,11 +1285,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           oprot.writeString(struct.assignment_id);
           oprot.writeFieldEnd();
         }
-      }
-      if (struct.is_set_server_port()) {
-        oprot.writeFieldBegin(SERVER_PORT_FIELD_DESC);
-        oprot.writeI32(struct.server_port);
-        oprot.writeFieldEnd();
       }
       if (struct.used_ports != null) {
         if (struct.is_set_used_ports()) {
@@ -1361,6 +1356,11 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           oprot.writeFieldEnd();
         }
       }
+      if (struct.is_set_server_port()) {
+        oprot.writeFieldBegin(SERVER_PORT_FIELD_DESC);
+        oprot.writeI32(struct.server_port);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1384,33 +1384,30 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
       if (struct.is_set_assignment_id()) {
         optionals.set(0);
       }
-      if (struct.is_set_server_port()) {
+      if (struct.is_set_used_ports()) {
         optionals.set(1);
       }
-      if (struct.is_set_used_ports()) {
+      if (struct.is_set_meta()) {
         optionals.set(2);
       }
-      if (struct.is_set_meta()) {
+      if (struct.is_set_scheduler_meta()) {
         optionals.set(3);
       }
-      if (struct.is_set_scheduler_meta()) {
+      if (struct.is_set_uptime_secs()) {
         optionals.set(4);
       }
-      if (struct.is_set_uptime_secs()) {
+      if (struct.is_set_version()) {
         optionals.set(5);
       }
-      if (struct.is_set_version()) {
+      if (struct.is_set_resources_map()) {
         optionals.set(6);
       }
-      if (struct.is_set_resources_map()) {
+      if (struct.is_set_server_port()) {
         optionals.set(7);
       }
       oprot.writeBitSet(optionals, 8);
       if (struct.is_set_assignment_id()) {
         oprot.writeString(struct.assignment_id);
-      }
-      if (struct.is_set_server_port()) {
-        oprot.writeI32(struct.server_port);
       }
       if (struct.is_set_used_ports()) {
         {
@@ -1456,6 +1453,9 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           }
         }
       }
+      if (struct.is_set_server_port()) {
+        oprot.writeI32(struct.server_port);
+      }
     }
 
     @Override
@@ -1471,10 +1471,6 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
         struct.set_assignment_id_isSet(true);
       }
       if (incoming.get(1)) {
-        struct.server_port = iprot.readI32();
-        struct.set_server_port_isSet(true);
-      }
-      if (incoming.get(2)) {
         {
           org.apache.thrift.protocol.TList _list644 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
           struct.used_ports = new ArrayList<Long>(_list644.size);
@@ -1487,7 +1483,7 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
         }
         struct.set_used_ports_isSet(true);
       }
-      if (incoming.get(3)) {
+      if (incoming.get(2)) {
         {
           org.apache.thrift.protocol.TList _list647 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
           struct.meta = new ArrayList<Long>(_list647.size);
@@ -1500,7 +1496,7 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
         }
         struct.set_meta_isSet(true);
       }
-      if (incoming.get(4)) {
+      if (incoming.get(3)) {
         {
           org.apache.thrift.protocol.TMap _map650 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
           struct.scheduler_meta = new HashMap<String,String>(2*_map650.size);
@@ -1515,15 +1511,15 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
         }
         struct.set_scheduler_meta_isSet(true);
       }
-      if (incoming.get(5)) {
+      if (incoming.get(4)) {
         struct.uptime_secs = iprot.readI64();
         struct.set_uptime_secs_isSet(true);
       }
-      if (incoming.get(6)) {
+      if (incoming.get(5)) {
         struct.version = iprot.readString();
         struct.set_version_isSet(true);
       }
-      if (incoming.get(7)) {
+      if (incoming.get(6)) {
         {
           org.apache.thrift.protocol.TMap _map654 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.STRING, org.apache.thrift.protocol.TType.DOUBLE, iprot.readI32());
           struct.resources_map = new HashMap<String,Double>(2*_map654.size);
@@ -1537,6 +1533,10 @@ public class SupervisorInfo implements org.apache.thrift.TBase<SupervisorInfo, S
           }
         }
         struct.set_resources_map_isSet(true);
+      }
+      if (incoming.get(7)) {
+        struct.server_port = iprot.readI32();
+        struct.set_server_port_isSet(true);
       }
     }
   }

--- a/storm-client/src/py/storm/Nimbus-remote
+++ b/storm-client/src/py/storm/Nimbus-remote
@@ -92,6 +92,7 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
   print('  void sendSupervisorWorkerHeartbeats(SupervisorWorkerHeartbeats heartbeats)')
   print('  void sendSupervisorWorkerHeartbeat(SupervisorWorkerHeartbeat heatbeat)')
   print('  void processWorkerMetrics(WorkerMetrics metrics)')
+  print('  bool isRemoteBlobExists(string blobKey)')
   print('')
   sys.exit(0)
 
@@ -447,6 +448,12 @@ elif cmd == 'processWorkerMetrics':
     print('processWorkerMetrics requires 1 args')
     sys.exit(1)
   pp.pprint(client.processWorkerMetrics(eval(args[0]),))
+
+elif cmd == 'isRemoteBlobExists':
+  if len(args) != 1:
+    print('isRemoteBlobExists requires 1 args')
+    sys.exit(1)
+  pp.pprint(client.isRemoteBlobExists(args[0],))
 
 else:
   print('Unrecognized method %s' % cmd)

--- a/storm-client/src/py/storm/ttypes.py
+++ b/storm-client/src/py/storm/ttypes.py
@@ -9168,13 +9168,13 @@ class SupervisorInfo:
    - time_secs
    - hostname
    - assignment_id
-   - server_port
    - used_ports
    - meta
    - scheduler_meta
    - uptime_secs
    - version
    - resources_map
+   - server_port
   """
 
   thrift_spec = (
@@ -9182,26 +9182,26 @@ class SupervisorInfo:
     (1, TType.I64, 'time_secs', None, None, ), # 1
     (2, TType.STRING, 'hostname', None, None, ), # 2
     (3, TType.STRING, 'assignment_id', None, None, ), # 3
-    (4, TType.I32, 'server_port', None, None, ), # 4
-    (5, TType.LIST, 'used_ports', (TType.I64,None), None, ), # 5
-    (6, TType.LIST, 'meta', (TType.I64,None), None, ), # 6
-    (7, TType.MAP, 'scheduler_meta', (TType.STRING,None,TType.STRING,None), None, ), # 7
-    (8, TType.I64, 'uptime_secs', None, None, ), # 8
-    (9, TType.STRING, 'version', None, None, ), # 9
-    (10, TType.MAP, 'resources_map', (TType.STRING,None,TType.DOUBLE,None), None, ), # 10
+    (4, TType.LIST, 'used_ports', (TType.I64,None), None, ), # 4
+    (5, TType.LIST, 'meta', (TType.I64,None), None, ), # 5
+    (6, TType.MAP, 'scheduler_meta', (TType.STRING,None,TType.STRING,None), None, ), # 6
+    (7, TType.I64, 'uptime_secs', None, None, ), # 7
+    (8, TType.STRING, 'version', None, None, ), # 8
+    (9, TType.MAP, 'resources_map', (TType.STRING,None,TType.DOUBLE,None), None, ), # 9
+    (10, TType.I32, 'server_port', None, None, ), # 10
   )
 
-  def __init__(self, time_secs=None, hostname=None, assignment_id=None, server_port=None, used_ports=None, meta=None, scheduler_meta=None, uptime_secs=None, version=None, resources_map=None,):
+  def __init__(self, time_secs=None, hostname=None, assignment_id=None, used_ports=None, meta=None, scheduler_meta=None, uptime_secs=None, version=None, resources_map=None, server_port=None,):
     self.time_secs = time_secs
     self.hostname = hostname
     self.assignment_id = assignment_id
-    self.server_port = server_port
     self.used_ports = used_ports
     self.meta = meta
     self.scheduler_meta = scheduler_meta
     self.uptime_secs = uptime_secs
     self.version = version
     self.resources_map = resources_map
+    self.server_port = server_port
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -9228,11 +9228,6 @@ class SupervisorInfo:
         else:
           iprot.skip(ftype)
       elif fid == 4:
-        if ftype == TType.I32:
-          self.server_port = iprot.readI32()
-        else:
-          iprot.skip(ftype)
-      elif fid == 5:
         if ftype == TType.LIST:
           self.used_ports = []
           (_etype559, _size556) = iprot.readListBegin()
@@ -9242,7 +9237,7 @@ class SupervisorInfo:
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
-      elif fid == 6:
+      elif fid == 5:
         if ftype == TType.LIST:
           self.meta = []
           (_etype565, _size562) = iprot.readListBegin()
@@ -9252,7 +9247,7 @@ class SupervisorInfo:
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
-      elif fid == 7:
+      elif fid == 6:
         if ftype == TType.MAP:
           self.scheduler_meta = {}
           (_ktype569, _vtype570, _size568 ) = iprot.readMapBegin()
@@ -9263,17 +9258,17 @@ class SupervisorInfo:
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
-      elif fid == 8:
+      elif fid == 7:
         if ftype == TType.I64:
           self.uptime_secs = iprot.readI64()
         else:
           iprot.skip(ftype)
-      elif fid == 9:
+      elif fid == 8:
         if ftype == TType.STRING:
           self.version = iprot.readString().decode('utf-8')
         else:
           iprot.skip(ftype)
-      elif fid == 10:
+      elif fid == 9:
         if ftype == TType.MAP:
           self.resources_map = {}
           (_ktype576, _vtype577, _size575 ) = iprot.readMapBegin()
@@ -9282,6 +9277,11 @@ class SupervisorInfo:
             _val581 = iprot.readDouble()
             self.resources_map[_key580] = _val581
           iprot.readMapEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 10:
+        if ftype == TType.I32:
+          self.server_port = iprot.readI32()
         else:
           iprot.skip(ftype)
       else:
@@ -9306,26 +9306,22 @@ class SupervisorInfo:
       oprot.writeFieldBegin('assignment_id', TType.STRING, 3)
       oprot.writeString(self.assignment_id.encode('utf-8'))
       oprot.writeFieldEnd()
-    if self.server_port is not None:
-      oprot.writeFieldBegin('server_port', TType.I32, 4)
-      oprot.writeI32(self.server_port)
-      oprot.writeFieldEnd()
     if self.used_ports is not None:
-      oprot.writeFieldBegin('used_ports', TType.LIST, 5)
+      oprot.writeFieldBegin('used_ports', TType.LIST, 4)
       oprot.writeListBegin(TType.I64, len(self.used_ports))
       for iter582 in self.used_ports:
         oprot.writeI64(iter582)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.meta is not None:
-      oprot.writeFieldBegin('meta', TType.LIST, 6)
+      oprot.writeFieldBegin('meta', TType.LIST, 5)
       oprot.writeListBegin(TType.I64, len(self.meta))
       for iter583 in self.meta:
         oprot.writeI64(iter583)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.scheduler_meta is not None:
-      oprot.writeFieldBegin('scheduler_meta', TType.MAP, 7)
+      oprot.writeFieldBegin('scheduler_meta', TType.MAP, 6)
       oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.scheduler_meta))
       for kiter584,viter585 in self.scheduler_meta.items():
         oprot.writeString(kiter584.encode('utf-8'))
@@ -9333,20 +9329,24 @@ class SupervisorInfo:
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.uptime_secs is not None:
-      oprot.writeFieldBegin('uptime_secs', TType.I64, 8)
+      oprot.writeFieldBegin('uptime_secs', TType.I64, 7)
       oprot.writeI64(self.uptime_secs)
       oprot.writeFieldEnd()
     if self.version is not None:
-      oprot.writeFieldBegin('version', TType.STRING, 9)
+      oprot.writeFieldBegin('version', TType.STRING, 8)
       oprot.writeString(self.version.encode('utf-8'))
       oprot.writeFieldEnd()
     if self.resources_map is not None:
-      oprot.writeFieldBegin('resources_map', TType.MAP, 10)
+      oprot.writeFieldBegin('resources_map', TType.MAP, 9)
       oprot.writeMapBegin(TType.STRING, TType.DOUBLE, len(self.resources_map))
       for kiter586,viter587 in self.resources_map.items():
         oprot.writeString(kiter586.encode('utf-8'))
         oprot.writeDouble(viter587)
       oprot.writeMapEnd()
+      oprot.writeFieldEnd()
+    if self.server_port is not None:
+      oprot.writeFieldBegin('server_port', TType.I32, 10)
+      oprot.writeI32(self.server_port)
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
@@ -9364,13 +9364,13 @@ class SupervisorInfo:
     value = (value * 31) ^ hash(self.time_secs)
     value = (value * 31) ^ hash(self.hostname)
     value = (value * 31) ^ hash(self.assignment_id)
-    value = (value * 31) ^ hash(self.server_port)
     value = (value * 31) ^ hash(self.used_ports)
     value = (value * 31) ^ hash(self.meta)
     value = (value * 31) ^ hash(self.scheduler_meta)
     value = (value * 31) ^ hash(self.uptime_secs)
     value = (value * 31) ^ hash(self.version)
     value = (value * 31) ^ hash(self.resources_map)
+    value = (value * 31) ^ hash(self.server_port)
     return value
 
   def __repr__(self):

--- a/storm-client/src/storm.thrift
+++ b/storm-client/src/storm.thrift
@@ -797,6 +797,10 @@ service Nimbus {
    */
   void sendSupervisorWorkerHeartbeat(1: SupervisorWorkerHeartbeat heatbeat) throws (1: AuthorizationException aze, 2: NotAliveException e);
   void processWorkerMetrics(1: WorkerMetrics metrics);
+  /**
+   * Decide if the blob is removed from cluster.
+   */
+  bool isRemoteBlobExists(1: string blobKey) throws (1: AuthorizationException aze);
 }
 
 struct DRPCRequest {

--- a/storm-client/test/jvm/org/apache/storm/blobstore/ClientBlobStoreTest.java
+++ b/storm-client/test/jvm/org/apache/storm/blobstore/ClientBlobStoreTest.java
@@ -47,6 +47,11 @@ public class ClientBlobStoreTest {
     }
 
     @Override
+    public boolean isRemoteBlobExists(String blobKey) throws AuthorizationException {
+      return allBlobs.containsKey(blobKey);
+    }
+
+    @Override
     protected AtomicOutputStream createBlobToExtend(String key, SettableBlobMeta meta) throws AuthorizationException, KeyAlreadyExistsException {
       allBlobs.put(key, meta);
       return null;

--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -1161,6 +1161,11 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
         getNimbus().processWorkerMetrics(metrics);
     }
 
+    @Override
+    public boolean isRemoteBlobExists(String blobKey) throws AuthorizationException, TException {
+        throw new KeyNotFoundException("BLOBS NOT SUPPORTED IN LOCAL MODE");
+    }
+
     public static void main(final String [] args) throws Exception {
         if (args.length < 1) {
             throw new IllegalArgumentException("No class was specified to run");

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -4616,4 +4616,13 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         }
     }
 
+    @Override
+    public boolean isRemoteBlobExists(String blobKey) throws AuthorizationException {
+        try {
+            blobStore.getBlobMeta(blobKey, getSubject());
+        } catch (KeyNotFoundException e) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
@@ -497,7 +497,6 @@ public class Slot extends Thread implements AutoCloseable, BlobChangingCallback 
         assert(dynamicState.container.areAllProcessesDead());
         
         dynamicState.container.cleanUp();
-        staticState.localizer.releaseSlotFor(dynamicState.currentAssignment, staticState.port);
         DynamicState ret = dynamicState.withCurrentAssignment(null, null);
         if (nextState != null) {
             ret = ret.withState(nextState);
@@ -671,10 +670,13 @@ public class Slot extends Thread implements AutoCloseable, BlobChangingCallback 
             if (dynamicState.currentAssignment != null) {
                 staticState.localizer.releaseSlotFor(dynamicState.currentAssignment, staticState.port);
             }
-            staticState.localizer.releaseSlotFor(dynamicState.pendingChangingBlobsAssignment, staticState.port);
-            return prepareForNewAssignmentNoWorkersRunning(dynamicState.withCurrentAssignment(null, null)
-                    .withPendingChangingBlobs(Collections.emptySet(), null),
-                staticState);
+
+            if (!equivalent(dynamicState.newAssignment, dynamicState.pendingChangingBlobsAssignment)) {
+                staticState.localizer.releaseSlotFor(dynamicState.pendingChangingBlobsAssignment, staticState.port);
+                return prepareForNewAssignmentNoWorkersRunning(dynamicState.withCurrentAssignment(null, null)
+                        .withPendingChangingBlobs(Collections.emptySet(), null),
+                    staticState);
+            }
         }
 
         dynamicState = filterChangingBlobsFor(dynamicState, dynamicState.pendingChangingBlobsAssignment);

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -276,7 +276,8 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
             // This isn't strictly necessary, but it doesn't hurt and ensures that the machine stays up
             // to date even if callbacks don't all work exactly right
             eventTimer.scheduleRecurring(0, 10,
-                    new EventManagerPushCallback(new SynchronizeAssignments(this, null, readState), eventManager));
+                new EventManagerPushCallback(new SynchronizeAssignments(this, null, readState),
+                    eventManager));
 
             // supervisor health check
             eventTimer.scheduleRecurring(30, 30, new SupervisorHealthCheck(this));

--- a/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedBlob.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedBlob.java
@@ -30,7 +30,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import org.apache.storm.blobstore.BlobStore;
 import org.apache.storm.blobstore.ClientBlobStore;
 import org.apache.storm.blobstore.InputStreamWithMeta;
 import org.apache.storm.daemon.supervisor.IAdvancedFSOps;

--- a/storm-server/src/test/java/org/apache/storm/daemon/supervisor/SlotTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/supervisor/SlotTest.java
@@ -332,7 +332,6 @@ public class SlotTest {
             nextState = Slot.stateMachineStep(nextState, staticState);
             assertEquals(MachineState.WAITING_FOR_BLOB_LOCALIZATION, nextState.state);
             verify(cContainer).cleanUp();
-            verify(localizer).releaseSlotFor(cAssignment, port);
             assertTrue(Time.currentTimeMillis() > 2000);
             
             nextState = Slot.stateMachineStep(nextState, staticState);
@@ -413,7 +412,6 @@ public class SlotTest {
             nextState = Slot.stateMachineStep(nextState, staticState);
             assertEquals(MachineState.EMPTY, nextState.state);
             verify(cContainer).cleanUp();
-            verify(localizer).releaseSlotFor(cAssignment, port);
             assertEquals(null, nextState.container);
             assertEquals(null, nextState.currentAssignment);
             assertTrue(Time.currentTimeMillis() > 2000);


### PR DESCRIPTION
When we kill a topology, at the moment of topology blob-files be removed, Supervisor executor may still request blob-files and get an KeyNotFoundException.

I stepped in and found the reason:
1. We do not add a guarded lock on AsyncLocalize#`topologyBlobs` which is singleton to a supervisor node.
2. And we remove jar/code/conf blob keys in `topologyBlobs` of killed storm only in a timer task: AsyncLocalize#`cleanUp`, the remove condition is :[no one reference the blobs] AND [ blobs removed by master OR exceeds the max configured size ], the default scheduling interval is 30 seconds. Here we may remove `topologyBlobs` overdue keys if condition is matched.
3. When we have killed a storm on a node[ which means that the slot container are empty], the AsyncLocalizer will do: `releaseSlotFor` to only remove reference on the blobs [`topologyBlobs` overdue keys are still there].
4. Then the container is empty, and Slot.java will do: `cleanupCurrentContainer` to invoke AsyncLocalizer #`releaseSlotFor` for releasing the slot.
5. AsyncLocalizer have a timer task: `updateBlobs` to update base/user blobs every 30 seconds, which based on the AsyncLocalizer#`topologyBlobs` based keys.
6. We know that AsyncLocalizer#`topologyBlobs` overdue keys are only removed by its AsyncLocalizer#`cleanUp` which is also a timer task.
7. So when we kill a storm, AsyncLocalizer#`updateBlobs` may update based on a removed jar/code/conf blob-keys and fire a exception[if the AsyncLocalize#`cleanUp not cleaned these keys], then retried until the configured max times to end.

Here is how i fixed it:
1. Just remove the base blob keys eagerly when we do AsyncLocalizer #`releaseSlotFor` when there is no reference [no one used] on the blobs, and remove the overdue keys in AsyncLocalizer#`topologyBlobs`
2. Guard the AsyncLocalizer#`updateBlobs` and AsyncLocalizer #`releaseSlotFor` by the same lock.
3. When container is empty, we do not need to exec AsyncLocalizer #`releaseSlotFor`[because we have already deleted them].
4. I also add a new RPC api for decide if there exists a remote blob, we can use it to decide it the blob could be removed instead of use `getBlobMeta` and catch a confusing `KeyNotFoundException` [both on supervisors and master log for every base blobs].

This is the JIRA: [STORM-2905](https://issues.apache.org/jira/browse/STORM-2905)