### PR TITLE
STORM-3087: Make FluxBuilder.canInvokeWithArgs check whether the actu…

### DIFF
--- a/flux/flux-core/src/main/java/org/apache/storm/flux/FluxBuilder.java
+++ b/flux/flux-core/src/main/java/org/apache/storm/flux/FluxBuilder.java
@@ -557,7 +557,7 @@ public class FluxBuilder {
         for (Method method : methods) {
             Class[] paramClasses = method.getParameterTypes();
             if (paramClasses.length == args.size() && method.getName().equals(methodName)) {
-                LOG.debug("found constructor with same number of args..");
+                LOG.debug("found method with same number of args.");
                 boolean invokable = false;
                 if (args.size() == 0) {
                     // it's a method with zero args
@@ -698,6 +698,10 @@ public class FluxBuilder {
                 LOG.debug("Yes, assignment is possible.");
             } else if (isPrimitiveNumber(paramType) || Number.class.isAssignableFrom(paramType)
                     && Number.class.isAssignableFrom(objectType)) {
+                LOG.debug("Param is a number, checking whether argument can be coerced");
+                if (!Number.class.isAssignableFrom(objectType)) {
+                    return false;
+                }
                 LOG.debug("Yes, assignment is possible.");
             } else if (paramType.isEnum() && objectType.equals(String.class)) {
                 LOG.debug("Yes, will convert a String to enum");

--- a/flux/flux-core/src/test/java/org/apache/storm/flux/TCKTest.java
+++ b/flux/flux-core/src/test/java/org/apache/storm/flux/TCKTest.java
@@ -31,8 +31,14 @@ import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.Properties;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 public class TCKTest {
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
     @Test
     public void testTCK() throws Exception {
         TopologyDef topologyDef = FluxParser.parseResource("/configs/tck.yaml", false, true, null, false);
@@ -53,14 +59,16 @@ public class TCKTest {
         topology.validate();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadShellComponents() throws Exception {
         TopologyDef topologyDef = FluxParser.parseResource("/configs/bad_shell_test.yaml", false, true, null, false);
         Config conf = FluxBuilder.buildConfig(topologyDef);
         ExecutionContext context = new ExecutionContext(topologyDef, conf);
-        StormTopology topology = FluxBuilder.buildTopology(context);
-        assertNotNull(topology);
-        topology.validate();
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Unable to find configuration method");
+        
+        FluxBuilder.buildTopology(context);
     }
 
     @Test
@@ -115,14 +123,16 @@ public class TCKTest {
         topology.validate();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadHbase() throws Exception {
         TopologyDef topologyDef = FluxParser.parseResource("/configs/bad_hbase.yaml", false, true, null, false);
         Config conf = FluxBuilder.buildConfig(topologyDef);
         ExecutionContext context = new ExecutionContext(topologyDef, conf);
-        StormTopology topology = FluxBuilder.buildTopology(context);
-        assertNotNull(topology);
-        topology.validate();
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Couldn't find a suitable constructor");
+        
+        FluxBuilder.buildTopology(context);
     }
 
     @Test
@@ -265,5 +275,18 @@ public class TCKTest {
                Collections.singletonList("A string list"),
                is(context.getTopologyDef().getConfig().get("list.property.target")));
 
+    }
+    
+    @Test
+    public void testTopologyWithInvalidStaticFactoryArgument() throws Exception {
+        //STORM-3087.
+        TopologyDef topologyDef = FluxParser.parseResource("/configs/bad_static_factory_test.yaml", false, true, null, false);
+        Config conf = FluxBuilder.buildConfig(topologyDef);
+        ExecutionContext context = new ExecutionContext(topologyDef, conf);
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Couldn't find a suitable static method");
+        
+        FluxBuilder.buildTopology(context);
     }
 }

--- a/flux/flux-core/src/test/java/org/apache/storm/flux/test/TestBolt.java
+++ b/flux/flux-core/src/test/java/org/apache/storm/flux/test/TestBolt.java
@@ -148,4 +148,8 @@ public class TestBolt extends BaseBasicBolt {
     public static TestBolt newInstance(TestEnum te){
         return new TestBolt(te);
     }
+    
+    public static TestBolt newLongInstance(long l) {
+        return new TestBolt(l);
+    }
 }

--- a/flux/flux-core/src/test/resources/configs/bad_static_factory_test.yaml
+++ b/flux/flux-core/src/test/resources/configs/bad_static_factory_test.yaml
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: "yaml-topology"
+
+#
+config:
+  topology.workers: 1
+  # ...
+
+# spout definitions
+spouts:
+  - id: "spout-1"
+    className: "org.apache.storm.testing.TestWordSpout"
+    parallelism: 1
+    # ...
+
+# bolt definitions
+bolts:
+  - id: "bolt-1"
+    className: "org.apache.storm.flux.test.TestBolt"
+    factory: "newLongInstance"
+    factoryArgs:
+      - "This is not a valid parameter, so should trigger an error"
+    parallelism: 1
+#stream definitions
+# stream definitions define connections between spouts and bolts.
+# note that such connections can be cyclical
+streams:
+  - name: "spout-1 --> bolt-1" # name isn't used (placeholder for logging, UI, etc.)
+#    id: "connection-1"
+    from: "spout-1"
+    to: "bolt-1"
+    grouping:
+      type: SHUFFLE
+
+
+
+
+
+
+
+


### PR DESCRIPTION
…al argument type is assignable to Number before deciding that a method with a primitive parameter can be invoked

https://issues.apache.org/jira/browse/STORM-3087

The added test checks whether Flux throws an IllegalArgumentException because it couldn't find the right method, or because it found the wrong method and tried to call it (in which case the IAE would have a null message).

A more useful example would be trying to use code like this:

```
public MyClass(String s){}
public MyClass(long l){}
```

Using a topology definition that tries to invoke the String-typed constructor, Flux will sometimes erroneously pick the long-type constructor instead. The test is the way it is because trying to test an example like this will inherently be flaky, since the order Flux encounters methods in is random.