### PR TITLE
fix STORM-3051

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/container/cgroup/CgroupCenter.java
+++ b/storm-client/src/jvm/org/apache/storm/container/cgroup/CgroupCenter.java
@@ -97,9 +97,11 @@ public class CgroupCenter implements CgroupOperation {
     @Override
     public boolean isSubSystemEnabled(SubSystemType subSystemType) {
         Set<SubSystem> subSystems = this.getSubSystems();
-        for (SubSystem subSystem : subSystems) {
-            if (subSystem.getType() == subSystemType) {
-                return true;
+        if (subSystems != null){
+            for (SubSystem subSystem : subSystems) {
+                if (subSystem.getType() == subSystemType) {
+                    return true;
+                }
             }
         }
         return false;
@@ -113,6 +115,9 @@ public class CgroupCenter implements CgroupOperation {
     @Override
     public Hierarchy getHierarchyWithSubSystems(List<SubSystemType> subSystems) {
         List<Hierarchy> hierarchies = this.getHierarchies();
+        if (hierarchies == null) {
+            return null;
+        }
         for (Hierarchy hierarchy : hierarchies) {
             Hierarchy ret = hierarchy;
             for (SubSystemType subSystem : subSystems) {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/RAS_Node.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/RAS_Node.java
@@ -206,7 +206,8 @@ public class RAS_Node {
     }
 
     public int totalSlotsUsed(String topId) {
-        return getUsedSlots(topId).size();
+        Collection<WorkerSlot> usedSlots = getUsedSlots(topId);
+        return usedSlots == null ? 0 : usedSlots.size();
     }
 
     public int totalSlots() {


### PR DESCRIPTION
We have developed a static analysis tool NPEDetector to find some potential NPE. Our analysis shows that some callees may return null in corner case(e.g. node crash , IO exception), some of their callers have  !=null check but some do not have. 

### Bug:

1.  callee CgroupCenter#getSubSystems return null when meet exception:
<pre>
} catch (Exception e) {
LOG.error("Get subSystems error {}", e);
}
return null;
</pre>
but its caller use it without check:
<pre>
public boolean isSubSystemEnabled(SubSystemType subSystemType) {
  Set<SubSystem> subSystems = this.getSubSystems();
  for (SubSystem subSystem : subSystems) {
     if (subSystem.getType() == subSystemType) {
     return true;
  }
  }
  return false;
}
</pre>
other callee and caller pair that have same problem.

2. callee RAS_Node#getUsedSlots and caller RAS_Node#totalSlotsUsed
3. CgroupCenter#getHierarchies and caller CgroupCenter#isMounted, 