### PR TITLE
STORM-3077 Upgrade Disruptor version to 3.3.11 (1.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <snakeyaml.version>1.11</snakeyaml.version>
         <httpclient.version>4.3.3</httpclient.version>
         <clojure.tools.cli.version>0.2.4</clojure.tools.cli.version>
-        <disruptor.version>3.3.2</disruptor.version>
+        <disruptor.version>3.3.11</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>16.0.1</guava.version>
         <netty.version>3.9.9.Final</netty.version>


### PR DESCRIPTION
No need to port forward to 2.x since we no longer use Disruptor in 2.x.