### PR TITLE
STORM-3083 Upgrade HikariCP version to 2.4.7

### DIFF
--- a/external/storm-jdbc/pom.xml
+++ b/external/storm-jdbc/pom.xml
@@ -36,7 +36,7 @@
     </developers>
 
     <properties>
-        <hikari.version>2.4.3</hikari.version>
+        <hikari.version>2.4.7</hikari.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
* Please refer https://issues.apache.org/jira/browse/STORM-3083 for more details

This can be safely ported back to 1.x-branch as well.