### PR TITLE
STORM-3053 prevent race deleting blobs before topologies can be submitted

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -50,6 +50,7 @@ storm.nimbus.retry.interval.millis: 2000
 storm.nimbus.retry.intervalceiling.millis: 60000
 storm.nimbus.zookeeper.acls.check: true
 storm.nimbus.zookeeper.acls.fixup: true
+
 storm.auth.simple-white-list.users: []
 storm.cluster.state.store: "org.apache.storm.cluster.ZKStateStorageFactory"
 storm.meta.serialization.delegate: "org.apache.storm.serialization.GzipThriftSerializationDelegate"
@@ -83,6 +84,7 @@ nimbus.local.assignments.backend.class: "org.apache.storm.assignments.InMemoryAs
 nimbus.assignments.service.threads: 10
 nimbus.assignments.service.thread.queue.size: 100
 nimbus.worker.heartbeats.recovery.strategy.class: "org.apache.storm.nimbus.TimeOutWorkerHeartbeatsRecoveryStrategy"
+nimbus.topology.blobstore.deletion.delay.ms: 300000
 
 ### ui.* configs are for the master
 ui.host: 0.0.0.0

--- a/storm-core/test/clj/org/apache/storm/nimbus_test.clj
+++ b/storm-core/test/clj/org/apache/storm/nimbus_test.clj
@@ -1885,7 +1885,7 @@
         hb-cache (into {}(map vector inactive-topos '(nil nil)))
         mock-state (mock-cluster-state)
         mock-blob-store (Mockito/mock BlobStore)
-        conf {NIMBUS-MONITOR-FREQ-SECS 10 NIMBUS-TOPOLOGY-BLOBSTORE-DELETION-DELAY-MSEC 0}]
+        conf {NIMBUS-MONITOR-FREQ-SECS 10 NIMBUS-TOPOLOGY-BLOBSTORE-DELETION-DELAY-MS 0}]
     (with-open [_ (MockedZookeeper. (proxy [Zookeeper] []
                     (zkLeaderElectorImpl [conf zk blob-store tc cluster-state acls] (MockLeaderElector. ))))]
       (let [nimbus (Mockito/spy (Nimbus. conf nil mock-state nil mock-blob-store nil nil))]

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -280,6 +280,12 @@ public class DaemonConfig implements Validated {
     public static final String NIMBUS_WORKER_HEARTBEATS_RECOVERY_STRATEGY_CLASS = "nimbus.worker.heartbeats.recovery.strategy.class";
 
     /**
+     * This controls the number of milliseconds nimbus will wait before deleting a topology blobstore once detected it is able to delete.
+     */
+    @isInteger
+    public static final String NIMBUS_TOPOLOGY_BLOBSTORE_DELETION_DELAY_MSEC = "nimbus.topology.blobstore.deletion.delay.msec";
+
+    /**
      * Storm UI binds to this host/interface.
      */
     @isString

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -283,7 +283,7 @@ public class DaemonConfig implements Validated {
      * This controls the number of milliseconds nimbus will wait before deleting a topology blobstore once detected it is able to delete.
      */
     @isInteger
-    public static final String NIMBUS_TOPOLOGY_BLOBSTORE_DELETION_DELAY_MSEC = "nimbus.topology.blobstore.deletion.delay.msec";
+    public static final String NIMBUS_TOPOLOGY_BLOBSTORE_DELETION_DELAY_MS = "nimbus.topology.blobstore.deletion.delay.ms";
 
     /**
      * Storm UI binds to this host/interface.

--- a/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
@@ -72,14 +72,15 @@ public class NimbusTest {
         idleTopologies.add("topology1");
         Mockito.when(store.storedTopoIds()).thenReturn(idleTopologies);
         Map<String, Object> conf = new HashMap<>();
+        conf.put(DaemonConfig.NIMBUS_TOPOLOGY_BLOBSTORE_DELETION_DELAY_MS, 300000);
 
         try (Time.SimulatedTime t = new Time.SimulatedTime(null)) {
-            Set<String> toDelete = Nimbus.getIdleTopologyIds(store, conf);
+            Set<String> toDelete = Nimbus.getExpiredTopologyIds(store, conf);
             Assert.assertTrue(toDelete.isEmpty());
 
             Time.advanceTime(10 * 60 * 1000L);
 
-            toDelete = Nimbus.getIdleTopologyIds(store, conf);
+            toDelete = Nimbus.getExpiredTopologyIds(store, conf);
             Assert.assertTrue(toDelete.contains("topology1"));
             Assert.assertEquals(1, toDelete.size());
 


### PR DESCRIPTION
When submitting a toplogy, the jar first gets uploaded, and then the topology is submitted.  Between these two events, a nimbus timer can go off and it finds that the jar belongs to a topology that does not exist, and removes it, causing topology submission to fail.

This change logs when a blob is first detected for deletion.  It then waits a period of time (defaulting to 5 minutes) before considering it idle.


