### PR TITLE
STORM-3099: Extend metrics on supervisor, workers and DRPC

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/ShellUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ShellUtils.java
@@ -12,6 +12,7 @@
 
 package org.apache.storm.utils;
 
+import com.codahale.metrics.Meter;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -36,8 +37,12 @@ abstract public class ShellUtils {
     public static final boolean FREEBSD = (osType == OSType.OS_TYPE_FREEBSD);
     public static final boolean LINUX = (osType == OSType.OS_TYPE_LINUX);
     public static final boolean OTHER = (osType == OSType.OS_TYPE_OTHER);
+
+    //Meter declared here can be registered by any daemon, and is currently used by Supervisor
+    public static final Meter numShellExceptions = new Meter();
+
     /**
-     * Token separator regex used to parse Shell tool outputs
+     * Token separator regex used to parse Shell tool outputs.
      */
     public static final String TOKEN_SEPARATOR_REGEX
         = WINDOWS ? "[|\n\r]" : "[ \t\n\r\f]";
@@ -186,7 +191,12 @@ abstract public class ShellUtils {
             return;
         }
         exitCode = 0; // reset for next run
-        runCommand();
+        try {
+            runCommand();
+        } catch (IOException e) {
+            numShellExceptions.mark();
+            throw e;
+        }
     }
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/TimedWritableByteChannel.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/TimedWritableByteChannel.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.storm.daemon.nimbus;
+
+import com.codahale.metrics.Timer;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+import org.apache.storm.metric.timed.TimedResource;
+
+public class TimedWritableByteChannel extends TimedResource<WritableByteChannel> implements WritableByteChannel {
+
+    public TimedWritableByteChannel(WritableByteChannel measured, Timer timer) {
+        super(measured, timer);
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return getMeasured().write(src);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return getMeasured().isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            super.close();
+        } catch (Exception e) {
+            //WritableByteChannel is a Channel which implements Closeable.
+            // Hence although declared AutoCloseable super#close here should only throws IOException
+            //We rethrow to conform the signature
+            throw (IOException) e;
+        }
+    }
+}

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Container.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Container.java
@@ -18,6 +18,8 @@
 
 package org.apache.storm.daemon.supervisor;
 
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -68,6 +70,13 @@ public abstract class Container implements Killable {
     private static final ConcurrentHashMap<Integer, TopoAndMemory> _reservedMemory =
         new ConcurrentHashMap<>();
 
+    private static final Meter numCleanupExceptions = StormMetricsRegistry.registerMeter("supervisor:num-cleanup-exceptions");
+    private static final Meter numKillExceptions = StormMetricsRegistry.registerMeter("supervisor:num-kill-exceptions");
+    private static final Meter numForceKillExceptions = StormMetricsRegistry.registerMeter("supervisor:num-force-kill-exceptions");
+    private static final Meter numForceKill = StormMetricsRegistry.registerMeter("supervisor:num-workers-force-kill");
+    private static final Timer shutdownDuration = StormMetricsRegistry.registerTimer("supervisor:worker-shutdown-duration-ns");
+    private static final Timer cleanupDuration = StormMetricsRegistry.registerTimer("supervisor:worker-per-call-clean-up-duration-ns");
+
     static {
         StormMetricsRegistry.registerGauge(
             "supervisor:current-used-memory-mb",
@@ -106,6 +115,8 @@ public abstract class Container implements Killable {
     protected String _workerId;
     protected ContainerType _type;
     private long lastMetricProcessTime = 0L;
+    private Timer.Context shutdownTimer = null;
+
     /**
      * Create a new Container.
      *
@@ -204,20 +215,34 @@ public abstract class Container implements Killable {
     @Override
     public void kill() throws IOException {
         LOG.info("Killing {}:{}", _supervisorId, _workerId);
-        Set<Long> pids = getAllPids();
+        if (shutdownTimer == null) {
+            shutdownTimer = shutdownDuration.time();
+        }
+        try {
+            Set<Long> pids = getAllPids();
 
-        for (Long pid : pids) {
-            kill(pid);
+            for (Long pid : pids) {
+                kill(pid);
+            }
+        } catch (IOException e) {
+            numKillExceptions.mark();
+            throw e;
         }
     }
 
     @Override
     public void forceKill() throws IOException {
         LOG.info("Force Killing {}:{}", _supervisorId, _workerId);
-        Set<Long> pids = getAllPids();
+        numForceKill.mark();
+        try {
+            Set<Long> pids = getAllPids();
 
-        for (Long pid : pids) {
-            forceKill(pid);
+            for (Long pid : pids) {
+                forceKill(pid);
+            }
+        } catch (IOException e) {
+            numForceKillExceptions.mark();
+            throw e;
         }
     }
 
@@ -318,14 +343,26 @@ public abstract class Container implements Killable {
                 break;
             }
         }
+
+        if (allDead && shutdownTimer != null) {
+            shutdownTimer.stop();
+            shutdownTimer = null;
+        }
+
         return allDead;
     }
 
     @Override
     public void cleanUp() throws IOException {
-        _usedMemory.remove(_port);
-        _reservedMemory.remove(_port);
-        cleanUpForRestart();
+        try (Timer.Context t = cleanupDuration.time()) {
+            _usedMemory.remove(_port);
+            _reservedMemory.remove(_port);
+            cleanUpForRestart();
+        } catch (IOException e) {
+            //This may or may not be reported depending on when process exits
+            numCleanupExceptions.mark();
+            throw e;
+        }
     }
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -69,6 +69,7 @@ import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.utils.LocalState;
 import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.ServerConfigUtils;
+import org.apache.storm.utils.ShellUtils;
 import org.apache.storm.utils.Time;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.utils.VersionInfo;
@@ -312,6 +313,9 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
             Utils.addShutdownHookWithForceKillIn1Sec(this::close);
 
             StormMetricsRegistry.registerGauge("supervisor:num-slots-used-gauge", () -> SupervisorUtils.supervisorWorkerIds(conf).size());
+            //This will only get updated once
+            StormMetricsRegistry.registerMeter("supervisor:num-launched").mark();
+            StormMetricsRegistry.registerMeter("supervisor:num-shell-exceptions", ShellUtils.numShellExceptions);
             StormMetricsRegistry.startMetricsReporters(conf);
 
             // blocking call under the hood, must invoke after launch cause some services must be initialized

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/TimerDecoratedAssignment.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/TimerDecoratedAssignment.java
@@ -3,29 +3,32 @@
  * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
  * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package org.apache.storm.localizer;
+package org.apache.storm.daemon.supervisor;
+
+import com.codahale.metrics.Timer;
 
 import org.apache.storm.generated.LocalAssignment;
+import org.apache.storm.metric.timed.TimerDecorated;
 
-public interface PortAndAssignment {
-    String getToplogyId();
+public class TimerDecoratedAssignment extends LocalAssignment implements TimerDecorated {
+    private final Timer.Context timing;
 
-    String getOwner();
+    public TimerDecoratedAssignment(LocalAssignment other, Timer timer) {
+        super(other);
+        timing = timer.time();
+    }
 
-    int getPort();
-
-    LocalAssignment getAssignment();
-
-    default void complete() {
-
+    @Override
+    public long stopTiming() {
+        return stopTiming(timing);
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/localizer/PortAndAssignmentImpl.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/PortAndAssignmentImpl.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.localizer;
+
+import org.apache.storm.generated.LocalAssignment;
+
+/**
+ * A Port and a LocalAssignment used to reference count resources.
+ */
+class PortAndAssignmentImpl implements PortAndAssignment {
+    private final int port;
+    private final LocalAssignment assignment;
+
+    public PortAndAssignmentImpl(int port, LocalAssignment assignment) {
+        this.port = port;
+        this.assignment = assignment;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof PortAndAssignmentImpl)) {
+            return false;
+        }
+        PortAndAssignmentImpl pna = (PortAndAssignmentImpl) other;
+        return pna.port == port && assignment.equals(pna.assignment);
+    }
+
+    @Override
+    public String getToplogyId() {
+        return assignment.get_topology_id();
+    }
+
+    @Override
+    public String getOwner() {
+        return assignment.get_owner();
+    }
+
+    @Override
+    public int hashCode() {
+        return (17 * port) + assignment.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "{" + assignment.get_topology_id() + " on " + port + "}";
+    }
+
+    /**
+     * Return the port associated with this.
+     */
+    @Override
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * return the assigment for this.
+     */
+    @Override
+    public LocalAssignment getAssignment() {
+        return assignment;
+    }
+}

--- a/storm-server/src/main/java/org/apache/storm/localizer/TimePortAndAssignment.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/TimePortAndAssignment.java
@@ -14,18 +14,38 @@
 
 package org.apache.storm.localizer;
 
+import com.codahale.metrics.Timer;
 import org.apache.storm.generated.LocalAssignment;
+import org.apache.storm.metric.timed.Timed;
 
-public interface PortAndAssignment {
-    String getToplogyId();
+public class TimePortAndAssignment extends Timed<PortAndAssignment> implements PortAndAssignment {
 
-    String getOwner();
+    public TimePortAndAssignment(PortAndAssignment measured, Timer timer) {
+        super(measured, timer);
+    }
 
-    int getPort();
+    @Override
+    public String getToplogyId() {
+        return getMeasured().getToplogyId();
+    }
 
-    LocalAssignment getAssignment();
+    @Override
+    public String getOwner() {
+        return getMeasured().getOwner();
+    }
 
-    default void complete() {
+    @Override
+    public int getPort() {
+        return getMeasured().getPort();
+    }
 
+    @Override
+    public LocalAssignment getAssignment() {
+        return getMeasured().getAssignment();
+    }
+
+    @Override
+    public void complete() {
+        stopTiming();
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/metric/StormMetricsRegistry.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/StormMetricsRegistry.java
@@ -19,6 +19,8 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Timer;
+
 import java.util.Map;
 
 import org.apache.storm.daemon.metrics.MetricsUtils;
@@ -46,6 +48,14 @@ public class StormMetricsRegistry extends MetricRegistry {
 
     public static Meter registerMeter(String name) {
         return REGISTRY.register(name, new Meter());
+    }
+
+    public static void registerMeter(String name, Meter meter) {
+        REGISTRY.register(name, meter);
+    }
+
+    public static Timer registerTimer(String name) {
+        return REGISTRY.register(name, new Timer());
     }
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/Timed.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/Timed.java
@@ -3,29 +3,34 @@
  * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
  * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package org.apache.storm.localizer;
+package org.apache.storm.metric.timed;
 
-import org.apache.storm.generated.LocalAssignment;
+import com.codahale.metrics.Timer;
 
-public interface PortAndAssignment {
-    String getToplogyId();
+public class Timed<T> implements TimerDecorated {
+    private final T measured;
+    private final Timer.Context timing;
 
-    String getOwner();
+    public Timed(T measured, Timer timer) {
+        this.measured = measured;
+        timing = timer.time();
+    }
 
-    int getPort();
+    public T getMeasured() {
+        return measured;
+    }
 
-    LocalAssignment getAssignment();
-
-    default void complete() {
-
+    @Override
+    public long stopTiming() {
+        return stopTiming(timing);
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/TimedResource.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/TimedResource.java
@@ -3,29 +3,31 @@
  * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
  * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package org.apache.storm.localizer;
+package org.apache.storm.metric.timed;
 
-import org.apache.storm.generated.LocalAssignment;
+import com.codahale.metrics.Timer;
 
-public interface PortAndAssignment {
-    String getToplogyId();
+public class TimedResource<T extends AutoCloseable> extends Timed<T> {
 
-    String getOwner();
+    public TimedResource(T measured, Timer timer) {
+        super(measured, timer);
+    }
 
-    int getPort();
-
-    LocalAssignment getAssignment();
-
-    default void complete() {
-
+    @Override
+    public void close() throws Exception {
+        try {
+            super.close();
+        } finally {
+            getMeasured().close();
+        }
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/TimerDecorated.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/TimerDecorated.java
@@ -3,29 +3,36 @@
  * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
  * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-package org.apache.storm.localizer;
+package org.apache.storm.metric.timed;
 
-import org.apache.storm.generated.LocalAssignment;
+import com.codahale.metrics.Timer;
 
-public interface PortAndAssignment {
-    String getToplogyId();
+public interface TimerDecorated extends AutoCloseable {
 
-    String getOwner();
+    long stopTiming();
 
-    int getPort();
+    /**
+     * Stop the timer for measured object. (Copied from {@link Timer.Context#stop()})
+     * Call to this method will not reset the start time.
+     * Multiple calls result in multiple updates.
+     *
+     * @return Time a object is in use, or under measurement, in nanoseconds.
+     */
+    default long stopTiming(final Timer.Context timing) {
+        return timing.stop();
+    }
 
-    LocalAssignment getAssignment();
-
-    default void complete() {
-
+    @Override
+    default void close() throws Exception {
+        stopTiming();
     }
 }

--- a/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
@@ -141,7 +141,7 @@ public class AsyncLocalizerTest {
         try {
             when(mockedRU.newInstanceImpl(ClientBlobStore.class)).thenReturn(blobStore);
 
-            PortAndAssignment pna = new PortAndAssignment(port, la);
+            PortAndAssignment pna = new PortAndAssignmentImpl(port, la);
             Future<Void> f = bl.requestDownloadBaseTopologyBlobs(pna, null);
             f.get(20, TimeUnit.SECONDS);
 
@@ -345,7 +345,7 @@ public class AsyncLocalizerTest {
         arrUser1Keys.add(new LocalResource(archive1, true, false));
         LocalAssignment topo1 = new LocalAssignment("topo1", Collections.emptyList());
         topo1.set_owner(user1);
-        localizer.addReferences(arrUser1Keys, new PortAndAssignment(1, topo1), null);
+        localizer.addReferences(arrUser1Keys, new PortAndAssignmentImpl(1, topo1), null);
 
         ConcurrentMap<String, LocalizedResource> lrsrcFiles = localizer.getUserFiles().get(user1);
         ConcurrentMap<String, LocalizedResource> lrsrcArchives = localizer.getUserArchives().get(user1);
@@ -444,7 +444,7 @@ public class AsyncLocalizerTest {
             assertTrue("failed to create user dir", user1Dir.mkdirs());
             LocalAssignment topo1Assignment = new LocalAssignment(topo1, Collections.emptyList());
             topo1Assignment.set_owner(user1);
-            PortAndAssignment topo1Pna = new PortAndAssignment(1, topo1Assignment);
+            PortAndAssignment topo1Pna = new PortAndAssignmentImpl(1, topo1Assignment);
             LocalizedResource lrsrc = localizer.getBlob(new LocalResource(key1, true, false), topo1Pna, null);
             Time.advanceTime(10);
             long timeAfter = Time.currentTimeMillis();
@@ -529,7 +529,7 @@ public class AsyncLocalizerTest {
             Time.advanceTime(10);
             LocalAssignment topo1Assignment = new LocalAssignment(topo1, Collections.emptyList());
             topo1Assignment.set_owner(user1);
-            PortAndAssignment topo1Pna = new PortAndAssignment(1, topo1Assignment);
+            PortAndAssignment topo1Pna = new PortAndAssignmentImpl(1, topo1Assignment);
             LocalizedResource lrsrc = localizer.getBlob(new LocalResource(key1, false, false), topo1Pna, null);
             long timeAfter = Time.currentTimeMillis();
             Time.advanceTime(10);
@@ -609,7 +609,7 @@ public class AsyncLocalizerTest {
 
             LocalAssignment topo1Assignment = new LocalAssignment(topo1, Collections.emptyList());
             topo1Assignment.set_owner(user1);
-            PortAndAssignment topo1Pna = new PortAndAssignment(1, topo1Assignment);
+            PortAndAssignment topo1Pna = new PortAndAssignmentImpl(1, topo1Assignment);
             List<LocalizedResource> lrsrcs = localizer.getBlobs(keys, topo1Pna, null);
             LocalizedResource lrsrc = lrsrcs.get(0);
             LocalizedResource lrsrc2 = lrsrcs.get(1);
@@ -707,7 +707,7 @@ public class AsyncLocalizerTest {
 
         LocalAssignment topo1Assignment = new LocalAssignment(topo1, Collections.emptyList());
         topo1Assignment.set_owner(user1);
-        PortAndAssignment topo1Pna = new PortAndAssignment(1, topo1Assignment);
+        PortAndAssignment topo1Pna = new PortAndAssignmentImpl(1, topo1Assignment);
         // This should throw AuthorizationException because auth failed
         localizer.getBlob(new LocalResource(key1, false, false), topo1Pna, null);
     }
@@ -758,17 +758,17 @@ public class AsyncLocalizerTest {
 
         LocalAssignment topo1Assignment = new LocalAssignment(topo1, Collections.emptyList());
         topo1Assignment.set_owner(user1);
-        PortAndAssignment topo1Pna = new PortAndAssignment(1, topo1Assignment);
+        PortAndAssignment topo1Pna = new PortAndAssignmentImpl(1, topo1Assignment);
         LocalizedResource lrsrc = localizer.getBlob(new LocalResource(key1, false, false), topo1Pna, null);
 
         LocalAssignment topo2Assignment = new LocalAssignment(topo2, Collections.emptyList());
         topo2Assignment.set_owner(user2);
-        PortAndAssignment topo2Pna = new PortAndAssignment(2, topo2Assignment);
+        PortAndAssignment topo2Pna = new PortAndAssignmentImpl(2, topo2Assignment);
         LocalizedResource lrsrc2 = localizer.getBlob(new LocalResource(key2, false, false), topo2Pna, null);
 
         LocalAssignment topo3Assignment = new LocalAssignment(topo3, Collections.emptyList());
         topo3Assignment.set_owner(user3);
-        PortAndAssignment topo3Pna = new PortAndAssignment(3, topo3Assignment);
+        PortAndAssignment topo3Pna = new PortAndAssignmentImpl(3, topo3Assignment);
         LocalizedResource lrsrc3 = localizer.getBlob(new LocalResource(key3, false, false), topo3Pna, null);
 
         // make sure we support different user reading same blob
@@ -846,7 +846,7 @@ public class AsyncLocalizerTest {
         assertTrue("failed to create user dir", user1Dir.mkdirs());
         LocalAssignment topo1Assignment = new LocalAssignment(topo1, Collections.emptyList());
         topo1Assignment.set_owner(user1);
-        PortAndAssignment topo1Pna = new PortAndAssignment(1, topo1Assignment);
+        PortAndAssignment topo1Pna = new PortAndAssignmentImpl(1, topo1Assignment);
         LocalizedResource lrsrc = localizer.getBlob(new LocalResource(key1, false, false), topo1Pna, null);
 
         String expectedUserDir = joinPath(baseDir.toString(), USERCACHE, user1);
@@ -868,7 +868,7 @@ public class AsyncLocalizerTest {
 
         LocalAssignment topo2Assignment = new LocalAssignment(topo2, Collections.emptyList());
         topo2Assignment.set_owner(user1);
-        PortAndAssignment topo2Pna = new PortAndAssignment(1, topo2Assignment);
+        PortAndAssignment topo2Pna = new PortAndAssignmentImpl(1, topo2Assignment);
         localizer.getBlob(new LocalResource(key1, false, false), topo2Pna, null);
         assertTrue("blob version file not created", versionFile.exists());
         assertEquals("blob version not correct", 2, LocalizedResource.localVersionOfBlob(keyVersionFile));

--- a/storm-server/src/test/java/org/apache/storm/localizer/LocalizedResourceRetentionSetTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/LocalizedResourceRetentionSetTest.java
@@ -36,8 +36,8 @@ public class LocalizedResourceRetentionSetTest {
 
     @Test
     public void testAddResources() throws Exception {
-        PortAndAssignment pna1 = new PortAndAssignment(1, new LocalAssignment("topo1", Collections.emptyList()));
-        PortAndAssignment pna2 = new PortAndAssignment(1, new LocalAssignment("topo2", Collections.emptyList()));
+        PortAndAssignment pna1 = new PortAndAssignmentImpl(1, new LocalAssignment("topo1", Collections.emptyList()));
+        PortAndAssignment pna2 = new PortAndAssignmentImpl(1, new LocalAssignment("topo2", Collections.emptyList()));
         String user = "user";
         Map<String, Object> conf = new HashMap<>();
         IAdvancedFSOps ops = mock(IAdvancedFSOps.class);
@@ -74,7 +74,7 @@ public class LocalizedResourceRetentionSetTest {
     public void testCleanup() throws Exception {
         ClientBlobStore mockBlobstore = mock(ClientBlobStore.class);
         when(mockBlobstore.getBlobMeta(any())).thenReturn(new ReadableBlobMeta(new SettableBlobMeta(), 1));
-        PortAndAssignment pna1 = new PortAndAssignment(1, new LocalAssignment("topo1", Collections.emptyList()));
+        PortAndAssignment pna1 = new PortAndAssignmentImpl(1, new LocalAssignment("topo1", Collections.emptyList()));
         String user = "user";
         Map<String, Object> conf = new HashMap<>();
         IAdvancedFSOps ops = mock(IAdvancedFSOps.class);

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
@@ -145,8 +145,7 @@ public class DRPCServer implements AutoCloseable {
     @VisibleForTesting
     void start() throws Exception {
         LOG.info("Starting Distributed RPC servers...");
-        new Thread(() -> invokeServer.serve()).start();
-        
+        new Thread(invokeServer::serve).start();
         if (httpServer != null) {
             httpServer.start();
         }
@@ -223,7 +222,7 @@ public class DRPCServer implements AutoCloseable {
         Utils.setupDefaultUncaughtExceptionHandler();
         Map<String, Object> conf = Utils.readStormConfig();
         try (DRPCServer server = new DRPCServer(conf)) {
-            Utils.addShutdownHookWithForceKillIn1Sec(() -> server.close());
+            Utils.addShutdownHookWithForceKillIn1Sec(server::close);
             StormMetricsRegistry.startMetricsReporters(conf);
             server.start();
             server.awaitTermination();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCResource.java
@@ -19,6 +19,7 @@
 package org.apache.storm.daemon.drpc.webapp;
 
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
@@ -29,11 +30,11 @@ import javax.ws.rs.core.Context;
 
 import org.apache.storm.daemon.drpc.DRPC;
 import org.apache.storm.metric.StormMetricsRegistry;
-import org.apache.storm.thrift.TException;
 
 @Path("/drpc/")
 public class DRPCResource {
     private static final Meter meterHttpRequests = StormMetricsRegistry.registerMeter("drpc:num-execute-http-requests");
+    private static final Timer responseDuration = StormMetricsRegistry.registerTimer("drpc:HTTP-request-response-duration");
     private final DRPC drpc;
 
     public DRPCResource(DRPC drpc) {
@@ -43,24 +44,24 @@ public class DRPCResource {
     //TODO put in some better exception mapping...
     //TODO move populateContext to a filter...
     @POST
-    @Path("/{func}") 
-    public String post(@PathParam("func") String func, String args, @Context HttpServletRequest request) throws TException {
+    @Path("/{func}")
+    public String post(@PathParam("func") String func, String args, @Context HttpServletRequest request) throws Exception {
         meterHttpRequests.mark();
-        return drpc.executeBlocking(func, args);
+        return responseDuration.time(() -> drpc.executeBlocking(func, args));
     }
     
     @GET
     @Path("/{func}/{args}") 
     public String get(@PathParam("func") String func, @PathParam("args") String args,
-                      @Context HttpServletRequest request) throws TException {
+                      @Context HttpServletRequest request) throws Exception {
         meterHttpRequests.mark();
-        return drpc.executeBlocking(func, args);
+        return responseDuration.time(() -> drpc.executeBlocking(func, args));
     }
     
     @GET
-    @Path("/{func}") 
-    public String get(@PathParam("func") String func, @Context HttpServletRequest request) throws TException {
+    @Path("/{func}")
+    public String get(@PathParam("func") String func, @Context HttpServletRequest request) throws Exception {
         meterHttpRequests.mark();
-        return drpc.executeBlocking(func, "");
+        return responseDuration.time(() -> drpc.executeBlocking(func, ""));
     }
 }


### PR DESCRIPTION
This PR depends on #2743 and #2771.

New supervisor level metrics: 

- Worker Kill/Restart Statistics
	- [x] Kill Count by Category - assignment change/HB too old/Heap space/blob change?
	- [ ] Worker Suicide Cnt - category:  internal error or Assignment Change
		- [x] - Implementation reports all process exit cases instead. Does not actually differentiate suicide from normal exit.
	- [x] Worker idle period
		- The metrics records the duration machine spent in each state (in histogram) and how many times it transitions into/out from a certain state.
	- [x] Time to Actually Kill worker (from identifying need by supervisor and actual change in the state of the worker) - (This is only an estimation, accuracy affected by SleepTime)
		- This does not tracks `storm kill_workers` as it's a client-side command and does not invoke StormMetricsRegistry.
	- [x] Time to start worker for topology from reading assignment for the first time.
	- [x] Worker cleanup time
		- This does not tracks duration for `cleanupForRelaunch`.
- [x] Supervisor Level Metrics:
	- [x] Supervisor restart Count
		- Simply report every time it restarts.
	- [x] Blobstore (Request to download time)
		- [x] Download time individual blob (inside localizer) localizer gettting requst to actually download hdfs request to finish
			- I assume this to be [the complete process] from initiating download to commit download to local blob cache and inform relative workers
		- [x] Download rate individual blob (inside localizer)
			- This is tracks the actual download rate of a blob retrieval, in MB/s
		- [x] Supervisor localizer thread blob download - how long (outside localizer)
			- I put this inside async localizer as it turns out to be better suited for purpose. This tracks the time for a topology blob download request to be completely processed.
		- [x] Blob update is also considered.
	- [x] Blobstore Update due to Version change Cnts
    - [x] Worker exceptions count for clean-up, kill and force-kill.
    - [x] Internal Error/Exception Cnt. on running external process/linux commands

DRPC metrics:

- [x] Avg/Max Time to respond to Http Request
