### PR TITLE
[STORM-3021] Fix wrong usages of Config.TOPOLOGY_WORKERS on RAS cluster

### DIFF
--- a/docs/Resource_Aware_Scheduler_overview.md
+++ b/docs/Resource_Aware_Scheduler_overview.md
@@ -184,6 +184,10 @@ The user can set some default configurations for the Resource Aware Scheduler in
     topology.worker.max.heap.size.mb: 768.0
 ```
 
+### Warning
+
+If Resource Aware Scheduling is enabled, it will dynamically calculate the number of workers and the `topology.workers` setting is ignored.
+
 <div id='Topology-Priorities-and-Per-User-Resource'/>
 
 ## Topology Priorities and Per User Resource 

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -180,7 +180,8 @@ public class Config extends HashMap<String, Object> {
     /**
      * How many processes should be spawned around the cluster to execute this topology. Each process will execute some number of tasks as
      * threads within them. This parameter should be used in conjunction with the parallelism hints on each component in the topology to
-     * tune the performance of a topology.
+     * tune the performance of a topology. The number of workers will be dynamically calculated when the Resource Aware scheduler is used,
+     * in which case this parameter will not be honored.
      */
     @isInteger
     @isPositiveNumber
@@ -331,9 +332,10 @@ public class Config extends HashMap<String, Object> {
     /**
      * How many executors to spawn for ackers.
      *
-     * <p>By not setting this variable or setting it as null, Storm will set the number of acker executors
-     * to be equal to the number of workers configured for this topology. If this variable is set to 0, then Storm will immediately ack
-     * tuples as soon as they come off the spout, effectively disabling reliability.</p>
+     * <p>By not setting this variable or setting it as null, Storm will set the number of acker executors to be equal to
+     * the number of workers configured for this topology (or the estimated number of workers if the Resource Aware Scheduler is used).
+     * If this variable is set to 0, then Storm will immediately ack tuples as soon as they come off the spout,
+     * effectively disabling reliability.</p>
      */
     @isInteger
     @isPositiveNumber(includeZero = true)
@@ -351,8 +353,9 @@ public class Config extends HashMap<String, Object> {
     /**
      * How many executors to spawn for event logger.
      *
-     * <p>By not setting this variable or setting it as null, Storm will set the number of eventlogger executors
-     * to be equal to the number of workers configured for this topology. If this variable is set to 0, event logging will be disabled.</p>
+     * <p>By setting it as null, Storm will set the number of eventlogger executors to be equal to the number of workers
+     * configured for this topology (or the estimated number of workers if the Resource Aware Scheduler is used).
+     * If this variable is set to 0, event logging will be disabled.</p>
      */
     @isInteger
     @isPositiveNumber(includeZero = true)

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -731,6 +731,25 @@ public class WorkerState {
         return this.outboundTasks;
     }
 
+    /**
+     * Check if this worker has remote outbound tasks.
+     * @return true if this worker has remote outbound tasks; false otherwise.
+     */
+    public boolean hasRemoteOutboundTasks() {
+        Set<Integer> remoteTasks = Sets.difference(new HashSet<>(outboundTasks), new HashSet<>(localTaskIds));
+        return !remoteTasks.isEmpty();
+    }
+
+    /**
+     * If all the tasks are local tasks, the topology has only one worker.
+     * @return true if this worker is the single worker; false otherwise.
+     */
+    public boolean isSingleWorker() {
+        Set<Integer> nonLocalTasks = Sets.difference(getTaskToComponent().keySet(),
+                new HashSet<>(localTaskIds));
+        return nonLocalTasks.isEmpty();
+    }
+
     public void haltWorkerTransfer() {
         workerTransfer.haltTransferThd();
     }

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -684,6 +684,7 @@ public class DaemonConfig implements Validated {
 
     /**
      * A number representing the maximum number of workers any single topology can acquire.
+     * This will be ignored if the Resource Aware Scheduler is used.
      */
     @isInteger
     @isPositiveNumber(includeZero = true)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3021

The Resource Aware Scheduler doesn't honor `Config.TOPOLOGY_WORKERS`. So we need to fix the code where it uses `Config.TOPOLOGY_WORKERS` incorrectly.  Also fix docs/javadocs to avoid confusion. 
