### PR TITLE
STORM-3100 : Introducing CustomIndexArray to speedup HashMap lookups

### DIFF
--- a/examples/storm-elasticsearch-examples/src/main/java/org/apache/storm/elasticsearch/common/EsTestUtil.java
+++ b/examples/storm-elasticsearch-examples/src/main/java/org/apache/storm/elasticsearch/common/EsTestUtil.java
@@ -28,6 +28,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.CustomIndexArray;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
@@ -56,7 +57,7 @@ public final class EsTestUtil {
         GeneralTopologyContext topologyContext = new GeneralTopologyContext(
                 builder.createTopology(),
                 new Config(),
-                new HashMap<>(),
+                new CustomIndexArray<String>(0,0),
                 new HashMap<>(),
                 new HashMap<>(),
                 "") {

--- a/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/common/EsTestUtil.java
+++ b/external/storm-elasticsearch/src/test/java/org/apache/storm/elasticsearch/common/EsTestUtil.java
@@ -39,6 +39,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.CustomIndexArray;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.Requests;
@@ -63,7 +64,7 @@ public class EsTestUtil {
     public static Tuple generateTestTuple(String source, String index, String type, String id) {
         TopologyBuilder builder = new TopologyBuilder();
         GeneralTopologyContext topologyContext = new GeneralTopologyContext(builder.createTopology(),
-                new Config(), new HashMap<>(), new HashMap<>(), new HashMap<>(), "") {
+                new Config(), new CustomIndexArray<String>(0,0), new HashMap<>(), new HashMap<>(), "") {
             @Override
             public Fields getComponentOutputFields(String componentId, String streamId) {
                 return new Fields("source", "index", "type", "id");

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBoltTest.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/AvroGenericRecordBoltTest.java
@@ -45,6 +45,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.CustomIndexArray;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -111,7 +112,7 @@ public class AvroGenericRecordBoltTest {
     private static Tuple generateTestTuple(GenericRecord record) {
         TopologyBuilder builder = new TopologyBuilder();
         GeneralTopologyContext topologyContext = new GeneralTopologyContext(builder.createTopology(),
-                                                                            new Config(), new HashMap(), new HashMap(), new HashMap(), "") {
+                                                                            new Config(), new CustomIndexArray<>(0,1), new HashMap(), new HashMap(), "") {
             @Override
             public Fields getComponentOutputFields(String componentId, String streamId) {
                 return new Fields("record");

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestHdfsBolt.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestHdfsBolt.java
@@ -42,6 +42,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.MockTupleHelpers;
 import org.junit.After;
 import org.junit.Assert;
@@ -231,7 +232,7 @@ public class TestHdfsBolt {
     private Tuple generateTestTuple(Object id, Object msg, Object city, Object state) {
         TopologyBuilder builder = new TopologyBuilder();
         GeneralTopologyContext topologyContext = new GeneralTopologyContext(builder.createTopology(),
-                                                                            new Config(), new HashMap<>(), new HashMap<>(), new HashMap<>(),
+                                                                            new Config(), new CustomIndexArray<>(0,1), new HashMap<>(), new HashMap<>(),
                                                                             "") {
             @Override
             public Fields getComponentOutputFields(String componentId, String streamId) {

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestSequenceFileBolt.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/TestSequenceFileBolt.java
@@ -40,6 +40,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.CustomIndexArray;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -155,7 +156,7 @@ public class TestSequenceFileBolt {
     private Tuple generateTestTuple(Long key, String value) {
         TopologyBuilder builder = new TopologyBuilder();
         GeneralTopologyContext topologyContext = new GeneralTopologyContext(builder.createTopology(),
-                                                                            new Config(), new HashMap<>(), new HashMap<>(), new HashMap<>(),
+                                                                            new Config(), new CustomIndexArray<>(0,1), new HashMap<>(), new HashMap<>(),
                                                                             "") {
             @Override
             public Fields getComponentOutputFields(String componentId, String streamId) {

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/format/TestSimpleFileNameFormat.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/format/TestSimpleFileNameFormat.java
@@ -17,6 +17,7 @@ import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.storm.task.TopologyContext;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.Utils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -69,8 +70,8 @@ public class TestSimpleFileNameFormat {
     }
 
     private TopologyContext createTopologyContext(Map<String, Object> topoConf) {
-        Map<Integer, String> taskToComponent = new HashMap<Integer, String>();
-        taskToComponent.put(7, "Xcom");
+        CustomIndexArray<String> taskToComponent = new CustomIndexArray<>(7,7);
+        taskToComponent.set(7, "Xcom");
         return new TopologyContext(null, topoConf, taskToComponent, null, null, null, null, null, null, 7, 6703, null, null, null, null,
                                    null, null);
     }

--- a/external/storm-hive/src/test/java/org/apache/storm/hive/bolt/TestHiveBolt.java
+++ b/external/storm-hive/src/test/java/org/apache/storm/hive/bolt/TestHiveBolt.java
@@ -40,6 +40,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.MockTupleHelpers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -442,7 +443,7 @@ public class TestHiveBolt {
     private Tuple generateTestTuple(Object id, Object msg, Object city, Object state) {
         TopologyBuilder builder = new TopologyBuilder();
         GeneralTopologyContext topologyContext = new GeneralTopologyContext(builder.createTopology(),
-                                                                            new Config(), new HashMap(), new HashMap(), new HashMap(), "") {
+                                                                            new Config(), new CustomIndexArray<>(0,1), new HashMap(), new HashMap(), "") {
             @Override
             public Fields getComponentOutputFields(String componentId, String streamId) {
                 return new Fields("id", "msg", "city", "state");

--- a/external/storm-hive/src/test/java/org/apache/storm/hive/common/TestHiveWriter.java
+++ b/external/storm-hive/src/test/java/org/apache/storm/hive/common/TestHiveWriter.java
@@ -38,6 +38,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.CustomIndexArray;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -134,7 +135,7 @@ public class TestHiveWriter {
     private Tuple generateTestTuple(Object id, Object msg) {
         TopologyBuilder builder = new TopologyBuilder();
         GeneralTopologyContext topologyContext = new GeneralTopologyContext(builder.createTopology(),
-                                                                            new Config(), new HashMap(), new HashMap(), new HashMap(), "") {
+                                                                            new Config(), new CustomIndexArray<>(0,1), new HashMap(), new HashMap(), "") {
             @Override
             public Fields getComponentOutputFields(String componentId, String streamId) {
                 return new Fields("id", "msg");

--- a/storm-client/src/jvm/org/apache/storm/daemon/StormCommon.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/StormCommon.java
@@ -46,9 +46,11 @@ import org.apache.storm.task.IBolt;
 import org.apache.storm.task.WorkerTopologyContext;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.ConfigUtils;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.utils.WrappedInvalidTopologyException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -455,7 +457,7 @@ public class StormCommon {
         return Thrift.getParallelismHint(common);
     }
 
-    public static Map<Integer, String> stormTaskInfo(StormTopology userTopology, Map<String, Object> topoConf) throws
+    public static CustomIndexArray<String> stormTaskInfo(StormTopology userTopology, Map<String, Object> topoConf) throws
         InvalidTopologyException {
         return _instance.stormTaskInfoImpl(userTopology, topoConf);
     }
@@ -491,7 +493,8 @@ public class StormCommon {
         try {
             StormTopology stormTopology = (StormTopology) workerData.get(Constants.SYSTEM_TOPOLOGY);
             Map<String, Object> topoConf = (Map) workerData.get(Constants.STORM_CONF);
-            Map<Integer, String> taskToComponent = (Map<Integer, String>) workerData.get(Constants.TASK_TO_COMPONENT);
+            CustomIndexArray<String> taskToComponent =
+                new CustomIndexArray<>((Map<Integer, String>) workerData.get(Constants.TASK_TO_COMPONENT));
             Map<String, List<Integer>> componentToSortedTasks =
                 (Map<String, List<Integer>>) workerData.get(Constants.COMPONENT_TO_SORTED_TASKS);
             Map<String, Map<String, Fields>> componentToStreamToFields =
@@ -537,7 +540,7 @@ public class StormCommon {
     /*
      * Returns map from task -> componentId
      */
-    protected Map<Integer, String> stormTaskInfoImpl(StormTopology userTopology, Map<String, Object> topoConf) throws
+    protected CustomIndexArray<String> stormTaskInfoImpl(StormTopology userTopology, Map<String, Object> topoConf) throws
         InvalidTopologyException {
         Map<Integer, String> taskIdToComponentId = new HashMap<>();
 
@@ -560,7 +563,7 @@ public class StormCommon {
                 taskId++;
             }
         }
-        return taskIdToComponentId;
+        return new CustomIndexArray<String>(taskIdToComponentId);
     }
 
     protected IAuthorizer mkAuthorizationHandlerImpl(String klassName, Map<String, Object> conf)

--- a/storm-client/src/jvm/org/apache/storm/daemon/Task.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/Task.java
@@ -112,15 +112,15 @@ public class Task {
     public List<Integer> getOutgoingTasks(Integer outTaskId, String stream, List<Object> values) {
         if (debug) {
             LOG.info("Emitting direct: {}; {} {} {} ", outTaskId, componentId, stream, values);
-        }
-        String targetComponent = workerTopologyContext.getComponentId(outTaskId);
-        Map<String, LoadAwareCustomStreamGrouping> componentGrouping = streamComponentToGrouper.get(stream);
-        LoadAwareCustomStreamGrouping grouping = componentGrouping.get(targetComponent);
-        if (null == grouping) {
-            outTaskId = null;
-        }
-        if (grouping != null && grouping != GrouperFactory.DIRECT) {
-            throw new IllegalArgumentException("Cannot emitDirect to a task expecting a regular grouping");
+            String targetComponent = workerTopologyContext.getComponentId(outTaskId);
+            Map<String, LoadAwareCustomStreamGrouping> componentGrouping = streamComponentToGrouper.get(stream);
+            LoadAwareCustomStreamGrouping grouping = componentGrouping.get(targetComponent);
+            if (null == grouping) {
+                outTaskId = null;
+            }
+            if (grouping != null && grouping != GrouperFactory.DIRECT) {
+                throw new IllegalArgumentException("Cannot emitDirect to a task expecting a regular grouping");
+            }
         }
         if (!userTopologyContext.getHooks().isEmpty()) {
             new EmitInfo(values, stream, taskId, Collections.singletonList(outTaskId)).applyOn(userTopologyContext);

--- a/storm-client/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/Executor.java
@@ -68,6 +68,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
 import org.apache.storm.utils.ConfigUtils;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.JCQueue;
 import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.Time;
@@ -93,7 +94,7 @@ public abstract class Executor implements Callable, JCQueue.Consumer {
     protected final AtomicReference<Map<String, DebugOptions>> stormComponentDebug;
     protected final Runnable suicideFn;
     protected final IStormClusterState stormClusterState;
-    protected final Map<Integer, String> taskToComponent;
+    protected final CustomIndexArray<String> taskToComponent;
     protected final Map<Integer, Map<Integer, Map<String, IMetric>>> intervalToTaskToMetricToRegistry;
     protected final Map<String, Map<String, LoadAwareCustomStreamGrouping>> streamToComponentToGrouper;
     protected final List<LoadAwareCustomStreamGrouping> groupers;

--- a/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutOutputCollectorImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutOutputCollectorImpl.java
@@ -163,8 +163,8 @@ public class SpoutOutputCollectorImpl implements ISpoutOutputCollector {
             // Reusing TupleInfo object as we directly call executor.ackSpoutMsg() & are not sending msgs. perf critical
             if (isDebug) {
                 if (spoutExecutorThdId != Thread.currentThread().getId()) {
-                    throw new RuntimeException("Detected background thread emitting tuples for the spout. " +
-                                               "Spout Output Collector should only emit from the main spout executor thread.");
+                    throw new RuntimeException("Detected background thread emitting tuples for the spout. "
+                                             + "Spout Output Collector should only emit from the main spout executor thread.");
                 }
             }
             globalTupleInfo.clear();

--- a/storm-client/src/jvm/org/apache/storm/stats/StatsUtil.java
+++ b/storm-client/src/jvm/org/apache/storm/stats/StatsUtil.java
@@ -55,6 +55,7 @@ import org.apache.storm.generated.WorkerResources;
 import org.apache.storm.generated.WorkerSummary;
 import org.apache.storm.scheduler.WorkerSlot;
 import org.apache.storm.shade.com.google.common.collect.Lists;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.Time;
 import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
@@ -627,7 +628,7 @@ public class StatsUtil {
      * @return TopologyPageInfo thrift structure
      */
     public static TopologyPageInfo aggTopoExecsStats(
-        String topologyId, Map exec2nodePort, Map task2component, Map<List<Integer>, Map<String, Object>> beats,
+        String topologyId, Map exec2nodePort, CustomIndexArray<String> task2component, Map<List<Integer>, Map<String, Object>> beats,
         StormTopology topology, String window, boolean includeSys, IStormClusterState clusterState) {
         List<Map<String, Object>> beatList = extractDataFromHb(exec2nodePort, task2component, beats, includeSys, topology);
         Map<String, Object> topoStats = aggregateTopoStats(window, includeSys, beatList);
@@ -653,7 +654,7 @@ public class StatsUtil {
         return initVal;
     }
 
-    public static TopologyPageInfo postAggregateTopoStats(Map task2comp, Map exec2nodePort, Map<String, Object> accData,
+    public static TopologyPageInfo postAggregateTopoStats(CustomIndexArray<String> task2comp, Map exec2nodePort, Map<String, Object> accData,
                                                           String topologyId, IStormClusterState clusterState) {
         TopologyPageInfo ret = new TopologyPageInfo(topologyId);
 
@@ -1213,7 +1214,7 @@ public class StatsUtil {
      * @return ComponentPageInfo thrift structure
      */
     public static ComponentPageInfo aggCompExecsStats(
-        Map exec2hostPort, Map task2component, Map<List<Integer>, Map<String, Object>> beats,
+        Map exec2hostPort, CustomIndexArray<String> task2component, Map<List<Integer>, Map<String, Object>> beats,
         String window, boolean includeSys, String topologyId, StormTopology topology, String componentId) {
 
         List<Map<String, Object>> beatList =
@@ -1237,7 +1238,7 @@ public class StatsUtil {
      * @return List<WorkerSummary> thrift structures
      */
     public static List<WorkerSummary> aggWorkerStats(String stormId, String stormName,
-                                                     Map<Integer, String> task2Component,
+                                                     CustomIndexArray<String> task2Component,
                                                      Map<List<Integer>, Map<String, Object>> beats,
                                                      Map<List<Long>, List<Object>> exec2NodePort,
                                                      Map<String, String> nodeHost,
@@ -1337,7 +1338,7 @@ public class StatsUtil {
      * @return List<WorkerSummary> thrift structures
      */
     public static List<WorkerSummary> aggWorkerStats(String stormId, String stormName,
-                                                     Map<Integer, String> task2Component,
+                                                     CustomIndexArray<String> task2Component,
                                                      Map<List<Integer>, Map<String, Object>> beats,
                                                      Map<List<Long>, List<Object>> exec2NodePort,
                                                      Map<String, String> nodeHost,
@@ -1489,7 +1490,7 @@ public class StatsUtil {
      * @return a list of host+port
      */
     public static List<Map<String, Object>> extractNodeInfosFromHbForComp(
-        Map<List<? extends Number>, List<Object>> exec2hostPort, Map<Integer, String> task2component, boolean includeSys, String compId) {
+        Map<List<? extends Number>, List<Object>> exec2hostPort, CustomIndexArray<String> task2component, boolean includeSys, String compId) {
         List<Map<String, Object>> ret = new ArrayList<>();
 
         Set<List> hostPorts = new HashSet<>();
@@ -1618,13 +1619,13 @@ public class StatsUtil {
     /**
      * extracts a list of executor data from heart beats
      */
-    public static List<Map<String, Object>> extractDataFromHb(Map executor2hostPort, Map task2component,
+    public static List<Map<String, Object>> extractDataFromHb(Map executor2hostPort, CustomIndexArray<String> task2component,
                                                               Map<List<Integer>, Map<String, Object>> beats,
                                                               boolean includeSys, StormTopology topology) {
         return extractDataFromHb(executor2hostPort, task2component, beats, includeSys, topology, null);
     }
 
-    public static List<Map<String, Object>> extractDataFromHb(Map executor2hostPort, Map task2component,
+    public static List<Map<String, Object>> extractDataFromHb(Map executor2hostPort, CustomIndexArray<String> task2component,
                                                               Map<List<Integer>, Map<String, Object>> beats,
                                                               boolean includeSys, StormTopology topology, String compId) {
         List<Map<String, Object>> ret = new ArrayList<>();

--- a/storm-client/src/jvm/org/apache/storm/task/GeneralTopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/GeneralTopologyContext.java
@@ -34,6 +34,7 @@ import org.apache.storm.shade.org.json.simple.JSONValue;
 import org.apache.storm.shade.org.json.simple.parser.ParseException;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.ConfigUtils;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.ThriftTopologyUtils;
 
@@ -41,14 +42,14 @@ public class GeneralTopologyContext implements JSONAware {
     protected Map<String, Object> _topoConf;
     protected boolean _doSanityCheck;
     private StormTopology _topology;
-    private Map<Integer, String> _taskToComponent;
+    private CustomIndexArray<String> _taskToComponent;
     private Map<String, List<Integer>> _componentToTasks;
     private Map<String, Map<String, Fields>> _componentToStreamToFields;
     private String _stormId;
 
     // pass in componentToSortedTasks for the case of running tons of tasks in single executor
     public GeneralTopologyContext(StormTopology topology, Map<String, Object> topoConf,
-                                  Map<Integer, String> taskToComponent, Map<String, List<Integer>> componentToSortedTasks,
+                                  CustomIndexArray<String> taskToComponent, Map<String, List<Integer>> componentToSortedTasks,
                                   Map<String, Map<String, Fields>> componentToStreamToFields, String stormId) {
         _topology = topology;
         _topoConf = topoConf;
@@ -174,7 +175,7 @@ public class GeneralTopologyContext implements JSONAware {
     /**
      * Gets a map from task id to component id.
      */
-    public Map<Integer, String> getTaskToComponent() {
+    public CustomIndexArray<String> getTaskToComponent() {
         return _taskToComponent;
     }
 

--- a/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
@@ -38,6 +38,7 @@ import org.apache.storm.shade.org.apache.commons.lang.NotImplementedException;
 import org.apache.storm.shade.org.json.simple.JSONValue;
 import org.apache.storm.state.ISubscribedState;
 import org.apache.storm.tuple.Fields;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.Utils;
 
 /**
@@ -59,7 +60,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
 
     public TopologyContext(StormTopology topology,
                            Map<String, Object> topoConf,
-                           Map<Integer, String> taskToComponent,
+                           CustomIndexArray<String> taskToComponent,
                            Map<String, List<Integer>> componentToSortedTasks,
                            Map<String, Map<String, Fields>> componentToStreamToFields,
                            Map<String, Long> blobToLastKnownVersionShared,

--- a/storm-client/src/jvm/org/apache/storm/task/WorkerTopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/WorkerTopologyContext.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.storm.generated.NodeInfo;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.tuple.Fields;
+import org.apache.storm.utils.CustomIndexArray;
 
 public class WorkerTopologyContext extends GeneralTopologyContext {
     public static final String SHARED_EXECUTOR = "executor";
@@ -36,7 +37,7 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
     public WorkerTopologyContext(
         StormTopology topology,
         Map<String, Object> topoConf,
-        Map<Integer, String> taskToComponent,
+        CustomIndexArray<String> taskToComponent,
         Map<String, List<Integer>> componentToSortedTasks,
         Map<String, Map<String, Fields>> componentToStreamToFields,
         String stormId,
@@ -72,7 +73,7 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
     public WorkerTopologyContext(
         StormTopology topology,
         Map<String, Object> topoConf,
-        Map<Integer, String> taskToComponent,
+        CustomIndexArray<String> taskToComponent,
         Map<String, List<Integer>> componentToSortedTasks,
         Map<String, Map<String, Fields>> componentToStreamToFields,
         String stormId,

--- a/storm-client/src/jvm/org/apache/storm/utils/CustomIndexArray.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/CustomIndexArray.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.utils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/***
+ *  A fixed size array with a customizable indexing range. The index range can have -ve lower / upper bound.
+ *  Intended to be a faster alternative to HashMap<Integer, .. >. Only applicable as a substitute if the
+ *  largest & smallest indices are known at time of creation.
+ *  This class does not inherit from :
+ *   - Map<Integer,T> : For performance reasons. The get(Object key) method requires key to be cast to Integer before use.
+ *   - ArrayList<T> : as this class supports negative indexes & cannot grow/shrink.
+ */
+
+public class CustomIndexArray<T>  {
+
+    public final int baseIndex;
+    private final ArrayList<T> elements;
+    private final int elemCount;
+
+    /**
+     * Creates the array with (upperIndex-lowerIndex+1) elements, initialized to null.
+     * @param lowerIndex Smallest (inclusive) valid index for the array. Can be +ve, -ve or 0.
+     * @param upperIndex Largest  (inclusive) valid index for the array. Can be +ve, -ve or 0. Must be >= lowerIndex
+     */
+    public CustomIndexArray(int lowerIndex, int upperIndex) {
+        if (lowerIndex > upperIndex) {
+            throw new IllegalArgumentException("lowerIndex must be < upperIndex");
+        }
+
+        this.baseIndex = lowerIndex;
+        this.elemCount = upperIndex - lowerIndex + 1;
+
+        this.elements = makeNullInitializedArray(elemCount);
+    }
+
+    private static <T> ArrayList<T> makeNullInitializedArray(int elemCount) {
+        ArrayList<T> result = new ArrayList<T>(elemCount);
+        for (int i = 0; i < elemCount; i++) {
+            result.add(null);
+        }
+        return result;
+    }
+
+    /**
+     * Initializes the array with elements from a HashTable.
+     *
+     * @param src  the source map from which to initialize
+     */
+    public CustomIndexArray(Map<Integer, T> src) {
+        Integer lowerIndex = Integer.MAX_VALUE;
+        Integer upperIndex = Integer.MIN_VALUE;
+
+        for (Integer key : src.keySet()) { // calculate smallest & largest indexes
+            if (key < lowerIndex) {
+                lowerIndex = key;
+            }
+            if (key > upperIndex) {
+                upperIndex = key;
+            }
+        }
+        this.baseIndex = lowerIndex;
+        this.elemCount = upperIndex - lowerIndex + 1;
+
+        this.elements = makeNullInitializedArray(elemCount);
+
+        for (Map.Entry<Integer, T> entry : src.entrySet()) {
+            elements.set(entry.getKey() - baseIndex, entry.getValue());
+        }
+    }
+
+    /**
+     * Get the value at the index.
+     * @throws IndexOutOfBoundsException if index is outside of bounds specified to constructor
+     */
+    public T get(int index) {
+        return elements.get(index - baseIndex);
+    }
+
+    /**
+     * Set the value at the index.
+     * @throws IndexOutOfBoundsException if index is outside of bounds specified to constructor
+     */
+    public T set(int index, T value) {
+        return elements.set(index - baseIndex, value);
+    }
+
+    /**
+     * Returns the number of elements (including null elements).
+     */
+    public int size() {
+        return elemCount;
+    }
+
+
+    /**
+     * Check if index is valid.
+     */
+    public boolean isValidIndex(int index) {
+        int actualIndex = index - baseIndex;
+        if (actualIndex < 0  ||  actualIndex >= elemCount) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns the index range as an ordered Set.
+     * Returns a new set each time.
+     */
+    public Set<Integer> indices() {
+        Set<Integer> result = new TreeSet<>(); // retain order
+        for (int i = 0; i < elemCount; i++) {
+            result.add(i + baseIndex);
+        }
+        return result;
+    }
+
+    /**
+     * Inverts this array into a Map.
+     */
+    public Map<T, List<Integer>> getReverseMap() {
+        HashMap<T, List<Integer>> result = new HashMap<>(elemCount);
+        for (int i = 0; i < elements.size(); i++) {
+            T item = elements.get(i);
+            if (item == null) {
+                continue;
+            }
+            List<Integer> tmp = result.get(item);
+            if (tmp == null) {
+                tmp = new ArrayList<>();
+                result.put(item, tmp);
+            }
+            tmp.add(i + baseIndex);
+        }
+        return result;
+    }
+
+    /**
+     * Returns the stored values as an ArrayList.
+     */
+    public ArrayList<T> getItems() {
+        return elements;
+    }
+}

--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -945,29 +945,6 @@ public class Utils {
         return findAndReadConfigFile(name, true);
     }
 
-    /**
-     * "[[:a 1] [:b 1] [:c 2]} -> {1 [:a :b] 2 :c}" Reverses an assoc-list style Map like reverseMap(Map...)
-     *
-     * @param listSeq to reverse
-     * @return a reversed map
-     */
-    public static Map<Object, List<Object>> reverseMap(List<List<Object>> listSeq) {
-        Map<Object, List<Object>> rtn = new HashMap<>();
-        if (listSeq == null) {
-            return rtn;
-        }
-        for (List<Object> listEntry : listSeq) {
-            Object key = listEntry.get(0);
-            Object val = listEntry.get(1);
-            List<Object> list = rtn.get(val);
-            if (list == null) {
-                list = new ArrayList<>();
-                rtn.put(val, list);
-            }
-            list.add(key);
-        }
-        return rtn;
-    }
 
     /**
      * parses the arguments to extract jvm heap memory size in MB.

--- a/storm-client/test/jvm/org/apache/storm/topology/WindowedBoltExecutorTest.java
+++ b/storm-client/test/jvm/org/apache/storm/topology/WindowedBoltExecutorTest.java
@@ -30,6 +30,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.windowing.TupleWindow;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,7 +53,7 @@ public class WindowedBoltExecutorTest {
     private GeneralTopologyContext getContext(final Fields fields) {
         TopologyBuilder builder = new TopologyBuilder();
         return new GeneralTopologyContext(builder.createTopology(),
-                                          new Config(), new HashMap(), new HashMap(), new HashMap(), "") {
+                                          new Config(), new CustomIndexArray<>(0,1), new HashMap(), new HashMap(), "") {
             @Override
             public Fields getComponentOutputFields(String componentId, String streamId) {
                 return fields;

--- a/storm-client/test/jvm/org/apache/storm/utils/CustomIndexArrayTest.java
+++ b/storm-client/test/jvm/org/apache/storm/utils/CustomIndexArrayTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CustomIndexArrayTest {
+
+    @Test
+    public void testIndexing() {
+        CustomIndexArray<String> arr;
+        arr = new CustomIndexArray<>(-3, +2);
+        arr.set(-3, "-three");
+        arr.set(-2, "-two");
+        arr.set(-1, "-one");
+        arr.set(1, "+one");
+        arr.set(2, "+two");
+
+        validateContents(arr, -3, +2, "-three", "-two", "-one", null, "+one", "+two");
+    }
+
+    @Test
+    public void testSingleItem() {
+        CustomIndexArray<String> arr = new CustomIndexArray<>(0, 0);
+        arr.set(0, null);
+        Assert.assertEquals(arr.get(0), null);
+        validateContents(arr, 0, 0, new String[] {null});
+    }
+
+    @Test
+    public void testReverseMap() {
+        CustomIndexArray<String> arr = new CustomIndexArray<>(-3, +2);
+        arr.set(-3, "-three");
+        arr.set(-2, "-two");
+        arr.set(-1, "-one");
+        arr.set(0, "zero");
+        arr.set(1, "+one");
+        arr.set(2, "-three");
+
+        Map<String, List<Integer>> revMap = arr.getReverseMap();
+
+        Assert.assertEquals(0L, (long) revMap.get("zero").get(0));
+        Assert.assertEquals(1, (long) revMap.get("zero").size());
+
+        Assert.assertEquals(-2, (long) revMap.get("-two").get(0));
+        Assert.assertEquals(1, (long) revMap.get("-two").size());
+
+        Assert.assertEquals(-3, (long) revMap.get("-three").get(0));
+        Assert.assertEquals(2, (long) revMap.get("-three").get(1));
+        Assert.assertEquals(2, (long) revMap.get("-three").size());
+
+        Assert.assertEquals(1, (long) revMap.get("+one").get(0));
+        Assert.assertEquals(1, (long) revMap.get("+one").size());
+
+        Assert.assertEquals(-1, (long) revMap.get("-one").get(0));
+        Assert.assertEquals(1, (long) revMap.get("-one").size());
+
+        Assert.assertEquals(5, revMap.size());
+
+    }
+
+    @Test
+    public void testInitializeFromMap() {
+        HashMap<Integer, String> src = new HashMap<>();
+        src.put(-3, "-three");
+        src.put(-2, "-two");
+        src.put(-1, "-one");
+        src.put(1, "+one");
+        src.put(2, "+two");
+
+        CustomIndexArray<String> arr = new CustomIndexArray<>(src);
+
+        validateContents(arr, -3, +2, "-three", "-two", "-one", null, "+one", "+two");
+    }
+
+    @Test
+    public void testBothNegativeBounds() {
+        //  both upper & lower bounds are -ve
+        CustomIndexArray<String> arr = new CustomIndexArray<>(-5, -2);
+
+        arr.set(-5, "-five");
+        arr.set(-4, "-four");
+        arr.set(-3, "-three");
+        arr.set(-2, "-two");
+
+        validateContents(arr, -5, -2, "-five", "-four", "-three", "-two");
+    }
+
+    @Test
+    public void testNegativeLowerBound() {
+        //  lower bound is -ve
+        CustomIndexArray<String> arr = new CustomIndexArray<String>(-3, +2);
+        arr.set(-3, "-three");
+        arr.set(-2, "-two");
+        arr.set(-1, "-one");
+        arr.set(0, "zero");
+        arr.set(1, "+one");
+        arr.set(2, "+two");
+
+        validateContents(arr, -3, +2, "-three", "-two", "-one", "zero", "+one", "+two");
+    }
+
+    @Test
+    public void testPositiveBounds() {  // lower & upper bounds are +ve
+        CustomIndexArray<String> arr = new CustomIndexArray<String>(3, 7);
+        arr.set(3, "three");
+        arr.set(4, "four");
+        arr.set(5, "five");
+        arr.set(6, "six");
+        arr.set(7, "seven");
+
+        validateContents(arr, 3, 7, "three", "four", "five", "six", "seven");
+    }
+
+    private static void validateContents(CustomIndexArray<String> arr, int lowIndex, int highIndex, String... values) {
+        // 1) check size
+        Assert.assertEquals(highIndex - lowIndex + 1, arr.size() );
+
+        // 2) check valid indexes
+        int vindex = 0;
+        for (int i = lowIndex; i <= highIndex; i++) {
+            System.err.println(i + "=i  -:-  vindex=" + vindex + " values[vindex]=" + values[vindex]);
+            Assert.assertEquals(values[vindex++], arr.get(i));
+        }
+
+        // 3) check out of range indexes
+        try {
+            arr.get(lowIndex-1);
+            Assert.fail("Expected IndexOutOfBoundsException. But there wasn't one.");
+        } catch (IndexOutOfBoundsException expected) {
+        }
+
+        try {
+            arr.get(highIndex+1);
+            Assert.fail("Expected IndexOutOfBoundsException. But there wasn't one.");
+        } catch (IndexOutOfBoundsException expected) {
+        }
+    }
+
+
+}

--- a/storm-core/test/jvm/org/apache/storm/stats/TestStatsUtil.java
+++ b/storm-core/test/jvm/org/apache/storm/stats/TestStatsUtil.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.apache.storm.generated.WorkerResources;
 import org.apache.storm.generated.WorkerSummary;
 import org.apache.storm.scheduler.WorkerSlot;
+import org.apache.storm.utils.CustomIndexArray;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class TestStatsUtil {
     /*
      * aggWorkerStats tests
      */
-    private Map<Integer, String> task2Component = new HashMap<Integer, String>();
+    private CustomIndexArray<String> task2Component = new CustomIndexArray<>(1,7);
     private Map<List<Integer>, Map<String, Object>> beats = new HashMap<List<Integer>, Map<String, Object>>();
     private Map<List<Long>, List<Object>> exec2NodePort = new HashMap<List<Long>, List<Object>>();
     private Map<String, String> nodeHost = new HashMap<String, String>();
@@ -65,13 +66,13 @@ public class TestStatsUtil {
         beats.put(exec1, exec1Beat);
         beats.put(exec2, exec2Beat);
 
-        task2Component.put(1, "my-component");
-        task2Component.put(2, "__sys1");
-        task2Component.put(3, "__sys2");
-        task2Component.put(4, "__sys3");
-        task2Component.put(5, "__sys4");
-        task2Component.put(6, "__sys4");
-        task2Component.put(7, "my-component2");
+        task2Component.set(1, "my-component");
+        task2Component.set(2, "__sys1");
+        task2Component.set(3, "__sys2");
+        task2Component.set(4, "__sys3");
+        task2Component.set(5, "__sys4");
+        task2Component.set(6, "__sys4");
+        task2Component.set(7, "my-component2");
 
         WorkerResources ws1 = new WorkerResources();
         ws1.set_mem_on_heap(1);

--- a/storm-server/src/main/java/org/apache/storm/Testing.java
+++ b/storm-server/src/main/java/org/apache/storm/Testing.java
@@ -48,6 +48,7 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.TupleImpl;
 import org.apache.storm.utils.ConfigUtils;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.RegisteredGlobalState;
 import org.apache.storm.utils.Time;
 import org.apache.storm.utils.Time.SimulatedTime;
@@ -660,8 +661,8 @@ public class Testing {
             }
         }
 
-        Map<Integer, String> taskToComp = new HashMap<>();
-        taskToComp.put(task, component);
+        CustomIndexArray<String> taskToComp = new CustomIndexArray<>(task,task);
+        taskToComp.set(task, component);
         Map<String, Map<String, Fields>> compToStreamToFields = new HashMap<>();
         Map<String, Fields> streamToFields = new HashMap<>();
         streamToFields.put(stream, new Fields(fields));

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -188,6 +188,7 @@ import org.apache.storm.stats.StatsUtil;
 import org.apache.storm.thrift.TException;
 import org.apache.storm.utils.BufferInputStream;
 import org.apache.storm.utils.ConfigUtils;
+import org.apache.storm.utils.CustomIndexArray;
 import org.apache.storm.utils.LocalState;
 import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.ReflectionUtils;
@@ -1729,8 +1730,8 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         Map<String, Integer> compToExecutors = base.get_component_executors();
         List<List<Integer>> ret = new ArrayList<>();
         if (compToExecutors != null) {
-            Map<Integer, String> taskInfo = StormCommon.stormTaskInfo(topology, topoConf);
-            Map<String, List<Integer>> compToTaskList = Utils.reverseMap(taskInfo);
+            CustomIndexArray<String> taskInfo = StormCommon.stormTaskInfo(topology, topoConf);
+            Map<String, List<Integer>> compToTaskList = taskInfo.getReverseMap();
             for (Entry<String, List<Integer>> entry : compToTaskList.entrySet()) {
                 List<Integer> comps = entry.getValue();
                 comps.sort(null);
@@ -1750,7 +1751,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                                                                   Map<String, Object> topoConf, StormTopology topology)
         throws KeyNotFoundException, AuthorizationException, InvalidTopologyException, IOException {
         List<List<Integer>> executors = new ArrayList<>(getOrUpdateExecutors(topoId, base, topoConf, topology));
-        Map<Integer, String> taskToComponent = StormCommon.stormTaskInfo(topology, topoConf);
+        CustomIndexArray<String> taskToComponent = StormCommon.stormTaskInfo(topology, topoConf);
         Map<List<Integer>, String> ret = new HashMap<>();
         for (List<Integer> executor : executors) {
             ret.put(executor, taskToComponent.get(executor.get(0)));
@@ -2731,7 +2732,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                                                                                                     .get_executor_node_port())) :
             Collections
             .emptyMap();
-        ret.allComponents = new HashSet<>(ret.taskToComponent.values());
+        ret.allComponents = new HashSet<>(ret.taskToComponent.getItems());
         return ret;
     }
 
@@ -3924,7 +3925,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             int launchTimeSecs = common.launchTimeSecs;
             Assignment assignment = common.assignment;
             Map<List<Integer>, Map<String, Object>> beats = common.beats;
-            Map<Integer, String> taskToComp = common.taskToComponent;
+            CustomIndexArray<String> taskToComp = common.taskToComponent;
             StormTopology topology = common.topology;
             Map<String, Object> topoConf = Utils.merge(conf, common.topoConf);
             StormBase base = common.base;
@@ -4071,7 +4072,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                     String topoName = common.topoName;
                     Assignment assignment = common.assignment;
                     Map<List<Integer>, Map<String, Object>> beats = common.beats;
-                    Map<Integer, String> taskToComp = common.taskToComponent;
+                    CustomIndexArray<String> taskToComp = common.taskToComponent;
                     Map<List<Long>, List<Object>> exec2NodePort = new HashMap<>();
                     Map<String, String> nodeToHost;
                     if (assignment != null) {
@@ -4159,7 +4160,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 }
             }
             // Add the event logger details.
-            Map<String, List<Integer>> compToTasks = Utils.reverseMap(info.taskToComponent);
+            Map<String, List<Integer>> compToTasks = info.taskToComponent.getReverseMap();
             if (compToTasks.containsKey(StormCommon.EVENTLOGGER_COMPONENT_ID)) {
                 List<Integer> tasks = compToTasks.get(StormCommon.EVENTLOGGER_COMPONENT_ID);
                 tasks.sort(null);
@@ -4661,7 +4662,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         public Map<String, Object> topoConf;
         public String topoName;
         public StormTopology topology;
-        public Map<Integer, String> taskToComponent;
+        public CustomIndexArray<String> taskToComponent;
         public StormBase base;
         public int launchTimeSecs;
         public Assignment assignment;


### PR DESCRIPTION
- Added Unit Tests
- Ran below perf numbers on my mid 2015 macbook pro for single worker.

Ran these perf topos to check perf impact:

### 1) ConstSpoutIdBoltNullBoltTopo With 1 Acker
**Before:**  Throughput= 1,067,128 /sec .  Latency = 1.038 ms
**After:**  Throughput= 1,294,511 /sec .  Latency = 1.037 ms
- Throughput improved ~21%.  No signifiant change in latency.

### 2) ConstSpoutIdBoltNullBoltTopo With 0 Acker
**Before:**  Throughput= 4,389,133
**After:**  Throughput= 4,748,744 /sec

- Throughput improved ~8%.

### 3) TVL : --rate 350000 --spouts 1 --splitters 2 --counters 2 -c topology.max.spout.pending=500 -c topology.acker.executors=2  -c topology.disable.loadaware.messaging=true

No significant change observed in Throughput or Latency.



