### PR TITLE
STORM-3110: Skip the user while checking isProcessAlive

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/daemon/supervisor/RunAsUserContainer.java
+++ b/storm-core/src/jvm/org/apache/storm/daemon/supervisor/RunAsUserContainer.java
@@ -93,4 +93,16 @@ public class RunAsUserContainer extends BasicContainer {
         List<String> commandPrefix = null;
         SupervisorUtils.processLauncher(_conf, user, commandPrefix, args, null, logPrefix, processExitCallback, targetDir);
     }
+
+    /**
+     * If 'supervisor.run.worker.as.user' is set, worker will be launched as the user that launched the topology.
+     */
+    @Override
+    protected String getRunWorkerAsUser() {
+        try {
+            return getWorkerUser();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
 }

--- a/storm-core/test/jvm/org/apache/storm/daemon/supervisor/ContainerTest.java
+++ b/storm-core/test/jvm/org/apache/storm/daemon/supervisor/ContainerTest.java
@@ -20,10 +20,8 @@ package org.apache.storm.daemon.supervisor;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +36,6 @@ import org.apache.storm.Config;
 import org.apache.storm.daemon.supervisor.Container.ContainerType;
 import org.apache.storm.generated.LocalAssignment;
 import org.apache.storm.generated.ProfileRequest;
-import org.junit.Assert;
 import org.junit.Test;
 import org.yaml.snakeyaml.Yaml;
 
@@ -264,56 +261,5 @@ public class ContainerTest {
         verify(ops).deleteIfExists(eq(new File(workerRoot, "heartbeats")), eq(user), any(String.class));
         verify(ops).deleteIfExists(eq(workerRoot), eq(user), any(String.class));
         verify(ops).deleteIfExists(workerUserFile);
-    }
-
-    @Test
-    public void testAreAllProcessesDeadPosix() throws Exception {
-        final String topoId = "test_topology";
-        final Map<String, Object> superConf = new HashMap<>();
-        AdvancedFSOps ops = mock(AdvancedFSOps.class);
-        when(ops.doRequiredTopoFilesExist(superConf, topoId)).thenReturn(true);
-
-        LocalAssignment la = new LocalAssignment();
-        la.set_topology_id(topoId);
-        MockContainer mc = new MockContainer(ContainerType.LAUNCH, superConf,
-                "SUPERVISOR", 8080, la, "worker", new HashMap<String, Object>(), ops);
-
-        MockContainer spy = spy(mc);
-        doReturn(false).when(spy).isOnWindows();
-        when(spy.getAllPids()).thenReturn(Collections.singleton(0L));
-        InputStream psout = new ByteArrayInputStream("USER\nmockuser".getBytes());
-        when(spy.getPosixProcessInputStream(0)).thenReturn(psout);
-
-        Assert.assertFalse(spy.areAllProcessesDead());
-
-        psout = new ByteArrayInputStream("USER\n".getBytes());
-        when(spy.getPosixProcessInputStream(0)).thenReturn(psout);
-
-        Assert.assertTrue(spy.areAllProcessesDead());
-    }
-
-    @Test
-    public void testAreAllProcessesDeadWindows() throws Exception {
-        final String topoId = "test_topology";
-        final Map<String, Object> superConf = new HashMap<>();
-        AdvancedFSOps ops = mock(AdvancedFSOps.class);
-        when(ops.doRequiredTopoFilesExist(superConf, topoId)).thenReturn(true);
-
-        LocalAssignment la = new LocalAssignment();
-        la.set_topology_id(topoId);
-        MockContainer mc = new MockContainer(ContainerType.LAUNCH, superConf,
-                "SUPERVISOR", 8080, la, "worker", new HashMap<String, Object>(), ops);
-        MockContainer spy = spy(mc);
-        doReturn(true).when(spy).isOnWindows();
-        when(spy.getAllPids()).thenReturn(Collections.singleton(0L));
-        InputStream psout = new ByteArrayInputStream("User Name:    exampleDomain\\exampleUser".getBytes());
-        doReturn(psout).when(spy).getWindowsProcessInputStream(0L);
-
-        Assert.assertFalse(spy.areAllProcessesDead());
-
-        psout = new ByteArrayInputStream("".getBytes());
-        doReturn(psout).when(spy).getWindowsProcessInputStream(0L);
-
-        Assert.assertTrue(spy.areAllProcessesDead());
     }
 }


### PR DESCRIPTION
While running in secure mode, supervisor sets the worker user (in workers local state) as the user that launched the topology.

However the worker OS process does not actually run as the user (instead runs as storm user) unless `supervisor.run.worker.as.user` is also set.

If the supervisor's assignment changes, the supervisor in some cases checks if all processes are dead by matching the "pid+user". Here if the worker is running as a different user (say storm) the supervisor wrongly assumes that the worker process is dead.

Later when supervisor tries to launch a worker at that same port, it throws a bind exception

We can skip the user check while determining if the worker processes are alive.