### PR TITLE
STORM-3013: Keep KafkaConsumer open when storm-kafka-client spout is …

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/metrics/KafkaOffsetMetric.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/metrics/KafkaOffsetMetric.java
@@ -51,13 +51,14 @@ import org.slf4j.LoggerFactory;
  * topicName/totalRecordsInPartitions //total number of records in all the associated partitions of this spout
  * </p>
  */
-public class KafkaOffsetMetric implements IMetric {
+public class KafkaOffsetMetric<K, V> implements IMetric {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaOffsetMetric.class);
     private final Supplier<Map<TopicPartition, OffsetManager>> offsetManagerSupplier;
-    private final Supplier<KafkaConsumer> consumerSupplier;
+    private final Supplier<KafkaConsumer<K,V>> consumerSupplier;
 
-    public KafkaOffsetMetric(Supplier<Map<TopicPartition, OffsetManager>> offsetManagerSupplier, Supplier<KafkaConsumer> consumerSupplier) {
+    public KafkaOffsetMetric(Supplier<Map<TopicPartition, OffsetManager>> offsetManagerSupplier,
+        Supplier<KafkaConsumer<K, V>> consumerSupplier) {
         this.offsetManagerSupplier = offsetManagerSupplier;
         this.consumerSupplier = consumerSupplier;
     }
@@ -66,7 +67,7 @@ public class KafkaOffsetMetric implements IMetric {
     public Object getValueAndReset() {
 
         Map<TopicPartition, OffsetManager> offsetManagers = offsetManagerSupplier.get();
-        KafkaConsumer kafkaConsumer = consumerSupplier.get();
+        KafkaConsumer<K,V> kafkaConsumer = consumerSupplier.get();
 
         if (offsetManagers == null || offsetManagers.isEmpty() || kafkaConsumer == null) {
             LOG.debug("Metrics Tick: offsetManagers or kafkaConsumer is null.");

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutAbstractTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutAbstractTest.java
@@ -59,7 +59,7 @@ public abstract class KafkaSpoutAbstractTest {
     final SpoutOutputCollector collectorMock = mock(SpoutOutputCollector.class);
     final long commitOffsetPeriodMs;
 
-    KafkaConsumer<String, String> consumerSpy;
+    private KafkaConsumer<String, String> consumerSpy;
     KafkaSpout<String, String> spout;
 
     @Captor
@@ -84,6 +84,10 @@ public abstract class KafkaSpoutAbstractTest {
         spout = new KafkaSpout<>(spoutConfig, createConsumerFactory(), new TopicAssigner());
 
         simulatedTime = new Time.SimulatedTime();
+    }
+    
+    protected KafkaConsumer<String, String> getKafkaConsumer() {
+        return consumerSpy;
     }
 
     private KafkaConsumerFactory<String, String> createConsumerFactory() {

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutReactivationTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutReactivationTest.java
@@ -17,7 +17,8 @@
 package org.apache.storm.kafka.spout;
 
 import static org.apache.storm.kafka.spout.KafkaSpout.TIMER_DELAY_MS;
-import static org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy.UNCOMMITTED_EARLIEST;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -35,6 +36,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.storm.kafka.KafkaUnitExtension;
+import org.apache.storm.kafka.spout.KafkaSpoutConfig.FirstPollOffsetStrategy;
 import org.apache.storm.kafka.spout.config.builder.SingleTopicKafkaSpoutConfiguration;
 import org.apache.storm.kafka.spout.internal.KafkaConsumerFactory;
 import org.apache.storm.kafka.spout.internal.KafkaConsumerFactoryDefault;
@@ -64,30 +66,23 @@ public class KafkaSpoutReactivationTest {
     private final SpoutOutputCollector collector = mock(SpoutOutputCollector.class);
     private final long commitOffsetPeriodMs = 2_000;
     private KafkaConsumer<String, String> consumerSpy;
-    private KafkaConsumer<String, String> postReactivationConsumerSpy;
     private KafkaSpout<String, String> spout;
     private final int maxPollRecords = 10;
 
-    @BeforeEach
-    public void setUp() {
+    public void prepareSpout(int messageCount, FirstPollOffsetStrategy firstPollOffsetStrategy) throws Exception {
         KafkaSpoutConfig<String, String> spoutConfig =
             SingleTopicKafkaSpoutConfiguration.setCommonSpoutConfig(KafkaSpoutConfig.builder("127.0.0.1:" + kafkaUnitExtension.getKafkaUnit().getKafkaPort(),
                     SingleTopicKafkaSpoutConfiguration.TOPIC))
-                .setFirstPollOffsetStrategy(UNCOMMITTED_EARLIEST)
+                .setFirstPollOffsetStrategy(firstPollOffsetStrategy)
                 .setOffsetCommitPeriodMs(commitOffsetPeriodMs)
                 .setProp(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords)
                 .build();
         KafkaConsumerFactory<String, String> consumerFactory = new KafkaConsumerFactoryDefault<>();
         this.consumerSpy = spy(consumerFactory.createConsumer(spoutConfig));
-        this.postReactivationConsumerSpy = spy(consumerFactory.createConsumer(spoutConfig));
         KafkaConsumerFactory<String, String> consumerFactoryMock = mock(KafkaConsumerFactory.class);
         when(consumerFactoryMock.createConsumer(any()))
-            .thenReturn(consumerSpy)
-            .thenReturn(postReactivationConsumerSpy);
+            .thenReturn(consumerSpy);
         this.spout = new KafkaSpout<>(spoutConfig, consumerFactoryMock, new TopicAssigner());
-    }
-
-    private void prepareSpout(int messageCount) throws Exception {
         SingleTopicKafkaUnitSetupHelper.populateTopicData(kafkaUnitExtension.getKafkaUnit(), SingleTopicKafkaSpoutConfiguration.TOPIC, messageCount);
         SingleTopicKafkaUnitSetupHelper.initializeSpout(spout, conf, topologyContext, collector);
     }
@@ -100,11 +95,10 @@ public class KafkaSpoutReactivationTest {
         return messageId.getValue();
     }
 
-    @Test
-    public void testSpoutMustHandleReactivationGracefully() throws Exception {
+    private void doReactivationTest(FirstPollOffsetStrategy firstPollOffsetStrategy) throws Exception {
         try (Time.SimulatedTime time = new Time.SimulatedTime()) {
             int messageCount = maxPollRecords * 2;
-            prepareSpout(messageCount);
+            prepareSpout(messageCount, firstPollOffsetStrategy);
 
             //Emit and ack some tuples, ensure that some polled tuples remain cached in the spout by emitting less than maxPollRecords
             int beforeReactivationEmits = maxPollRecords - 3;
@@ -118,6 +112,7 @@ public class KafkaSpoutReactivationTest {
             //Cycle spout activation
             spout.deactivate();
             SingleTopicKafkaUnitSetupHelper.verifyAllMessagesCommitted(consumerSpy, commitCapture, beforeReactivationEmits - 1);
+            clearInvocations(consumerSpy);
             //Tuples may be acked/failed after the spout deactivates, so we have to be able to handle this too
             spout.ack(ackAfterDeactivateMessageId);
             spout.activate();
@@ -133,13 +128,41 @@ public class KafkaSpoutReactivationTest {
             spout.nextTuple();
 
             //Verify that no more tuples are emitted and all tuples are committed
-            SingleTopicKafkaUnitSetupHelper.verifyAllMessagesCommitted(postReactivationConsumerSpy, commitCapture, messageCount);
+            SingleTopicKafkaUnitSetupHelper.verifyAllMessagesCommitted(consumerSpy, commitCapture, messageCount);
 
             clearInvocations(collector);
             spout.nextTuple();
             verify(collector, never()).emit(any(), any(), any());
         }
 
+    }
+
+    @Test
+    public void testSpoutShouldResumeWhereItLeftOffWithUncommittedEarliestStrategy() throws Exception {
+        //With uncommitted earliest the spout should pick up where it left off when reactivating.
+        doReactivationTest(FirstPollOffsetStrategy.UNCOMMITTED_EARLIEST);
+    }
+
+    @Test
+    public void testSpoutShouldResumeWhereItLeftOffWithEarliestStrategy() throws Exception {
+        //With earliest, the spout should also resume where it left off, rather than restart at the earliest offset.
+        doReactivationTest(FirstPollOffsetStrategy.EARLIEST);
+    }
+
+    @Test
+    public void testSpoutMustHandleGettingMetricsWhileDeactivated() throws Exception {
+        //Storm will try to get metrics from the spout even while deactivated, the spout must be able to handle this
+        prepareSpout(10, FirstPollOffsetStrategy.UNCOMMITTED_EARLIEST);
+
+        for (int i = 0; i < 5; i++) {
+            KafkaSpoutMessageId msgId = emitOne();
+            spout.ack(msgId);
+        }
+
+        spout.deactivate();
+
+        Map<String, Long> offsetMetric = (Map<String, Long>) spout.getKafkaOffsetMetric().getValueAndReset();
+        assertThat(offsetMetric.get(SingleTopicKafkaSpoutConfiguration.TOPIC + "/totalSpoutLag"), is(5L));
     }
 
 }

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutSingleTopicTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutSingleTopicTest.java
@@ -101,7 +101,7 @@ public class KafkaSpoutSingleTopicTest extends KafkaSpoutAbstractTest {
         Time.advanceTime(KafkaSpout.TIMER_DELAY_MS + commitOffsetPeriodMs);
         spout.ack(failedIdReplayCaptor.getValue());
         spout.nextTuple();
-        verify(consumerSpy).commitSync(commitCapture.capture());
+        verify(getKafkaConsumer()).commitSync(commitCapture.capture());
 
         Map<TopicPartition, OffsetAndMetadata> capturedCommit = commitCapture.getValue();
         TopicPartition expectedTp = new TopicPartition(SingleTopicKafkaSpoutConfiguration.TOPIC, 0);

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutTopologyDeployActivateDeactivateTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutTopologyDeployActivateDeactivateTest.java
@@ -52,8 +52,6 @@ public class KafkaSpoutTopologyDeployActivateDeactivateTest extends KafkaSpoutAb
 
         verifyAllMessagesCommitted(1);
 
-        consumerSpy = createConsumerSpy();
-
         spout.activate();
 
         nextTuple_verifyEmitted_ack_resetCollector(1);


### PR DESCRIPTION
…deactivated, in order to keep metrics working

See https://issues.apache.org/jira/browse/STORM-3013

The changes here are to fix a crash that occur if the spout is deactivated and Storm asks for metrics. The KafkaConsumer is closed when the spout deactivates, and the metrics provider tries to use the consumer to generate a few metrics.

The suggested fix is to not close the KafkaConsumer when deactivating the spout. There's no real reason to do it as far as I can tell, and having to replace the consumer makes the spout a bit more complex than it would otherwise be.