### PR TITLE
STORM-3103 allow nimbus to shutdown properly

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/StormTimer.java
+++ b/storm-client/src/jvm/org/apache/storm/StormTimer.java
@@ -35,7 +35,6 @@ public class StormTimer implements AutoCloseable {
      *
      * @param name   name of the timer
      * @param onKill function to call when timer is killed unexpectedly
-     * @return StormTimerTask object that was initialized
      */
     public StormTimer(String name, Thread.UncaughtExceptionHandler onKill) {
         if (onKill == null) {
@@ -67,7 +66,7 @@ public class StormTimer implements AutoCloseable {
     }
 
     /**
-     * Same as schedule with millisecond resolution
+     * Same as schedule with millisecond resolution.
      *
      * @param delayMs     the number of milliseconds to delay before running the function
      * @param func        the function to run
@@ -249,8 +248,9 @@ public class StormTimer implements AutoCloseable {
                 } catch (Throwable e) {
                     if (!(Utils.exceptionCauseIsInstanceOf(InterruptedException.class, e))
                         && !(Utils.exceptionCauseIsInstanceOf(ClosedByInterruptException.class, e))) {
-                        this.onKill.uncaughtException(this, e);
+                        // need to set active false before calling onKill() - current implementation does not return.
                         this.setActive(false);
+                        this.onKill.uncaughtException(this, e);
                     }
                 }
             }


### PR DESCRIPTION
Nimbus registers exitProcess() for the StormTimer.onKill routine.  This does not return once called.  This basically locks up the timer with active being set.

Then when Nimbus shuts down, it calls timer.close().  Since the timer is stuck in the onKill routine forever with active set on, timer close is deadlocked waiting for the join() to occur here:

https://github.com/apache/storm/blob/master/storm-client/src/jvm/org/apache/storm/StormTimer.java#L173

The proposed fix is to just set active to false before calling the onKill() for the timer.

