### PR TITLE
STORM-3061: Upgrade version of hdrhistogram

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <thrift.version>0.11.0</thrift.version>
         <junit.version>4.11</junit.version>
         <metrics-clojure.version>2.5.1</metrics-clojure.version>
-        <hdrhistogram.version>2.1.7</hdrhistogram.version>
+        <hdrhistogram.version>2.1.10</hdrhistogram.version>
         <hamcrest.version>2.0.0.0</hamcrest.version>
         <cassandra.version>2.1.7</cassandra.version>
         <druid.version>0.8.2</druid.version>


### PR DESCRIPTION
not too much is using hdrhistogram.

storm-metrics,
storm-loadgen,
storm-starter,
storm-elasticsearch,
storm-elasticsearch-examples

The ES code is not running because of what appear to be issues with the version of guava.  when we shade guava it should take care of that, and I will be able to test these changes better.

I think I am going to change focus for a while and put in shading so we can fix some of these issues and actually test these things.  I manually tested the others and the code works.