### PR TITLE
STORM-3096 prevent race condition during topology submission

### DIFF
--- a/storm-core/test/clj/org/apache/storm/nimbus_test.clj
+++ b/storm-core/test/clj/org/apache/storm/nimbus_test.clj
@@ -635,6 +635,7 @@
                                       (.withSupervisors 2)
                                       (.withPortsPerSupervisor 5)
                                       (.withDaemonConf {SUPERVISOR-ENABLE false
+                  NIMBUS-TOPOLOGY-BLOBSTORE-DELETION-DELAY-MS 0
                   NIMBUS-TASK-TIMEOUT-SECS 30
                   NIMBUS-MONITOR-FREQ-SECS 10
                   TOPOLOGY-ACKER-EXECUTORS 0
@@ -1856,7 +1857,7 @@
          (let [mock-state (mock-cluster-state (list "topo1") (list "topo1" "topo2" "topo3"))
                store (Mockito/mock BlobStore)]
               (.thenReturn (Mockito/when (.storedTopoIds store)) #{})
-              (is (= (Nimbus/topoIdsToClean mock-state store (new java.util.HashMap)) #{"topo2" "topo3"}))))
+              (is (= (Nimbus/topoIdsToClean mock-state store {NIMBUS-TOPOLOGY-BLOBSTORE-DELETION-DELAY-MS 0}) #{"topo2" "topo3"}))))
 
 (deftest cleanup-storm-ids-performs-union-of-storm-ids-with-active-znodes
   (let [active-topos (list "hb1" "e2" "bp3")
@@ -1866,7 +1867,7 @@
         mock-state (mock-cluster-state active-topos hb-topos error-topos bp-topos)
         store (Mockito/mock BlobStore)]
     (.thenReturn (Mockito/when (.storedTopoIds store)) #{})
-    (is (= (Nimbus/topoIdsToClean mock-state store (new java.util.HashMap))
+    (is (= (Nimbus/topoIdsToClean mock-state store {NIMBUS-TOPOLOGY-BLOBSTORE-DELETION-DELAY-MS 0})
            #{"hb2" "hb3" "e1" "e3" "bp1" "bp2"}))))
 
 (deftest cleanup-storm-ids-returns-empty-set-when-all-topos-are-active

--- a/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import org.apache.storm.Config;
 import org.apache.storm.DaemonConfig;
-import org.apache.storm.blobstore.BlobStore;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.scheduler.resource.strategies.priority.DefaultSchedulingPriorityStrategy;
 import org.apache.storm.scheduler.resource.strategies.scheduling.DefaultResourceAwareStrategy;
@@ -34,7 +33,6 @@ import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.utils.Time;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import static org.junit.Assert.fail;
 
@@ -67,20 +65,18 @@ public class NimbusTest {
 
     @Test
     public void uploadedBlobPersistsMinimumTime() {
-        BlobStore store = Mockito.mock(BlobStore.class);
         Set<String> idleTopologies = new HashSet<>();
         idleTopologies.add("topology1");
-        Mockito.when(store.storedTopoIds()).thenReturn(idleTopologies);
         Map<String, Object> conf = new HashMap<>();
         conf.put(DaemonConfig.NIMBUS_TOPOLOGY_BLOBSTORE_DELETION_DELAY_MS, 300000);
 
         try (Time.SimulatedTime t = new Time.SimulatedTime(null)) {
-            Set<String> toDelete = Nimbus.getExpiredTopologyIds(store, conf);
+            Set<String> toDelete = Nimbus.getExpiredTopologyIds(idleTopologies, conf);
             Assert.assertTrue(toDelete.isEmpty());
 
             Time.advanceTime(10 * 60 * 1000L);
 
-            toDelete = Nimbus.getExpiredTopologyIds(store, conf);
+            toDelete = Nimbus.getExpiredTopologyIds(idleTopologies, conf);
             Assert.assertTrue(toDelete.contains("topology1"));
             Assert.assertEquals(1, toDelete.size());
 


### PR DESCRIPTION
My previous attempt at fixing this addressed the race in store.storedTopoIds().  But state.idsOfTopologiesWithPrivateWorkerKeys() will also return a topology as ready to clean up while the topology is being submitted.

The fix is to delay deletion on all topologies found for all the state and store checks.

I was able to reproduce the issue and validate the fix properly this time by forcing a Nimbus cleanup to be called as part of topology submission.
