### PR TITLE
STORM-3040: Improve scheduler performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
 
 
         <!-- Java and clojure build lifecycle test properties are defined here to avoid having to create a default profile -->
-        <java.unit.test.exclude>org.apache.storm.testing.IntegrationTest</java.unit.test.exclude>
+        <java.unit.test.exclude>org.apache.storm.testing.IntegrationTest, org.apache.storm.testing.PerformanceTest</java.unit.test.exclude>
         <java.unit.test.include>**/Test*.java, **/*Test.java, **/*TestCase.java</java.unit.test.include>    <!--maven surefire plugin default test list-->
         <java.integration.test.include>no.tests</java.integration.test.include>
         <!-- by default the clojure test set are all clojure tests that are not integration tests. This property is overridden in the profiles -->
@@ -626,10 +626,19 @@
             <id>all-tests</id>
             <properties>
                 <java.integration.test.include>**/*.java</java.integration.test.include>
+                <!-- add perf tests back in -->
+                <java.unit.test.exclude>org.apache.storm.testing.IntegrationTest</java.unit.test.exclude>
                 <clojure.test.set>*.*</clojure.test.set>
             </properties>
         </profile>
         <profile>
+            <id>performance-tests</id>
+            <properties>
+                <!-- add perf tests back in -->
+                <java.unit.test.exclude>org.apache.storm.testing.IntegrationTest</java.unit.test.exclude>
+            </properties>
+        </profile> 
+	<profile>
             <id>integration-tests-only</id>
             <properties>
                 <!--Java-->

--- a/storm-client/src/jvm/org/apache/storm/testing/PerformanceTest.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/PerformanceTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.storm.testing;
+
+/**
+ * Marker interface used to mark performance tests. Performance tests will be run if the profile performance-tests or all-tests are enabled.
+ * <p/>
+ * Performance tests can be in the same package as unit tests. To mark a test as a performance test,
+ * add the annotation @Category(PerformanceTest.class) to the class definition as well as to its hierarchy of superclasses.
+ * For example:
+ * <p/>
+ *
+ *
+ * @ Category(PerformanceTest.class)<br/>
+ * public class MyPerformanceTest {<br/>
+ *  ...<br/>
+ * }
+ *
+ *  In general performance tests should have a time limit on them, but the time limit should be liberal enough to account
+ *  for running on CI systems like travis ci, or the apache jenkins build.
+ */
+public interface PerformanceTest {
+}

--- a/storm-client/src/jvm/org/apache/storm/testing/PerformanceTest.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/PerformanceTest.java
@@ -25,13 +25,11 @@ package org.apache.storm.testing;
  * add the annotation @Category(PerformanceTest.class) to the class definition as well as to its hierarchy of superclasses.
  * For example:
  * <p/>
- *
- *
  * @ Category(PerformanceTest.class)<br/>
  * public class MyPerformanceTest {<br/>
  *  ...<br/>
  * }
- *
+ * <p/>
  *  In general performance tests should have a time limit on them, but the time limit should be liberal enough to account
  *  for running on CI systems like travis ci, or the apache jenkins build.
  */

--- a/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
@@ -47,6 +47,9 @@ import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The current state of the storm cluster.  Cluster is not currently thread safe.
+ */
 public class Cluster implements ISchedulingState {
     private static final Logger LOG = LoggerFactory.getLogger(Cluster.class);
     private static final Function<String, Set<WorkerSlot>> MAKE_SET = (x) -> new HashSet<>();

--- a/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.storm.Config;
 import org.apache.storm.Constants;
@@ -48,6 +49,9 @@ import org.slf4j.LoggerFactory;
 
 public class Cluster implements ISchedulingState {
     private static final Logger LOG = LoggerFactory.getLogger(Cluster.class);
+    private static final Function<String, Set<WorkerSlot>> MAKE_SET = (x) -> new HashSet<>();
+    private static final Function<String, Map<WorkerSlot, NormalizedResourceRequest>> MAKE_MAP = (x) -> new HashMap<>();
+
     /**
      * key: supervisor id, value: supervisor details.
      */
@@ -72,6 +76,7 @@ public class Cluster implements ISchedulingState {
     private final Topologies topologies;
     private final Map<String, Map<WorkerSlot, NormalizedResourceRequest>> nodeToScheduledResourcesCache;
     private final Map<String, Set<WorkerSlot>> nodeToUsedSlotsCache;
+    private final Map<String, NormalizedResourceRequest> totalResourcesPerNodeCache = new HashMap<>();
     private SchedulerAssignmentImpl assignment;
     private Set<String> blackListedHosts = new HashSet<>();
     private INimbus inimbus;
@@ -147,7 +152,7 @@ public class Cluster implements ISchedulingState {
         this.conf = conf;
         this.topologies = topologies;
 
-        ArrayList<String> supervisorHostNames = new ArrayList<String>();
+        ArrayList<String> supervisorHostNames = new ArrayList<>();
         for (SupervisorDetails s : supervisors.values()) {
             supervisorHostNames.add(s.getHost());
         }
@@ -294,7 +299,7 @@ public class Cluster implements ISchedulingState {
 
     @Override
     public List<TopologyDetails> needsSchedulingTopologies() {
-        List<TopologyDetails> ret = new ArrayList<TopologyDetails>();
+        List<TopologyDetails> ret = new ArrayList<>();
         for (TopologyDetails topology : getTopologies()) {
             if (needsScheduling(topology)) {
                 ret.add(topology);
@@ -349,8 +354,10 @@ public class Cluster implements ISchedulingState {
 
     @Override
     public Set<Integer> getUsedPorts(SupervisorDetails supervisor) {
-        return nodeToUsedSlotsCache.computeIfAbsent(supervisor.getId(), (x) -> new HashSet<>()).stream().map(WorkerSlot::getPort)
-                                   .collect(Collectors.toSet());
+        return nodeToUsedSlotsCache.computeIfAbsent(supervisor.getId(), MAKE_SET)
+            .stream()
+            .map(WorkerSlot::getPort)
+            .collect(Collectors.toSet());
     }
 
     @Override
@@ -374,7 +381,7 @@ public class Cluster implements ISchedulingState {
 
     @Override
     public List<WorkerSlot> getAvailableSlots() {
-        List<WorkerSlot> slots = new ArrayList<WorkerSlot>();
+        List<WorkerSlot> slots = new ArrayList<>();
         for (SupervisorDetails supervisor : this.supervisors.values()) {
             slots.addAll(this.getAvailableSlots(supervisor));
         }
@@ -385,7 +392,7 @@ public class Cluster implements ISchedulingState {
     @Override
     public List<WorkerSlot> getAvailableSlots(SupervisorDetails supervisor) {
         Set<Integer> ports = this.getAvailablePorts(supervisor);
-        List<WorkerSlot> slots = new ArrayList<WorkerSlot>(ports.size());
+        List<WorkerSlot> slots = new ArrayList<>(ports.size());
 
         for (Integer port : ports) {
             slots.add(new WorkerSlot(supervisor.getId(), port));
@@ -397,7 +404,7 @@ public class Cluster implements ISchedulingState {
     @Override
     public List<WorkerSlot> getAssignableSlots(SupervisorDetails supervisor) {
         Set<Integer> ports = this.getAssignablePorts(supervisor);
-        List<WorkerSlot> slots = new ArrayList<WorkerSlot>(ports.size());
+        List<WorkerSlot> slots = new ArrayList<>(ports.size());
 
         for (Integer port : ports) {
             slots.add(new WorkerSlot(supervisor.getId(), port));
@@ -408,7 +415,7 @@ public class Cluster implements ISchedulingState {
 
     @Override
     public List<WorkerSlot> getAssignableSlots() {
-        List<WorkerSlot> slots = new ArrayList<WorkerSlot>();
+        List<WorkerSlot> slots = new ArrayList<>();
         for (SupervisorDetails supervisor : this.supervisors.values()) {
             slots.addAll(this.getAssignableSlots(supervisor));
         }
@@ -419,7 +426,7 @@ public class Cluster implements ISchedulingState {
     @Override
     public Collection<ExecutorDetails> getUnassignedExecutors(TopologyDetails topology) {
         if (topology == null) {
-            return new ArrayList<ExecutorDetails>(0);
+            return new ArrayList<>(0);
         }
 
         Collection<ExecutorDetails> ret = new HashSet<>(topology.getExecutors());
@@ -441,7 +448,7 @@ public class Cluster implements ISchedulingState {
             return 0;
         }
 
-        Set<WorkerSlot> slots = new HashSet<WorkerSlot>();
+        Set<WorkerSlot> slots = new HashSet<>();
         slots.addAll(assignment.getExecutorToSlot().values());
         return slots.size();
     }
@@ -608,6 +615,7 @@ public class Cluster implements ISchedulingState {
         double sharedOffHeapMemory = calculateSharedOffHeapMemory(nodeId, assignment);
         assignment.setTotalSharedOffHeapMemory(nodeId, sharedOffHeapMemory);
         updateCachesForWorkerSlot(slot, resources, sharedOffHeapMemory);
+        totalResourcesPerNodeCache.remove(slot.getNodeId());
     }
 
     /**
@@ -676,10 +684,12 @@ public class Cluster implements ISchedulingState {
                 String nodeId = slot.getNodeId();
                 assignment.setTotalSharedOffHeapMemory(
                     nodeId, calculateSharedOffHeapMemory(nodeId, assignment));
-                nodeToScheduledResourcesCache.computeIfAbsent(nodeId, (x) -> new HashMap<>()).put(slot, new NormalizedResourceRequest());
-                nodeToUsedSlotsCache.computeIfAbsent(nodeId, (x) -> new HashSet<>()).remove(slot);
+                nodeToScheduledResourcesCache.computeIfAbsent(nodeId, MAKE_MAP).put(slot, new NormalizedResourceRequest());
+                nodeToUsedSlotsCache.computeIfAbsent(nodeId, MAKE_SET).remove(slot);
             }
         }
+        //Invalidate the cache as something on the node changed
+        totalResourcesPerNodeCache.remove(slot.getNodeId());
     }
 
     /**
@@ -697,7 +707,7 @@ public class Cluster implements ISchedulingState {
 
     @Override
     public boolean isSlotOccupied(WorkerSlot slot) {
-        return nodeToUsedSlotsCache.computeIfAbsent(slot.getNodeId(), (x) -> new HashSet<>()).contains(slot);
+        return nodeToUsedSlotsCache.computeIfAbsent(slot.getNodeId(), MAKE_SET).contains(slot);
     }
 
     @Override
@@ -731,7 +741,7 @@ public class Cluster implements ISchedulingState {
     @Override
     public List<SupervisorDetails> getSupervisorsByHost(String host) {
         List<String> nodeIds = this.hostToId.get(host);
-        List<SupervisorDetails> ret = new ArrayList<SupervisorDetails>();
+        List<SupervisorDetails> ret = new ArrayList<>();
 
         if (nodeIds != null) {
             for (String nodeId : nodeIds) {
@@ -744,7 +754,7 @@ public class Cluster implements ISchedulingState {
 
     @Override
     public Map<String, SchedulerAssignment> getAssignments() {
-        return new HashMap<String, SchedulerAssignment>(assignments);
+        return new HashMap<>(assignments);
     }
 
     /**
@@ -763,6 +773,7 @@ public class Cluster implements ISchedulingState {
             assertValidTopologyForModification(assignment.getTopologyId());
         }
         assignments.clear();
+        totalResourcesPerNodeCache.clear();
         nodeToScheduledResourcesCache.values().forEach(Map::clear);
         nodeToUsedSlotsCache.values().forEach(Set::clear);
         for (SchedulerAssignment assignment : newAssignments.values()) {
@@ -916,28 +927,27 @@ public class Cluster implements ISchedulingState {
         return ret;
     }
 
-
     /**
-     * This medhod updates ScheduledResources and UsedSlots cache for given workerSlot
-     *
-     * @param workerSlot
-     * @param workerResources
-     * @param sharedoffHeapMemory
+     * This medhod updates ScheduledResources and UsedSlots cache for given workerSlot.
      */
     private void updateCachesForWorkerSlot(WorkerSlot workerSlot, WorkerResources workerResources, Double sharedoffHeapMemory) {
         String nodeId = workerSlot.getNodeId();
         NormalizedResourceRequest normalizedResourceRequest = new NormalizedResourceRequest();
         normalizedResourceRequest.add(workerResources);
         normalizedResourceRequest.addOffHeap(sharedoffHeapMemory);
-        nodeToScheduledResourcesCache.computeIfAbsent(nodeId, (x) -> new HashMap<>()).put(workerSlot, normalizedResourceRequest);
-        nodeToUsedSlotsCache.computeIfAbsent(nodeId, (x) -> new HashSet<>()).add(workerSlot);
+        nodeToScheduledResourcesCache.computeIfAbsent(nodeId, MAKE_MAP).put(workerSlot, normalizedResourceRequest);
+        nodeToUsedSlotsCache.computeIfAbsent(nodeId, MAKE_SET).add(workerSlot);
     }
 
     @Override
     public NormalizedResourceRequest getAllScheduledResourcesForNode(String nodeId) {
-        NormalizedResourceRequest totalScheduledResources = new NormalizedResourceRequest();
-        nodeToScheduledResourcesCache.computeIfAbsent(nodeId, (x) -> new HashMap<>()).values().forEach(totalScheduledResources::add);
-        return totalScheduledResources;
+        return totalResourcesPerNodeCache.computeIfAbsent(nodeId, (nid) -> {
+            NormalizedResourceRequest totalScheduledResources = new NormalizedResourceRequest();
+            for (NormalizedResourceRequest req : nodeToScheduledResourcesCache.computeIfAbsent(nodeId, MAKE_MAP).values()) {
+                totalScheduledResources.add(req);
+            }
+            return totalScheduledResources;
+        });
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/scheduler/ISchedulingState.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/ISchedulingState.java
@@ -29,6 +29,7 @@ import org.apache.storm.scheduler.resource.normalization.NormalizedResourceReque
 
 /**
  * An interface that provides access to the current scheduling state.
+ * The scheduling state is not guaranteed to be thread safe.
  */
 public interface ISchedulingState {
 

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/RAS_Node.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/RAS_Node.java
@@ -53,6 +53,14 @@ public class RAS_Node {
     private boolean isAlive;
     private SupervisorDetails sup;
 
+    /**
+     * Create a new node.
+     * @param nodeId the id of the node.
+     * @param sup the supervisor this is for.
+     * @param cluster the cluster this is a part of.
+     * @param workerIdToWorker the mapping of slots already assigned to this node.
+     * @param assignmentMap the mapping of executors already assigned to this node.
+     */
     public RAS_Node(
         String nodeId,
         SupervisorDetails sup,
@@ -99,26 +107,6 @@ public class RAS_Node {
         }
     }
 
-    public static int countFreeSlotsAlive(Collection<RAS_Node> nodes) {
-        int total = 0;
-        for (RAS_Node n : nodes) {
-            if (n.isAlive()) {
-                total += n.totalSlotsFree();
-            }
-        }
-        return total;
-    }
-
-    public static int countTotalSlotsAlive(Collection<RAS_Node> nodes) {
-        int total = 0;
-        for (RAS_Node n : nodes) {
-            if (n.isAlive()) {
-                total += n.totalSlots();
-            }
-        }
-        return total;
-    }
-
     public String getId() {
         return nodeId;
     }
@@ -135,6 +123,10 @@ public class RAS_Node {
         return ret;
     }
 
+    /**
+     * Get the IDs of all free slots on this node.
+     * @return the ids of the free slots.
+     */
     public Collection<String> getFreeSlotsId() {
         if (!isAlive) {
             return new HashSet<>();
@@ -164,6 +156,11 @@ public class RAS_Node {
         return workerIdsToWorkers(getUsedSlotsId());
     }
 
+    /**
+     * Get slots used by the given topology.
+     * @param topId the id of the topology to get.
+     * @return the slots currently assigned to that topology on this node.
+     */
     public Collection<WorkerSlot> getUsedSlots(String topId) {
         Collection<WorkerSlot> ret = null;
         if (topIdToUsedSlots.get(topId) != null) {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOffer.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOffer.java
@@ -96,7 +96,7 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
     /**
      * Calculate the average percentage used.
      * @see NormalizedResources#calculateAveragePercentageUsedBy(org.apache.storm.scheduler.resource.normalization.NormalizedResources,
-     *     double, double).
+     *     double, double)
      */
     public double calculateAveragePercentageUsedBy(NormalizedResourceOffer used) {
         return normalizedResources.calculateAveragePercentageUsedBy(
@@ -115,7 +115,7 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
     /**
      * Check if resources might be able to fit.
      * @see NormalizedResources#couldHoldIgnoringSharedMemory(org.apache.storm.scheduler.resource.normalization.NormalizedResources, double,
-     *     double).
+     *     double)
      */
     public boolean couldHoldIgnoringSharedMemory(NormalizedResourcesWithMemory other) {
         return normalizedResources.couldHoldIgnoringSharedMemory(
@@ -136,6 +136,11 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
         return "Normalized resources: " + toNormalizedMap();
     }
 
+    /**
+     * If a node or rack has a kind of resource not in a request, make that resource negative so when sorting that node or rack will
+     * be less likely to be selected.
+     * @param requestedResources the requested resources.
+     */
     public void updateForRareResourceAffinity(NormalizedResourceRequest requestedResources) {
         normalizedResources.updateForRareResourceAffinity(requestedResources.getNormalizedResources());
     }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOffer.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOffer.java
@@ -43,10 +43,18 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
         this.normalizedResources = new NormalizedResources(normalizedResourceMap);
     }
 
+    /**
+     * Create an offer with all resources set to 0.
+     */
     public NormalizedResourceOffer() {
-        this((Map<String, ? extends Number>) null);
+        normalizedResources = new NormalizedResources();
+        totalMemoryMb = 0.0;
     }
 
+    /**
+     * Copy Constructor.
+     * @param other what to copy.
+     */
     public NormalizedResourceOffer(NormalizedResourceOffer other) {
         this.totalMemoryMb = other.totalMemoryMb;
         this.normalizedResources = new NormalizedResources(other.normalizedResources);
@@ -57,6 +65,10 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
         return totalMemoryMb;
     }
 
+    /**
+     * Return these resources as a normalized map.
+     * @return the normalized map.
+     */
     public Map<String, Double> toNormalizedMap() {
         Map<String, Double> ret = normalizedResources.toNormalizedMap();
         ret.put(Constants.COMMON_TOTAL_MEMORY_RESOURCE_NAME, totalMemoryMb);
@@ -68,6 +80,10 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
         totalMemoryMb += other.getTotalMemoryMb();
     }
 
+    /**
+     * Remove the resources in other from this.
+     * @param other what to remove.
+     */
     public void remove(NormalizedResourcesWithMemory other) {
         normalizedResources.remove(other.getNormalizedResources());
         totalMemoryMb -= other.getTotalMemoryMb();
@@ -75,10 +91,10 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
             normalizedResources.throwBecauseResourceBecameNegative(
                 Constants.COMMON_TOTAL_MEMORY_RESOURCE_NAME, totalMemoryMb, other.getTotalMemoryMb());
         }
-        ;
     }
 
     /**
+     * Calculate the average percentage used.
      * @see NormalizedResources#calculateAveragePercentageUsedBy(org.apache.storm.scheduler.resource.normalization.NormalizedResources,
      *     double, double).
      */
@@ -88,6 +104,7 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
     }
 
     /**
+     * Calculate the min percentage used of the resource.
      * @see NormalizedResources#calculateMinPercentageUsedBy(org.apache.storm.scheduler.resource.normalization.NormalizedResources, double,
      *     double)
      */
@@ -96,6 +113,7 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
     }
 
     /**
+     * Check if resources might be able to fit.
      * @see NormalizedResources#couldHoldIgnoringSharedMemory(org.apache.storm.scheduler.resource.normalization.NormalizedResources, double,
      *     double).
      */
@@ -111,5 +129,20 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
     @Override
     public NormalizedResources getNormalizedResources() {
         return normalizedResources;
+    }
+
+    @Override
+    public String toString() {
+        return "Normalized resources: " + toNormalizedMap();
+    }
+
+    public void updateForRareResourceAffinity(NormalizedResourceRequest requestedResources) {
+        normalizedResources.updateForRareResourceAffinity(requestedResources.getNormalizedResources());
+    }
+
+    @Override
+    public void clear() {
+        this.totalMemoryMb = 0.0;
+        this.normalizedResources.clear();
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
@@ -43,15 +43,24 @@ public class NormalizedResourceRequest implements NormalizedResourcesWithMemory 
 
     private NormalizedResourceRequest(Map<String, ? extends Number> resources,
                                       Map<String, Double> defaultResources) {
-        Map<String, Double> normalizedResourceMap = NormalizedResources.RESOURCE_NAME_NORMALIZER.normalizedResourceMap(defaultResources);
-        normalizedResourceMap.putAll(NormalizedResources.RESOURCE_NAME_NORMALIZER.normalizedResourceMap(resources));
-        onHeap = normalizedResourceMap.getOrDefault(Constants.COMMON_ONHEAP_MEMORY_RESOURCE_NAME, 0.0);
-        offHeap = normalizedResourceMap.getOrDefault(Constants.COMMON_OFFHEAP_MEMORY_RESOURCE_NAME, 0.0);
-        normalizedResources = new NormalizedResources(normalizedResourceMap);
+        if (resources == null && defaultResources == null) {
+            onHeap = 0.0;
+            offHeap = 0.0;
+            normalizedResources = new NormalizedResources();
+        } else {
+            Map<String, Double> normalizedResourceMap = NormalizedResources.RESOURCE_NAME_NORMALIZER
+                .normalizedResourceMap(defaultResources);
+            normalizedResourceMap.putAll(NormalizedResources.RESOURCE_NAME_NORMALIZER.normalizedResourceMap(resources));
+            onHeap = normalizedResourceMap.getOrDefault(Constants.COMMON_ONHEAP_MEMORY_RESOURCE_NAME, 0.0);
+            offHeap = normalizedResourceMap.getOrDefault(Constants.COMMON_OFFHEAP_MEMORY_RESOURCE_NAME, 0.0);
+            normalizedResources = new NormalizedResources(normalizedResourceMap);
+        }
     }
+
     public NormalizedResourceRequest(ComponentCommon component, Map<String, Object> topoConf) {
         this(parseResources(component.get_json_conf()), getDefaultResources(topoConf));
     }
+
     public NormalizedResourceRequest(Map<String, Object> topoConf) {
         this((Map<String, ? extends Number>) null, getDefaultResources(topoConf));
     }
@@ -174,7 +183,7 @@ public class NormalizedResourceRequest implements NormalizedResourcesWithMemory 
 
     @Override
     public String toString() {
-        return super.toString() + " onHeap: " + onHeap + " offHeap: " + offHeap;
+        return "Normalized resources: " + toNormalizedMap();
     }
 
     public double getTotalCpu() {
@@ -184,5 +193,12 @@ public class NormalizedResourceRequest implements NormalizedResourcesWithMemory 
     @Override
     public NormalizedResources getNormalizedResources() {
         return this.normalizedResources;
+    }
+
+    @Override
+    public void clear() {
+        normalizedResources.clear();
+        offHeap = 0.0;
+        onHeap = 0.0;
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
@@ -134,6 +134,10 @@ public class NormalizedResourceRequest implements NormalizedResourcesWithMemory 
         return topologyResources;
     }
 
+    /**
+     * Convert to a map that is used by configuration and the UI.
+     * @return a map with the key as the resource name and the value the resource amount.
+     */
     public Map<String, Double> toNormalizedMap() {
         Map<String, Double> ret = this.normalizedResources.toNormalizedMap();
         ret.put(Constants.COMMON_OFFHEAP_MEMORY_RESOURCE_NAME, offHeap);
@@ -168,6 +172,10 @@ public class NormalizedResourceRequest implements NormalizedResourcesWithMemory 
         offHeap += other.offHeap;
     }
 
+    /**
+     * Add the resources from a worker to those in this.
+     * @param value the resources on the worker.
+     */
     public void add(WorkerResources value) {
         this.normalizedResources.add(value);
         //The resources are already normalized

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResources.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResources.java
@@ -45,6 +45,14 @@ public class NormalizedResources {
     private double[] otherResources;
 
     /**
+     * Create an empty NormalizedResources.
+     */
+    NormalizedResources() {
+        cpu = 0.0;
+        otherResources = RESOURCE_MAP_ARRAY_BRIDGE.empty();
+    }
+
+    /**
      * Copy constructor.
      */
     public NormalizedResources(NormalizedResources other) {
@@ -224,12 +232,6 @@ public class NormalizedResources {
      *                                  resources that are not present in the total.
      */
     public double calculateAveragePercentageUsedBy(NormalizedResources used, double totalMemoryMb, double usedMemoryMb) {
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("Calculating avg percentage used by. Used Mem: {} Total Mem: {}"
-                      + " Used Normalized Resources: {} Total Normalized Resources: {}", totalMemoryMb, usedMemoryMb,
-                      toNormalizedMap(), used.toNormalizedMap());
-        }
-
         int skippedResourceTypes = 0;
         double total = 0.0;
         if (usedMemoryMb > totalMemoryMb) {
@@ -343,5 +345,24 @@ public class NormalizedResources {
             min = Math.min(min, used.otherResources[i] / otherResources[i]);
         }
         return min * 100.0;
+    }
+
+    public void updateForRareResourceAffinity(NormalizedResources other) {
+        int length = Math.min(this.otherResources.length, other.otherResources.length);
+        for (int i = 0; i < length; i++) {
+            if (other.getResourceAt(i) == 0.0) {
+                this.otherResources[i] = -1 * this.otherResources[i];
+            }
+        }
+    }
+
+    /**
+     * Set all resources to 0.
+     */
+    public void clear() {
+        this.cpu = 0.0;
+        for (int i = 0; i < otherResources.length; i++) {
+            otherResources[i] = 0.0;
+        }
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResources.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResources.java
@@ -347,10 +347,15 @@ public class NormalizedResources {
         return min * 100.0;
     }
 
-    public void updateForRareResourceAffinity(NormalizedResources other) {
-        int length = Math.min(this.otherResources.length, other.otherResources.length);
+    /**
+     * If a node or rack has a kind of resource not in a request, make that resource negative so when sorting that node or rack will
+     * be less likely to be selected.
+     * @param request the requested resources.
+     */
+    public void updateForRareResourceAffinity(NormalizedResources request) {
+        int length = Math.min(this.otherResources.length, request.otherResources.length);
         for (int i = 0; i < length; i++) {
-            if (other.getResourceAt(i) == 0.0) {
+            if (request.getResourceAt(i) == 0.0) {
                 this.otherResources[i] = -1 * this.otherResources[i];
             }
         }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourcesWithMemory.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourcesWithMemory.java
@@ -25,4 +25,9 @@ public interface NormalizedResourcesWithMemory {
 
     double getTotalMemoryMb();
 
+    /**
+     * Set all resources to 0.
+     */
+    void clear();
+
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/ResourceMapArrayBridge.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/ResourceMapArrayBridge.java
@@ -65,7 +65,7 @@ public class ResourceMapArrayBridge {
     }
 
     /**
-     * Create an array that has all values 0;
+     * Create an array that has all values 0.
      * @return the empty array.
      */
     public double[] empty() {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/ResourceMapArrayBridge.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/ResourceMapArrayBridge.java
@@ -65,6 +65,14 @@ public class ResourceMapArrayBridge {
     }
 
     /**
+     * Create an array that has all values 0;
+     * @return the empty array.
+     */
+    public double[] empty() {
+        return new double[counter.get()];
+    }
+
+    /**
      * Translates an array of resource values to a normalized resource map.
      *
      * @param resources The resource array to translate

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
@@ -24,35 +24,64 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.storm.generated.ComponentType;
+import org.apache.storm.networktopography.DNSToSwitchMapping;
 import org.apache.storm.scheduler.Cluster;
 import org.apache.storm.scheduler.Component;
 import org.apache.storm.scheduler.ExecutorDetails;
+import org.apache.storm.scheduler.SchedulerAssignment;
 import org.apache.storm.scheduler.TopologyDetails;
 import org.apache.storm.scheduler.WorkerSlot;
 import org.apache.storm.scheduler.resource.RAS_Node;
 import org.apache.storm.scheduler.resource.RAS_Nodes;
+import org.apache.storm.scheduler.resource.SchedulingResult;
+import org.apache.storm.scheduler.resource.SchedulingStatus;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResourceOffer;
+import org.apache.storm.scheduler.resource.normalization.NormalizedResourceRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class BaseResourceAwareStrategy implements IStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(BaseResourceAwareStrategy.class);
     protected Cluster cluster;
-    protected RAS_Nodes nodes;
+    // Rack id to list of host names in that rack
     private Map<String, List<String>> networkTopography;
+    private final Map<String, String> superIdToRack = new HashMap<>();
+    private final Map<String, String> superIdToHostname = new HashMap<>();
+    private final Map<String, List<RAS_Node>> hostnameToNodes = new HashMap<>();
+    private final Map<String, List<RAS_Node>> rackIdToNodes = new HashMap<>();
+    protected RAS_Nodes nodes;
 
     @VisibleForTesting
     void prepare(Cluster cluster) {
         this.cluster = cluster;
         nodes = new RAS_Nodes(cluster);
         networkTopography = cluster.getNetworkTopography();
+        Map<String, String> hostToRack = new HashMap<>();
+        for (Map.Entry<String, List<String>> entry : networkTopography.entrySet()) {
+            String rackId = entry.getKey();
+            for (String hostName: entry.getValue()) {
+                hostToRack.put(hostName, rackId);
+            }
+        }
+        for (RAS_Node node: nodes.getNodes()) {
+            String superId = node.getId();
+            String hostName = node.getHostname();
+            String rackId = hostToRack.getOrDefault(hostName, DNSToSwitchMapping.DEFAULT_RACK);
+            superIdToHostname.put(superId, hostName);
+            superIdToRack.put(superId, rackId);
+            hostnameToNodes.computeIfAbsent(hostName, (hn) -> new ArrayList<>()).add(node);
+            rackIdToNodes.computeIfAbsent(rackId, (hn) -> new ArrayList<>()).add(node);
+        }
         logClusterInfo();
     }
 
@@ -61,15 +90,22 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
         //NOOP
     }
 
+    protected SchedulingResult mkNotEnoughResources(TopologyDetails td) {
+        return  SchedulingResult.failure(
+            SchedulingStatus.FAIL_NOT_ENOUGH_RESOURCES,
+            td.getExecutors().size() + " executors not scheduled");
+    }
+
     /**
      * Schedule executor exec from topology td.
      *
      * @param exec           the executor to schedule
      * @param td             the topology executor exec is a part of
      * @param scheduledTasks executors that have been scheduled
+     * @return true if scheduled successfully, else false.
      */
-    protected void scheduleExecutor(
-        ExecutorDetails exec, TopologyDetails td, Collection<ExecutorDetails> scheduledTasks, List<ObjectResources> sortedNodes) {
+    protected boolean scheduleExecutor(
+            ExecutorDetails exec, TopologyDetails td, Collection<ExecutorDetails> scheduledTasks, Iterable<String> sortedNodes) {
         WorkerSlot targetSlot = findWorkerForExec(exec, td, sortedNodes);
         if (targetSlot != null) {
             RAS_Node targetNode = idToNode(targetSlot.getNodeId());
@@ -86,8 +122,12 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
                 targetNode.getTotalCpuResources(),
                 targetSlot,
                 nodeToRack(targetNode));
+            return true;
         } else {
-            LOG.error("Not Enough Resources to schedule Task {}", exec);
+            String comp = td.getExecutorToComponent().get(exec);
+            NormalizedResourceRequest requestedResources = td.getTotalResources(exec);
+            LOG.error("Not Enough Resources to schedule Task {} - {} {}", exec, comp, requestedResources);
+            return false;
         }
     }
 
@@ -103,12 +143,14 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
      * @param td   the topology that the executor is a part of
      * @return a worker to assign exec on. Returns null if a worker cannot be successfully found in cluster
      */
-    protected WorkerSlot findWorkerForExec(ExecutorDetails exec, TopologyDetails td, List<ObjectResources> sortedNodes) {
-        for (ObjectResources nodeResources : sortedNodes) {
-            RAS_Node node = nodes.getNodeById(nodeResources.id);
-            for (WorkerSlot ws : node.getSlotsAvailbleTo(td)) {
-                if (node.wouldFit(ws, exec, td)) {
-                    return ws;
+    protected WorkerSlot findWorkerForExec(ExecutorDetails exec, TopologyDetails td, Iterable<String> sortedNodes) {
+        for (String id : sortedNodes) {
+            RAS_Node node = nodes.getNodeById(id);
+            if (node.couldEverFit(exec, td)) {
+                for (WorkerSlot ws : node.getSlotsAvailableToScheduleOn()) {
+                    if (node.wouldFit(ws, exec, td)) {
+                        return ws;
+                    }
                 }
             }
         }
@@ -133,96 +175,219 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
      * @return a sorted list of nodes.
      */
     protected TreeSet<ObjectResources> sortNodes(
-        List<RAS_Node> availNodes, ExecutorDetails exec, TopologyDetails topologyDetails, String rackId) {
-        AllResources allResources = new AllResources("RACK");
-        List<ObjectResources> nodes = allResources.objectResources;
+            List<RAS_Node> availNodes, ExecutorDetails exec, TopologyDetails topologyDetails, String rackId,
+            Map<String, AtomicInteger> scheduledCount) {
+        AllResources allRackResources = new AllResources("RACK");
+        List<ObjectResources> nodes = allRackResources.objectResources;
 
         for (RAS_Node rasNode : availNodes) {
-            String nodeId = rasNode.getId();
-            ObjectResources node = new ObjectResources(nodeId);
+            String superId = rasNode.getId();
+            ObjectResources node = new ObjectResources(superId);
 
             node.availableResources = rasNode.getTotalAvailableResources();
             node.totalResources = rasNode.getTotalResources();
 
             nodes.add(node);
-            allResources.availableResourcesOverall.add(node.availableResources);
-            allResources.totalResourcesOverall.add(node.totalResources);
+            allRackResources.availableResourcesOverall.add(node.availableResources);
+            allRackResources.totalResourcesOverall.add(node.totalResources);
 
         }
 
         LOG.debug(
             "Rack {}: Overall Avail [ {} ] Total [ {} ]",
             rackId,
-            allResources.availableResourcesOverall,
-            allResources.totalResourcesOverall);
+            allRackResources.availableResourcesOverall,
+            allRackResources.totalResourcesOverall);
 
-        String topoId = topologyDetails.getId();
         return sortObjectResources(
-            allResources,
+            allRackResources,
             exec,
             topologyDetails,
-            new ExistingScheduleFunc() {
-                @Override
-                public int getNumExistingSchedule(String objectId) {
-
-                    //Get execs already assigned in rack
-                    Collection<ExecutorDetails> execs = new LinkedList<>();
-                    if (cluster.getAssignmentById(topoId) != null) {
-                        for (Map.Entry<ExecutorDetails, WorkerSlot> entry :
-                            cluster.getAssignmentById(topoId).getExecutorToSlot().entrySet()) {
-                            WorkerSlot workerSlot = entry.getValue();
-                            ExecutorDetails exec = entry.getKey();
-                            if (workerSlot.getNodeId().equals(objectId)) {
-                                execs.add(exec);
-                            }
-                        }
-                    }
-                    return execs.size();
+            (superId) -> {
+                AtomicInteger count = scheduledCount.get(superId);
+                if (count == null) {
+                    return 0;
                 }
+                return count.get();
             });
     }
 
-    protected List<ObjectResources> sortAllNodes(TopologyDetails td, ExecutorDetails exec,
-                                                 List<String> favoredNodes, List<String> unFavoredNodes) {
-        TreeSet<ObjectResources> sortedRacks = sortRacks(exec, td);
-        ArrayList<ObjectResources> totallySortedNodes = new ArrayList<>();
-        for (ObjectResources rack : sortedRacks) {
-            final String rackId = rack.id;
-            TreeSet<ObjectResources> sortedNodes = sortNodes(
-                getAvailableNodesFromRack(rackId), exec, td, rackId);
-            totallySortedNodes.addAll(sortedNodes);
+    protected List<String> makeHostToNodeIds(List<String> hosts) {
+        if (hosts == null) {
+            return Collections.emptyList();
         }
-        //Now do some post processing to add make some nodes preferred over others.
-        if (favoredNodes != null || unFavoredNodes != null) {
-            HashMap<String, Integer> hostOrder = new HashMap<>();
-            if (favoredNodes != null) {
-                int size = favoredNodes.size();
-                for (int i = 0; i < size; i++) {
-                    //First in the list is the most desired so gets the Lowest possible value
-                    hostOrder.put(favoredNodes.get(i), -(size - i));
+        List<String> ret = new ArrayList<>(hosts.size());
+        for (String host: hosts) {
+            List<RAS_Node> nodes = hostnameToNodes.get(host);
+            if (nodes != null) {
+                for (RAS_Node node : nodes) {
+                    ret.add(node.getId());
                 }
             }
-            if (unFavoredNodes != null) {
-                int size = unFavoredNodes.size();
-                for (int i = 0; i < size; i++) {
-                    //First in the list is the least desired so gets the highest value
-                    hostOrder.put(unFavoredNodes.get(i), size - i);
+        }
+        return ret;
+    }
+
+    private static class LazyNodeSortingIterator implements Iterator<String> {
+        private final LazyNodeSorting parent;
+        private final Iterator<ObjectResources> rackIterator;
+        private Iterator<ObjectResources> nodeIterator;
+        private String nextValueFromNode = null;
+        private final Iterator<String> pre;
+        private final Iterator<String> post;
+        private final Set<String> skip;
+
+        public LazyNodeSortingIterator(LazyNodeSorting parent,
+                                       TreeSet<ObjectResources> sortedRacks) {
+            this.parent = parent;
+            rackIterator = sortedRacks.iterator();
+            pre = parent.favoredNodeIds.iterator();
+            post = parent.unFavoredNodeIds.iterator();
+            skip = parent.skippedNodeIds;
+        }
+
+        private Iterator<ObjectResources> getNodeIterator() {
+            if (nodeIterator != null && nodeIterator.hasNext()) {
+                return nodeIterator;
+            }
+            //need to get the next node iterator
+            if (rackIterator.hasNext()) {
+                ObjectResources rack = rackIterator.next();
+                final String rackId = rack.id;
+                nodeIterator = parent.getSortedNodesFor(rackId).iterator();
+                return nodeIterator;
+            }
+
+            return null;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (pre.hasNext()) {
+                return true;
+            }
+            while (true) {
+                //For the node we don't know if we have another one unless we look at the contents
+                Iterator<ObjectResources> nodeIterator = getNodeIterator();
+                if (nodeIterator == null || !nodeIterator.hasNext()) {
+                    break;
+                }
+                nextValueFromNode = nodeIterator.next().id;
+                if (!skip.contains(nextValueFromNode)) {
+                    return true;
                 }
             }
-            //java guarantees a stable sort so we can just return 0 for values we don't want to move.
-            Collections.sort(totallySortedNodes, (o1, o2) -> {
-                RAS_Node n1 = this.nodes.getNodeById(o1.id);
-                String host1 = n1.getHostname();
-                int h1Value = hostOrder.getOrDefault(host1, 0);
-
-                RAS_Node n2 = this.nodes.getNodeById(o2.id);
-                String host2 = n2.getHostname();
-                int h2Value = hostOrder.getOrDefault(host2, 0);
-
-                return Integer.compare(h1Value, h2Value);
-            });
+            if (post.hasNext()) {
+                return true;
+            }
+            return false;
         }
-        return totallySortedNodes;
+
+        @Override
+        public String next() {
+            if (pre.hasNext()) {
+                return pre.next();
+            }
+            if (nextValueFromNode != null) {
+                String tmp = nextValueFromNode;
+                nextValueFromNode = null;
+                return tmp;
+            }
+            return post.next();
+        }
+    }
+
+    private class LazyNodeSorting implements Iterable<String> {
+        private final Map<String, AtomicInteger> perNodeScheduledCount = new HashMap<>();
+        private final TreeSet<ObjectResources> sortedRacks;
+        private final Map<String, TreeSet<ObjectResources>> cachedNodes = new HashMap<>();
+        private final ExecutorDetails exec;
+        private final TopologyDetails td;
+        private final List<String> favoredNodeIds;
+        private final List<String> unFavoredNodeIds;
+        private final Set<String> skippedNodeIds = new HashSet<>();
+
+        public LazyNodeSorting(TopologyDetails td, ExecutorDetails exec,
+                               List<String> favoredNodeIds, List<String> unFavoredNodeIds) {
+            this.favoredNodeIds = favoredNodeIds;
+            this.unFavoredNodeIds = unFavoredNodeIds;
+            this.unFavoredNodeIds.removeAll(favoredNodeIds);
+            skippedNodeIds.addAll(favoredNodeIds);
+            skippedNodeIds.addAll(unFavoredNodeIds);
+
+            this.td = td;
+            this.exec = exec;
+            String topoId = td.getId();
+            SchedulerAssignment assignment = cluster.getAssignmentById(topoId);
+            if (assignment != null) {
+                for (Map.Entry<WorkerSlot, Collection<ExecutorDetails>> entry :
+                    assignment.getSlotToExecutors().entrySet()) {
+                    String superId = entry.getKey().getNodeId();
+                    perNodeScheduledCount.computeIfAbsent(superId, (sid) -> new AtomicInteger(0))
+                        .getAndAdd(entry.getValue().size());
+                }
+            }
+            sortedRacks = sortRacks(exec, td);
+        }
+
+        private TreeSet<ObjectResources> getSortedNodesFor(String rackId) {
+            return cachedNodes.computeIfAbsent(rackId,
+                (rid) -> sortNodes(rackIdToNodes.get(rid), exec, td, rid, perNodeScheduledCount));
+        }
+
+        @Override
+        public Iterator<String> iterator() {
+            return new LazyNodeSortingIterator(this, sortedRacks);
+        }
+    }
+
+    protected Iterable<String> sortAllNodes(TopologyDetails td, ExecutorDetails exec,
+                                            List<String> favoredNodeIds, List<String> unFavoredNodeIds) {
+        return new LazyNodeSorting(td, exec, favoredNodeIds, unFavoredNodeIds);
+    }
+
+    private AllResources createClusterAllResources() {
+        AllResources allResources = new AllResources("Cluster");
+        List<ObjectResources> racks = allResources.objectResources;
+
+        //This is the first time so initialize the resources.
+        for (Map.Entry<String, List<String>> entry : networkTopography.entrySet()) {
+            String rackId = entry.getKey();
+            List<String> nodeHosts = entry.getValue();
+            ObjectResources rack = new ObjectResources(rackId);
+            racks.add(rack);
+            for (String nodeHost : nodeHosts) {
+                for (RAS_Node node : hostnameToNodes(nodeHost)) {
+                    rack.availableResources.add(node.getTotalAvailableResources());
+                    rack.totalResources.add(node.getTotalAvailableResources());
+                }
+            }
+
+            allResources.totalResourcesOverall.add(rack.totalResources);
+            allResources.availableResourcesOverall.add(rack.availableResources);
+        }
+
+        LOG.debug(
+            "Cluster Overall Avail [ {} ] Total [ {} ]",
+            allResources.availableResourcesOverall,
+            allResources.totalResourcesOverall);
+        return allResources;
+    }
+
+    private Map<String, AtomicInteger> getScheduledCount(TopologyDetails topologyDetails) {
+        String topoId = topologyDetails.getId();
+        SchedulerAssignment assignment = cluster.getAssignmentById(topoId);
+        Map<String, AtomicInteger> scheduledCount = new HashMap<>();
+        if (assignment != null) {
+            for (Map.Entry<WorkerSlot, Collection<ExecutorDetails>> entry :
+                assignment.getSlotToExecutors().entrySet()) {
+                String superId = entry.getKey().getNodeId();
+                String rackId = superIdToRack.get(superId);
+                scheduledCount.computeIfAbsent(rackId, (rid) -> new AtomicInteger(0))
+                    .getAndAdd(entry.getValue().size());
+            }
+        }
+        return scheduledCount;
     }
 
     /**
@@ -242,55 +407,20 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
      */
     @VisibleForTesting
     TreeSet<ObjectResources> sortRacks(ExecutorDetails exec, TopologyDetails topologyDetails) {
-        AllResources allResources = new AllResources("Cluster");
-        List<ObjectResources> racks = allResources.objectResources;
 
-        final Map<String, String> nodeIdToRackId = new HashMap<String, String>();
+        final AllResources allResources = createClusterAllResources();
+        final Map<String, AtomicInteger> scheduledCount = getScheduledCount(topologyDetails);
 
-        for (Map.Entry<String, List<String>> entry : networkTopography.entrySet()) {
-            String rackId = entry.getKey();
-            List<String> nodeIds = entry.getValue();
-            ObjectResources rack = new ObjectResources(rackId);
-            racks.add(rack);
-            for (String nodeId : nodeIds) {
-                RAS_Node node = nodes.getNodeById(nodeHostnameToId(nodeId));
-                rack.availableResources.add(node.getTotalAvailableResources());
-                rack.totalResources.add(node.getTotalAvailableResources());
-
-                nodeIdToRackId.put(nodeId, rack.id);
-
-                allResources.totalResourcesOverall.add(rack.totalResources);
-                allResources.availableResourcesOverall.add(rack.availableResources);
-
-            }
-        }
-        LOG.debug(
-            "Cluster Overall Avail [ {} ] Total [ {} ]",
-            allResources.availableResourcesOverall,
-            allResources.totalResourcesOverall);
-
-        String topoId = topologyDetails.getId();
         return sortObjectResources(
             allResources,
             exec,
             topologyDetails,
-            (objectId) -> {
-                String rackId = objectId;
-                //Get execs already assigned in rack
-                Collection<ExecutorDetails> execs = new LinkedList<>();
-                if (cluster.getAssignmentById(topoId) != null) {
-                    for (Map.Entry<ExecutorDetails, WorkerSlot> entry :
-                        cluster.getAssignmentById(topoId).getExecutorToSlot().entrySet()) {
-                        String nodeId = entry.getValue().getNodeId();
-                        String hostname = idToNode(nodeId).getHostname();
-                        ExecutorDetails exec1 = entry.getKey();
-                        if (nodeIdToRackId.get(hostname) != null
-                            && nodeIdToRackId.get(hostname).equals(rackId)) {
-                            execs.add(exec1);
-                        }
-                    }
+            (rackId) -> {
+                AtomicInteger count = scheduledCount.get(rackId);
+                if (count == null) {
+                    return 0;
                 }
-                return execs.size();
+                return count.get();
             });
     }
 
@@ -301,27 +431,7 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
      * @return the rack id
      */
     protected String nodeToRack(RAS_Node node) {
-        for (Map.Entry<String, List<String>> entry : networkTopography.entrySet()) {
-            if (entry.getValue().contains(node.getHostname())) {
-                return entry.getKey();
-            }
-        }
-        LOG.error("Node: {} not found in any racks", node.getHostname());
-        return null;
-    }
-
-    /**
-     * get a list nodes from a rack.
-     *
-     * @param rackId the rack id of the rack to get nodes from
-     * @return a list of nodes
-     */
-    protected List<RAS_Node> getAvailableNodesFromRack(String rackId) {
-        List<RAS_Node> retList = new ArrayList<>();
-        for (String nodeId : networkTopography.get(rackId)) {
-            retList.add(nodes.getNodeById(this.nodeHostnameToId(nodeId)));
-        }
-        return retList;
+        return superIdToRack.get(node.getId());
     }
 
     /**
@@ -459,9 +569,7 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
     }
 
     /**
-     * Get the amount of resources available and total for each node.
-     *
-     * @return a String with cluster resource info for debug
+     * Log a bunch of stuff for debugging.
      */
     private void logClusterInfo() {
         if (LOG.isDebugEnabled()) {
@@ -470,40 +578,32 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
                 String rackId = clusterEntry.getKey();
                 LOG.debug("Rack: {}", rackId);
                 for (String nodeHostname : clusterEntry.getValue()) {
-                    RAS_Node node = idToNode(this.nodeHostnameToId(nodeHostname));
-                    LOG.debug("-> Node: {} {}", node.getHostname(), node.getId());
-                    LOG.debug(
-                        "--> Avail Resources: {Mem {}, CPU {} Slots: {}}",
-                        node.getAvailableMemoryResources(),
-                        node.getAvailableCpuResources(),
-                        node.totalSlotsFree());
-                    LOG.debug(
-                        "--> Total Resources: {Mem {}, CPU {} Slots: {}}",
-                        node.getTotalMemoryResources(),
-                        node.getTotalCpuResources(),
-                        node.totalSlots());
+                    for (RAS_Node node : hostnameToNodes(nodeHostname)) {
+                        LOG.debug("-> Node: {} {}", node.getHostname(), node.getId());
+                        LOG.debug(
+                            "--> Avail Resources: {Mem {}, CPU {} Slots: {}}",
+                            node.getAvailableMemoryResources(),
+                            node.getAvailableCpuResources(),
+                            node.totalSlotsFree());
+                        LOG.debug(
+                            "--> Total Resources: {Mem {}, CPU {} Slots: {}}",
+                            node.getTotalMemoryResources(),
+                            node.getTotalCpuResources(),
+                            node.totalSlots());
+                    }
                 }
             }
         }
     }
 
     /**
-     * hostname to Id.
+     * hostname to Ids.
      *
-     * @param hostname the hostname to convert to node id
-     * @return the id of a node
+     * @param hostname the hostname.
+     * @return the ids n that node.
      */
-    public String nodeHostnameToId(String hostname) {
-        for (RAS_Node n : nodes.getNodes()) {
-            if (n.getHostname() == null) {
-                continue;
-            }
-            if (n.getHostname().equals(hostname)) {
-                return n.getId();
-            }
-        }
-        LOG.error("Cannot find Node with hostname {}", hostname);
-        return null;
+    public List<RAS_Node> hostnameToNodes(String hostname) {
+        return hostnameToNodes.get(hostname);
     }
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/GenericResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/GenericResourceAwareStrategy.java
@@ -44,6 +44,10 @@ public class GenericResourceAwareStrategy extends BaseResourceAwareStrategy impl
         final AllResources allResources, ExecutorDetails exec, TopologyDetails topologyDetails,
         final ExistingScheduleFunc existingScheduleFunc) {
         AllResources affinityBasedAllResources = new AllResources(allResources);
+        NormalizedResourceRequest requestedResources = topologyDetails.getTotalResources(exec);
+        for (ObjectResources objectResources : affinityBasedAllResources.objectResources) {
+            objectResources.availableResources.updateForRareResourceAffinity(requestedResources);
+        }
 
         TreeSet<ObjectResources> sortedObjectResources =
             new TreeSet<>((o1, o2) -> {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/GenericResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/GenericResourceAwareStrategy.java
@@ -30,6 +30,7 @@ import org.apache.storm.scheduler.ExecutorDetails;
 import org.apache.storm.scheduler.TopologyDetails;
 import org.apache.storm.scheduler.resource.SchedulingResult;
 import org.apache.storm.scheduler.resource.SchedulingStatus;
+import org.apache.storm.scheduler.resource.normalization.NormalizedResourceRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +82,7 @@ public class GenericResourceAwareStrategy extends BaseResourceAwareStrategy impl
         }
         Collection<ExecutorDetails> unassignedExecutors =
             new HashSet<>(this.cluster.getUnassignedExecutors(td));
-        LOG.info("ExecutorsNeedScheduling: {}", unassignedExecutors);
+        LOG.debug("Num ExecutorsNeedScheduling: {}", unassignedExecutors.size());
         Collection<ExecutorDetails> scheduledTasks = new ArrayList<>();
         List<Component> spouts = this.getSpouts(td);
 
@@ -92,10 +93,10 @@ public class GenericResourceAwareStrategy extends BaseResourceAwareStrategy impl
         }
 
         //order executors to be scheduled
-        List<ExecutorDetails> orderedExecutors = this.orderExecutors(td, unassignedExecutors);
+        List<ExecutorDetails> orderedExecutors = orderExecutors(td, unassignedExecutors);
         Collection<ExecutorDetails> executorsNotScheduled = new HashSet<>(unassignedExecutors);
-        List<String> favoredNodes = (List<String>) td.getConf().get(Config.TOPOLOGY_SCHEDULER_FAVORED_NODES);
-        List<String> unFavoredNodes = (List<String>) td.getConf().get(Config.TOPOLOGY_SCHEDULER_UNFAVORED_NODES);
+        List<String> favoredNodeIds = makeHostToNodeIds((List<String>) td.getConf().get(Config.TOPOLOGY_SCHEDULER_FAVORED_NODES));
+        List<String> unFavoredNodeIds = makeHostToNodeIds((List<String>) td.getConf().get(Config.TOPOLOGY_SCHEDULER_UNFAVORED_NODES));
 
         for (ExecutorDetails exec : orderedExecutors) {
             LOG.debug(
@@ -103,17 +104,24 @@ public class GenericResourceAwareStrategy extends BaseResourceAwareStrategy impl
                 exec,
                 td.getExecutorToComponent().get(exec),
                 td.getTaskResourceReqList(exec));
-            final List<ObjectResources> sortedNodes = this.sortAllNodes(td, exec, favoredNodes, unFavoredNodes);
+            final Iterable<String> sortedNodes = sortAllNodes(td, exec, favoredNodeIds, unFavoredNodeIds);
 
-            scheduleExecutor(exec, td, scheduledTasks, sortedNodes);
+            if (!scheduleExecutor(exec, td, scheduledTasks, sortedNodes)) {
+                return mkNotEnoughResources(td);
+            }
         }
 
         executorsNotScheduled.removeAll(scheduledTasks);
-        LOG.error("/* Scheduling left over task (most likely sys tasks) */");
-        // schedule left over system tasks
-        for (ExecutorDetails exec : executorsNotScheduled) {
-            final List<ObjectResources> sortedNodes = this.sortAllNodes(td, exec, favoredNodes, unFavoredNodes);
-            scheduleExecutor(exec, td, scheduledTasks, sortedNodes);
+        if (!executorsNotScheduled.isEmpty()) {
+            LOG.warn("Scheduling {} left over task (most likely sys tasks)", executorsNotScheduled);
+            // schedule left over system tasks
+            for (ExecutorDetails exec : executorsNotScheduled) {
+                final Iterable<String> sortedNodes = sortAllNodes(td, exec, favoredNodeIds, unFavoredNodeIds);
+                if (!scheduleExecutor(exec, td, scheduledTasks, sortedNodes)) {
+                    return mkNotEnoughResources(td);
+                }
+            }
+            executorsNotScheduled.removeAll(scheduledTasks);
         }
 
         SchedulingResult result;

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -319,7 +319,7 @@ public class TestDefaultResourceAwareStrategy {
         List<String> nodeHostnames = rackToNodes.get("rack-1");
         for (int i = 0; i< topo2.getExecutors().size()/2; i++) {
             String nodeHostname = nodeHostnames.get(i % nodeHostnames.size());
-            RAS_Node node = rs.idToNode(rs.nodeHostnameToId(nodeHostname));
+            RAS_Node node = rs.hostnameToNodes(nodeHostname).get(0);
             WorkerSlot targetSlot = node.getFreeSlots().iterator().next();
             ExecutorDetails targetExec = executorIterator.next();
             // to keep track of free slots
@@ -444,7 +444,7 @@ public class TestDefaultResourceAwareStrategy {
         List<String> nodeHostnames = rackToNodes.get("rack-1");
         for (int i = 0; i< topo2.getExecutors().size()/2; i++) {
             String nodeHostname = nodeHostnames.get(i % nodeHostnames.size());
-            RAS_Node node = rs.idToNode(rs.nodeHostnameToId(nodeHostname));
+            RAS_Node node = rs.hostnameToNodes(nodeHostname).get(0);
             WorkerSlot targetSlot = node.getFreeSlots().iterator().next();
             ExecutorDetails targetExec = executorIterator.next();
             // to keep track of free slots


### PR DESCRIPTION
There are a lot of different scheduler improvements.  Mostly these are either caching, storing data in multiple ways so we can look it up quickly, and finally lazily sorting nodes in a rack only when it is needed, instead of all ahead of time.

I also added in performance tests.  They currently pass on travis, but I would like to hear from others on if this solution looks good or if there is a better way for us to do performance testing.