### PR TITLE
STORM-3073: Uncap pendingEmits for bolt executors, and prevent LoadSpout from overflowing pendingEmits in spout executors

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/Executor.java
@@ -108,7 +108,7 @@ public abstract class Executor implements Callable, JCQueue.Consumer {
     protected final Boolean hasEventLoggers;
     protected final boolean ackingEnabled;
     protected final ErrorReportingMetrics errorReportingMetrics;
-    protected final MpscChunkedArrayQueue<AddressedTuple> pendingEmits = new MpscChunkedArrayQueue<>(1024);
+    protected final MpscChunkedArrayQueue<AddressedTuple> pendingEmits = new MpscChunkedArrayQueue<>(1024, (int)Math.pow(2, 30));
     private final AddressedTuple flushTuple;
     protected ExecutorTransfer executorTransfer;
     protected ArrayList<Task> idToTask;

--- a/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
@@ -378,5 +378,6 @@ public class SpoutExecutor extends Executor {
 
     public long getThreadId() {
         return threadId;
-    }
+    }   
+    
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3073

The first commit contains the changes I made to ExclamationTopology to provoke the error. I'll remove it after review, it is just included so it's easier to understand the error.

There are two changes in this PR. The first is to uncap the pendingEmits queue for bolt executors. It's currently capped at 1024 elements, which makes it dangerous for bolts to emit more than 1024 tuples in an execute invocation. If the bolt executor is experiencing backpressure and tries to add the tuples to pendingEmits, the queue size will be exceeded and the worker will crash.

The second change is to make LoadSpout emit failed tuples from nextTuple instead of doing it from fail. Since the spout executor is also limited to 1024 tuples in the pending queue, it is likely that the spout executor will exceed the queue limit and crash if a bunch of tuples fail at the same time (e.g. due to timeout) while the spout is adding tuples to pendingEmits. Since the spout won't call nextTuple if there are tuples in pendingEmits, we can just move the retries to that method to prevent the spout from exceeding the pendingEmits limit.