### PR TITLE
STORM-3090 - Fix bug when different topics use the same offset for a partition

### DIFF
--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/PartitionManager.java
@@ -104,9 +104,9 @@ public class PartitionManager {
             _emittedToOffset = previousManager._emittedToOffset;
             _waitingToEmit = previousManager._waitingToEmit;
             _pending = previousManager._pending;
-            LOG.info("Recreating PartitionManager based on previous manager, _waitingToEmit size: {}, _pending size: {}",
-                    _waitingToEmit.size(),
-                    _pending.size());
+            LOG.info("Recreating PartitionManager based on previous manager, host: {}, topic: {}, partition: {}, "
+                    + "_committedTo: {}, _emittedToOffset: {}, _waitingToEmit size: {}, _pending size: {} ",
+                id.host, id.topic, id.partition, _committedTo, _emittedToOffset, _waitingToEmit.size(), _pending.size());
         } else {
             try {
                 _failedMsgRetryManager = (FailedMsgRetryManager) Class.forName(spoutConfig.failedMsgRetryManagerClass).newInstance();

--- a/external/storm-kafka/src/jvm/org/apache/storm/kafka/ZkCoordinator.java
+++ b/external/storm-kafka/src/jvm/org/apache/storm/kafka/ZkCoordinator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.storm.kafka;
 
+import kafka.common.TopicAndPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.storm.kafka.trident.GlobalPartitionInformation;
@@ -33,8 +34,8 @@ public class ZkCoordinator implements PartitionCoordinator {
     int _totalTasks;
     int _taskId;
     String _topologyInstanceId;
-    Map<Partition, PartitionManager> _managers = new HashMap();
-    List<PartitionManager> _cachedList = new ArrayList<PartitionManager>();
+    Map<Partition, PartitionManager> _managers = new HashMap<>();
+    List<PartitionManager> _cachedList = new ArrayList<>();
     Long _lastRefreshTime = null;
     int _refreshFreqMs;
     DynamicPartitionConnections _connections;
@@ -82,22 +83,24 @@ public class ZkCoordinator implements PartitionCoordinator {
             List<Partition> mine = KafkaUtils.calculatePartitionsForTask(brokerInfo, _totalTasks, _taskIndex, _taskId);
 
             Set<Partition> curr = _managers.keySet();
-            Set<Partition> newPartitions = new HashSet<Partition>(mine);
+            Set<Partition> newPartitions = new HashSet<>(mine);
             newPartitions.removeAll(curr);
 
-            Set<Partition> deletedPartitions = new HashSet<Partition>(curr);
+            Set<Partition> deletedPartitions = new HashSet<>(curr);
             deletedPartitions.removeAll(mine);
 
-            LOG.info(taskPrefix(_taskIndex, _totalTasks, _taskId) + " Deleted partition managers: " + deletedPartitions.toString());
+            LOG.info("{} Deleted partition managers: {}",
+                taskPrefix(_taskIndex, _totalTasks, _taskId), deletedPartitions);
 
-            Map<Integer, PartitionManager> deletedManagers = new HashMap<>();
+            Map<TopicAndPartition, PartitionManager> deletedManagers = new HashMap<>();
             for (Partition id : deletedPartitions) {
-                deletedManagers.put(id.partition, _managers.remove(id));
+                PartitionManager manager = _managers.remove(id);
+                manager.close();
+                deletedManagers.put(new TopicAndPartition(id.topic, id.partition), manager);
             }
-            for (PartitionManager manager : deletedManagers.values()) {
-                if (manager != null) manager.close();
-            }
-            LOG.info(taskPrefix(_taskIndex, _totalTasks, _taskId) + " New partition managers: " + newPartitions.toString());
+
+            LOG.info("{} New partition managers: {}",
+                taskPrefix(_taskIndex, _totalTasks, _taskId), newPartitions);
 
             for (Partition id : newPartitions) {
                 PartitionManager man = new PartitionManager(
@@ -107,14 +110,14 @@ public class ZkCoordinator implements PartitionCoordinator {
                         _stormConf,
                         _spoutConfig,
                         id,
-                        deletedManagers.get(id.partition));
+                        deletedManagers.get(new TopicAndPartition(id.topic, id.partition)));
                 _managers.put(id, man);
             }
 
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        _cachedList = new ArrayList<PartitionManager>(_managers.values());
+        _cachedList = new ArrayList<>(_managers.values());
         LOG.info(taskPrefix(_taskIndex, _totalTasks, _taskId) + " Finished refreshing");
     }
 

--- a/external/storm-kafka/src/test/org/apache/storm/kafka/TestUtils.java
+++ b/external/storm-kafka/src/test/org/apache/storm/kafka/TestUtils.java
@@ -40,18 +40,20 @@ public class TestUtils {
         return buildPartitionInfo(numPartitions, 9092);
     }
 
-    public static List<GlobalPartitionInformation> buildPartitionInfoList(GlobalPartitionInformation partitionInformation) {
-        List<GlobalPartitionInformation> map = new ArrayList<GlobalPartitionInformation>();
-        map.add(partitionInformation);
-        return map;
+    public static List<GlobalPartitionInformation> buildPartitionInfoList(GlobalPartitionInformation... partitionInformation) {
+        return new ArrayList<>(Arrays.asList(partitionInformation));
     }
 
-    public static GlobalPartitionInformation buildPartitionInfo(int numPartitions, int brokerPort) {
-        GlobalPartitionInformation globalPartitionInformation = new GlobalPartitionInformation(TOPIC);
+    public static GlobalPartitionInformation buildPartitionInfo(String topic, int numPartitions, int brokerPort) {
+        GlobalPartitionInformation globalPartitionInformation = new GlobalPartitionInformation(topic);
         for (int i = 0; i < numPartitions; i++) {
             globalPartitionInformation.addPartition(i, Broker.fromString("broker-" + i + " :" + brokerPort));
         }
         return globalPartitionInformation;
+    }
+
+    public static GlobalPartitionInformation buildPartitionInfo(int numPartitions, int brokerPort) {
+        return buildPartitionInfo(TOPIC, numPartitions, brokerPort);
     }
 
     public static SimpleConsumer getKafkaConsumer(KafkaTestBroker broker) {


### PR DESCRIPTION
In the current implementation of `ZkCoordinator` deleted partition managers are used as state holders for newly created partition managers. Such behaviour was introduced in the scope of [this](https://issues.apache.org/jira/browse/STORM-2296) ticket. However existing lookup is based only on partition number.

```
Map<Integer, PartitionManager> deletedManagers = new HashMap<>();
for (Partition id : deletedPartitions) {
    deletedManagers.put(id.partition, _managers.remove(id));
}
for (PartitionManager manager : deletedManagers.values()) {
    if (manager != null) manager.close();
}
LOG.info(taskPrefix(_taskIndex, _totalTasks, _taskId) + " New partition managers: " + newPartitions.toString());

for (Partition id : newPartitions) {
    PartitionManager man = new PartitionManager(
        _connections,
        _topologyInstanceId,
        _state,
        _topoConf,
        _spoutConfig,
        id,
        deletedManagers.get(id.partition));
    _managers.put(id, man);
```
Which is definitely incorrect as the same task is able to manage multiple partitions with the same number but for different topics. In this case all new partition managers obtain the same offset value from a random deleted partition manager (as `HashMap` is used). And all fetch requests for the new partition managers fail with `TopicOffsetOutOfRangeException`. Some of them are recovered via this logic if assigned offset is smaller than the real one, but other continue to repetitively fail with offset out of range exception preventing fetching messages from Kafka.
```
if (offset > _emittedToOffset) {
    _lostMessageCount.incrBy(offset - _emittedToOffset);
    _emittedToOffset = offset;
    LOG.warn("{} Using new offset: {}", _partition, _emittedToOffset);
}
```
I assume that state holder lookup should be based both on topic and partition number.