### PR TITLE
STORM-3087: Make FluxBuilder.canInvokeWithArgs check whether the actu…

### DIFF
--- a/external/flux/flux-core/src/main/java/org/apache/storm/flux/FluxBuilder.java
+++ b/external/flux/flux-core/src/main/java/org/apache/storm/flux/FluxBuilder.java
@@ -550,7 +550,7 @@ public class FluxBuilder {
         for (Method method : methods) {
             Class[] paramClasses = method.getParameterTypes();
             if (paramClasses.length == args.size() && method.getName().equals(methodName)) {
-                LOG.debug("found constructor with same number of args..");
+                LOG.debug("found method with same number of args.");
                 boolean invokable = false;
                 if (args.size() == 0) {
                     // it's a method with zero args
@@ -691,6 +691,10 @@ public class FluxBuilder {
                 LOG.debug("Yes, assignment is possible.");
             } else if (isPrimitiveNumber(paramType) || Number.class.isAssignableFrom(paramType)
                     && Number.class.isAssignableFrom(objectType)) {
+                LOG.debug("Param is a number, checking whether argument can be coerced");
+                if (!Number.class.isAssignableFrom(objectType)) {
+                    return false;
+                }
                 LOG.debug("Yes, assignment is possible.");
             } else if (paramType.isEnum() && objectType.equals(String.class)) {
                 LOG.debug("Yes, will convert a String to enum");

--- a/external/flux/flux-core/src/test/java/org/apache/storm/flux/test/TestBolt.java
+++ b/external/flux/flux-core/src/test/java/org/apache/storm/flux/test/TestBolt.java
@@ -147,4 +147,8 @@ public class TestBolt extends BaseBasicBolt {
     public static TestBolt newInstance(TestEnum te){
         return new TestBolt(te);
     }
+    
+    public static TestBolt newLongInstance(long l) {
+        return new TestBolt(l);
+    }
 }

--- a/external/flux/flux-core/src/test/resources/configs/bad_static_factory_test.yaml
+++ b/external/flux/flux-core/src/test/resources/configs/bad_static_factory_test.yaml
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: "yaml-topology"
+
+#
+config:
+  topology.workers: 1
+  # ...
+
+# spout definitions
+spouts:
+  - id: "spout-1"
+    className: "org.apache.storm.testing.TestWordSpout"
+    parallelism: 1
+    # ...
+
+# bolt definitions
+bolts:
+  - id: "bolt-1"
+    className: "org.apache.storm.flux.test.TestBolt"
+    factory: "newLongInstance"
+    factoryArgs:
+      - "This is not a valid parameter, so should trigger an error"
+    parallelism: 1
+#stream definitions
+# stream definitions define connections between spouts and bolts.
+# note that such connections can be cyclical
+streams:
+  - name: "spout-1 --> bolt-1" # name isn't used (placeholder for logging, UI, etc.)
+#    id: "connection-1"
+    from: "spout-1"
+    to: "bolt-1"
+    grouping:
+      type: SHUFFLE
+
+
+
+
+
+
+
+


### PR DESCRIPTION
…al argument type is assignable to Number before deciding that a method with a primitive parameter can be invoked

1.x version of https://github.com/apache/storm/pull/2695