### PR TITLE
STORM-3109: Fixed incorrect conversion from relative path to absolute path for STORM_LOCAL_DIR

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/command/KillWorkers.java
+++ b/storm-core/src/jvm/org/apache/storm/command/KillWorkers.java
@@ -22,7 +22,6 @@ import org.apache.storm.utils.Utils;
 public class KillWorkers {
     public static void main(String[] args) throws Exception {
         Map<String, Object> conf = Utils.readStormConfig();
-        conf.put(Config.STORM_LOCAL_DIR, new File((String) conf.get(Config.STORM_LOCAL_DIR)).getCanonicalPath());
         try (Supervisor supervisor = new Supervisor(conf, null, new StandaloneSupervisor())) {
             supervisor.shutdownAllWorkers(null, null);
         }


### PR DESCRIPTION
See issue: https://issues.apache.org/jira/browse/STORM-3109