### PR TITLE
STORM-3028 HdfsSpout: handle empty file in case of ackers

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
@@ -101,7 +101,6 @@ public class HdfsSpout extends BaseRichSpout {
     private final AtomicBoolean commitTimeElapsed = new AtomicBoolean(false);
     private Timer commitTimer;
     private boolean fileReadCompletely = true;
-    private boolean newReader = false;
 
     private String configKey = Configs.DEFAULT_HDFS_CONFIG_KEY; // key for hdfs Kerberos configs
 
@@ -222,6 +221,7 @@ public class HdfsSpout extends BaseRichSpout {
         while (true) {
             try {
                 // 3) Select a new file if one is not open already
+                boolean newReader = false;
                 if (reader == null) {
                     reader = pickNextFile();
                     if (reader == null) {

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
@@ -231,8 +231,6 @@ public class HdfsSpout extends BaseRichSpout {
                         fileReadCompletely = false;
                         newReader = true;
                     }
-                } else {
-                    newReader = false;
                 }
                 if (fileReadCompletely) { // wait for more ACKs before proceeding
                     return;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
@@ -101,6 +101,7 @@ public class HdfsSpout extends BaseRichSpout {
     private final AtomicBoolean commitTimeElapsed = new AtomicBoolean(false);
     private Timer commitTimer;
     private boolean fileReadCompletely = true;
+    private boolean newReader = false;
 
     private String configKey = Configs.DEFAULT_HDFS_CONFIG_KEY; // key for hdfs Kerberos configs
 
@@ -228,7 +229,10 @@ public class HdfsSpout extends BaseRichSpout {
                         return;
                     } else {
                         fileReadCompletely = false;
+                        newReader = true;
                     }
+                } else {
+                    newReader = false;
                 }
                 if (fileReadCompletely) { // wait for more ACKs before proceeding
                     return;
@@ -250,7 +254,8 @@ public class HdfsSpout extends BaseRichSpout {
                     return;
                 } else {
                     fileReadCompletely = true;
-                    if (!ackEnabled) {
+                    // if newReader is true and tuple is null then it is an empty reader
+                    if (!ackEnabled || newReader) {
                         markFileAsDone(reader.getFilePath());
                     }
                 }

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -154,6 +154,35 @@ public class TestHdfsSpout {
     }
 
     @Test
+    public void testEmptySimpleText_ACK() throws Exception {
+        Path file1 = new Path(source.toString() + "/file_empty.txt");
+        createTextFile(file1, 0);
+
+        Path file2 = new Path(source.toString() + "/file.txt");
+        createTextFile(file2, 5);
+
+        try (AutoCloseableHdfsSpout closeableSpout = makeSpout(Configs.TEXT, TextFileReader.defaultFields)) {
+            HdfsSpout spout = closeableSpout.spout;
+            spout.setCommitFrequencyCount(1);
+            spout.setCommitFrequencySec(1);
+
+            Map<String, Object> conf = getCommonConfigs();
+            conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, "1"); // enable ACKing
+            openSpout(spout, 0, conf);
+
+            // consume empty file
+            runSpout(spout, "r6");
+            Path arc1 = new Path(archive.toString() + "/file_empty.txt");
+            checkCollectorOutput_txt((MockCollector) spout.getCollector(), arc1);
+
+            // consume file 2
+            runSpout(spout, "r5", "a0", "a1", "a2", "a3", "a4");
+            Path arc2 = new Path(archive.toString() + "/file.txt");
+            checkCollectorOutput_txt((MockCollector) spout.getCollector(), arc1, arc2);
+        }
+    }
+
+    @Test
     public void testResumeAbandoned_Text_NoAck() throws Exception {
         Path file1 = new Path(source.toString() + "/file1.txt");
         createTextFile(file1, 6);

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -164,14 +164,13 @@ public class TestHdfsSpout {
         try (AutoCloseableHdfsSpout closeableSpout = makeSpout(Configs.TEXT, TextFileReader.defaultFields)) {
             HdfsSpout spout = closeableSpout.spout;
             spout.setCommitFrequencyCount(1);
-            spout.setCommitFrequencySec(1);
 
             Map<String, Object> conf = getCommonConfigs();
             conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, "1"); // enable ACKing
             openSpout(spout, 0, conf);
 
             // consume empty file
-            runSpout(spout, "r6");
+            runSpout(spout, "r1");
             Path arc1 = new Path(archive.toString() + "/file_empty.txt");
             checkCollectorOutput_txt((MockCollector) spout.getCollector(), arc1);
 


### PR DESCRIPTION
There is a problem with all the storm-hdfs junit tests. The test results may not be valid.