### PR TITLE
[STORM-2687] Group Topology executors by network proximity needs and schedule them on network wise close slots

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/Component.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Component.java
@@ -18,11 +18,15 @@
 
 package org.apache.storm.scheduler;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.storm.generated.ComponentType;
+import org.apache.storm.generated.GlobalStreamId;
+import org.apache.storm.generated.Grouping;
 
 public class Component {
     private final String id;
@@ -30,6 +34,7 @@ public class Component {
     private final ComponentType type;
     private final Set<String> parents = new HashSet<>();
     private final Set<String> children = new HashSet<>();
+    private final Map<GlobalStreamId,Grouping> input = new HashMap<>();
 
     /**
      * Create a new component.
@@ -37,10 +42,11 @@ public class Component {
      * @param compId the id of the component
      * @param execs the executors for this component.
      */
-    public Component(ComponentType type, String compId, List<ExecutorDetails> execs) {
+    public Component(ComponentType type, String compId, List<ExecutorDetails> execs, Map<GlobalStreamId, Grouping> input) {
         this.type = type;
         this.id = compId;
         this.execs = execs;
+        this.input.putAll(input);
     }
 
     /**
@@ -73,16 +79,19 @@ public class Component {
         return children;
     }
 
+    public Map<GlobalStreamId, Grouping> getInput() {
+        return input;
+    }
+
     @Override
     public String toString() {
-        return "{id: "
-            + getId()
-            + " Parents: "
-            + getParents()
-            + " Children: "
-            + getChildren()
-            + " Execs: "
-            + getExecs()
-            + "}";
+        return "Component{" +
+                "id='" + id + '\'' +
+                ", execs=" + execs +
+                ", type=" + type +
+                ", parents=" + parents +
+                ", children=" + children +
+                ", input=" + input +
+                '}';
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/TopologyDetails.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/TopologyDetails.java
@@ -209,8 +209,9 @@ public class TopologyDetails {
         if (spouts != null) {
             for (Map.Entry<String, SpoutSpec> entry : spouts.entrySet()) {
                 String compId = entry.getKey();
+                SpoutSpec spout = entry.getValue();
                 if (!Utils.isSystemId(compId)) {
-                    Component comp = new Component(ComponentType.SPOUT, compId, componentToExecs(compId));
+                    Component comp = new Component(ComponentType.SPOUT, compId, componentToExecs(compId), spout.get_common().get_inputs());
                     ret.put(compId, comp);
                 }
             }
@@ -218,8 +219,9 @@ public class TopologyDetails {
         if (bolts != null) {
             for (Map.Entry<String, Bolt> entry : bolts.entrySet()) {
                 String compId = entry.getKey();
+                Bolt bolt = entry.getValue();
                 if (!Utils.isSystemId(compId)) {
-                    Component comp = new Component(ComponentType.BOLT, compId, componentToExecs(compId));
+                    Component comp = new Component(ComponentType.BOLT, compId, componentToExecs(compId), bolt.get_common().get_inputs());
                     ret.put(compId, comp);
                 }
             }

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -201,17 +201,18 @@ public class TestDefaultResourceAwareStrategy {
 
         rs.prepare(conf);
         rs.schedule(topologies, cluster);
+        //:<[[[0, 0], [6, 6], [2, 2]], [[3, 3]], [[5, 5], [4, 4], [1, 1]]]>
 
         HashSet<HashSet<ExecutorDetails>> expectedScheduling = new HashSet<>();
-        expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(0, 0)))); //Spout
         expectedScheduling.add(new HashSet<>(Arrays.asList(
-            new ExecutorDetails(2, 2), //bolt-1
-            new ExecutorDetails(4, 4), //bolt-2
-            new ExecutorDetails(6, 6)))); //bolt-3
+            new ExecutorDetails(0, 0), //spout
+            new ExecutorDetails(6, 6), //bolt-2
+            new ExecutorDetails(2, 2)))); //bolt-1
+        expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(3, 3)))); //bolt-3
         expectedScheduling.add(new HashSet<>(Arrays.asList(
-            new ExecutorDetails(1, 1), //bolt-1
-            new ExecutorDetails(3, 3), //bolt-2
-            new ExecutorDetails(5, 5)))); //bolt-3
+            new ExecutorDetails(5, 5), //bolt-2
+            new ExecutorDetails(4, 4), //bolt-3
+            new ExecutorDetails(1, 1)))); //bolt-1
         HashSet<HashSet<ExecutorDetails>> foundScheduling = new HashSet<>();
         SchedulerAssignment assignment = cluster.getAssignmentById("testTopology-id");
         for (Collection<ExecutorDetails> execs : assignment.getSlotToExecutors().values()) {

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
@@ -195,25 +195,16 @@ public class TestGenericResourceAwareStrategy {
         rs.prepare(conf);
         rs.schedule(topologies, cluster);
 
-        //We need to have 3 slots on 3 separate hosts. The topology needs 6 GPUs 3500 MB memory and 350% CPU
-        // The bolt-3 instances must be on separate nodes because they each need 2 GPUs.
-        // The bolt-2 instances must be on the same node as they each need 1 GPU
-        // (this assumes that we are packing the components to avoid fragmentation).
-        // The bolt-1 and spout instances fill in the rest.
-
         HashSet<HashSet<ExecutorDetails>> expectedScheduling = new HashSet<>();
-        expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(3, 3)))); //bolt-3 - 500 MB, 50% CPU, 2 GPU
-        //Total 500 MB, 50% CPU, 2 - GPU -> this node has 1000 MB, 100% cpu, 0 GPU left
         expectedScheduling.add(new HashSet<>(Arrays.asList(
-            new ExecutorDetails(2, 2), //bolt-1 - 500 MB, 50% CPU, 0 GPU
-            new ExecutorDetails(5, 5), //bolt-2 - 500 MB, 50% CPU, 1 GPU
-            new ExecutorDetails(6, 6)))); //bolt-2 - 500 MB, 50% CPU, 1 GPU
-        //Total 1500 MB, 150% CPU, 2 GPU -> this node has 0 MB, 0% CPU, 0 GPU left
+                new ExecutorDetails(0, 0),
+                new ExecutorDetails(2, 2),
+                new ExecutorDetails(6, 6))));
         expectedScheduling.add(new HashSet<>(Arrays.asList(
-            new ExecutorDetails(0, 0), //Spout - 500 MB, 50% CPU, 0 GPU
-            new ExecutorDetails(1, 1), //bolt-1 - 500 MB, 50% CPU, 0 GPU
-            new ExecutorDetails(4, 4)))); //bolt-3 500 MB, 50% cpu, 2 GPU
-        //Total 1500 MB, 150% CPU, 2 GPU -> this node has 0 MB, 0% CPU, 0 GPU left
+                new ExecutorDetails(4, 4),
+                new ExecutorDetails(1, 1))));
+        expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(5, 5))));
+        expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(3, 3))));
         HashSet<HashSet<ExecutorDetails>> foundScheduling = new HashSet<>();
         SchedulerAssignment assignment = cluster.getAssignmentById("testTopology-id");
         for (Collection<ExecutorDetails> execs : assignment.getSlotToExecutors().values()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-2687

This tries to schedule topology upstream and downstream executors closely.

Doing performance testing on this. 