### PR TITLE
[STORM-3054] Add Topology level configuration socket timeout for DRPC Invocation Client

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -41,6 +41,7 @@ storm.cluster.mode: "distributed" # can be distributed or local
 storm.local.mode.zmq: false
 storm.thrift.transport: "org.apache.storm.security.auth.SimpleTransportPlugin"
 storm.thrift.socket.timeout.ms: 600000
+topology.drpc.invocations.thrift.socket.timeout.ms: 60000
 storm.principal.tolocal: "org.apache.storm.security.auth.DefaultPrincipalToLocal"
 storm.group.mapping.service: "org.apache.storm.security.auth.ShellBasedGroupsMapping"
 storm.group.mapping.service.params: null

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -1002,6 +1002,12 @@ public class Config extends HashMap<String, Object> {
     @isPositiveNumber
     public static final String DRPC_INVOCATIONS_THREADS = "drpc.invocations.threads";
     /**
+     * ForTopology level DRPC Invocation Client, how long before a Thrift Client socket hangs before timeout and restart the socket with
+     * default of 60000 milliseconds.
+     */
+    @isInteger
+    public static final String TOPOLOGY_DRPC_INVOCATIONS_THRIFT_SOCKET_TIMEOUT_MS = "topology.drpc.invocations.thrift.socket.timeout.ms";
+    /**
      * Initialization parameters for the group mapping service plugin. Provides a way for a
      * @link{STORM_GROUP_MAPPING_SERVICE_PROVIDER_PLUGIN}
      * implementation to access optional settings.

--- a/storm-client/src/jvm/org/apache/storm/drpc/DRPCInvocationsClient.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/DRPCInvocationsClient.java
@@ -20,6 +20,7 @@ import org.apache.storm.generated.DRPCRequest;
 import org.apache.storm.generated.DistributedRPCInvocations;
 import org.apache.storm.security.auth.ThriftClient;
 import org.apache.storm.security.auth.ThriftConnectionType;
+import org.apache.storm.utils.ObjectReader;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
@@ -32,7 +33,8 @@ public class DRPCInvocationsClient extends ThriftClient implements DistributedRP
     private int port;
 
     public DRPCInvocationsClient(Map<String, Object> conf, String host, int port) throws TTransportException {
-        super(conf, ThriftConnectionType.DRPC_INVOCATIONS, host, port, null);
+        super(conf, ThriftConnectionType.DRPC_INVOCATIONS, host, port, ObjectReader
+            .getInt(conf.getOrDefault(org.apache.storm.Config.TOPOLOGY_DRPC_INVOCATIONS_THRIFT_SOCKET_TIMEOUT_MS, 60000), 60000));
         this.host = host;
         this.port = port;
         client.set(new DistributedRPCInvocations.Client(_protocol));

--- a/storm-client/src/jvm/org/apache/storm/drpc/ReturnResults.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/ReturnResults.java
@@ -51,6 +51,7 @@ public class ReturnResults extends BaseRichBolt {
     public void execute(Tuple input) {
         String result = (String) input.getValue(0);
         String returnInfo = (String) input.getValue(1);
+        LOG.debug("Request Info: {}, Result: {}", returnInfo, result);
         if (returnInfo != null) {
             Map<String, Object> retMap;
             try {
@@ -63,6 +64,7 @@ public class ReturnResults extends BaseRichBolt {
             final String host = (String) retMap.get("host");
             final int port = ObjectReader.getInt(retMap.get("port"));
             String id = (String) retMap.get("id");
+            LOG.debug("Request Id: {}, Result: {}", id, result);
             DistributedRPCInvocations.Iface client = getDRPCClient(host, port);
 
             int retryCnt = 0;
@@ -70,6 +72,7 @@ public class ReturnResults extends BaseRichBolt {
             while (retryCnt < maxRetries) {
                 retryCnt++;
                 try {
+                    LOG.debug("Trying to publish Request Id: {}, Result: {}, to DRPC {}", id, result, host);
                     client.result(id, result);
                     _collector.ack(input);
                     break;

--- a/storm-client/src/jvm/org/apache/storm/security/auth/ThriftConnectionType.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/ThriftConnectionType.java
@@ -29,9 +29,10 @@ public enum ThriftConnectionType {
                Config.SUPERVISOR_THRIFT_SOCKET_TIMEOUT_MS, WorkerTokenServiceType.SUPERVISOR, false),
     //A DRPC token only works for the invocations transport, not for the basic thrift transport.
     DRPC(Config.DRPC_THRIFT_TRANSPORT_PLUGIN, Config.DRPC_PORT, Config.DRPC_QUEUE_SIZE,
-         Config.DRPC_WORKER_THREADS, Config.DRPC_MAX_BUFFER_SIZE, null, null, false),
-    DRPC_INVOCATIONS(Config.DRPC_INVOCATIONS_THRIFT_TRANSPORT_PLUGIN, Config.DRPC_INVOCATIONS_PORT, null,
-                     Config.DRPC_INVOCATIONS_THREADS, Config.DRPC_MAX_BUFFER_SIZE, null, WorkerTokenServiceType.DRPC, false),
+         Config.DRPC_WORKER_THREADS, Config.DRPC_MAX_BUFFER_SIZE, null, null, false), DRPC_INVOCATIONS(
+        Config.DRPC_INVOCATIONS_THRIFT_TRANSPORT_PLUGIN, Config.DRPC_INVOCATIONS_PORT, null, Config.DRPC_INVOCATIONS_THREADS,
+        Config.DRPC_MAX_BUFFER_SIZE, Config.TOPOLOGY_DRPC_INVOCATIONS_THRIFT_SOCKET_TIMEOUT_MS, WorkerTokenServiceType.DRPC,
+        false),
     LOCAL_FAKE;
 
     private final String transConf;


### PR DESCRIPTION
This patch fixes following this:

- Add Topology level configuration socket timeout for DRPC Invocation Client
- Fix the `_clients` map key in `ReturnResults`
- Add `ReturnResults` debug log entries.