### PR TITLE
[STORM-3018] Fix integration test DemoTest#testExclamationTopology fa…

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -196,6 +196,9 @@ worker.log.level.reset.poll.secs: 30
 topology.worker.receiver.thread.count: 1
 
 # Executor metrics reporting interval.
+# Cause the ui only show built in metrics, we should keep sync with the built in metrics interval,
+# also the metrics consumer's collecting interval.
+# See topology.builtin.metrics.bucket.size.secs and storm.cluster.metrics.consumer.publish.interval.secs.
 executor.metrics.frequency.secs: 60
 
 task.heartbeat.frequency.secs: 3

--- a/integration-test/config/storm.yaml
+++ b/integration-test/config/storm.yaml
@@ -27,6 +27,10 @@ storm.messaging.netty.max_retries: 10
 storm.messaging.netty.min_wait_ms: 1000
 storm.messaging.netty.max_wait_ms: 5000
 
+# Executor metrics reporting interval, keep it short enough for cases fetching executors metrics
+# through restful API
+executor.metrics.frequency.secs: 3
+
 drpc.servers:
   - "node1"
 

--- a/integration-test/src/test/java/org/apache/storm/st/DemoTest.java
+++ b/integration-test/src/test/java/org/apache/storm/st/DemoTest.java
@@ -54,6 +54,7 @@ public final class DemoTest extends AbstractTest {
         topo.submitSuccessfully();
         final int minExclaim2Emits = 500;
         final int minSpountEmits = 10000;
+        //Keep the check time to be gt Config.EXECUTOR_METRICS_FREQUENCY_SECS.
         for(int i = 0; i < 10; ++i) {
             TopologyInfo topologyInfo = topo.getInfo();
             log.info(topologyInfo.toString());


### PR DESCRIPTION
For [STORM-2693](https://github.com/apache/storm/pull/2433) i changed the task metrics reporting interval default to 60 seconds, which is same with the DemoTest#testExclamationTopology check time.

So fix it here.

See [STORM-3018](https://issues.apache.org/jira/projects/STORM/issues/STORM-3018?filter=allopenissues)