### PR TITLE
STORM-3120: Clean up leftover null checks in Time, ensure idle thread…

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -700,6 +700,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
 
     @Override
     public void advanceClusterTime(int secs, int incSecs) throws InterruptedException {
+        waitForIdle();
         for (int amountLeft = secs; amountLeft > 0; amountLeft -= incSecs) {
             int diff = Math.min(incSecs, amountLeft);
             Time.advanceTimeSecs(diff);

--- a/storm-server/src/main/java/org/apache/storm/Testing.java
+++ b/storm-server/src/main/java/org/apache/storm/Testing.java
@@ -82,7 +82,7 @@ public class Testing {
      * passed
      * @param condition what we are waiting for
      * @param body what to run in the loop
-     * @throws AssertionError if teh loop timed out.
+     * @throws AssertionError if the loop timed out.
      */
     public static void whileTimeout(Condition condition, Runnable body) {
         whileTimeout(TEST_TIMEOUT_MS, condition, body);
@@ -94,7 +94,7 @@ public class Testing {
      * @param timeoutMs the number of ms to wait before timing out.
      * @param condition what we are waiting for
      * @param body what to run in the loop
-     * @throws AssertionError if teh loop timed out.
+     * @throws AssertionError if the loop timed out.
      */
     public static void whileTimeout(long timeoutMs, Condition condition, Runnable body) {
         long endTime = System.currentTimeMillis() + timeoutMs;


### PR DESCRIPTION
…s get to run when cluster time is advanced

https://issues.apache.org/jira/browse/STORM-3120

Some of the Time code didn't make sense, e.g. checking for null on the final THREAD_SLEEP_TIMES_NANOS map. It was left over from an earlier refactor of Time. Cleaned it up, and deleted the deprecated Time methods. Also made sure that when simulated time is advanced, idle threads are removed from the THREAD_SLEEP_TIMES_NANOS immediately. When the LocalCluster waits for the topology to be idle, it checks whether all timer threads are in the THREAD_SLEEP_TIMES_NANOS map. It looks to me like there was no guarantee that sleeping threads actually got a chance to run when time was advanced, because they remained in the THREAD_SLEEP_TIMES_NANOS map until they happened to be scheduled. With bad luck, a thread might end up being counted as idle when it just hadn't exited the Time.sleepUntilNanos loop yet.