### PR TITLE
STORM-3061: Clean up some storm-druid dependencies

### DIFF
--- a/external/storm-druid/pom.xml
+++ b/external/storm-druid/pom.xml
@@ -64,29 +64,12 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.11.8</version>
-            <scope>provided</scope>
+            <version>2.11.12</version>
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>
             <artifactId>util-core_2.11</artifactId>
             <version>6.30.0</version>
-        </dependency>
-        <!-- tranquility library depends on jackson 2.4.6 version -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.4.6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.4.6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-smile</artifactId>
-            <version>2.4.6</version>
         </dependency>
 
         <!--test dependencies -->


### PR DESCRIPTION
`mvn dependency:tree` showed that the only real dependency changes were for scala and jackson that went from 2.4.6 to 2.9.4.

I am not totally sure how to test this currently as there is an open issue right now that it does not work. 

If others want to try this feel welcome to, if not we can try to fix any remaining issues as a part of https://issues.apache.org/jira/browse/STORM-2884