### PR TITLE
[STORM-3129]: Fixed startTime assignment to using Storm Time util.

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
@@ -1025,7 +1025,7 @@ public class Slot extends Thread implements AutoCloseable, BlobChangingCallback 
                 state = MachineState.RUNNING;
             }
 
-            this.startTime = System.currentTimeMillis();
+            this.startTime = Time.currentTimeMillis();
             this.newAssignment = newAssignment;
             this.pendingLocalization = null;
             this.pendingDownload = null;


### PR DESCRIPTION
Current implementation uses System.currentTimeMillis() instead of Time.currentTimeMillis() to get state start time. This may create problem in unit test as it uses simulated time controlled by Storm Time util.