### PR TITLE
[WIP] Detach storm-kafka-client release from Storm proper

### DIFF
--- a/dev-tools/storm-kafka-client/release_notes.py
+++ b/dev-tools/storm-kafka-client/release_notes.py
@@ -19,7 +19,7 @@
 
 Depends on https://pypi.python.org/pypi/jira/, please use pip to install this module.
 
-Generates release notes for a Storm release by generating an HTML doc containing some introductory information about the
+Generates release notes for a Storm-kafka-client release by generating an HTML doc containing some introductory information about the
  release with links to the Storm docs followed by a list of issues resolved in the release. The script will fail if it finds
  any unresolved issues still marked with the target release. You should run this script after either resolving all issues or
  moving outstanding issues to a later release.
@@ -57,7 +57,7 @@ def issue_link(issue):
 
 if __name__ == "__main__":
     apache = JIRA(JIRA_BASE_URL)
-    issues = get_issues(apache, 'project=STORM and fixVersion=%s and component!=storm-kafka-client' % version)
+    issues = get_issues(apache, 'project=STORM and fixVersion=%s and component=storm-kafka-client' % version)
     if not issues:
         print >>sys.stderr, "Didn't find any issues for the target fix version"
         sys.exit(1)
@@ -101,11 +101,11 @@ if __name__ == "__main__":
     print "<html lang=\"en\">"
     print "<head>"
     print "<meta charset=\"utf-8\">"
-    print "<title>Storm %(version)s Release Notes</title>" % { 'version': version }
+    print "<title>Storm-kafka-client %(version)s Release Notes</title>" % { 'version': version }
     print "</head>"
     print "<body>"
-    print "<h1>Release Notes for Storm %s</h1>" % version
-    print """<p>JIRA issues addressed in the %(version)s release of Storm. Documentation for this
+    print "<h1>Release Notes for Storm-kafka-client %s</h1>" % version
+    print """<p>JIRA issues addressed in the %(version)s release of Storm-kafka-client. Documentation for this
     release is available at the <a href="http://storm.apache.org/">Apache Storm
     project site</a>.</p>""" % { 'version': version }
     for itype, issues in by_group:

--- a/docs/storm-kafka-client.md
+++ b/docs/storm-kafka-client.md
@@ -8,7 +8,15 @@ This includes the new Apache Kafka consumer API.
 
 ## Compatibility
 
-Apache Kafka versions 0.10 onwards
+Apache Kafka versions 0.10 onwards. 
+Note that unlike Storm 1.x, this module requires Java 8.
+Compatible Storm versions are listed below, for each active Storm release line.
+
+| Storm release line | Earliest supported version |
+| --- | --- |
+| 1.1.x | 1.1.3 |
+| 1.2.x | 1.2.2 |
+| 2.x | 2.0.0 |
 
 ## Writing to Kafka as part of your topology
 You can create an instance of org.apache.storm.kafka.bolt.KafkaBolt and attach it as a component to your topology or if you

--- a/examples/storm-kafka-client-examples/pom.xml
+++ b/examples/storm-kafka-client-examples/pom.xml
@@ -41,13 +41,13 @@
         <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-kafka-client</artifactId>
-            <version>${project.version}</version>
+            <version>${storm.kafka.client.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${storm.kafka.client.version}</version>
+            <version>${kafka.client.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/examples/storm-perf/pom.xml
+++ b/examples/storm-perf/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-kafka-client</artifactId>
-            <version>${project.version}</version>
+            <version>${storm.kafka.client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--/**
-        * Licensed to the Apache Software Foundation (ASF) under one
-        * or more contributor license agreements.  See the NOTICE file
-        * distributed with this work for additional information
-        * regarding copyright ownership.  The ASF licenses this file
-        * to you under the Apache License, Version 2.0 (the
-        * "License"); you may not use this file except in compliance
-        * with the License.  You may obtain a copy of the License at
-        *
-        * http://www.apache.org/licenses/LICENSE-2.0
-        *
-        * Unless required by applicable law or agreed to in writing, software
-        * distributed under the License is distributed on an "AS IS" BASIS,
-        * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        * See the License for the specific language governing permissions and
-        * limitations under the License.
-        */-->
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>storm-kafka-client</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
     <name>storm-kafka-client</name>
 
     <packaging>jar</packaging>
@@ -40,26 +41,63 @@
         </developer>
     </developers>
 
-    <dependencies>
-        <!--parent module dependency-->
-        <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>storm-client</artifactId>
-            <version>${project.version}</version>
-            <scope>${provided.scope}</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>storm-server</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
+    <properties>
+        <kafka.client.version>0.10.1.0</kafka.client.version>
+        <storm.release.line>2.x</storm.release.line>
+    </properties>
+    
+    <profiles>
+        <profile>
+            <id>storm-2.x</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <storm.version>2.0.0-SNAPSHOT</storm.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.storm</groupId>
+                    <artifactId>storm-client</artifactId>
+                    <version>${storm.version}</version>
+                    <scope>${provided.scope}</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.storm</groupId>
+                    <artifactId>storm-server</artifactId>
+                    <version>${storm.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>storm-1.x</id>
+            <activation>
+                <property>
+                    <name>storm.release.line</name>
+                    <value>1.x</value>
+                </property>
+            </activation>
+            <properties>
+                <storm.version>1.2.2-SNAPSHOT</storm.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.storm</groupId>
+                    <artifactId>storm-core</artifactId>
+                    <version>${storm.version}</version>
+                    <scope>${provided.scope}</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
+    <dependencies>
         <!--kafka libraries-->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${storm.kafka.client.version}</version>
+            <version>${kafka.client.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>
@@ -83,6 +121,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
         <!--test dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>
@@ -100,7 +142,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.11</artifactId>
-            <version>${storm.kafka.client.version}</version>
+            <version>${kafka.client.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>
             <exclusions>
@@ -113,14 +155,14 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${storm.kafka.client.version}</version>
+            <version>${kafka.client.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.11</artifactId>
-            <version>${storm.kafka.client.version}</version>
+            <version>${kafka.client.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -128,6 +170,10 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
         </dependency>
     </dependencies>
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/bolt/KafkaBolt.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/bolt/KafkaBolt.java
@@ -99,12 +99,12 @@ public class KafkaBolt<K, V> extends BaseTickTupleAwareRichBolt {
     }
 
     @Override
-    public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
+    public void prepare(@SuppressWarnings("rawtypes") Map topoConf, TopologyContext context, OutputCollector collector) {
         LOG.info("Preparing bolt with configuration {}", this);
         //for backward compatibility.
         if (mapper == null) {
             LOG.info("Mapper not specified. Setting default mapper to {}", FieldNameBasedTupleToKafkaMapper.class.getSimpleName());
-            this.mapper = new FieldNameBasedTupleToKafkaMapper<K,V>();
+            this.mapper = new FieldNameBasedTupleToKafkaMapper<>();
         }
 
         //for backward compatibility.

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -118,7 +118,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
     }
 
     @Override
-    public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
+    public void open(@SuppressWarnings("rawtypes") Map conf, TopologyContext context, SpoutOutputCollector collector) {
         this.context = context;
 
         // Spout internals

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaque.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutOpaque.java
@@ -43,12 +43,12 @@ public class KafkaTridentSpoutOpaque<K,V> implements IOpaquePartitionedTridentSp
 
     @Override
     public Emitter<List<Map<String, Object>>, KafkaTridentSpoutTopicPartition, Map<String, Object>> getEmitter(
-            Map<String, Object> conf, TopologyContext context) {
+            @SuppressWarnings("rawtypes") Map conf, TopologyContext context) {
         return new KafkaTridentSpoutEmitter<>(kafkaSpoutConfig, context);
     }
 
     @Override
-    public Coordinator<List<Map<String, Object>>> getCoordinator(Map<String, Object> conf, TopologyContext context) {
+    public Coordinator<List<Map<String, Object>>> getCoordinator(@SuppressWarnings("rawtypes") Map conf, TopologyContext context) {
         return new KafkaTridentSpoutOpaqueCoordinator<>(kafkaSpoutConfig);
     }
 

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaStateFactory.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/trident/TridentKafkaStateFactory.java
@@ -53,7 +53,7 @@ public class TridentKafkaStateFactory<K, V> implements StateFactory {
     }
 
     @Override
-    public State makeState(Map<String, Object> conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
+    public State makeState(@SuppressWarnings("rawtypes") Map conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
         LOG.info("makeState(partitonIndex={}, numpartitions={}", partitionIndex, numPartitions);
         TridentKafkaState<K, V> state = new TridentKafkaState<>();
         state.withKafkaTopicSelector(this.topicSelector)

--- a/external/storm-kafka-migration/pom.xml
+++ b/external/storm-kafka-migration/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${storm.kafka.client.version}</version>
+            <version>${kafka.client.version}</version>
             <scope>provided</scope>
         </dependency>
         

--- a/external/storm-kafka-monitor/pom.xml
+++ b/external/storm-kafka-monitor/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${storm.kafka.client.version}</version>
+            <version>${kafka.client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/flux/flux-core/pom.xml
+++ b/flux/flux-core/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-kafka-client</artifactId>
-            <version>${project.version}</version>
+            <version>${storm.kafka.client.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flux/flux-examples/pom.xml
+++ b/flux/flux-examples/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-kafka-client</artifactId>
-            <version>${project.version}</version>
+            <version>${storm.kafka.client.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -324,8 +324,10 @@
         <storm.kafka.artifact.id>kafka_2.10</storm.kafka.artifact.id>
 
         <!-- kafka version used by new storm-kafka-client spout code -->
-        <storm.kafka.client.version>0.10.1.0</storm.kafka.client.version>
-
+        <kafka.client.version>0.10.1.0</kafka.client.version>
+        <!-- version of the storm-kafka-client artifact to use when building dependent modules -->
+        <!-- TODO: This should not be a snapshot version since storm-kafka-client is released independently -->
+        <storm.kafka.client.version>2.0.0-SNAPSHOT</storm.kafka.client.version>
 
         <!-- Java and clojure build lifecycle test properties are defined here to avoid having to create a default profile -->
         <java.unit.test.exclude>org.apache.storm.testing.IntegrationTest</java.unit.test.exclude>
@@ -383,7 +385,6 @@
         <module>external/storm-cassandra</module>
         <module>external/storm-mqtt</module>
         <module>external/storm-mongodb</module>
-        <module>external/storm-kafka-client</module>
         <module>external/storm-kafka-migration</module>
         <module>external/storm-opentsdb</module>
         <module>external/storm-kafka-monitor</module>
@@ -1075,7 +1076,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>${storm.kafka.client.version}</version>
+                <version>${kafka.client.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Opening this to get feedback on detaching the storm-kafka-client release cycle from Storm, as discussed on the mailing list. I'm putting this up so we can get an idea what we need to do to detach storm-kafka-client from Storm's release cycle, before we decide whether we want to try it.

I've made the following changes:
* Detached storm-kafka-client from Storm. It still uses the Storm parent POM, but is otherwise an independent project
* Copied the release_notes script so we can generate release notes for storm-kafka-client. Exclude storm-kafka-client issues from Storm release notes
* Addded a set of profiles to the storm-kafka-client POM so we can build against both Storm 1.x and 2.x. We can build against 1.x by doing e.g. `mvn clean install -Dstorm.release.line=1.x -Dstorm.version=1.2.2-SNAPSHOT`
* Reverted to raw maps in e.g. the spout open method. Having the generic types is nice, but prevents the spout from running on 1.x.

I ran into two API issues against Storm 1.x when trying to get this version running on both 1.x and 2.x. One is the map generics mentioned above, the other is a change I'd like to backport to 1.x here https://github.com/apache/storm/pull/2650. The issue is the type of the third parameter to IOpaquePartitionedTridentSpout.Emitter.getPartitionsForTask, which was changed in master.

Edit: Just to make clear, this version of the spout won't run on 1.x unless STORM-3047 goes in.