### PR TITLE
[STORM-3094] : Added topology name validation at client side

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -231,6 +231,9 @@ public class StormSubmitter {
                     if (topologyNameExists(name, client)) {
                         throw new RuntimeException("Topology with name `" + name + "` already exists on cluster");
                     }
+                    if (!Utils.isValidKey(name)) {
+                        throw new IllegalArgumentException(name + " does not appear to be a valid topology name.");
+                    }
 
                     // Dependency uploading only makes sense for distributed mode
                     List<String> jarsBlobKeys = Collections.emptyList();

--- a/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
@@ -31,8 +31,8 @@ import org.apache.storm.generated.ReadableBlobMeta;
 import org.apache.storm.generated.SettableBlobMeta;
 import org.apache.storm.nimbus.ILeaderElector;
 import org.apache.storm.nimbus.NimbusInfo;
-import org.apache.storm.shade.org.apache.commons.lang.StringUtils;
 import org.apache.storm.utils.ConfigUtils;
+import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
 public abstract class BlobStore implements Shutdownable {
     protected static final String BASE_BLOBS_DIR_NAME = "blobs";
     private static final Logger LOG = LoggerFactory.getLogger(BlobStore.class);
-    private static final Pattern KEY_PATTERN = Pattern.compile("^[\\w \\t\\._-]+$", Pattern.UNICODE_CHARACTER_CLASS);
     private static final KeyFilter<String> TO_TOPO_ID = (key) -> ConfigUtils.getIdFromBlobKey(key);
 
     /**
@@ -60,9 +59,7 @@ public abstract class BlobStore implements Shutdownable {
      * @param key Key for the blob.
      */
     public static final void validateKey(String key) throws IllegalArgumentException {
-        if (StringUtils.isEmpty(key) || "..".equals(key) || ".".equals(key) || !KEY_PATTERN.matcher(key).matches()) {
-            LOG.error("'{}' does not appear to be valid. It must match {}. And it can't be \".\", \"..\", null or empty string.", key,
-                      KEY_PATTERN);
+        if (!Utils.isValidKey(key)) {
             throw new IllegalArgumentException(key + " does not appear to be a valid blob key");
         }
     }

--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -89,6 +89,7 @@ import org.apache.storm.shade.com.google.common.collect.MapDifference;
 import org.apache.storm.shade.com.google.common.collect.Maps;
 import org.apache.storm.shade.org.apache.commons.io.FileUtils;
 import org.apache.storm.shade.org.apache.commons.io.input.ClassLoaderObjectInputStream;
+import org.apache.storm.shade.org.apache.commons.lang.StringUtils;
 import org.apache.storm.shade.org.apache.zookeeper.ZooDefs;
 import org.apache.storm.shade.org.apache.zookeeper.data.ACL;
 import org.apache.storm.shade.org.apache.zookeeper.data.Id;
@@ -117,6 +118,7 @@ public class Utils {
     // tests by subclassing.
     private static Utils _instance = new Utils();
     private static String memoizedLocalHostnameString = null;
+    public static final Pattern TOPOLOGY_KEY_PATTERN = Pattern.compile("^[\\w \\t\\._-]+$", Pattern.UNICODE_CHARACTER_CLASS);
 
     static {
         localConf = readStormConfig();
@@ -1635,6 +1637,20 @@ public class Utils {
             return memoizedLocalHostname();
         }
         return (String) hostnameString;
+    }
+
+    /**
+     * Validates topology name / blob key.
+     *
+     * @param key topology name / Key for the blob.
+     */
+    public static boolean isValidKey(String key) {
+        if (StringUtils.isEmpty(key) || "..".equals(key) || ".".equals(key) || !TOPOLOGY_KEY_PATTERN.matcher(key).matches()) {
+            LOG.error("'{}' does not appear to be valid. It must match {}. And it can't be \".\", \"..\", null or empty string.", key,
+                    TOPOLOGY_KEY_PATTERN);
+            return false;
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Current Behavior : Execute topology with invalid topology name is throwing exception after uploading the jar.

Improvement : Validating topology name at client side before uploading the jar.