### PR TITLE
STORM-3059: Fix NPE when the processing guarantee is not AT_LEAST_ONC…

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -486,9 +486,11 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                 /*if a null tuple is not configured to be emitted, it should be marked as emitted and acked immediately
                 * to allow its offset to be commited to Kafka*/
                 LOG.debug("Not emitting null tuple for record [{}] as defined in configuration.", record);
-                msgId.setNullTuple(true);
-                offsetManagers.get(tp).addToEmitMsgs(msgId.offset());
-                ack(msgId);
+                if (isAtLeastOnceProcessing()) {
+                    msgId.setNullTuple(true);
+                    offsetManagers.get(tp).addToEmitMsgs(msgId.offset());
+                    ack(msgId);
+                }
             }
         }
         return false;

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/NullRecordTranslator.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/NullRecordTranslator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.kafka;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.storm.kafka.spout.RecordTranslator;
+import org.apache.storm.tuple.Fields;
+
+public class NullRecordTranslator<K, V> implements RecordTranslator<K, V> {
+
+    @Override
+    public List<Object> apply(ConsumerRecord<K, V> record) {
+        return null;
+
+    }
+
+    @Override
+    public Fields getFieldsFor(String stream) {
+        return new Fields("topic", "key", "value");
+    }
+}

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutMessagingGuaranteeTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutMessagingGuaranteeTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -42,6 +43,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.storm.kafka.NullRecordTranslator;
 import org.apache.storm.kafka.spout.config.builder.SingleTopicKafkaSpoutConfiguration;
 import org.apache.storm.kafka.spout.internal.CommitMetadataManager;
 import org.apache.storm.kafka.spout.subscription.ManualPartitioner;
@@ -63,7 +65,7 @@ public class KafkaSpoutMessagingGuaranteeTest {
 
     @Captor
     private ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> commitCapture;
-    
+
     private final TopologyContext contextMock = mock(TopologyContext.class);
     private final SpoutOutputCollector collectorMock = mock(SpoutOutputCollector.class);
     private final Map<String, Object> conf = new HashMap<>();
@@ -95,7 +97,7 @@ public class KafkaSpoutMessagingGuaranteeTest {
         inOrder.verify(consumerMock).poll(anyLong());
         inOrder.verify(consumerMock).commitSync(commitCapture.capture());
         inOrder.verify(collectorMock).emit(eq(SingleTopicKafkaSpoutConfiguration.STREAM), anyList());
-        
+
         CommitMetadataManager metadataManager = new CommitMetadataManager(contextMock, KafkaSpoutConfig.ProcessingGuarantee.AT_MOST_ONCE);
         Map<TopicPartition, OffsetAndMetadata> committedOffsets = commitCapture.getValue();
         assertThat(committedOffsets.get(partition).offset(), is(0L));
@@ -190,7 +192,7 @@ public class KafkaSpoutMessagingGuaranteeTest {
             .setTupleTrackingEnforced(true)
             .build();
         try (SimulatedTime time = new SimulatedTime()) {
-            KafkaSpout<String, String> spout = SpoutWithMockedConsumerSetupHelper.setupSpout(spoutConfig, conf, contextMock, collectorMock, consumerMock,partition);
+            KafkaSpout<String, String> spout = SpoutWithMockedConsumerSetupHelper.setupSpout(spoutConfig, conf, contextMock, collectorMock, consumerMock, partition);
 
             when(consumerMock.poll(anyLong())).thenReturn(new ConsumerRecords<>(Collections.singletonMap(partition,
                 SpoutWithMockedConsumerSetupHelper.createRecords(partition, 0, 1))));
@@ -203,13 +205,13 @@ public class KafkaSpoutMessagingGuaranteeTest {
             assertThat("Should have captured a message id", msgIdCaptor.getValue(), not(nullValue()));
 
             spout.ack(msgIdCaptor.getValue());
-            
+
             Time.advanceTime(KafkaSpout.TIMER_DELAY_MS + spoutConfig.getOffsetsCommitPeriodMs());
-            
+
             when(consumerMock.poll(anyLong())).thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
-            
+
             spout.nextTuple();
-            
+
             verify(consumerMock, never()).commitSync(argThat(arg -> {
                 return !arg.containsKey(partition);
             }));
@@ -223,32 +225,60 @@ public class KafkaSpoutMessagingGuaranteeTest {
             .setProcessingGuarantee(KafkaSpoutConfig.ProcessingGuarantee.NO_GUARANTEE)
             .setTupleTrackingEnforced(true)
             .build();
-        
+
         try (SimulatedTime time = new SimulatedTime()) {
-            KafkaSpout<String, String> spout = SpoutWithMockedConsumerSetupHelper.setupSpout(spoutConfig, conf, contextMock, collectorMock, consumerMock,partition);
+            KafkaSpout<String, String> spout = SpoutWithMockedConsumerSetupHelper.setupSpout(spoutConfig, conf, contextMock, collectorMock, consumerMock, partition);
 
             when(consumerMock.poll(anyLong())).thenReturn(new ConsumerRecords<>(Collections.singletonMap(partition,
                 SpoutWithMockedConsumerSetupHelper.createRecords(partition, 0, 1))));
 
             spout.nextTuple();
-            
+
             when(consumerMock.position(partition)).thenReturn(1L);
 
             ArgumentCaptor<KafkaSpoutMessageId> msgIdCaptor = ArgumentCaptor.forClass(KafkaSpoutMessageId.class);
             verify(collectorMock).emit(eq(SingleTopicKafkaSpoutConfiguration.STREAM), anyList(), msgIdCaptor.capture());
             assertThat("Should have captured a message id", msgIdCaptor.getValue(), not(nullValue()));
-            
+
             Time.advanceTime(KafkaSpout.TIMER_DELAY_MS + spoutConfig.getOffsetsCommitPeriodMs());
-            
+
             spout.nextTuple();
-            
+
             verify(consumerMock).commitAsync(commitCapture.capture(), isNull());
-            
+
             CommitMetadataManager metadataManager = new CommitMetadataManager(contextMock, KafkaSpoutConfig.ProcessingGuarantee.NO_GUARANTEE);
             Map<TopicPartition, OffsetAndMetadata> committedOffsets = commitCapture.getValue();
             assertThat(committedOffsets.get(partition).offset(), is(1L));
             assertThat(committedOffsets.get(partition).metadata(), is(metadataManager.getCommitMetadata()));
         }
+    }
+
+    private void doFilterNullTupleTest(KafkaSpoutConfig.ProcessingGuarantee processingGuaranteee) {
+        //STORM-3059
+        KafkaSpoutConfig<String, String> spoutConfig = createKafkaSpoutConfigBuilder(mock(TopicFilter.class), mock(ManualPartitioner.class), -1)
+            .setProcessingGuarantee(processingGuaranteee)
+            .setTupleTrackingEnforced(true)
+            .setRecordTranslator(new NullRecordTranslator<>())
+            .build();
+        
+        KafkaSpout<String, String> spout = SpoutWithMockedConsumerSetupHelper.setupSpout(spoutConfig, conf, contextMock, collectorMock, consumerMock, partition);
+
+        when(consumerMock.poll(anyLong())).thenReturn(new ConsumerRecords<>(Collections.singletonMap(partition,
+            SpoutWithMockedConsumerSetupHelper.createRecords(partition, 0, 1))));
+
+        spout.nextTuple();
+        
+        verify(collectorMock, never()).emit(any(), any(), any());
+    }
+    
+    @Test
+    public void testAtMostOnceModeCanFilterNullTuples() {
+        doFilterNullTupleTest(KafkaSpoutConfig.ProcessingGuarantee.AT_MOST_ONCE);
+    }
+    
+    @Test
+    public void testNoGuaranteeModeCanFilterNullTuples() {
+        doFilterNullTupleTest(KafkaSpoutConfig.ProcessingGuarantee.NO_GUARANTEE);
     }
 
 }

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutNullTupleTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutNullTupleTest.java
@@ -18,18 +18,17 @@
 package org.apache.storm.kafka.spout;
 
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.storm.kafka.spout.config.builder.SingleTopicKafkaSpoutConfiguration;
-import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Time;
 import org.junit.Test;
 
-import java.util.List;
 import java.util.regex.Pattern;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+
+import org.apache.storm.kafka.NullRecordTranslator;
 
 public class KafkaSpoutNullTupleTest extends KafkaSpoutAbstractTest {
 
@@ -40,11 +39,10 @@ public class KafkaSpoutNullTupleTest extends KafkaSpoutAbstractTest {
 
     @Override
     KafkaSpoutConfig<String, String> createSpoutConfig() {
-
         return KafkaSpoutConfig.builder("127.0.0.1:" + kafkaUnitRule.getKafkaUnit().getKafkaPort(),
                 Pattern.compile(SingleTopicKafkaSpoutConfiguration.TOPIC))
                 .setOffsetCommitPeriodMs(commitOffsetPeriodMs)
-                .setRecordTranslator(new NullRecordExtractor())
+                .setRecordTranslator(new NullRecordTranslator<>())
                 .build();
     }
 
@@ -69,25 +67,5 @@ public class KafkaSpoutNullTupleTest extends KafkaSpoutAbstractTest {
 
         verifyAllMessagesCommitted(messageCount);
     }
-
-    private class NullRecordExtractor implements RecordTranslator {
-
-        @Override
-        public List<Object> apply(ConsumerRecord record) {
-            return null;
-
-        }
-
-        @Override
-        public Fields getFieldsFor(String stream) {
-            return new Fields("topic", "key", "value");
-        }
-
-        @Override
-        public Object apply(Object record) {
-            return null;
-        }
-    }
-
 
 }


### PR DESCRIPTION
…E and the spout filters out a null tuple

https://issues.apache.org/jira/browse/STORM-3059