### PR TITLE
[STORM-3055] 1.1.x remove conext connection cache

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/messaging/IContext.java
+++ b/storm-core/src/jvm/org/apache/storm/messaging/IContext.java
@@ -50,6 +50,8 @@ public interface IContext {
     
     /**
      * This method establish a client side connection to a remote server
+     * implementation should return a new connection every call
+     *
      * @param storm_id topology ID
      * @param host remote host
      * @param port remote port


### PR DESCRIPTION
worker has already cache connection use supervisor_id + port
and if context and worker both cache connection, there can be some problem describe in jira