### PR TITLE
[STORM-3130]: Add Wrappers for Timer registration and timed object

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/TimedWritableByteChannel.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/TimedWritableByteChannel.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.storm.daemon.nimbus;
+
+import com.codahale.metrics.Timer;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+
+import org.apache.storm.metric.timed.TimedResource;
+
+public class TimedWritableByteChannel extends TimedResource<WritableByteChannel> implements WritableByteChannel {
+    public TimedWritableByteChannel(WritableByteChannel measured, Timer timer) {
+        super(measured, timer);
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return getMeasured().write(src);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return getMeasured().isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            super.close();
+        } catch (Exception e) {
+            throw (IOException) e;
+        }
+    }
+}

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/TimedWritableByteChannel.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/TimedWritableByteChannel.java
@@ -22,6 +22,7 @@ import java.nio.channels.WritableByteChannel;
 import org.apache.storm.metric.timed.TimedResource;
 
 public class TimedWritableByteChannel extends TimedResource<WritableByteChannel> implements WritableByteChannel {
+
     public TimedWritableByteChannel(WritableByteChannel measured, Timer timer) {
         super(measured, timer);
     }

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/TimedWritableByteChannel.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/TimedWritableByteChannel.java
@@ -42,6 +42,9 @@ public class TimedWritableByteChannel extends TimedResource<WritableByteChannel>
         try {
             super.close();
         } catch (Exception e) {
+            //WritableByteChannel is a Channel which implements Closeable.
+            // Hence although declared AutoCloseable super#close here should only throws IOException
+            //We rethrow to conform the signature
             throw (IOException) e;
         }
     }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/TimerDecoratedAssignment.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/TimerDecoratedAssignment.java
@@ -15,29 +15,20 @@
 package org.apache.storm.daemon.supervisor;
 
 import com.codahale.metrics.Timer;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.storm.generated.ExecutorInfo;
 import org.apache.storm.generated.LocalAssignment;
 import org.apache.storm.metric.timed.TimerDecorated;
 
 public class TimerDecoratedAssignment extends LocalAssignment implements TimerDecorated {
-    //TODO: Does this have to volatile?
-    private final AtomicReference<Timer.Context> timingRef;
+    private final Timer.Context timing;
 
     public TimerDecoratedAssignment(LocalAssignment other, Timer timer) {
         super(other);
-        timingRef = new AtomicReference<>(timer.time());
-    }
-
-    @Override
-    public boolean hasStopped() {
-        return hasStopped(timingRef);
+        timing = timer.time();
     }
 
     @Override
     public long stopTiming() {
-        return stopTiming(timingRef);
+        return stopTiming(timing);
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/TimerDecoratedAssignment.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/TimerDecoratedAssignment.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.storm.daemon.supervisor;
+
+import com.codahale.metrics.Timer;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.storm.generated.ExecutorInfo;
+import org.apache.storm.generated.LocalAssignment;
+import org.apache.storm.metric.timed.TimerDecorated;
+
+public class TimerDecoratedAssignment extends LocalAssignment implements TimerDecorated {
+    //TODO: Does this have to volatile?
+    private final AtomicReference<Timer.Context> timingRef = new AtomicReference<>();
+
+    public TimerDecoratedAssignment(Timer.Context timing) {
+        this.timingRef.set(timing);
+    }
+
+    public TimerDecoratedAssignment(String topology_id, List<ExecutorInfo> executors, Timer.Context timing) {
+        super(topology_id, executors);
+        this.timingRef.set(timing);
+    }
+
+    public TimerDecoratedAssignment(LocalAssignment other, Timer.Context timing) {
+        super(other);
+        this.timingRef.set(timing);
+    }
+
+    @Override
+    public boolean hasStopped() {
+        return hasStopped(timingRef);
+    }
+
+    @Override
+    public long stopTiming() {
+        return stopTiming(timingRef);
+    }
+}

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/TimerDecoratedAssignment.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/TimerDecoratedAssignment.java
@@ -24,20 +24,11 @@ import org.apache.storm.metric.timed.TimerDecorated;
 
 public class TimerDecoratedAssignment extends LocalAssignment implements TimerDecorated {
     //TODO: Does this have to volatile?
-    private final AtomicReference<Timer.Context> timingRef = new AtomicReference<>();
+    private final AtomicReference<Timer.Context> timingRef;
 
-    public TimerDecoratedAssignment(Timer.Context timing) {
-        this.timingRef.set(timing);
-    }
-
-    public TimerDecoratedAssignment(String topology_id, List<ExecutorInfo> executors, Timer.Context timing) {
-        super(topology_id, executors);
-        this.timingRef.set(timing);
-    }
-
-    public TimerDecoratedAssignment(LocalAssignment other, Timer.Context timing) {
+    public TimerDecoratedAssignment(LocalAssignment other, Timer timer) {
         super(other);
-        this.timingRef.set(timing);
+        timingRef = new AtomicReference<>(timer.time());
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/metric/StormMetricsRegistry.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/StormMetricsRegistry.java
@@ -19,6 +19,8 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Reservoir;
+import com.codahale.metrics.Timer;
+
 import java.util.Map;
 
 import org.apache.storm.daemon.metrics.MetricsUtils;
@@ -46,6 +48,10 @@ public class StormMetricsRegistry extends MetricRegistry {
 
     public static Meter registerMeter(String name) {
         return REGISTRY.register(name, new Meter());
+    }
+
+    public static Timer registerTimer(String name) {
+        return REGISTRY.register(name, new Timer());
     }
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/Timed.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/Timed.java
@@ -21,11 +21,11 @@ import java.util.concurrent.atomic.AtomicReference;
 public class Timed<T> implements TimerDecorated {
     private final T measured;
     //TODO: Does this have to volatile?
-    private final AtomicReference<Timer.Context> timingRef = new AtomicReference<>();
+    private final AtomicReference<Timer.Context> timingRef;
 
     public Timed(T measured, Timer timer) {
         this.measured = measured;
-        this.timingRef.set(timer.time());
+        timingRef = new AtomicReference<>(timer.time());
     }
 
     public T getMeasured() {

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/Timed.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/Timed.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.storm.metric.timed;
+
+import com.codahale.metrics.Timer;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class Timed<T> implements TimerDecorated {
+    private final T measured;
+    //TODO: Does this have to volatile?
+    private final AtomicReference<Timer.Context> timingRef = new AtomicReference<>();
+
+    public Timed(T measured, Timer timer) {
+        this.measured = measured;
+        this.timingRef.set(timer.time());
+    }
+
+    public T getMeasured() {
+        return measured;
+    }
+
+    @Override
+    public boolean hasStopped() {
+        return hasStopped(timingRef);
+    }
+
+    @Override
+    public long stopTiming() {
+        return stopTiming(timingRef);
+    }
+}

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/Timed.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/Timed.java
@@ -16,16 +16,13 @@ package org.apache.storm.metric.timed;
 
 import com.codahale.metrics.Timer;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 public class Timed<T> implements TimerDecorated {
     private final T measured;
-    //TODO: Does this have to volatile?
-    private final AtomicReference<Timer.Context> timingRef;
+    private final Timer.Context timing;
 
     public Timed(T measured, Timer timer) {
         this.measured = measured;
-        timingRef = new AtomicReference<>(timer.time());
+        timing = timer.time();
     }
 
     public T getMeasured() {
@@ -33,12 +30,7 @@ public class Timed<T> implements TimerDecorated {
     }
 
     @Override
-    public boolean hasStopped() {
-        return hasStopped(timingRef);
-    }
-
-    @Override
     public long stopTiming() {
-        return stopTiming(timingRef);
+        return stopTiming(timing);
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/TimedResource.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/TimedResource.java
@@ -17,13 +17,17 @@ package org.apache.storm.metric.timed;
 import com.codahale.metrics.Timer;
 
 public class TimedResource<T extends AutoCloseable> extends Timed<T> {
+
     public TimedResource(T measured, Timer timer) {
         super(measured, timer);
     }
 
     @Override
     public void close() throws Exception {
-        super.close();
-        getMeasured().close();
+        try {
+            super.close();
+        } finally {
+            getMeasured().close();
+        }
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/TimedResource.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/TimedResource.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.storm.metric.timed;
+
+import com.codahale.metrics.Timer;
+
+public class TimedResource<T extends AutoCloseable> extends Timed<T> {
+    public TimedResource(T measured, Timer timer) {
+        super(measured, timer);
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        getMeasured().close();
+    }
+}

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/TimerDecorated.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/TimerDecorated.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.storm.metric.timed;
+
+import com.codahale.metrics.Timer;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public interface TimerDecorated extends AutoCloseable {
+    boolean hasStopped();
+
+    default boolean hasStopped(final AtomicReference<Timer.Context> timing) {
+        return timing.get() == null;
+    }
+
+    long stopTiming();
+
+    /**
+     * Stop the timer for measured object. Should be executed only once.
+     *
+     * @return Time a object is in use, or under measurement, in nanoseconds.
+     * @throws NullPointerException this method is called more than once.
+     */
+    default long stopTiming(final AtomicReference<Timer.Context> timingRef) throws NullPointerException {
+        Timer.Context timing = timingRef.getAndSet(null);
+        if (timing != null) {
+            return timing.stop();
+        }
+        throw new NullPointerException("Timer for this object has stopped and cleared");
+    }
+
+    @Override
+    default void close() throws Exception {
+        stopTiming();
+    }
+}

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/TimerDecorated.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/TimerDecorated.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Timer;
 import java.util.concurrent.atomic.AtomicReference;
 
 public interface TimerDecorated extends AutoCloseable {
+
     boolean hasStopped();
 
     default boolean hasStopped(final AtomicReference<Timer.Context> timing) {
@@ -31,14 +32,12 @@ public interface TimerDecorated extends AutoCloseable {
      * Stop the timer for measured object. Should be executed only once.
      *
      * @return Time a object is in use, or under measurement, in nanoseconds.
-     * @throws NullPointerException this method is called more than once.
+     * @throws NullPointerException if this method is called more than once.
      */
-    default long stopTiming(final AtomicReference<Timer.Context> timingRef) throws NullPointerException {
+    default long stopTiming(final AtomicReference<Timer.Context> timingRef) {
         Timer.Context timing = timingRef.getAndSet(null);
-        if (timing != null) {
-            return timing.stop();
-        }
-        throw new NullPointerException("Timer for this object has stopped and cleared");
+        assert timing != null;
+        return timing.stop();
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/metric/timed/TimerDecorated.java
+++ b/storm-server/src/main/java/org/apache/storm/metric/timed/TimerDecorated.java
@@ -16,27 +16,18 @@ package org.apache.storm.metric.timed;
 
 import com.codahale.metrics.Timer;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 public interface TimerDecorated extends AutoCloseable {
-
-    boolean hasStopped();
-
-    default boolean hasStopped(final AtomicReference<Timer.Context> timing) {
-        return timing.get() == null;
-    }
 
     long stopTiming();
 
     /**
-     * Stop the timer for measured object. Should be executed only once.
+     * Stop the timer for measured object. (Copied from {@link Timer.Context#stop()})
+     * Call to this method will not reset the start time.
+     * Multiple calls result in multiple updates.
      *
      * @return Time a object is in use, or under measurement, in nanoseconds.
-     * @throws NullPointerException if this method is called more than once.
      */
-    default long stopTiming(final AtomicReference<Timer.Context> timingRef) {
-        Timer.Context timing = timingRef.getAndSet(null);
-        assert timing != null;
+    default long stopTiming(final Timer.Context timing) {
         return timing.stop();
     }
 


### PR DESCRIPTION
The idea was originally conceived because a few Storm server metrics were requested on timing procedure's efficiency (e.g., how long does it take for a file/jar to be uploaded, how long does it takes to actually launch an assignment in the worker). Since many operations are processed asynchronously, there's no easy way to track the timing. However I noticed that in many cases, even the operation itself is convoluted, the object on which the operation applied is likely to be passed along all method invocation, which gives us a way to keep track the time of a procedure by observing the lifespan of the targeted object.

I've tried to attach the timer to existing object through decorator or through inheritance, and they seem both to be working in certain situations. But to me it's still not ideal to have different patterns that implements the same functionality. I'd like to come up with a generic approach this kind of problem so it'd be easier to track time this way. I'd appreciate if you can have any suggestions on how I should tackle this problem.