### PR TITLE
MINOR: Mkdir for storm.home when running LocalCluster

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -196,8 +196,11 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
             this.tmpDirs.add(nimbusTmp);
             stormHomeBackup = System.getProperty(ConfigUtils.STORM_HOME);
             TmpPath stormHome = new TmpPath();
+            if (!stormHome.getFile().mkdirs()) {
+                throw new IllegalStateException("Failed to create storm.home directory " + stormHome.getPath());
+            }
             this.tmpDirs.add(stormHome);
-            System.setProperty(ConfigUtils.STORM_HOME, stormHome.getPath());   
+            System.setProperty(ConfigUtils.STORM_HOME, stormHome.getPath());
             Map<String, Object> conf = ConfigUtils.readStormConfig();
             conf.put(Config.TOPOLOGY_SKIP_MISSING_KRYO_REGISTRATIONS, true);
             conf.put(Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS, false);


### PR DESCRIPTION
Turns out Rocksdb doesn't handle creating parent directories, so https://github.com/apache/storm/pull/2728 doesn't prevent it from throwing an exception when Nimbus is started.

That said, we're still getting an exception when Nimbus is started from https://github.com/apache/storm/blob/4137328b75c06771f84414c3c2113e2d1c757c08/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/StringMetadataCache.java#L64, so this doesn't by itself prevent the metrics store from failing to initialize in tests.