### PR TITLE
[STORM-3023] fix the issue that Storm UI not showing correct values for component CPU, Memory and Executors

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/stats/StatsUtil.java
+++ b/storm-client/src/jvm/org/apache/storm/stats/StatsUtil.java
@@ -617,25 +617,13 @@ public class StatsUtil {
         // (merge-with merge-agg-comp-stats-topo-page-bolt/spout (acc-stats comp-key) cid->statk->num)
         // (acc-stats comp-key) ==> bolt2stats/spout2stats
         if (isSpout) {
-            Set<String> spouts = new HashSet<>();
-            spouts.addAll(spout2stats.keySet());
-            spouts.addAll(cid2stats.keySet());
-
-            Map<String, Object> mm = new HashMap<>();
-            for (String spout : spouts) {
-                mm.put(spout, mergeAggCompStatsTopoPageSpout((Map) spout2stats.get(spout), (Map) cid2stats.get(spout)));
+            for (String spout : cid2stats.keySet()) {
+                spout2stats.put(spout, mergeAggCompStatsTopoPageSpout((Map) spout2stats.get(spout), (Map) cid2stats.get(spout)));
             }
-            putKV(ret, SPOUT_TO_STATS, mm);
         } else {
-            Set<String> bolts = new HashSet<>();
-            bolts.addAll(bolt2stats.keySet());
-            bolts.addAll(cid2stats.keySet());
-
-            Map<String, Object> mm = new HashMap<>();
-            for (String bolt : bolts) {
-                mm.put(bolt, mergeAggCompStatsTopoPageBolt((Map) bolt2stats.get(bolt), (Map) cid2stats.get(bolt)));
+            for (String bolt : cid2stats.keySet()) {
+                bolt2stats.put(bolt, mergeAggCompStatsTopoPageBolt((Map) bolt2stats.get(bolt), (Map) cid2stats.get(bolt)));
             }
-            putKV(ret, BOLT_TO_STATS, mm);
         }
 
         return ret;

--- a/storm-core/src/clj/org/apache/storm/ui/core.clj
+++ b/storm-core/src/clj/org/apache/storm/ui/core.clj
@@ -661,9 +661,9 @@
    "transferred" (.get_transferred common-stats)
    "acked" (.get_acked common-stats)
    "failed" (.get_failed common-stats)
-   "requestedMemOnHeap" (.get (.get_resources_map common-stats) Config/TOPOLOGY_COMPONENT_RESOURCES_ONHEAP_MEMORY_MB)
-   "requestedMemOffHeap" (.get (.get_resources_map common-stats) Config/TOPOLOGY_COMPONENT_RESOURCES_OFFHEAP_MEMORY_MB)
-   "requestedCpu" (.get (.get_resources_map common-stats) Config/TOPOLOGY_COMPONENT_CPU_PCORE_PERCENT)})
+   "requestedMemOnHeap" (.get (.get_resources_map common-stats) Constants/COMMON_ONHEAP_MEMORY_RESOURCE_NAME)
+   "requestedMemOffHeap" (.get (.get_resources_map common-stats) Constants/COMMON_OFFHEAP_MEMORY_RESOURCE_NAME)
+   "requestedCpu" (.get (.get_resources_map common-stats) Constants/COMMON_CPU_RESOURCE_NAME)})
 
 (defmulti comp-agg-stats-json
   "Returns a JSON representation of aggregated statistics."
@@ -1105,9 +1105,9 @@
        "name" (.get_topology_name comp-page-info)
        "executors" (.get_num_executors comp-page-info)
        "tasks" (.get_num_tasks comp-page-info)
-       "requestedMemOnHeap" (.get (.get_resources_map comp-page-info) Config/TOPOLOGY_COMPONENT_RESOURCES_ONHEAP_MEMORY_MB)
-       "requestedMemOffHeap" (.get (.get_resources_map comp-page-info) Config/TOPOLOGY_COMPONENT_RESOURCES_OFFHEAP_MEMORY_MB)
-       "requestedCpu" (.get (.get_resources_map comp-page-info) Config/TOPOLOGY_COMPONENT_CPU_PCORE_PERCENT)
+       "requestedMemOnHeap" (.get (.get_resources_map comp-page-info) Constants/COMMON_ONHEAP_MEMORY_RESOURCE_NAME)
+       "requestedMemOffHeap" (.get (.get_resources_map comp-page-info) Constants/COMMON_OFFHEAP_MEMORY_RESOURCE_NAME)
+       "requestedCpu" (.get (.get_resources_map comp-page-info) Constants/COMMON_CPU_RESOURCE_NAME)
        "schedulerDisplayResource" (*STORM-CONF* SCHEDULER-DISPLAY-RESOURCE)
        "topologyId" topology-id
        "topologyStatus" (.get_topology_status comp-page-info)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3023

(1) The component page of the UI is showing a blank for requested resources (CPU and Memory).
(2) for the topology page what is being showed for them is the total for the entire topology, not individual components.

It's because the storm rest api code is using wrong keys. The component `requestedMemOnHeap` is null and then the `Mustache` in ui code uses `requestedMemOnHeap` from the parent (which is the total sum)


(3) And the executors of components in topology page shows wrong numbers. 
This is a bug introduced when porting clojure to java https://github.com/apache/storm/pull/1147
The number of executors of components gets accumulated incorrectly 