### PR TITLE
STORM-3076:Fix the bug of examples in external can not be compiled

### DIFF
--- a/external/storm-hbase/pom.xml
+++ b/external/storm-hbase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>storm</artifactId>
         <groupId>org.apache.storm</groupId>
-        <version>0.9.5-SNAPSHOT</version>
+        <version>0.9.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
In the external package,the modules include storm-hbase,storm-hdfs and storm-kafka , can not be compiled successfully, due to the lack of specific implements of ILocalCluster in the storm-core-0.9.5