### PR TITLE
STORM-3039 handle slot ports in TIME_WAIT state

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/Server.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/Server.java
@@ -97,6 +97,7 @@ class Server extends ConnectionWithStatus implements IStatefulObject, ISaslServe
         bootstrap.setOption("child.tcpNoDelay", true);
         bootstrap.setOption("child.receiveBufferSize", buffer_size);
         bootstrap.setOption("child.keepAlive", true);
+        bootstrap.setOption("reuseAddress", true);
         bootstrap.setOption("backlog", backlog);
 
         // Set up the pipeline factory.


### PR DESCRIPTION
When worker is killed slot port remains in TIME_WAIT state. Since worker process is killed it is secure to start a new worker process on the same port.