### PR TITLE
STORM-3101: Fix unexpected metrics registration in StormMetricsRegistry.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/cluster/DaemonType.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/DaemonType.java
@@ -73,6 +73,7 @@ public enum DaemonType {
         }
     },
     PACEMAKER,
+    DRPC,
     UNKNOWN;
 
     @VisibleForTesting
@@ -105,5 +106,10 @@ public enum DaemonType {
      */
     public List<ACL> getZkSecretAcls(WorkerTokenServiceType type, Map<String, Object> conf) {
         throw new IllegalArgumentException(name() + " does not support storing secrets.");
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/daemon/drpc/DRPC.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/drpc/DRPC.java
@@ -18,6 +18,8 @@
 
 package org.apache.storm.daemon.drpc;
 
+import static org.apache.storm.cluster.DaemonType.DRPC;
+
 import com.codahale.metrics.Meter;
 import java.security.Principal;
 import java.util.HashMap;
@@ -52,11 +54,16 @@ public class DRPC implements AutoCloseable {
     private static final DRPCExecutionException TIMED_OUT = new WrappedDRPCExecutionException("Timed Out");
     private static final DRPCExecutionException SHUT_DOWN = new WrappedDRPCExecutionException("Server Shutting Down");
     private static final DRPCExecutionException DEFAULT_FAILED = new WrappedDRPCExecutionException("Request failed");
-    private static final Meter meterServerTimedOut = StormMetricsRegistry.registerMeter("drpc:num-server-timedout-requests");
-    private static final Meter meterExecuteCalls = StormMetricsRegistry.registerMeter("drpc:num-execute-calls");
-    private static final Meter meterResultCalls = StormMetricsRegistry.registerMeter("drpc:num-result-calls");
-    private static final Meter meterFailRequestCalls = StormMetricsRegistry.registerMeter("drpc:num-failRequest-calls");
-    private static final Meter meterFetchRequestCalls = StormMetricsRegistry.registerMeter("drpc:num-fetchRequest-calls");
+    private static final Meter meterServerTimedOut = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(DRPC, "num-server-timedout-requests"));
+    private static final Meter meterExecuteCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(DRPC, "num-execute-calls"));
+    private static final Meter meterResultCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(DRPC, "num-result-calls"));
+    private static final Meter meterFailRequestCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(DRPC, "num-failRequest-calls"));
+    private static final Meter meterFetchRequestCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(DRPC, "num-fetchRequest-calls"));
 
     static {
         TIMED_OUT.set_type(DRPCExceptionType.SERVER_TIMEOUT);

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -18,6 +18,8 @@
 
 package org.apache.storm.daemon.nimbus;
 
+import static org.apache.storm.cluster.DaemonType.NIMBUS;
+
 import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
@@ -218,45 +220,75 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     public static final SimpleVersion MIN_VERSION_SUPPORT_RPC_HEARTBEAT = new SimpleVersion("2.0.0");
     private static final Logger LOG = LoggerFactory.getLogger(Nimbus.class);
     //    Metrics
-    private static final Meter submitTopologyWithOptsCalls = StormMetricsRegistry.registerMeter("nimbus:num-submitTopologyWithOpts-calls");
-    private static final Meter submitTopologyCalls = StormMetricsRegistry.registerMeter("nimbus:num-submitTopology-calls");
-    private static final Meter killTopologyWithOptsCalls = StormMetricsRegistry.registerMeter("nimbus:num-killTopologyWithOpts-calls");
-    private static final Meter killTopologyCalls = StormMetricsRegistry.registerMeter("nimbus:num-killTopology-calls");
-    private static final Meter rebalanceCalls = StormMetricsRegistry.registerMeter("nimbus:num-rebalance-calls");
-    private static final Meter activateCalls = StormMetricsRegistry.registerMeter("nimbus:num-activate-calls");
-    private static final Meter deactivateCalls = StormMetricsRegistry.registerMeter("nimbus:num-deactivate-calls");
-    private static final Meter debugCalls = StormMetricsRegistry.registerMeter("nimbus:num-debug-calls");
-    private static final Meter setWorkerProfilerCalls = StormMetricsRegistry.registerMeter("nimbus:num-setWorkerProfiler-calls");
+    private static final Meter submitTopologyWithOptsCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-submitTopologyWithOpts-calls"));
+    private static final Meter submitTopologyCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-submitTopology-calls"));
+    private static final Meter killTopologyWithOptsCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-killTopologyWithOpts-calls"));
+    private static final Meter killTopologyCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-killTopology-calls"));
+    private static final Meter rebalanceCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-rebalance-calls"));
+    private static final Meter activateCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-activate-calls"));
+    private static final Meter deactivateCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-deactivate-calls"));
+    private static final Meter debugCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-debug-calls"));
+    private static final Meter setWorkerProfilerCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-setWorkerProfiler-calls"));
     private static final Meter getComponentPendingProfileActionsCalls = StormMetricsRegistry.registerMeter(
-        "nimbus:num-getComponentPendingProfileActions-calls");
-    private static final Meter setLogConfigCalls = StormMetricsRegistry.registerMeter("nimbus:num-setLogConfig-calls");
-    private static final Meter uploadNewCredentialsCalls = StormMetricsRegistry.registerMeter("nimbus:num-uploadNewCredentials-calls");
-    private static final Meter beginFileUploadCalls = StormMetricsRegistry.registerMeter("nimbus:num-beginFileUpload-calls");
-    private static final Meter uploadChunkCalls = StormMetricsRegistry.registerMeter("nimbus:num-uploadChunk-calls");
-    private static final Meter finishFileUploadCalls = StormMetricsRegistry.registerMeter("nimbus:num-finishFileUpload-calls");
-    private static final Meter beginFileDownloadCalls = StormMetricsRegistry.registerMeter("nimbus:num-beginFileDownload-calls");
-    private static final Meter downloadChunkCalls = StormMetricsRegistry.registerMeter("nimbus:num-downloadChunk-calls");
-    private static final Meter getNimbusConfCalls = StormMetricsRegistry.registerMeter("nimbus:num-getNimbusConf-calls");
-    private static final Meter getLogConfigCalls = StormMetricsRegistry.registerMeter("nimbus:num-getLogConfig-calls");
-    private static final Meter getTopologyConfCalls = StormMetricsRegistry.registerMeter("nimbus:num-getTopologyConf-calls");
-    private static final Meter getTopologyCalls = StormMetricsRegistry.registerMeter("nimbus:num-getTopology-calls");
-    private static final Meter getUserTopologyCalls = StormMetricsRegistry.registerMeter("nimbus:num-getUserTopology-calls");
-    private static final Meter getClusterInfoCalls = StormMetricsRegistry.registerMeter("nimbus:num-getClusterInfo-calls");
-    private static final Meter getLeaderCalls = StormMetricsRegistry.registerMeter("nimbus:num-getLeader-calls");
-    private static final Meter isTopologyNameAllowedCalls = StormMetricsRegistry.registerMeter("nimbus:num-isTopologyNameAllowed-calls");
+        StormMetricsRegistry.name(NIMBUS, "num-getComponentPendingProfileActions-calls"));
+    private static final Meter setLogConfigCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-setLogConfig-calls"));
+    private static final Meter uploadNewCredentialsCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-uploadNewCredentials-calls"));
+    private static final Meter beginFileUploadCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-beginFileUpload-calls"));
+    private static final Meter uploadChunkCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-uploadChunk-calls"));
+    private static final Meter finishFileUploadCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-finishFileUpload-calls"));
+    private static final Meter beginFileDownloadCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-beginFileDownload-calls"));
+    private static final Meter downloadChunkCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-downloadChunk-calls"));
+    private static final Meter getNimbusConfCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getNimbusConf-calls"));
+    private static final Meter getLogConfigCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getLogConfig-calls"));
+    private static final Meter getTopologyConfCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getTopologyConf-calls"));
+    private static final Meter getTopologyCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getTopology-calls"));
+    private static final Meter getUserTopologyCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getUserTopology-calls"));
+    private static final Meter getClusterInfoCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getClusterInfo-calls"));
+    private static final Meter getLeaderCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getLeader-calls"));
+    private static final Meter isTopologyNameAllowedCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-isTopologyNameAllowed-calls"));
     private static final Meter getTopologyInfoWithOptsCalls = StormMetricsRegistry.registerMeter(
-        "nimbus:num-getTopologyInfoWithOpts-calls");
-    private static final Meter getTopologyInfoCalls = StormMetricsRegistry.registerMeter("nimbus:num-getTopologyInfo-calls");
-    private static final Meter getTopologyPageInfoCalls = StormMetricsRegistry.registerMeter("nimbus:num-getTopologyPageInfo-calls");
-    private static final Meter getSupervisorPageInfoCalls = StormMetricsRegistry.registerMeter("nimbus:num-getSupervisorPageInfo-calls");
-    private static final Meter getComponentPageInfoCalls = StormMetricsRegistry.registerMeter("nimbus:num-getComponentPageInfo-calls");
-    private static final Histogram scheduleTopologyTimeMs = StormMetricsRegistry.registerHistogram("nimbus:time-scheduleTopology-ms",
-                                                                                                   new ExponentiallyDecayingReservoir());
+        StormMetricsRegistry.name(NIMBUS, "num-getTopologyInfoWithOpts-calls"));
+    private static final Meter getTopologyInfoCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getTopologyInfo-calls"));
+    private static final Meter getTopologyPageInfoCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getTopologyPageInfo-calls"));
+    private static final Meter getSupervisorPageInfoCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getSupervisorPageInfo-calls"));
+    private static final Meter getComponentPageInfoCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-getComponentPageInfo-calls"));
+    private static final Histogram scheduleTopologyTimeMs = StormMetricsRegistry.registerHistogram(
+            StormMetricsRegistry.name(NIMBUS, "time-scheduleTopology-ms"), new ExponentiallyDecayingReservoir());
     private static final Meter getOwnerResourceSummariesCalls = StormMetricsRegistry.registerMeter(
-        "nimbus:num-getOwnerResourceSummaries-calls");
+            StormMetricsRegistry.name(NIMBUS, "num-getOwnerResourceSummaries-calls"));
     // END Metrics
-    private static final Meter shutdownCalls = StormMetricsRegistry.registerMeter("nimbus:num-shutdown-calls");
-    private static final Meter processWorkerMetricsCalls = StormMetricsRegistry.registerMeter("nimbus:process-worker-metric-calls");
+    private static final Meter shutdownCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-shutdown-calls"));
+    private static final Meter processWorkerMetricsCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "process-worker-metric-calls"));
     private static final String STORM_VERSION = VersionInfo.getVersion();
 
     public static List<ACL> getNimbusAcls(Map<String, Object> conf) {
@@ -1133,6 +1165,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         validatePortAvailable(conf);
         final Nimbus nimbus = new Nimbus(conf, inimbus);
         nimbus.launchServer();
+        StormMetricsRegistry.setSource(NIMBUS);
         final ThriftServer server = new ThriftServer(conf, new Processor<>(nimbus), ThriftConnectionType.NIMBUS);
         Utils.addShutdownHookWithDelayedForceKill(() -> {
             nimbus.shutdown();
@@ -1168,13 +1201,13 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         String root = (String) conf.get(Config.STORM_ZOOKEEPER_ROOT);
         CuratorFramework ret = null;
         if (servers != null && port != null) {
-            ret = ClientZookeeper.mkClient(conf, servers, port, root, new DefaultWatcherCallBack(), conf, DaemonType.NIMBUS);
+            ret = ClientZookeeper.mkClient(conf, servers, port, root, new DefaultWatcherCallBack(), conf, NIMBUS);
         }
         return ret;
     }
 
     private static IStormClusterState makeStormClusterState(Map<String, Object> conf) throws Exception {
-        return ClusterUtils.mkStormClusterState(conf, new ClusterStateContext(DaemonType.NIMBUS, conf));
+        return ClusterUtils.mkStormClusterState(conf, new ClusterStateContext(NIMBUS, conf));
     }
 
     private static List<Integer> asIntExec(List<Long> exec) {
@@ -2794,21 +2827,30 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                                         }
                                     });
 
-            StormMetricsRegistry.registerGauge("nimbus:num-supervisors", () -> state.supervisors(null).size());
-            StormMetricsRegistry.registerGauge("nimbus:fragmented-memory", () -> fragmentedMemory());
-            StormMetricsRegistry.registerGauge("nimbus:fragmented-cpu", () -> fragmentedCpu());
-            StormMetricsRegistry.registerGauge("nimbus:available-memory", () -> nodeIdToResources.get().values().parallelStream()
-                                                                                                 .mapToDouble(
-                                                                                                     SupervisorResources::getAvailableMem)
-                                                                                                 .sum());
-            StormMetricsRegistry.registerGauge("nimbus:available-cpu", () -> nodeIdToResources.get().values().parallelStream().mapToDouble(
-                SupervisorResources::getAvailableCpu).sum());
-            StormMetricsRegistry.registerGauge("nimbus:total-memory", () -> nodeIdToResources.get().values().parallelStream()
-                                                                                             .mapToDouble(SupervisorResources::getTotalMem)
-                                                                                             .sum());
-            StormMetricsRegistry.registerGauge("nimbus:total-cpu", () -> nodeIdToResources.get().values().parallelStream()
-                                                                                          .mapToDouble(SupervisorResources::getTotalCpu)
-                                                                                          .sum());
+            StormMetricsRegistry.registerGauge(
+                    StormMetricsRegistry.name(NIMBUS, "num-supervisors"), () -> state.supervisors(null).size());
+            StormMetricsRegistry.registerGauge(
+                    StormMetricsRegistry.name(NIMBUS, "fragmented-memory"), () -> fragmentedMemory());
+            StormMetricsRegistry.registerGauge(
+                    StormMetricsRegistry.name(NIMBUS, "fragmented-cpu"), () -> fragmentedCpu());
+            StormMetricsRegistry.registerGauge(
+                    StormMetricsRegistry.name(NIMBUS, "available-memory"), () ->
+                            nodeIdToResources.get().values().parallelStream()
+                            .mapToDouble(SupervisorResources::getAvailableMem)
+                            .sum());
+            StormMetricsRegistry.registerGauge(
+                    StormMetricsRegistry.name(NIMBUS, "available-cpu"), () -> nodeIdToResources.get().values().parallelStream().mapToDouble(
+                            SupervisorResources::getAvailableCpu).sum());
+            StormMetricsRegistry.registerGauge(
+                    StormMetricsRegistry.name(NIMBUS, "total-memory"), () ->
+                            nodeIdToResources.get().values().parallelStream()
+                            .mapToDouble(SupervisorResources::getTotalMem)
+                            .sum());
+            StormMetricsRegistry.registerGauge(
+                    StormMetricsRegistry.name(NIMBUS, "total-cpu"), () ->
+                            nodeIdToResources.get().values().parallelStream()
+                            .mapToDouble(SupervisorResources::getTotalCpu)
+                            .sum());
             StormMetricsRegistry.startMetricsReporters(conf);
 
             if (clusterConsumerExceutors != null) {

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Container.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Container.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.storm.Config;
 import org.apache.storm.DaemonConfig;
+import org.apache.storm.cluster.DaemonType;
 import org.apache.storm.container.ResourceIsolationInterface;
 import org.apache.storm.generated.LSWorkerHeartbeat;
 import org.apache.storm.generated.LocalAssignment;
@@ -70,7 +71,7 @@ public abstract class Container implements Killable {
 
     static {
         StormMetricsRegistry.registerGauge(
-            "supervisor:current-used-memory-mb",
+            StormMetricsRegistry.name(DaemonType.SUPERVISOR, "current-used-memory-mb"),
             () -> {
                 Long val =
                     _usedMemory.values().stream().mapToLong((topoAndMem) -> topoAndMem.memory).sum();
@@ -81,7 +82,7 @@ public abstract class Container implements Killable {
                 return ret;
             });
         StormMetricsRegistry.registerGauge(
-            "supervisor:current-reserved-memory-mb",
+            StormMetricsRegistry.name(DaemonType.SUPERVISOR, "current-reserved-memory-mb"),
             () -> {
                 Long val =
                     _reservedMemory.values().stream().mapToLong((topoAndMem) -> topoAndMem.memory).sum();

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
@@ -12,6 +12,8 @@
 
 package org.apache.storm.daemon.supervisor;
 
+import static org.apache.storm.cluster.DaemonType.SUPERVISOR;
+
 import com.codahale.metrics.Meter;
 import java.io.IOException;
 import java.util.Collections;
@@ -55,17 +57,17 @@ import org.slf4j.LoggerFactory;
 public class Slot extends Thread implements AutoCloseable, BlobChangingCallback {
     private static final Logger LOG = LoggerFactory.getLogger(Slot.class);
     private static final Meter numWorkersLaunched =
-        StormMetricsRegistry.registerMeter("supervisor:num-workers-launched");
+        StormMetricsRegistry.registerMeter(StormMetricsRegistry.name(SUPERVISOR, "num-workers-launched"));
     private static final Meter numWorkersKilledProcessExit =
-        StormMetricsRegistry.registerMeter("supervisor:num-workers-killed-process-exit");
+        StormMetricsRegistry.registerMeter(StormMetricsRegistry.name(SUPERVISOR, "num-workers-killed-process-exit"));
     private static final Meter numWorkersKilledMemoryViolation =
-        StormMetricsRegistry.registerMeter("supervisor:num-workers-killed-memory-violation");
+        StormMetricsRegistry.registerMeter(StormMetricsRegistry.name(SUPERVISOR, "num-workers-killed-memory-violation"));
     private static final Meter numWorkersKilledHBTimeout =
-        StormMetricsRegistry.registerMeter("supervisor:num-workers-killed-hb-timeout");
+        StormMetricsRegistry.registerMeter(StormMetricsRegistry.name(SUPERVISOR, "num-workers-killed-hb-timeout"));
     private static final Meter numWorkersKilledHBNull =
-        StormMetricsRegistry.registerMeter("supervisor:num-workers-killed-hb-null");
+        StormMetricsRegistry.registerMeter(StormMetricsRegistry.name(SUPERVISOR, "num-workers-killed-hb-null"));
     private static final Meter numForceKill =
-        StormMetricsRegistry.registerMeter("supervisor:num-workers-force-kill");
+        StormMetricsRegistry.registerMeter(StormMetricsRegistry.name(SUPERVISOR, "num-workers-force-kill"));
     private static final long ONE_SEC_IN_NANO = TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
     private final AtomicReference<LocalAssignment> newAssignment = new AtomicReference<>();
     private final AtomicReference<Set<TopoProfileAction>> profiling = new AtomicReference<>(new HashSet<>());

--- a/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/RocksDbStore.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/RocksDbStore.java
@@ -59,6 +59,7 @@ public class RocksDbStore implements MetricStore, AutoCloseable {
     public void prepare(Map<String, Object> config) throws MetricException {
         validateConfig(config);
 
+        // TODO: update registry
         this.failureMeter = StormMetricsRegistry.registerMeter("RocksDB:metric-failures");
 
         RocksDB.loadLibrary();

--- a/storm-server/src/main/java/org/apache/storm/pacemaker/Pacemaker.java
+++ b/storm-server/src/main/java/org/apache/storm/pacemaker/Pacemaker.java
@@ -12,6 +12,8 @@
 
 package org.apache.storm.pacemaker;
 
+import static org.apache.storm.cluster.DaemonType.PACEMAKER;
+
 import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
@@ -38,12 +40,17 @@ import org.slf4j.LoggerFactory;
 public class Pacemaker implements IServerMessageHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(Pacemaker.class);
-    private final static Meter meterSendPulseCount = StormMetricsRegistry.registerMeter("pacemaker:send-pulse-count");
-    private final static Meter meterTotalReceivedSize = StormMetricsRegistry.registerMeter("pacemaker:total-receive-size");
-    private final static Meter meterGetPulseCount = StormMetricsRegistry.registerMeter("pacemaker:get-pulse=count");
-    private final static Meter meterTotalSentSize = StormMetricsRegistry.registerMeter("pacemaker:total-sent-size");
-    private final static Histogram histogramHeartbeatSize =
-        StormMetricsRegistry.registerHistogram("pacemaker:heartbeat-size", new ExponentiallyDecayingReservoir());
+    private static final Meter meterSendPulseCount = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(PACEMAKER, "send-pulse-count"));
+    private static final Meter meterTotalReceivedSize = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(PACEMAKER, "total-receive-size"));
+    private static final Meter meterGetPulseCount = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(PACEMAKER, "get-pulse=count"));
+    private static final Meter meterTotalSentSize = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(PACEMAKER, "total-sent-size"));
+    private static final Histogram histogramHeartbeatSize =
+        StormMetricsRegistry.registerHistogram(
+                StormMetricsRegistry.name(PACEMAKER, "heartbeat-size"), new ExponentiallyDecayingReservoir());
     private Map<String, byte[]> heartbeats;
     private Map<String, Object> conf;
 
@@ -51,13 +58,13 @@ public class Pacemaker implements IServerMessageHandler {
     public Pacemaker(Map<String, Object> conf) {
         heartbeats = new ConcurrentHashMap();
         this.conf = conf;
-        StormMetricsRegistry.registerGauge("pacemaker:size-total-keys",
-                                           new Callable() {
-                                               @Override
-                                               public Integer call() throws Exception {
-                                                   return heartbeats.size();
-                                               }
-                                           });
+        StormMetricsRegistry.registerGauge(StormMetricsRegistry.name(PACEMAKER, "size-total-keys"),
+                new Callable() {
+                    @Override
+                    public Integer call() throws Exception {
+                        return heartbeats.size();
+                    }
+                });
         StormMetricsRegistry.startMetricsReporters(conf);
     }
 

--- a/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/BlacklistScheduler.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/BlacklistScheduler.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import org.apache.storm.DaemonConfig;
+import org.apache.storm.cluster.DaemonType;
 import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.scheduler.Cluster;
 import org.apache.storm.scheduler.IScheduler;
@@ -89,13 +90,14 @@ public class BlacklistScheduler implements IScheduler {
         cachedSupervisors = new HashMap<>();
         blacklistHost = new HashSet<>();
 
-        StormMetricsRegistry.registerGauge("nimbus:num-blacklisted-supervisor", new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                //nimbus:num-blacklisted-supervisor + none blacklisted supervisor = nimbus:num-supervisors
-                return blacklistHost.size();
-            }
-        });
+        StormMetricsRegistry.registerGauge(StormMetricsRegistry.name(DaemonType.NIMBUS, "num-blacklisted-supervisor"),
+                new Callable<Integer>() {
+                    @Override
+                    public Integer call() throws Exception {
+                        //nimbus:num-blacklisted-supervisor + none blacklisted supervisor = nimbus:num-supervisors
+                        return blacklistHost.size();
+                    }
+                });
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResources.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResources.java
@@ -18,6 +18,8 @@
 
 package org.apache.storm.scheduler.resource.normalization;
 
+import static org.apache.storm.cluster.DaemonType.NIMBUS;
+
 import com.codahale.metrics.Meter;
 import java.util.Arrays;
 import java.util.Map;
@@ -35,7 +37,8 @@ import org.slf4j.LoggerFactory;
 public class NormalizedResources {
 
     private static final Logger LOG = LoggerFactory.getLogger(NormalizedResources.class);
-    public static final Meter numNegativeResourceEvents = StormMetricsRegistry.registerMeter("nimbus:num-negative-resource-events");
+    public static final Meter numNegativeResourceEvents = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(NIMBUS, "num-negative-resource-events"));
 
 
     public static ResourceNameNormalizer RESOURCE_NAME_NORMALIZER;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.servlet.DispatcherType;
 import org.apache.storm.Config;
 import org.apache.storm.DaemonConfig;
+import org.apache.storm.cluster.DaemonType;
 import org.apache.storm.daemon.drpc.webapp.DRPCApplication;
 import org.apache.storm.daemon.drpc.webapp.ReqContextFilter;
 import org.apache.storm.generated.DistributedRPC;
@@ -51,7 +52,8 @@ import org.slf4j.LoggerFactory;
 
 public class DRPCServer implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(DRPCServer.class);
-    private static final Meter meterShutdownCalls = StormMetricsRegistry.registerMeter("drpc:num-shutdown-calls");
+    private static final Meter meterShutdownCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(DaemonType.DRPC, "num-shutdown-calls"));
    
     //TODO in the future this might be better in a common webapp location
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCResource.java
@@ -27,13 +27,15 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 
+import org.apache.storm.cluster.DaemonType;
 import org.apache.storm.daemon.drpc.DRPC;
 import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.thrift.TException;
 
 @Path("/drpc/")
 public class DRPCResource {
-    private static final Meter meterHttpRequests = StormMetricsRegistry.registerMeter("drpc:num-execute-http-requests");
+    private static final Meter meterHttpRequests = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(DaemonType.DRPC, "num-execute-http-requests"));
     private final DRPC drpc;
 
     public DRPCResource(DRPC drpc) {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
@@ -53,8 +53,10 @@ import org.slf4j.LoggerFactory;
  * The main entry of Logviewer.
  */
 public class LogviewerServer implements AutoCloseable {
+    public static final String LOGVIEWER = "logviewer";
     private static final Logger LOG = LoggerFactory.getLogger(LogviewerServer.class);
-    private static final Meter meterShutdownCalls = StormMetricsRegistry.registerMeter("logviewer:num-shutdown-calls");
+    private static final Meter meterShutdownCalls = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(LOGVIEWER, "num-shutdown-calls"));
     private static final String stormHome = System.getProperty("storm.home");
     public static final String STATIC_RESOURCE_DIRECTORY_PATH = stormHome + "/public";
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerResource.java
@@ -18,6 +18,8 @@
 
 package org.apache.storm.daemon.logviewer.webapp;
 
+import static org.apache.storm.daemon.logviewer.LogviewerServer.LOGVIEWER;
+
 import com.codahale.metrics.Meter;
 
 import java.io.IOException;
@@ -52,14 +54,16 @@ import org.slf4j.LoggerFactory;
 public class LogviewerResource {
     private static final Logger LOG = LoggerFactory.getLogger(LogviewerResource.class);
 
-    private static final Meter meterLogPageHttpRequests = StormMetricsRegistry.registerMeter("logviewer:num-log-page-http-requests");
+    private static final Meter meterLogPageHttpRequests = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(LOGVIEWER, "num-log-page-http-requests"));
     private static final Meter meterDaemonLogPageHttpRequests = StormMetricsRegistry.registerMeter(
-            "logviewer:num-daemonlog-page-http-requests");
+            StormMetricsRegistry.name(LOGVIEWER, "num-daemonlog-page-http-requests"));
     private static final Meter meterDownloadLogFileHttpRequests = StormMetricsRegistry.registerMeter(
-            "logviewer:num-download-log-file-http-requests");
+            StormMetricsRegistry.name(LOGVIEWER, "num-download-log-file-http-requests"));
     private static final Meter meterDownloadLogDaemonFileHttpRequests = StormMetricsRegistry.registerMeter(
-            "logviewer:num-download-log-daemon-file-http-requests");
-    private static final Meter meterListLogsHttpRequests = StormMetricsRegistry.registerMeter("logviewer:num-list-logs-http-requests");
+            StormMetricsRegistry.name(LOGVIEWER, "num-download-log-daemon-file-http-requests"));
+    private static final Meter meterListLogsHttpRequests = StormMetricsRegistry.registerMeter(
+            StormMetricsRegistry.name(LOGVIEWER, "num-list-logs-http-requests"));
 
     private final LogviewerLogPageHandler logviewer;
     private final LogviewerProfileHandler profileHandler;


### PR DESCRIPTION
The current implementation is based on the idea to set the source to the running daemon. All the metrics not belonging to the source (e.g., supervisor) will be removed or rejected. This implementation also adds in the utility method for naming a metric.

Please refer to the apache issue page for the purpose of this improvement. This is actually a band-aid fix. I'm wondering if there's better approach.