### PR TITLE
Storm 3050:a potential NPE in ConstraintSolverStrategy#checkResourcesCorrect

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -13,6 +13,7 @@
 package org.apache.storm.scheduler.resource.strategies.scheduling;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -25,6 +26,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+
 import org.apache.storm.Config;
 import org.apache.storm.scheduler.Cluster;
 import org.apache.storm.scheduler.ExecutorDetails;
@@ -202,7 +204,10 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
             double cpuUsed = 0.0;
             double memoryUsed = 0.0;
             for (ExecutorDetails exec : execs) {
-                cpuUsed += topo.getTotalCpuReqTask(exec);
+                Double execCpu = topo.getTotalCpuReqTask(exec);
+                if (execCpu != null) {
+                	cpuUsed += execCpu;
+                }
                 memoryUsed += topo.getTotalMemReqTask(exec);
             }
             if (node.getAvailableCpuResources() != (node.getTotalCpuResources() - cpuUsed)) {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -13,7 +13,6 @@
 package org.apache.storm.scheduler.resource.strategies.scheduling;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -26,7 +25,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-
 import org.apache.storm.Config;
 import org.apache.storm.scheduler.Cluster;
 import org.apache.storm.scheduler.ExecutorDetails;

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestUtilsForResourceAwareScheduler.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestUtilsForResourceAwareScheduler.java
@@ -440,7 +440,10 @@ public class TestUtilsForResourceAwareScheduler {
             for (Map.Entry<SupervisorDetails, List<ExecutorDetails>> entry : supervisorToExecutors.entrySet()) {
                 Double supervisorUsedCpu = 0.0;
                 for (ExecutorDetails executor : entry.getValue()) {
-                    supervisorUsedCpu += topology.getTotalCpuReqTask(executor);
+                	Double execCpu = topology.getTotalCpuReqTask(executor);
+                    if (execCpu != null) {
+                        supervisorUsedCpu += execCpu;
+                    }
                 }
                 superToCpu.put(entry.getKey(), superToCpu.get(entry.getKey()) + supervisorUsedCpu);
             }

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestUtilsForResourceAwareScheduler.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestUtilsForResourceAwareScheduler.java
@@ -440,10 +440,7 @@ public class TestUtilsForResourceAwareScheduler {
             for (Map.Entry<SupervisorDetails, List<ExecutorDetails>> entry : supervisorToExecutors.entrySet()) {
                 Double supervisorUsedCpu = 0.0;
                 for (ExecutorDetails executor : entry.getValue()) {
-                	Double execCpu = topology.getTotalCpuReqTask(executor);
-                    if (execCpu != null) {
-                        supervisorUsedCpu += execCpu;
-                    }
+                    supervisorUsedCpu += topology.getTotalCpuReqTask(executor);
                 }
                 superToCpu.put(entry.getKey(), superToCpu.get(entry.getKey()) + supervisorUsedCpu);
             }


### PR DESCRIPTION
We have developed a static analysis tool [NPEDetector ](https://github.com/lujiefsi/NPEDetector) to find some potential NPE. Our analysis shows that some callees may return null in corner case(e.g. node crash , IO exception), some of their callers have  !=null check but some do not have. 
### Bug:
callee TopologyDetails#getTotalCpuReqTask have two callers, one of them have null checker:
<pre> 
    public double getTotalRequestedCpu() {
    double totalCpu = 0.0;
    for (ExecutorDetails exec : this.getExecutors()) {
         Double execCpu = getTotalCpuReqTask(exec);
        if (execCpu != null) {
            totalCpu += execCpu;
        }
   }
   return totalCpu;
}
</pre>
but ConstraintSolverStrategy#checkResourcesCorrect have no checker:
<pre> 
for (ExecutorDetails executor : entry.getValue()) {
      supervisorUsedCpu += topology.getTotalCpuReqTask(executor);
}
</pre>