### PR TITLE
STORM-3048 : A Potential NPE

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -98,7 +98,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
      */
     private static boolean checkConstraintsSatisfied(Cluster cluster, TopologyDetails topo) {
         LOG.info("Checking constraints...");
-        assert(cluster.getAssignmentById(topo.getId())!=null);
+        assert (cluster.getAssignmentById(topo.getId()) != null);
         Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
         Map<ExecutorDetails, String> execToComp = topo.getExecutorToComponent();
         //get topology constraints
@@ -136,7 +136,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
 
     private static boolean checkSpreadSchedulingValid(Cluster cluster, TopologyDetails topo) {
         LOG.info("Checking for a valid scheduling...");
-        assert(cluster.getAssignmentById(topo.getId())!=null);
+        assert (cluster.getAssignmentById(topo.getId()) != null);
         Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
         Map<ExecutorDetails, String> execToComp = topo.getExecutorToComponent();
         Map<WorkerSlot, HashSet<ExecutorDetails>> workerExecMap = new HashMap<>();
@@ -175,7 +175,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
      */
     private static boolean checkResourcesCorrect(Cluster cluster, TopologyDetails topo) {
         LOG.info("Checking Resources...");
-        assert(cluster.getAssignmentById(topo.getId())!=null);
+        assert (cluster.getAssignmentById(topo.getId()) != null);
         Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
         Map<RAS_Node, Collection<ExecutorDetails>> nodeToExecs = new HashMap<>();
         Map<ExecutorDetails, WorkerSlot> mergedExecToWorker = new HashMap<>();

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -98,6 +98,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
      */
     private static boolean checkConstraintsSatisfied(Cluster cluster, TopologyDetails topo) {
         LOG.info("Checking constraints...");
+        assert(cluster.getAssignmentById(topo.getId())!=null);
         Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
         Map<ExecutorDetails, String> execToComp = topo.getExecutorToComponent();
         //get topology constraints
@@ -135,6 +136,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
 
     private static boolean checkSpreadSchedulingValid(Cluster cluster, TopologyDetails topo) {
         LOG.info("Checking for a valid scheduling...");
+        assert(cluster.getAssignmentById(topo.getId())!=null);
         Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
         Map<ExecutorDetails, String> execToComp = topo.getExecutorToComponent();
         Map<WorkerSlot, HashSet<ExecutorDetails>> workerExecMap = new HashMap<>();
@@ -173,6 +175,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
      */
     private static boolean checkResourcesCorrect(Cluster cluster, TopologyDetails topo) {
         LOG.info("Checking Resources...");
+        assert(cluster.getAssignmentById(topo.getId())!=null);
         Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
         Map<RAS_Node, Collection<ExecutorDetails>> nodeToExecs = new HashMap<>();
         Map<ExecutorDetails, WorkerSlot> mergedExecToWorker = new HashMap<>();


### PR DESCRIPTION
We have developed a static analysis tool NPEDetector to find some potential NPE. Our analysis shows that some callees may return null in corner case(e.g. node crash , IO exception), some of their callers have  !=null check but some do not have. 

Bug:

Cluster#getAssignmentById has 20 callers, 18 callers have null checker like this:
<pre>
SchedulerAssignment assignment = cluster.getAssignmentById(td.getId());
if (assignment != null) {
    cpuNeeded -= getCpuUsed(assignment);
     memoryNeeded -= getMemoryUsed(assignment);
}
</pre>
the caller have no null checker :ConstraintSolverStrategy#checkSpreadSchedulingValid ConstraintSolverStrategy#checkConstraintsSatisfied.

I was feel uncertain about whether add null checker here, so i only add assert. If this bug are false positive,  please tell me.