### PR TITLE
 STORM-3061: rocket, jms, and mqtt updates

### DIFF
--- a/examples/storm-jms-examples/pom.xml
+++ b/examples/storm-jms-examples/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>storm-jms-examples</artifactId>
 
     <properties>
-        <spring.version>2.5.6</spring.version>
+        <spring.version>5.0.4.RELEASE</spring.version>
     </properties>
     <dependencies>
         <dependency>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.xbean</groupId>
             <artifactId>xbean-spring</artifactId>
-            <version>3.7</version>
+            <version>4.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>
@@ -72,18 +72,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-core</artifactId>
-            <version>5.4.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>activemq-client</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/examples/storm-mqtt-examples/pom.xml
+++ b/examples/storm-mqtt-examples/pom.xml
@@ -44,16 +44,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.storm</groupId>
       <artifactId>flux-core</artifactId>
       <version>${project.version}</version>
@@ -66,17 +56,14 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-broker</artifactId>
-      <version>5.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-mqtt</artifactId>
-      <version>5.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-kahadb-store</artifactId>
-      <version>5.9.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/examples/storm-mqtt-examples/src/main/java/org/apache/storm/mqtt/examples/CustomMessageMapper.java
+++ b/examples/storm-mqtt-examples/src/main/java/org/apache/storm/mqtt/examples/CustomMessageMapper.java
@@ -72,8 +72,8 @@ public final class CustomMessageMapper implements MqttMessageMapper {
     }
 
     /**
-     * Utility constructor.
+     * Constructor.
      */
-    private CustomMessageMapper() {
+    public CustomMessageMapper() {
     }
 }

--- a/examples/storm-rocketmq-examples/pom.xml
+++ b/examples/storm-rocketmq-examples/pom.xml
@@ -30,7 +30,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.storm</groupId>
-            <artifactId>storm-server</artifactId>
+            <artifactId>storm-client</artifactId>
             <version>${project.version}</version>
             <scope>${provided.scope}</scope>
         </dependency>

--- a/examples/storm-rocketmq-examples/src/main/java/org/apache/storm/rocketmq/topology/WordCountTopology.java
+++ b/examples/storm-rocketmq-examples/src/main/java/org/apache/storm/rocketmq/topology/WordCountTopology.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,11 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.topology;
 
+import java.util.Properties;
 import org.apache.storm.Config;
-import org.apache.storm.LocalCluster;
-import org.apache.storm.LocalCluster.LocalTopology;
 import org.apache.storm.StormSubmitter;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.rocketmq.RocketMqConfig;
@@ -32,8 +32,6 @@ import org.apache.storm.rocketmq.common.selector.TopicSelector;
 import org.apache.storm.rocketmq.spout.RocketMqSpout;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.tuple.Fields;
-
-import java.util.Properties;
 
 public class WordCountTopology {
     private static final String WORD_SPOUT = "WORD_SPOUT";
@@ -77,19 +75,16 @@ public class WordCountTopology {
     public static void main(String[] args) throws Exception {
         Config conf = new Config();
         conf.setMaxSpoutPending(5);
-        if (args.length == 2) {
-            try (LocalCluster cluster = new LocalCluster();
-                 LocalTopology topo = cluster.submitTopology("wordCounter", conf, buildTopology(args[0], args[1]));) {
-                Thread.sleep(120 * 1000);
-            }
-            System.exit(0);
-        }
-        else if(args.length == 3) {
-            conf.setNumWorkers(3);
-            StormSubmitter.submitTopology(args[2], conf, buildTopology(args[0], args[1]));
-        } else{
+        conf.setNumWorkers(3);
+
+        String topologyName = "wordCounter";
+        if (args.length < 2) {
             System.out.println("Usage: WordCountTopology <nameserver addr> <topic> [topology name]");
+        } else {
+            if (args.length > 3) {
+                topologyName = args[2];
+            }
+            StormSubmitter.submitTopology(topologyName, conf, buildTopology(args[0], args[1]));
         }
     }
-
 }

--- a/examples/storm-rocketmq-examples/src/main/java/org/apache/storm/rocketmq/trident/WordCountTrident.java
+++ b/examples/storm-rocketmq-examples/src/main/java/org/apache/storm/rocketmq/trident/WordCountTrident.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,11 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.storm.rocketmq.trident;
 
+import java.util.Properties;
 import org.apache.storm.Config;
-import org.apache.storm.LocalCluster;
-import org.apache.storm.LocalCluster.LocalTopology;
 import org.apache.storm.StormSubmitter;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.rocketmq.RocketMqConfig;
@@ -36,8 +36,6 @@ import org.apache.storm.trident.state.StateFactory;
 import org.apache.storm.trident.testing.FixedBatchSpout;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Values;
-
-import java.util.Properties;
 
 public class WordCountTrident {
 
@@ -76,19 +74,16 @@ public class WordCountTrident {
     public static void main(String[] args) throws Exception {
         Config conf = new Config();
         conf.setMaxSpoutPending(5);
-        if (args.length == 2) {
-            try (LocalCluster cluster = new LocalCluster();
-                 LocalTopology topo = cluster.submitTopology("wordCounter", conf, buildTopology(args[0], args[1]));) {
-                Thread.sleep(60 * 1000);
-            }
-            System.exit(0);
-        }
-        else if(args.length == 3) {
-            conf.setNumWorkers(3);
-            StormSubmitter.submitTopology(args[2], conf, buildTopology(args[0], args[1]));
-        } else{
+        conf.setNumWorkers(3);
+
+        String topologyName = "wordCounter";
+        if (args.length < 2) {
             System.out.println("Usage: WordCountTrident <nameserver addr> <topic> [topology name]");
+        } else {
+            if (args.length > 3) {
+                topologyName = args[2];
+            }
+            StormSubmitter.submitTopology(topologyName, conf, buildTopology(args[0], args[1]));
         }
     }
-
 }

--- a/external/storm-jms/pom.xml
+++ b/external/storm-jms/pom.xml
@@ -25,11 +25,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-
-
     <artifactId>storm-jms</artifactId>
-
-
 
     <developers>
         <developer>
@@ -59,11 +55,10 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Active MQ -->
+        <!-- Active MQ for testing JMS-->
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-core</artifactId>
-            <version>5.5.1</version>
+            <artifactId>activemq-all</artifactId>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/external/storm-mqtt/pom.xml
+++ b/external/storm-mqtt/pom.xml
@@ -29,9 +29,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-
-
-
     <repositories>
         <repository>
             <id>bintray</id>
@@ -49,19 +46,16 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-mqtt</artifactId>
-            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-kahadb-store</artifactId>
-            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,7 @@
         <solr.version>5.2.1</solr.version>
         <jpmml.version>1.0.22</jpmml.version>
         <jedis.version>2.9.0</jedis.version>
+        <activemq.version>5.15.3</activemq.version>
         <rocketmq.version>4.2.0</rocketmq.version>
 
         <jackson.version>2.9.4</jackson.version>
@@ -1118,6 +1119,51 @@
                 <artifactId>rocksdbjni</artifactId>
                 <version>${rocksdb-version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client</artifactId>
+                <version>${activemq.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-broker</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-mqtt</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-kahadb-store</artifactId>
+                <version>${activemq.version}</version>
+           </dependency>
+           <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-all</artifactId>
+                <version>${activemq.version}</version>
+                <exclusions>
+                   <exclusion>
+                       <groupId>org.slf4j</groupId>
+                       <artifactId>slf4j-api</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>log4j</groupId>
+                       <artifactId>log4j</artifactId>
+                   </exclusion>
+                </exclusions>
+           </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This updates some dependencies for the jms examples, mqtt examples, rocketmq examples, and updates activemq implementation used for testing jms, rocketmq, and activemq.

I ran some manual tests of the example topologies that I could find. I couldn't make all of them really work, because there was no clear documentation about most of them on how to setup or run the example topologies.

mqtt examples using flink had no documentation at all so I wasn't able to successfully run anything. storm-jms-examples fails with what appears to be a JNI issue, but it fails exactly the same way on 1.2.3-SNAPSHOT too.

If someone with more experience with these could improve the documentation about how to run them that would be great.