### PR TITLE
STORM-3119: Build Storm with Java 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ addons:
     - node1
 
 env:
-  - MODULES=storm-client
-  - MODULES=storm-server
-  - MODULES=storm-core
-  - MODULES='!storm-client,!storm-server,!storm-core'
-  - MODULES='INTEGRATION-TEST'
+  - MODULES=Client
+  - MODULES=Server
+  - MODULES=Core
+  - MODULES=External
+  - MODULES=Integration-Test
 
 dist: trusty
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ sudo: required
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk10
 before_install:
   - rvm reload
   - rvm use 2.4.2 --install

--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -31,7 +31,14 @@ else
   # Travis only has 3GB of memory, lets use 1GB for build, and 1.5GB for forked JVMs
   export MAVEN_OPTS="-Xmx1024m"
   
-  mvn --batch-mode test -fae -Pnative,all-tests '-P!include-shaded-deps' -Prat -pl "$2"
+  TEST_MODULES=$2
+  
+  if [ "$TRAVIS_JDK_VERSION" == "oraclejdk10" ] && [ "$TEST_MODULES" == "'!storm-client,!storm-server,!storm-core'" ]
+  then 
+    TEST_MODULES = '!storm-client,!storm-server,!storm-core,!external/storm-cassandra,!external/storm-hive'
+  fi
+  
+  mvn --batch-mode test -fae -Pnative,all-tests '-P!include-shaded-deps' -Prat -pl "$TEST_MODULES"
   BUILD_RET_VAL=$?
   
   for dir in `find . -type d -and -wholename \*/target/\*-reports`;

--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -16,37 +16,49 @@ echo "Ruby version   :  " `ruby -v`
 echo "NodeJs version :  " `node -v`
 echo "Maven version  :  " `mvn -v`
 
+set -x
+
 STORM_SRC_ROOT_DIR=$1
 
 TRAVIS_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 cd ${STORM_SRC_ROOT_DIR}
-  
-if [ "$2" == "INTEGRATION-TEST" ]
+
+if [ "$2" == "Integration-Test" ]
+  then
+  exec ./integration-test/run-it.sh
+elif [ "$2" == "Client" ]
 then
-  /bin/bash ./integration-test/run-it.sh
-else
-  # We should be concerned that Travis CI could be very slow because it uses VM
-  export STORM_TEST_TIMEOUT_MS=150000
-  # Travis only has 3GB of memory, lets use 1GB for build, and 1.5GB for forked JVMs
-  export MAVEN_OPTS="-Xmx1024m"
-  
-  TEST_MODULES=$2
-  
-  if [ "$TRAVIS_JDK_VERSION" == "oraclejdk10" ] && [ "$TEST_MODULES" == "'!storm-client,!storm-server,!storm-core'" ]
+  TEST_MODULES=storm-client
+elif [ "$2" == "Server" ]
+then
+  TEST_MODULES=storm-server
+elif [ "$2" == "Core" ]
+then
+  TEST_MODULES=storm-core
+elif [ "$2" == "External" ]
+then
+  if [ "$TRAVIS_JDK_VERSION" == "oraclejdk10" ]
   then 
-    TEST_MODULES = '!storm-client,!storm-server,!storm-core,!external/storm-cassandra,!external/storm-hive'
+    TEST_MODULES='!storm-client,!storm-server,!storm-core,!external/storm-cassandra,!external/storm-hive'
+  else
+    TEST_MODULES='!storm-client,!storm-server,!storm-core'
   fi
-  
-  mvn --batch-mode test -fae -Pnative,all-tests '-P!include-shaded-deps' -Prat -pl "$TEST_MODULES"
-  BUILD_RET_VAL=$?
-  
-  for dir in `find . -type d -and -wholename \*/target/\*-reports`;
-  do
-    echo "Looking for errors in ${dir}"
-    python ${TRAVIS_SCRIPT_DIR}/print-errors-from-test-reports.py "${dir}"
-  done
-  
-  exit ${BUILD_RET_VAL}
+fi
+# We should be concerned that Travis CI could be very slow because it uses VM
+export STORM_TEST_TIMEOUT_MS=150000
+# Travis only has 3GB of memory, lets use 1GB for build, and 1.5GB for forked JVMs
+export MAVEN_OPTS="-Xmx1024m"
+
+mvn --batch-mode test -fae -Pnative,all-tests '-P!include-shaded-deps' -Prat -pl "$TEST_MODULES"
+BUILD_RET_VAL=$?
+
+for dir in `find . -type d -and -wholename \*/target/\*-reports`;
+do
+  echo "Looking for errors in ${dir}"
+  python ${TRAVIS_SCRIPT_DIR}/print-errors-from-test-reports.py "${dir}"
+done
+
+exit ${BUILD_RET_VAL}
 fi
 

--- a/external/storm-opentsdb/pom.xml
+++ b/external/storm-opentsdb/pom.xml
@@ -79,6 +79,15 @@
             <artifactId>jersey-apache-connector</artifactId>
             <version>${jersey.version}</version>
         </dependency>
+        <!-- Java 9+ compatibility, ensure Java EE classes are on classpath when using jersey -->
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
 
         <!--test dependencies -->
         <dependency>

--- a/integration-test/config/Vagrantfile
+++ b/integration-test/config/Vagrantfile
@@ -53,8 +53,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     }
   end
 
-  config.vm.synced_folder "../../", "/home/ubuntu/build/vagrant/storm"
-  config.vm.synced_folder "~/.m2", "/home/ubuntu/.m2"
+  config.vm.synced_folder "../../", "/home/vagrant/build/vagrant/storm"
+  config.vm.synced_folder "~/.m2", "/home/vagrant/.m2"
 
   config.vm.define "node1" do |node1|
     node1.vm.provider "virtualbox" do |v|
@@ -62,7 +62,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     node1.vm.network "private_network", ip: "192.168.50.3"
     node1.vm.hostname = "node1"
-    node1.vm.provision :shell, :inline => "echo run integration test; whoami; env; cd /home/ubuntu/build/vagrant/storm/; pwd; bash integration-test/run-it.sh", privileged: false
+    node1.vm.provision :shell, env: {"JDK_VERSION" => ENV["JDK_VERSION"]}, :inline => "echo run integration test; whoami; env; cd /home/vagrant/build/vagrant/storm/; pwd; bash integration-test/run-it.sh", privileged: false
     #node1.vm.provision :shell, :inline => "sudo ln -fs /vagrant/etc-hosts /etc/hosts"
   end
 

--- a/integration-test/config/storm-java9.yaml
+++ b/integration-test/config/storm-java9.yaml
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Java 9 replaced a bunch of GC logging parameters for the JDK. This uses the Java 9+ syntax, whereas defaults.yaml currently uses the Java 8 syntax.
+
+worker.childopts: "-Xmx%HEAP-MEM%m -Xlog:gc*:artifacts/gc.log:time,uptime:filecount=10,filesize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"

--- a/pom.xml
+++ b/pom.xml
@@ -1114,6 +1114,11 @@
                 <version>${jaxb-version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.rocksdb</groupId>
                 <artifactId>rocksdbjni</artifactId>
                 <version>${rocksdb-version}</version>

--- a/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
@@ -156,7 +156,7 @@ public class BoltExecutor extends Executor {
         return new Callable<Long>() {
             int bpIdleCount = 0;
             int consumeIdleCounter = 0;
-            private ExitCondition tillNoPendingEmits = () -> pendingEmits.isEmpty();
+            private final ExitCondition tillNoPendingEmits = () -> pendingEmits.isEmpty();
 
             @Override
             public Long call() throws Exception {

--- a/storm-webapp/pom.xml
+++ b/storm-webapp/pom.xml
@@ -122,6 +122,15 @@
             <version>${dropwizard.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Java 9+ compatibility, ensure Java EE classes are on classpath when using jersey (through Dropwizard) -->
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3119

There are some changes in this PR that are only tangentially related to building with JDK10, namely fixes to some flaky tests that would have made it a pain to add extra test runs to every PR.

Changes:
* Add Java 10 to the Travis build matrix. Storm-cassandra and storm-hive are excluded, because Cassandra and Hive aren't Java 9+ compatible yet.
* Add relevant Java EE APIs to components that use Jersey. The Java EE APIs aren't available without add-modules in Java 9+, so we should include them explicitly as dependencies. This is already done in most of the components, but missed a few spots.
* The integration test Vagrant box has been updated so the user's name is vagrant rather than ubuntu, fix this in the scripts
* Added environment variable to allow people to use Java 10 in integration tests run via Vagrant
* Fixed the integration test so it runs on Java 10. The default worker.childopts include removed JVM parameters related to GC logging. There doesn't appear to be parameters that work on both Java 8 and 10, so we'll need to add to the documentation how people should override the worker.childopts, if they want to run on Java 10.
* Some of the Time code didn't make sense, e.g. checking for null on the final THREAD_SLEEP_TIMES_NANOS map. It was left over from an earlier refactor of Time. Cleaned it up, and deleted the deprecated Time methods. Also made sure that when simulated time is advanced, idle threads are removed from the THREAD_SLEEP_TIMES_NANOS immediately. When the LocalCluster waits for the topology to be idle, it checks whether all timer threads are in the THREAD_SLEEP_TIMES_NANOS map. It looks to me like there was no guarantee that sleeping threads actually got a chance to run when time was advanced, because they remained in the THREAD_SLEEP_TIMES_NANOS map until they happened to be scheduled. With bad luck, a thread might end up being counted as idle when it just hadn't exited the Time.sleepUntilNanos loop yet.
* The metrics-tests were doing assertions in a racy way. We can't guarantee that metrics fall in exact buckets, because the metrics are updated from the executor async loops, which aren't included in the threads covered by LocalCluster.waitForIdle. I've replaced the checks with validation that there are a certain number of metrics buckets, and that the metrics counters sum to the expected value.

Example of a failing metrics test:
```
classname: org.apache.storm.metrics-test / testname: test-custom-metric-with-multi-tasks
expected: (clojure.core/= [1 0 0 0 0 0 2] (clojure.core/subvec (org.apache.storm.metrics-test/lookup-bucket-by-comp-id-&-metric-name! "2" "my-custom-metric") 0 N__3207__auto__))
  actual: (not (clojure.core/= [1 0 0 0 0 0 2] [1 0 0 0 0 0 0]))
      at: test_runner.clj:105
```
In this case the missing 2 counts happen in a later bucket than the test is checking for, because the executor async loop happened to not have run when the metrics system added the last bucket.

Let me know if I need to split this PR up, or if a change is unclear. I ran the tests a few times on Travis, and they appear stable.