### PR TITLE
STORM-3065: Reduce storm-server test fork count to 1, fix some test-s…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/zookeeper/ClientZookeeper.java
+++ b/storm-client/src/jvm/org/apache/storm/zookeeper/ClientZookeeper.java
@@ -77,14 +77,14 @@ public class ClientZookeeper {
     // Deletes the state inside the zookeeper for a key, for which the
     // contents of the key starts with nimbus host port information
     public static void deleteNodeBlobstore(CuratorFramework zk, String parentPath, String hostPortInfo) {
-        String normalizedPatentPath = normalizePath(parentPath);
+        String normalizedParentPath = normalizePath(parentPath);
         List<String> childPathList = null;
-        if (existsNode(zk, normalizedPatentPath, false)) {
-            childPathList = getChildren(zk, normalizedPatentPath, false);
+        if (existsNode(zk, normalizedParentPath, false)) {
+            childPathList = getChildren(zk, normalizedParentPath, false);
             for (String child : childPathList) {
                 if (child.startsWith(hostPortInfo)) {
                     LOG.debug("deleteNode child {}", child);
-                    deleteNode(zk, normalizedPatentPath + "/" + child);
+                    deleteNode(zk, normalizedParentPath + "/" + child);
                 }
             }
         }

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -119,6 +119,13 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <configuration>
                     <reportsDirectories>

--- a/storm-server/src/main/java/org/apache/storm/testing/InProcessZookeeper.java
+++ b/storm-server/src/main/java/org/apache/storm/testing/InProcessZookeeper.java
@@ -26,21 +26,17 @@ public class InProcessZookeeper implements AutoCloseable {
 
     private final TmpPath zkTmp;
     private final NIOServerCnxnFactory zookeeper;
-    private final long zkPort;
 
     public InProcessZookeeper() throws Exception {
         zkTmp = new TmpPath();
-        @SuppressWarnings("unchecked")
-        List<Object> portAndHandle = Zookeeper.mkInprocessZookeeper(zkTmp.getPath(), null);
-        zkPort = (Long) portAndHandle.get(0);
-        zookeeper = (NIOServerCnxnFactory) portAndHandle.get(1);
+        zookeeper = Zookeeper.mkInprocessZookeeper(zkTmp.getPath(), null);
     }
 
     /**
      * @return the port ZK is listening on (localhost)
      */
     public long getPort() {
-        return zkPort;
+        return zookeeper.getLocalPort();
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/zookeeper/Zookeeper.java
+++ b/storm-server/src/main/java/org/apache/storm/zookeeper/Zookeeper.java
@@ -72,7 +72,7 @@ public class Zookeeper {
         _instance = INSTANCE;
     }
 
-    public static List mkInprocessZookeeper(String localdir, Integer port) throws Exception {
+    public static NIOServerCnxnFactory mkInprocessZookeeper(String localdir, Integer port) throws Exception {
         File localfile = new File(localdir);
         ZooKeeperServer zk = new ZooKeeperServer(localfile, localfile, 2000);
         NIOServerCnxnFactory factory = null;
@@ -96,7 +96,7 @@ public class Zookeeper {
         }
         LOG.info("Starting inprocess zookeeper at port {} and dir {}", report, localdir);
         factory.startup(zk);
-        return Arrays.asList((Object) new Long(report), (Object) factory);
+        return factory;
     }
 
     public static void shutdownInprocessZookeeper(NIOServerCnxnFactory handle) {

--- a/storm-server/src/test/java/org/apache/storm/blobstore/LocalFsBlobStoreTest.java
+++ b/storm-server/src/test/java/org/apache/storm/blobstore/LocalFsBlobStoreTest.java
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 public class LocalFsBlobStoreTest {
@@ -67,7 +66,7 @@ public class LocalFsBlobStoreTest {
     try {
       zk = new InProcessZookeeper();
     } catch (Exception e) {
-      e.printStackTrace();
+      throw new RuntimeException(e);
     }
   }
 
@@ -77,7 +76,7 @@ public class LocalFsBlobStoreTest {
     try {
       zk.close();
     } catch (Exception e) {
-      e.printStackTrace();
+      throw new RuntimeException(e);
     }
   }
 
@@ -100,7 +99,8 @@ public class LocalFsBlobStoreTest {
     conf.put(Config.STORM_ZOOKEEPER_PORT, zk.getPort());
     conf.put(Config.STORM_LOCAL_DIR, baseFile.getAbsolutePath());
     conf.put(Config.STORM_PRINCIPAL_TO_LOCAL_PLUGIN,"org.apache.storm.security.auth.DefaultPrincipalToLocal");
-    spy.prepare(conf, null, mock(NimbusInfo.class), null);
+    NimbusInfo nimbusInfo = new NimbusInfo("localhost", 0, false);
+    spy.prepare(conf, null, nimbusInfo, null);
     return spy;
   }
 


### PR DESCRIPTION
…pecific NPEs

https://issues.apache.org/jira/browse/STORM-3065

The changes to InProcessZookeeper aren't strictly necessary, but it seemed unnecessary to me to keep track of the Zookeeper port manually when the connection factory has a method to get it.