### PR TITLE
STORM-3042 restore topology.acker.cpu.pcore.percent

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -531,13 +531,13 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     @SuppressWarnings("deprecation")
     private static <T extends AutoCloseable> TimeCacheMap<String, T> fileCacheMap(Map<String, Object> conf) {
         return new TimeCacheMap<>(ObjectReader.getInt(conf.get(DaemonConfig.NIMBUS_FILE_COPY_EXPIRATION_SECS), 600),
-                                  (id, stream) -> {
-                                      try {
-                                          stream.close();
-                                      } catch (Exception e) {
-                                          throw new RuntimeException(e);
-                                      }
-                                  });
+            (id, stream) -> {
+                try {
+                    stream.close();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
     }
 
     private static <K, V> Map<K, V> mapDiff(Map<? extends K, ? extends V> first, Map<? extends K, ? extends V> second) {
@@ -1060,7 +1060,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                                                     Map<String, Object> topoConf) {
         NormalizedResourceRequest resources = compResourcesMap.get(compId);
         if (resources == null) {
-            compResourcesMap.put(compId, new NormalizedResourceRequest(topoConf));
+            compResourcesMap.put(compId, new NormalizedResourceRequest(topoConf, compId));
         }
     }
 
@@ -4036,13 +4036,13 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             if (compPageInfo.get_component_type() == ComponentType.SPOUT) {
                 NormalizedResourceRequest spoutResources = ResourceUtils.getSpoutResources(topology, topoConf, componentId);
                 if (spoutResources == null) {
-                    spoutResources = new NormalizedResourceRequest(topoConf);
+                    spoutResources = new NormalizedResourceRequest(topoConf, componentId);
                 }
                 compPageInfo.set_resources_map(spoutResources.toNormalizedMap());
             } else { //bolt
                 NormalizedResourceRequest boltResources = ResourceUtils.getBoltResources(topology, topoConf, componentId);
                 if (boltResources == null) {
-                    boltResources = new NormalizedResourceRequest(topoConf);
+                    boltResources = new NormalizedResourceRequest(topoConf, componentId);
                 }
                 compPageInfo.set_resources_map(boltResources.toNormalizedMap());
             }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/RAS_Node.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/RAS_Node.java
@@ -52,6 +52,7 @@ public class RAS_Node {
     private String hostname;
     private boolean isAlive;
     private SupervisorDetails sup;
+    private boolean loggedUnderageUsage = false;
 
     /**
      * Create a new node.
@@ -444,7 +445,12 @@ public class RAS_Node {
     public NormalizedResourceOffer getTotalAvailableResources() {
         if (sup != null) {
             NormalizedResourceOffer availableResources = new NormalizedResourceOffer(sup.getTotalResources());
-            availableResources.remove(cluster.getAllScheduledResourcesForNode(sup.getId()));
+            if (availableResources.remove(cluster.getAllScheduledResourcesForNode(sup.getId()))) {
+                if (!loggedUnderageUsage) {
+                    LOG.error("Resources on {} became negative and was clamped to 0 {}.", hostname, availableResources);
+                    loggedUnderageUsage = true;
+                }
+            }
             return availableResources;
         } else {
             return new NormalizedResourceOffer();

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceUtils.java
@@ -34,7 +34,7 @@ public class ResourceUtils {
                                                              String componentId) {
         if (topology.get_bolts() != null) {
             Bolt bolt = topology.get_bolts().get(componentId);
-            return new NormalizedResourceRequest(bolt.get_common(), topologyConf);
+            return new NormalizedResourceRequest(bolt.get_common(), topologyConf, componentId);
         }
         return null;
     }
@@ -44,7 +44,8 @@ public class ResourceUtils {
         Map<String, NormalizedResourceRequest> boltResources = new HashMap<>();
         if (topology.get_bolts() != null) {
             for (Map.Entry<String, Bolt> bolt : topology.get_bolts().entrySet()) {
-                NormalizedResourceRequest topologyResources = new NormalizedResourceRequest(bolt.getValue().get_common(), topologyConf);
+                NormalizedResourceRequest topologyResources = new NormalizedResourceRequest(bolt.getValue().get_common(),
+                        topologyConf, bolt.getKey());
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("Turned {} into {}", bolt.getValue().get_common().get_json_conf(), topologyResources);
                 }
@@ -58,7 +59,7 @@ public class ResourceUtils {
                                                               String componentId) {
         if (topology.get_spouts() != null) {
             SpoutSpec spout = topology.get_spouts().get(componentId);
-            return new NormalizedResourceRequest(spout.get_common(), topologyConf);
+            return new NormalizedResourceRequest(spout.get_common(), topologyConf, componentId);
         }
         return null;
     }
@@ -68,7 +69,8 @@ public class ResourceUtils {
         Map<String, NormalizedResourceRequest> spoutResources = new HashMap<>();
         if (topology.get_spouts() != null) {
             for (Map.Entry<String, SpoutSpec> spout : topology.get_spouts().entrySet()) {
-                NormalizedResourceRequest topologyResources = new NormalizedResourceRequest(spout.getValue().get_common(), topologyConf);
+                NormalizedResourceRequest topologyResources = new NormalizedResourceRequest(spout.getValue().get_common(),
+                        topologyConf, spout.getKey());
                 if (LOG.isTraceEnabled()) {
                     LOG.trace("Turned {} into {}", spout.getValue().get_common().get_json_conf(), topologyResources);
                 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOffer.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOffer.java
@@ -82,15 +82,18 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
 
     /**
      * Remove the resources in other from this.
-     * @param other what to remove.
+     * @param other the resources to be removed.
+     * @return true if one or more resources in other were larger than available resources in this, else false.
      */
-    public void remove(NormalizedResourcesWithMemory other) {
-        normalizedResources.remove(other.getNormalizedResources());
+    public boolean remove(NormalizedResourcesWithMemory other) {
+        boolean negativeResources = normalizedResources.remove(other.getNormalizedResources());
         totalMemoryMb -= other.getTotalMemoryMb();
         if (totalMemoryMb < 0.0) {
-            normalizedResources.throwBecauseResourceBecameNegative(
-                Constants.COMMON_TOTAL_MEMORY_RESOURCE_NAME, totalMemoryMb, other.getTotalMemoryMb());
+            negativeResources = true;
+            NormalizedResources.numNegativeResourceEvents.mark();
+            totalMemoryMb = 0.0;
         }
+        return negativeResources;
     }
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.storm.Config;
 import org.apache.storm.Constants;
+import org.apache.storm.daemon.Acker;
 import org.apache.storm.generated.ComponentCommon;
 import org.apache.storm.generated.WorkerResources;
 import org.apache.storm.utils.ObjectReader;
@@ -57,12 +58,12 @@ public class NormalizedResourceRequest implements NormalizedResourcesWithMemory 
         }
     }
 
-    public NormalizedResourceRequest(ComponentCommon component, Map<String, Object> topoConf) {
-        this(parseResources(component.get_json_conf()), getDefaultResources(topoConf));
+    public NormalizedResourceRequest(ComponentCommon component, Map<String, Object> topoConf, String componentId) {
+        this(parseResources(component.get_json_conf()), getDefaultResources(topoConf, componentId));
     }
 
-    public NormalizedResourceRequest(Map<String, Object> topoConf) {
-        this((Map<String, ? extends Number>) null, getDefaultResources(topoConf));
+    public NormalizedResourceRequest(Map<String, Object> topoConf, String componentId) {
+        this((Map<String, ? extends Number>) null, getDefaultResources(topoConf, componentId));
     }
 
     public NormalizedResourceRequest() {
@@ -78,10 +79,42 @@ public class NormalizedResourceRequest implements NormalizedResourcesWithMemory 
         }
     }
 
-    private static Map<String, Double> getDefaultResources(Map<String, Object> topoConf) {
+    private static Map<String, Double> getDefaultResources(Map<String, Object> topoConf, String componentId) {
         Map<String, Double> ret =
             NormalizedResources.RESOURCE_NAME_NORMALIZER.normalizedResourceMap((Map<String, Number>) topoConf.getOrDefault(
                 Config.TOPOLOGY_COMPONENT_RESOURCES_MAP, new HashMap<>()));
+
+        // Some components might have different resource configs.
+        if (componentId != null) {
+            if (componentId.equals(Acker.ACKER_COMPONENT_ID)) {
+                if (topoConf.containsKey(Config.TOPOLOGY_ACKER_RESOURCES_ONHEAP_MEMORY_MB)) {
+                    ret.put(Constants.COMMON_ONHEAP_MEMORY_RESOURCE_NAME,
+                            ObjectReader.getDouble(topoConf.get(Config.TOPOLOGY_ACKER_RESOURCES_ONHEAP_MEMORY_MB)));
+                }
+                if (topoConf.containsKey(Config.TOPOLOGY_ACKER_RESOURCES_OFFHEAP_MEMORY_MB)) {
+                    ret.put(Constants.COMMON_OFFHEAP_MEMORY_RESOURCE_NAME,
+                            ObjectReader.getDouble(topoConf.get(Config.TOPOLOGY_ACKER_RESOURCES_OFFHEAP_MEMORY_MB)));
+                }
+                if (topoConf.containsKey(Config.TOPOLOGY_ACKER_CPU_PCORE_PERCENT)) {
+                    ret.put(Constants.COMMON_CPU_RESOURCE_NAME,
+                            ObjectReader.getDouble(topoConf.get(Config.TOPOLOGY_ACKER_CPU_PCORE_PERCENT)));
+                }
+            } else if (componentId.startsWith(Constants.METRICS_COMPONENT_ID_PREFIX)) {
+                if (topoConf.containsKey(Config.TOPOLOGY_METRICS_CONSUMER_RESOURCES_ONHEAP_MEMORY_MB)) {
+                    ret.put(Constants.COMMON_ONHEAP_MEMORY_RESOURCE_NAME,
+                            ObjectReader.getDouble(topoConf.get(Config.TOPOLOGY_METRICS_CONSUMER_RESOURCES_ONHEAP_MEMORY_MB)));
+                }
+                if (topoConf.containsKey(Config.TOPOLOGY_METRICS_CONSUMER_RESOURCES_OFFHEAP_MEMORY_MB)) {
+                    ret.put(Constants.COMMON_OFFHEAP_MEMORY_RESOURCE_NAME,
+                            ObjectReader.getDouble(topoConf.get(Config.TOPOLOGY_METRICS_CONSUMER_RESOURCES_OFFHEAP_MEMORY_MB)));
+                }
+                if (topoConf.containsKey(Config.TOPOLOGY_METRICS_CONSUMER_CPU_PCORE_PERCENT)) {
+                    ret.put(Constants.COMMON_CPU_RESOURCE_NAME,
+                            ObjectReader.getDouble(topoConf.get(Config.TOPOLOGY_METRICS_CONSUMER_CPU_PCORE_PERCENT)));
+                }
+            }
+        }
+
         putIfMissing(ret, Constants.COMMON_CPU_RESOURCE_NAME, topoConf, Config.TOPOLOGY_COMPONENT_CPU_PCORE_PERCENT);
         putIfMissing(ret, Constants.COMMON_OFFHEAP_MEMORY_RESOURCE_NAME, topoConf, Config.TOPOLOGY_COMPONENT_RESOURCES_OFFHEAP_MEMORY_MB);
         putIfMissing(ret, Constants.COMMON_ONHEAP_MEMORY_RESOURCE_NAME, topoConf, Config.TOPOLOGY_COMPONENT_RESOURCES_ONHEAP_MEMORY_MB);

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOfferTest.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOfferTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.scheduler.resource.normalization;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.storm.Constants;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NormalizedResourceOfferTest {
+    @Test
+    public void testNodeOverExtendedCpu() {
+        NormalizedResourceOffer availableResources = createOffer(100.0, 0.0);
+        NormalizedResourceOffer scheduledResources = createOffer(110.0, 0.0);
+        availableResources.remove(scheduledResources);
+        Assert.assertEquals(0.0, availableResources.getTotalCpu(), 0.001);
+    }
+
+    @Test
+    public void testNodeOverExtendedMemory() {
+        NormalizedResourceOffer availableResources = createOffer(0.0, 5.0);
+        NormalizedResourceOffer scheduledResources = createOffer(0.0, 10.0);
+        availableResources.remove(scheduledResources);
+        Assert.assertEquals(0.0, availableResources.getTotalMemoryMb(), 0.001);
+    }
+
+    private NormalizedResourceOffer createOffer(Double cpu, Double memory) {
+        Map<String, Double> resourceMap = new HashMap<>();
+        resourceMap.put(Constants.COMMON_CPU_RESOURCE_NAME, cpu);
+        resourceMap.put(Constants.COMMON_TOTAL_MEMORY_RESOURCE_NAME, memory);
+        return new NormalizedResourceOffer(resourceMap);
+    }
+}

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequestTest.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequestTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.scheduler.resource.normalization;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.storm.Config;
+import org.apache.storm.Constants;
+import org.apache.storm.daemon.Acker;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NormalizedResourceRequestTest {
+
+    @Test
+    public void testAckerCPUSetting() {
+        Map<String, Object> topoConf = new HashMap<>();
+        topoConf.put(Config.TOPOLOGY_ACKER_CPU_PCORE_PERCENT, 40);
+        topoConf.put(Config.TOPOLOGY_COMPONENT_CPU_PCORE_PERCENT, 50);
+        NormalizedResourceRequest request = new NormalizedResourceRequest(topoConf, Acker.ACKER_COMPONENT_ID);
+        Map<String, Double> normalizedMap = request.toNormalizedMap();
+        Double cpu = normalizedMap.get(Constants.COMMON_CPU_RESOURCE_NAME);
+        Assert.assertNotNull(cpu);
+        Assert.assertEquals(40, cpu, 0.001);
+    }
+
+    @Test
+    public void testNonAckerCPUSetting() {
+        Map<String, Object> topoConf = new HashMap<>();
+        topoConf.put(Config.TOPOLOGY_ACKER_CPU_PCORE_PERCENT, 40);
+        topoConf.put(Config.TOPOLOGY_COMPONENT_CPU_PCORE_PERCENT, 50);
+        NormalizedResourceRequest request = new NormalizedResourceRequest(topoConf, "notAnAckerComponent");
+        Map<String, Double> normalizedMap = request.toNormalizedMap();
+        Double cpu = normalizedMap.get(Constants.COMMON_CPU_RESOURCE_NAME);
+        Assert.assertNotNull(cpu);
+        Assert.assertEquals(50, cpu, 0.001);
+    }
+}

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourcesTest.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourcesTest.java
@@ -90,21 +90,22 @@ public class NormalizedResourcesTest {
     }
     
     @Test
-    public void testRemoveThrowsIfResourcesBecomeNegative() {
+    public void testRemoveZeroesWhenResourcesBecomeNegative() {
         NormalizedResources resources = new NormalizedResources(normalize(Collections.singletonMap(gpuResourceName, 1)));
         NormalizedResources removedResources = new NormalizedResources(normalize(Collections.singletonMap(gpuResourceName, 2)));
-        
-        expectedException.expect(IllegalArgumentException.class);
+
         resources.remove(removedResources);
+        Map<String, Double> normalizedMap = resources.toNormalizedMap();
+        assertThat(normalizedMap.get(gpuResourceName), is(0.0));
     }
     
     @Test
-    public void testRemoveThrowsIfCpuBecomesNegative() {
+    public void testRemoveZeroesWhenCpuBecomesNegative() {
         NormalizedResources resources = new NormalizedResources(normalize(Collections.singletonMap(Constants.COMMON_CPU_RESOURCE_NAME, 1)));
         NormalizedResources removedResources = new NormalizedResources(normalize(Collections.singletonMap(Constants.COMMON_CPU_RESOURCE_NAME, 2)));
-        
-        expectedException.expect(IllegalArgumentException.class);
+
         resources.remove(removedResources);
+        assertThat(resources.getTotalCpu(), is(0.0));
     }
     
     @Test


### PR DESCRIPTION
TOPOLOGY_ACKER_CPU_PCORE_PERCENT and other similar settings in adjustResourcesForExec() were orphaned accidentally by a previous pull request.  This adds the functionality back.

When we deployed the change to clusters that were near full with some topologies that had this setting, because we were not previously honoring it, the nodes now looked over 100% full and were throwing exceptions during scheduling.  

The fix for this was to instead zero out the resources and track that the issue is occurring.  We had also logged that the error was occurring, and found that the logging became excessive, which also slowed scheduling.  A further change was added by @revans2 to limit the logging.




 