### PR TITLE
STORM-3136: Fix flaky integration test, clean up that code to be more…

### DIFF
--- a/integration-test/src/main/java/org/apache/storm/st/topology/TestableTopology.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/TestableTopology.java
@@ -19,11 +19,11 @@ package org.apache.storm.st.topology;
 
 import org.apache.storm.generated.StormTopology;
 
-import java.util.List;
-
 public interface TestableTopology {
     String DUMMY_FIELD = "dummy";
-    List<String> getExpectedOutput();
+    //Some tests rely on reading the worker log. If emits are too close together and too much is logged, the log might roll, breaking the test.
+    int MIN_SLEEP_BETWEEN_EMITS_MS = 10;
+    int MAX_SLEEP_BETWEEN_EMITS_MS = 100;
     StormTopology newTopology();
     String getBoltName();
     String getSpoutName();

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/IncrementingSpout.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/IncrementingSpout.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.st.topology.window;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.st.topology.TestableTopology;
+import org.apache.storm.st.utils.StringDecorator;
+import org.apache.storm.st.utils.TimeUtil;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichSpout;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IncrementingSpout extends BaseRichSpout {
+
+    public static final String NUMBER_FIELD = "number";
+    
+    private static final Logger LOG = LoggerFactory.getLogger(IncrementingSpout.class);
+    private SpoutOutputCollector collector;
+    private int currentNum;
+    private String componentId;
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        declarer.declare(new Fields(NUMBER_FIELD));
+    }
+
+    @Override
+    public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
+        componentId = context.getThisComponentId();
+        this.collector = collector;
+    }
+
+    @Override
+    public void nextTuple() {
+        //Emitting too quickly can lead to spurious test failures because the worker log may roll right before we read it
+        //Sleep a bit between emits
+        TimeUtil.sleepMilliSec(ThreadLocalRandom.current()
+            .nextInt(TestableTopology.MIN_SLEEP_BETWEEN_EMITS_MS, TestableTopology.MAX_SLEEP_BETWEEN_EMITS_MS));
+        currentNum++;
+        final Values tuple = new Values(currentNum);
+        LOG.info(StringDecorator.decorate(componentId, tuple.toString()));
+        collector.emit(tuple, currentNum);
+    }
+
+    @Override
+    public void ack(Object msgId) {
+        LOG.info("Received ACK for msgId : " + msgId);
+    }
+
+    @Override
+    public void fail(Object msgId) {
+        LOG.info("Received FAIL for msgId : " + msgId);
+    }
+}

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/SlidingTimeCorrectness.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/SlidingTimeCorrectness.java
@@ -17,33 +17,17 @@
 
 package org.apache.storm.st.topology.window;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import org.apache.storm.generated.StormTopology;
-import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.st.topology.TestableTopology;
 import org.apache.storm.st.topology.window.data.TimeData;
 import org.apache.storm.st.utils.StringDecorator;
-import org.apache.storm.st.utils.TimeUtil;
-import org.apache.storm.task.OutputCollector;
-import org.apache.storm.task.TopologyContext;
-import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.TopologyBuilder;
-import org.apache.storm.topology.base.BaseRichSpout;
 import org.apache.storm.topology.base.BaseWindowedBolt;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Tuple;
-import org.apache.storm.tuple.Values;
-import org.apache.storm.windowing.TupleWindow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -64,19 +48,22 @@ public class SlidingTimeCorrectness implements TestableTopology {
         boltName = prefix + "VerificationBolt";
     }
 
+    @Override
     public String getBoltName() {
         return boltName;
     }
 
+    @Override
     public String getSpoutName() {
         return spoutName;
     }
 
+    @Override
     public StormTopology newTopology() {
         TopologyBuilder builder = new TopologyBuilder();
-        builder.setSpout(getSpoutName(), new IncrementingSpout(), 2);
+        builder.setSpout(getSpoutName(), new TimeDataIncrementingSpout(), 2);
         builder.setBolt(getBoltName(),
-                new VerificationBolt()
+                new TimeDataVerificationBolt()
                         .withWindow(new BaseWindowedBolt.Duration(windowSec, TimeUnit.SECONDS),
                                 new BaseWindowedBolt.Duration(slideSec, TimeUnit.SECONDS))
                         .withTimestampField(TimeData.getTimestampFieldName())
@@ -84,89 +71,5 @@ public class SlidingTimeCorrectness implements TestableTopology {
                 1)
                 .globalGrouping(getSpoutName());
         return builder.createTopology();
-    }
-
-    public List<String> getExpectedOutput() {
-        return Lists.newArrayList(
-                StringDecorator.decorate(getBoltName(), "tuplesInWindow.size() = " + windowSec),
-                StringDecorator.decorate(getBoltName(), "newTuples.size() = " + slideSec),
-                StringDecorator.decorate(getBoltName(), "expiredTuples.size() = " + slideSec)
-        );
-    }
-
-    public static class IncrementingSpout extends BaseRichSpout {
-        private static final Logger LOG = LoggerFactory.getLogger(IncrementingSpout.class);
-        private SpoutOutputCollector collector;
-        private static int currentNum;
-        private static Random rng = new Random();
-        private String componentId;
-
-        @Override
-        public void declareOutputFields(OutputFieldsDeclarer declarer) {
-            declarer.declare(TimeData.getFields());
-        }
-
-        @Override
-        public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
-            componentId = context.getThisComponentId();
-            this.collector = collector;
-        }
-
-        @Override
-        public void nextTuple() {
-            //Emitting too quickly can lead to spurious test failures because the worker log may roll right before we read it
-            //Sleep a bit between emits
-            TimeUtil.sleepMilliSec(rng.nextInt(100));
-            currentNum++;
-            TimeData data = TimeData.newData(currentNum);
-            final Values tuple = data.getValues();
-            collector.emit(tuple);
-            LOG.info(StringDecorator.decorate(componentId, data.toString()));
-        }
-
-        @Override
-        public void ack(Object msgId) {
-            LOG.info("Received ACK for msgId : " + msgId);
-        }
-
-        @Override
-        public void fail(Object msgId) {
-            LOG.info("Received FAIL for msgId : " + msgId);
-        }
-    }
-
-    public static class VerificationBolt extends BaseWindowedBolt {
-        private OutputCollector collector;
-        private String componentId;
-
-        @Override
-        public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
-            componentId = context.getThisComponentId();
-            this.collector = collector;
-        }
-
-        @Override
-        public void execute(TupleWindow inputWindow) {
-            List<Tuple> tuplesInWindow = inputWindow.get();
-            List<Tuple> newTuples = inputWindow.getNew();
-            List<Tuple> expiredTuples = inputWindow.getExpired();
-            LOG.info("tuplesInWindow.size() = " + tuplesInWindow.size());
-            LOG.info("newTuples.size() = " + newTuples.size());
-            LOG.info("expiredTuples.size() = " + expiredTuples.size());
-            Collection<TimeData> dataInWindow = Collections2.transform(tuplesInWindow, new Function<Tuple, TimeData>() {
-                @Nullable
-                @Override
-                public TimeData apply(@Nullable Tuple input) {
-                    return TimeData.fromTuple(input);
-                }
-            });
-            final String jsonData = TimeData.toString(dataInWindow);
-            LOG.info(StringDecorator.decorate(componentId, jsonData));
-            collector.emit(new Values("dummyValue"));
-        }
-
-        public void declareOutputFields(OutputFieldsDeclarer declarer) {
-            declarer.declare(new Fields(DUMMY_FIELD));
-        }
     }
 }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/SlidingWindowCorrectness.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/SlidingWindowCorrectness.java
@@ -19,26 +19,14 @@ package org.apache.storm.st.topology.window;
 
 import com.google.common.collect.Lists;
 import org.apache.storm.generated.StormTopology;
-import org.apache.storm.spout.SpoutOutputCollector;
-import org.apache.storm.task.OutputCollector;
-import org.apache.storm.task.TopologyContext;
-import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.TopologyBuilder;
-import org.apache.storm.topology.base.BaseRichSpout;
 import org.apache.storm.topology.base.BaseWindowedBolt;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Tuple;
-import org.apache.storm.tuple.Values;
-import org.apache.storm.windowing.TupleWindow;
 import org.apache.storm.st.topology.TestableTopology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.storm.st.utils.StringDecorator;
-import org.apache.storm.st.utils.TimeUtil;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Random;
 
 /**
  * Computes sliding window sum
@@ -60,14 +48,17 @@ public class SlidingWindowCorrectness implements TestableTopology {
         boltName = prefix + "VerificationBolt";
     }
 
+    @Override
     public String getBoltName() {
         return boltName;
     }
 
+    @Override
     public String getSpoutName() {
         return spoutName;
     }
 
+    @Override
     public StormTopology newTopology() {
         TopologyBuilder builder = new TopologyBuilder();
         builder.setSpout(getSpoutName(), new IncrementingSpout(), 1);
@@ -77,79 +68,5 @@ public class SlidingWindowCorrectness implements TestableTopology {
                 1)
                 .shuffleGrouping(getSpoutName());
         return builder.createTopology();
-    }
-
-    public List<String> getExpectedOutput() {
-        return Lists.newArrayList(
-                StringDecorator.decorate(getBoltName(), "tuplesInWindow.size() = " + windowSize),
-                StringDecorator.decorate(getBoltName(), "newTuples.size() = " + slideSize),
-                StringDecorator.decorate(getBoltName(), "expiredTuples.size() = " + slideSize)
-        );
-    }
-
-    public static class IncrementingSpout extends BaseRichSpout {
-        private static final Logger LOG = LoggerFactory.getLogger(IncrementingSpout.class);
-        private SpoutOutputCollector collector;
-        private static int currentNum;
-        private static Random rng = new Random();
-        private String componentId;
-
-        @Override
-        public void declareOutputFields(OutputFieldsDeclarer declarer) {
-            declarer.declare(new Fields(NUMBER_FIELD, STRING_FIELD));
-        }
-
-        @Override
-        public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
-            componentId = context.getThisComponentId();
-            this.collector = collector;
-        }
-
-        @Override
-        public void nextTuple() {
-            TimeUtil.sleepMilliSec(rng.nextInt(10));
-            currentNum++;
-            final String numAsStr = "str(" + currentNum + ")str";
-            final Values tuple = new Values(currentNum, numAsStr);
-            LOG.info(StringDecorator.decorate(componentId, tuple.toString()));
-            collector.emit(tuple, currentNum);
-        }
-
-        @Override
-        public void ack(Object msgId) {
-            LOG.info("Received ACK for msgId : " + msgId);
-        }
-
-        @Override
-        public void fail(Object msgId) {
-            LOG.info("Received FAIL for msgId : " + msgId);
-        }
-    }
-
-    public static class VerificationBolt extends BaseWindowedBolt {
-        private OutputCollector collector;
-        private String componentId;
-
-        @Override
-        public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
-            componentId = context.getThisComponentId();
-            this.collector = collector;
-        }
-
-        @Override
-        public void execute(TupleWindow inputWindow) {
-            List<Tuple> tuplesInWindow = inputWindow.get();
-            List<Tuple> newTuples = inputWindow.getNew();
-            List<Tuple> expiredTuples = inputWindow.getExpired();
-            LOG.info("tuplesInWindow.size() = " + tuplesInWindow.size());
-            LOG.info("newTuples.size() = " + newTuples.size());
-            LOG.info("expiredTuples.size() = " + expiredTuples.size());
-            LOG.info(StringDecorator.decorate(componentId, "tuplesInWindow = " + tuplesInWindow.toString()));
-            collector.emit(new Values("dummyValue"));
-        }
-
-        public void declareOutputFields(OutputFieldsDeclarer declarer) {
-            declarer.declare(new Fields(DUMMY_FIELD));
-        }
     }
 }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/TimeDataIncrementingSpout.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/TimeDataIncrementingSpout.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.st.topology.window;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.st.topology.TestableTopology;
+import org.apache.storm.st.topology.window.data.TimeData;
+import org.apache.storm.st.utils.StringDecorator;
+import org.apache.storm.st.utils.TimeUtil;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichSpout;
+import org.apache.storm.tuple.Values;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TimeDataIncrementingSpout extends BaseRichSpout {
+        private static final Logger LOG = LoggerFactory.getLogger(TimeDataIncrementingSpout.class);
+        private SpoutOutputCollector collector;
+        private int currentNum;
+        private String componentId;
+
+        @Override
+        public void declareOutputFields(OutputFieldsDeclarer declarer) {
+            declarer.declare(TimeData.getFields());
+        }
+
+        @Override
+        public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
+            componentId = context.getThisComponentId();
+            this.collector = collector;
+        }
+
+        @Override
+        public void nextTuple() {
+            //Emitting too quickly can lead to spurious test failures because the worker log may roll right before we read it
+            //Sleep a bit between emits
+            TimeUtil.sleepMilliSec(ThreadLocalRandom.current()
+            .nextInt(TestableTopology.MIN_SLEEP_BETWEEN_EMITS_MS, TestableTopology.MAX_SLEEP_BETWEEN_EMITS_MS));
+            currentNum++;
+            TimeData data = TimeData.newData(currentNum);
+            final Values tuple = data.getValues();
+            collector.emit(tuple);
+            LOG.info(StringDecorator.decorate(componentId, data.toString()));
+        }
+    }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/TimeDataVerificationBolt.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/TimeDataVerificationBolt.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.st.topology.window;
+
+import static org.apache.storm.st.topology.TestableTopology.DUMMY_FIELD;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.storm.st.topology.window.data.TimeData;
+import org.apache.storm.st.utils.StringDecorator;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseWindowedBolt;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.windowing.TupleWindow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TimeDataVerificationBolt extends BaseWindowedBolt {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TimeDataVerificationBolt.class);
+    private OutputCollector collector;
+    private String componentId;
+
+    @Override
+    public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
+        componentId = context.getThisComponentId();
+        this.collector = collector;
+    }
+
+    @Override
+    public void execute(TupleWindow inputWindow) {
+        List<Tuple> tuplesInWindow = inputWindow.get();
+        List<Tuple> newTuples = inputWindow.getNew();
+        List<Tuple> expiredTuples = inputWindow.getExpired();
+        LOG.info("tuplesInWindow.size() = " + tuplesInWindow.size());
+        LOG.info("newTuples.size() = " + newTuples.size());
+        LOG.info("expiredTuples.size() = " + expiredTuples.size());
+        List<TimeData> dataInWindow = tuplesInWindow.stream()
+            .map(TimeData::fromTuple)
+            .collect(Collectors.toList());
+        final String jsonData = TimeData.toString(dataInWindow);
+        LOG.info(StringDecorator.decorate(componentId, jsonData));
+        collector.emit(new Values("dummyValue"));
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        declarer.declare(new Fields(DUMMY_FIELD));
+    }
+}

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/TumblingTimeCorrectness.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/TumblingTimeCorrectness.java
@@ -17,33 +17,17 @@
 
 package org.apache.storm.st.topology.window;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import org.apache.storm.generated.StormTopology;
-import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.st.topology.TestableTopology;
 import org.apache.storm.st.topology.window.data.TimeData;
-import org.apache.storm.st.utils.TimeUtil;
-import org.apache.storm.task.OutputCollector;
-import org.apache.storm.task.TopologyContext;
-import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.TopologyBuilder;
-import org.apache.storm.topology.base.BaseRichSpout;
 import org.apache.storm.topology.base.BaseWindowedBolt;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Tuple;
-import org.apache.storm.tuple.Values;
-import org.apache.storm.windowing.TupleWindow;
 import org.apache.storm.st.utils.StringDecorator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -62,108 +46,27 @@ public class TumblingTimeCorrectness implements TestableTopology {
         boltName = prefix + "VerificationBolt";
     }
 
+    @Override
     public String getBoltName() {
         return boltName;
     }
 
+    @Override
     public String getSpoutName() {
         return spoutName;
     }
 
+    @Override
     public StormTopology newTopology() {
         TopologyBuilder builder = new TopologyBuilder();
-        builder.setSpout(getSpoutName(), new IncrementingSpout(), 2);
+        builder.setSpout(getSpoutName(), new TimeDataIncrementingSpout(), 2);
         builder.setBolt(getBoltName(),
-                new VerificationBolt()
+                new TimeDataVerificationBolt()
                         .withTumblingWindow(new BaseWindowedBolt.Duration(tumbleSec, TimeUnit.SECONDS))
                         .withLag(new BaseWindowedBolt.Duration(10, TimeUnit.SECONDS))
                         .withTimestampField(TimeData.getTimestampFieldName()),
                 1)
                 .globalGrouping(getSpoutName());
         return builder.createTopology();
-    }
-
-    public List<String> getExpectedOutput() {
-        return Lists.newArrayList(
-                StringDecorator.decorate(getBoltName(), "tuplesInWindow.size() = " + tumbleSec),
-                StringDecorator.decorate(getBoltName(), "newTuples.size() = " + tumbleSec),
-                StringDecorator.decorate(getBoltName(), "expiredTuples.size() = " + tumbleSec)
-        );
-    }
-
-    public static class IncrementingSpout extends BaseRichSpout {
-        private static final Logger LOG = LoggerFactory.getLogger(IncrementingSpout.class);
-        private SpoutOutputCollector collector;
-        private static int currentNum;
-        private static Random rng = new Random();
-        private String componentId;
-
-        @Override
-        public void declareOutputFields(OutputFieldsDeclarer declarer) {
-            declarer.declare(TimeData.getFields());
-        }
-
-        @Override
-        public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
-            componentId = context.getThisComponentId();
-            this.collector = collector;
-        }
-
-        @Override
-        public void nextTuple() {
-            //Emitting too quickly can lead to spurious test failures because the worker log may roll right before we read it
-            //Sleep a bit between emits
-            TimeUtil.sleepMilliSec(rng.nextInt(100));
-            currentNum++;
-            TimeData data = TimeData.newData(currentNum);
-            final Values tuple = data.getValues();
-            collector.emit(tuple);
-            LOG.info(StringDecorator.decorate(componentId, data.toString()));
-        }
-
-        @Override
-        public void ack(Object msgId) {
-            LOG.info("Received ACK for msgId : " + msgId);
-        }
-
-        @Override
-        public void fail(Object msgId) {
-            LOG.info("Received FAIL for msgId : " + msgId);
-        }
-    }
-
-    public static class VerificationBolt extends BaseWindowedBolt {
-        private OutputCollector collector;
-        private String componentId;
-
-        @Override
-        public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
-            componentId = context.getThisComponentId();
-            this.collector = collector;
-        }
-
-        @Override
-        public void execute(TupleWindow inputWindow) {
-            List<Tuple> tuplesInWindow = inputWindow.get();
-            List<Tuple> newTuples = inputWindow.getNew();
-            List<Tuple> expiredTuples = inputWindow.getExpired();
-            LOG.info("tuplesInWindow.size() = " + tuplesInWindow.size());
-            LOG.info("newTuples.size() = " + newTuples.size());
-            LOG.info("expiredTuples.size() = " + expiredTuples.size());
-            Collection<TimeData> dataInWindow = Collections2.transform(tuplesInWindow, new Function<Tuple, TimeData>() {
-                @Nullable
-                @Override
-                public TimeData apply(@Nullable Tuple input) {
-                    return TimeData.fromTuple(input);
-                }
-            });
-            final String jsonData = TimeData.toString(dataInWindow);
-            LOG.info(StringDecorator.decorate(componentId, jsonData));
-            collector.emit(new Values("dummyValue"));
-        }
-
-        public void declareOutputFields(OutputFieldsDeclarer declarer) {
-            declarer.declare(new Fields(DUMMY_FIELD));
-        }
     }
 }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/TumblingWindowCorrectness.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/TumblingWindowCorrectness.java
@@ -19,26 +19,14 @@ package org.apache.storm.st.topology.window;
 
 import com.google.common.collect.Lists;
 import org.apache.storm.generated.StormTopology;
-import org.apache.storm.spout.SpoutOutputCollector;
-import org.apache.storm.task.OutputCollector;
-import org.apache.storm.task.TopologyContext;
-import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.TopologyBuilder;
-import org.apache.storm.topology.base.BaseRichSpout;
 import org.apache.storm.topology.base.BaseWindowedBolt;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Tuple;
-import org.apache.storm.tuple.Values;
-import org.apache.storm.windowing.TupleWindow;
 import org.apache.storm.st.topology.TestableTopology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.storm.st.utils.StringDecorator;
-import org.apache.storm.st.utils.TimeUtil;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Random;
 
 /**
  * Computes sliding window sum
@@ -58,14 +46,17 @@ public class TumblingWindowCorrectness implements TestableTopology {
         boltName = prefix + "VerificationBolt";
     }
 
+    @Override
     public String getBoltName() {
         return boltName;
     }
 
+    @Override
     public String getSpoutName() {
         return spoutName;
     }
 
+    @Override
     public StormTopology newTopology() {
         TopologyBuilder builder = new TopologyBuilder();
         builder.setSpout(getSpoutName(), new IncrementingSpout(), 1);
@@ -74,79 +65,5 @@ public class TumblingWindowCorrectness implements TestableTopology {
                         .withTumblingWindow(new BaseWindowedBolt.Count(tumbleSize)), 1)
                 .shuffleGrouping(getSpoutName());
         return builder.createTopology();
-    }
-
-    public List<String> getExpectedOutput() {
-        return Lists.newArrayList(
-                StringDecorator.decorate(getBoltName(), "tuplesInWindow.size() = " + tumbleSize),
-                StringDecorator.decorate(getBoltName(), "newTuples.size() = " + tumbleSize),
-                StringDecorator.decorate(getBoltName(), "expiredTuples.size() = " + tumbleSize)
-        );
-    }
-
-    public static class IncrementingSpout extends BaseRichSpout {
-        private static final Logger LOG = LoggerFactory.getLogger(IncrementingSpout.class);
-        private SpoutOutputCollector collector;
-        private static int currentNum;
-        private static Random rng = new Random();
-        private String componentId;
-
-        @Override
-        public void declareOutputFields(OutputFieldsDeclarer declarer) {
-            declarer.declare(new Fields(NUMBER_FIELD, STRING_FIELD));
-        }
-
-        @Override
-        public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
-            componentId = context.getThisComponentId();
-            this.collector = collector;
-        }
-
-        @Override
-        public void nextTuple() {
-            TimeUtil.sleepMilliSec(rng.nextInt(10));
-            currentNum++;
-            final String numAsStr = "str(" + currentNum + ")str";
-            final Values tuple = new Values(currentNum, numAsStr);
-            LOG.info(StringDecorator.decorate(componentId, tuple.toString()));
-            collector.emit(tuple, currentNum);
-        }
-
-        @Override
-        public void ack(Object msgId) {
-            LOG.info("Received ACK for msgId : " + msgId);
-        }
-
-        @Override
-        public void fail(Object msgId) {
-            LOG.info("Received FAIL for msgId : " + msgId);
-        }
-    }
-
-    public static class VerificationBolt extends BaseWindowedBolt {
-        private OutputCollector collector;
-        private String componentId;
-
-        @Override
-        public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
-            componentId = context.getThisComponentId();
-            this.collector = collector;
-        }
-
-        @Override
-        public void execute(TupleWindow inputWindow) {
-            List<Tuple> tuplesInWindow = inputWindow.get();
-            List<Tuple> newTuples = inputWindow.getNew();
-            List<Tuple> expiredTuples = inputWindow.getExpired();
-            LOG.info("tuplesInWindow.size() = " + tuplesInWindow.size());
-            LOG.info("newTuples.size() = " + newTuples.size());
-            LOG.info("expiredTuples.size() = " + expiredTuples.size());
-            LOG.info(StringDecorator.decorate(componentId, "tuplesInWindow = " + tuplesInWindow.toString()));
-            collector.emit(new Values("dummyValue"));
-        }
-
-        public void declareOutputFields(OutputFieldsDeclarer declarer) {
-            declarer.declare(new Fields(DUMMY_FIELD));
-        }
     }
 }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/VerificationBolt.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/VerificationBolt.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.st.topology.window;
+
+import static org.apache.storm.st.topology.TestableTopology.DUMMY_FIELD;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.storm.st.utils.StringDecorator;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseWindowedBolt;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.windowing.TupleWindow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VerificationBolt extends BaseWindowedBolt {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VerificationBolt.class);
+    private OutputCollector collector;
+    private String componentId;
+
+    @Override
+    public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
+        componentId = context.getThisComponentId();
+        this.collector = collector;
+    }
+
+    @Override
+    public void execute(TupleWindow inputWindow) {
+        List<Tuple> tuplesInWindow = inputWindow.get();
+        List<Tuple> newTuples = inputWindow.getNew();
+        List<Tuple> expiredTuples = inputWindow.getExpired();
+        LOG.info("tuplesInWindow.size() = " + tuplesInWindow.size());
+        LOG.info("newTuples.size() = " + newTuples.size());
+        LOG.info("expiredTuples.size() = " + expiredTuples.size());
+        LOG.info(StringDecorator.decorate(componentId, "tuplesInWindow = " + tuplesInWindow.toString()));
+        collector.emit(new Values("dummyValue"));
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        declarer.declare(new Fields(DUMMY_FIELD));
+    }
+}

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/data/TimeData.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/data/TimeData.java
@@ -26,12 +26,12 @@ import org.apache.storm.tuple.Values;
 import java.util.Collection;
 import java.util.Date;
 
-public class TimeData implements Comparable<TimeData>, FromJson<TimeData> {
+public class TimeData implements Comparable<TimeData> {
     public static final TimeData CLS = new TimeData(-1);
     private static final String NUMBER_FIELD_NAME = "number";
     private static final String STRING_FIELD_NAME = "dateAsStr";
     private static final String TIMESTAMP_FIELD_NAME = "date";
-    static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").create();
+    static final Gson GSON = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").create();
     private final int num;
     private final Date now;
     private final long timestamp;
@@ -54,16 +54,17 @@ public class TimeData implements Comparable<TimeData>, FromJson<TimeData> {
         return new TimeData(tuple.getIntegerByField(NUMBER_FIELD_NAME), new Date(tuple.getLongByField(TIMESTAMP_FIELD_NAME)));
     }
 
-    public TimeData fromJson(String jsonStr) {
-        return gson.fromJson(jsonStr, TimeData.class);
+    public static TimeData fromJson(String jsonStr) {
+        return GSON.fromJson(jsonStr, TimeData.class);
     }
 
+    @Override
     public String toString() {
-        return gson.toJson(this);
+        return GSON.toJson(this);
     }
 
     public static String toString(Collection<TimeData> elements) {
-        return gson.toJson(elements);
+        return GSON.toJson(elements);
     }
 
     public Values getValues() {

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/data/TimeDataWindow.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/data/TimeDataWindow.java
@@ -17,75 +17,47 @@
 
 package org.apache.storm.st.topology.window.data;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
 import com.google.gson.reflect.TypeToken;
-import org.joda.time.DateTime;
-
-import javax.annotation.Nullable;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
 
-public class TimeDataWindow extends ArrayList<TimeData> implements FromJson<TimeDataWindow> {
-    public static final TimeDataWindow CLS = new TimeDataWindow();
-    private static final Type listType = new TypeToken<List<TimeData>>() {}.getType();
+public class TimeDataWindow {
+    private static final Type LIST_TYPE = new TypeToken<List<TimeData>>() {}.getType(); 
+    
+    private final List<TimeData> data;
 
-    private TimeDataWindow() {
-    }
-
-    private TimeDataWindow(List<TimeData> data) {
-        super(data);
-    }
-
-    public static TimeDataWindow newInstance(Collection<TimeData> data) {
-        final List<TimeData> dataCopy = new ArrayList<>(data);
-        Collections.sort(dataCopy);
-        return new TimeDataWindow(dataCopy);
-    }
-
-    public static TimeDataWindow newInstance(Collection<TimeData> data, Predicate<TimeData> predicate) {
-        return newInstance(Collections2.filter(data, predicate));
-    }
-
-    public static TimeDataWindow newInstance(Collection<TimeData> data, final DateTime fromDate, final DateTime toDate) {
-        return TimeDataWindow.newInstance(data, new Predicate<TimeData>() {
-            @Override
-            public boolean apply(@Nullable TimeData input) {
-                if (input == null) {
-                    return false;
-                }
-                final DateTime inputDate = new DateTime(input.getDate());
-                return inputDate.isAfter(fromDate) && inputDate.isBefore(toDate.plusMillis(1));
-            }
-        });
-    }
-
-    public TimeData first() {
-        return get(0);
-    }
-
-    public TimeData last() {
-        return get(size()-1);
+    public TimeDataWindow(List<TimeData> data) {
+        this.data = data.stream()
+            .sorted()
+            .collect(Collectors.toList());
     }
 
     public String getDescription() {
-        final int size = size();
+        final int size = data.size();
         if (size > 0) {
-            final TimeData first = first();
-            final TimeData last = last();
+            final TimeData first = data.get(0);
+            final TimeData last = data.get(data.size() - 1);
             return "Total " + size + " items: " + first + " to " + last;
         }
         return "Total " + size + " items.";
     }
-
-    public TimeDataWindow fromJson(String jsonStr) {
-        final List<TimeData> dataList = TimeData.gson.fromJson(jsonStr, listType);
-        Collections.sort(dataList);
-        return TimeDataWindow.newInstance(dataList);
+    
+    public List<TimeData> getTimeData() {
+        return data;
     }
 
+    public static TimeDataWindow fromJson(String jsonStr) {
+        final List<TimeData> dataList = TimeData.GSON.fromJson(jsonStr, LIST_TYPE);
+        return new TimeDataWindow(dataList);
+    }
 
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+            .append(data)
+            .toString();
+    }
 }

--- a/integration-test/src/main/java/org/apache/storm/st/utils/StringDecorator.java
+++ b/integration-test/src/main/java/org/apache/storm/st/utils/StringDecorator.java
@@ -19,6 +19,11 @@ package org.apache.storm.st.utils;
 
 import org.apache.commons.lang.StringUtils;
 
+/**
+ * This class provides a method to pass data from the test bolts and spouts to the test method, via the worker log.
+ * Test components can use {@link #decorate(java.lang.String, java.lang.String) } to create a string containing a unique prefix. 
+ * Such prefixed log lines can be retrieved from the worker logs, and recognized via {@link #isDecorated(java.lang.String) }.
+ */
 public class StringDecorator {
 
     private static final String UNIQUE_PREFIX = "---bed91874d79720f7e324c43d49dba4ff---";

--- a/integration-test/src/test/java/org/apache/storm/st/tests/window/TumblingWindowTest.java
+++ b/integration-test/src/test/java/org/apache/storm/st/tests/window/TumblingWindowTest.java
@@ -29,7 +29,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public final class TumblingWindowTest extends AbstractTest {
-    private static Logger log = LoggerFactory.getLogger(TumblingWindowTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TumblingWindowTest.class);
+    private final WindowVerifier windowVerifier = new WindowVerifier();
     private TopoWrap topo;
 
     @DataProvider
@@ -58,7 +59,7 @@ public final class TumblingWindowTest extends AbstractTest {
             }
         }
         topo = new TopoWrap(cluster, topologyName, testable.newTopology());
-        SlidingWindowTest.runAndVerifyCount(tumbleSize, tumbleSize, testable, topo);
+        windowVerifier.runAndVerifyCount(tumbleSize, tumbleSize, testable, topo);
     }
 
     @DataProvider
@@ -87,7 +88,7 @@ public final class TumblingWindowTest extends AbstractTest {
             }
         }
         topo = new TopoWrap(cluster, topologyName, testable.newTopology());
-        SlidingWindowTest.runAndVerifyTime(tumbleSec, tumbleSec, testable, topo);
+        windowVerifier.runAndVerifyTime(tumbleSec, tumbleSec, testable, topo);
     }
 
     @AfterMethod

--- a/integration-test/src/test/java/org/apache/storm/st/tests/window/WindowVerifier.java
+++ b/integration-test/src/test/java/org/apache/storm/st/tests/window/WindowVerifier.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.st.tests.window;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.storm.st.topology.TestableTopology;
+import org.apache.storm.st.topology.window.data.TimeData;
+import org.apache.storm.st.topology.window.data.TimeDataWindow;
+import org.apache.storm.st.utils.StringDecorator;
+import org.apache.storm.st.utils.TimeUtil;
+import org.apache.storm.st.wrapper.DecoratedLogLine;
+import org.apache.storm.st.wrapper.TopoWrap;
+import org.apache.storm.thrift.TException;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+
+public class WindowVerifier {
+
+    public static final Logger LOG = LoggerFactory.getLogger(WindowVerifier.class);
+    
+    /**
+     * Run the topology and verify that the number and contents of count based windows is as expected
+     * once the spout and bolt have emitted sufficient tuples.
+     * The spout and bolt are required to log exactly one log line per emit/window using {@link StringDecorator}
+     */
+    public void runAndVerifyCount(int windowSize, int slideSize, TestableTopology testable, TopoWrap topo) throws IOException, TException, MalformedURLException {
+        topo.submitSuccessfully();
+        final int minBoltEmits = 5;
+        //Sliding windows should produce one window every slideSize tuples
+        //Wait for the spout to emit at least enough tuples to get minBoltEmit windows and at least one full window
+        final int minSpoutEmits = Math.max(windowSize, minBoltEmits * slideSize);
+        
+        String boltName = testable.getBoltName();
+        String spoutName = testable.getSpoutName();
+        //Waiting for spout tuples isn't strictly necessary since we also wait for bolt emits, but do it anyway
+        topo.assertProgress(minSpoutEmits, spoutName, 180);
+        topo.assertProgress(minBoltEmits, boltName, 180);
+        
+        final List<DecoratedLogLine> allDecoratedBoltLogs = topo.getDecoratedLogLines(boltName);
+        final List<DecoratedLogLine> allDecoratedSpoutLogs = topo.getDecoratedLogLines(spoutName);
+        //We expect the bolt to log exactly one decorated line per emit
+        Assert.assertTrue(allDecoratedBoltLogs.size() >= minBoltEmits,
+                "Expecting min " + minBoltEmits + " bolt emits, found: " + allDecoratedBoltLogs.size() + " \n\t" + allDecoratedBoltLogs);
+        
+        final int numberOfWindows = allDecoratedBoltLogs.size();
+        for(int i = 0; i < numberOfWindows; ++i ) {
+            LOG.info("Comparing window: " + (i + 1) + " of " + numberOfWindows);
+            final int toIndex = (i + 1) * slideSize;
+            final int fromIndex = toIndex - windowSize;
+            final int positiveFromIndex = fromIndex > 0 ? fromIndex : 0;
+            final List<DecoratedLogLine> expectedWindowContents = allDecoratedSpoutLogs.subList(positiveFromIndex, toIndex);
+            final String actualString = allDecoratedBoltLogs.get(i).toString();
+            for (DecoratedLogLine windowData : expectedWindowContents) {
+                final String logStr = windowData.getData();
+                Assert.assertTrue(actualString.contains(logStr),
+                        String.format("Missing: '%s' \nActual: '%s' \nCalculated window: '%s'", logStr, actualString, expectedWindowContents));
+            }
+        }
+    }
+    
+    /**
+     * Run the topology and verify that the number and contents of time based windows is as expected
+     * once the spout and bolt have emitted sufficient tuples.
+     * The spout and bolt are required to log exactly one log line per emit/window using {@link StringDecorator}
+     */
+    public void runAndVerifyTime(int windowSec, int slideSec, TestableTopology testable, TopoWrap topo) throws IOException, TException, java.net.MalformedURLException {
+        topo.submitSuccessfully();
+        final int minSpoutEmits = 100;
+        final int minBoltEmits = 5;
+        
+        String boltName = testable.getBoltName();
+        String spoutName = testable.getSpoutName();
+        
+        //Waiting for spout tuples isn't strictly necessary since we also wait for bolt emits, but do it anyway
+        topo.assertProgress(minSpoutEmits, spoutName, 60 + 10 * (windowSec + slideSec));
+        topo.assertProgress(minBoltEmits, boltName, 60 + 10 * (windowSec + slideSec));
+        
+        final List<TimeData> allSpoutLogLines = topo.getDeserializedDecoratedLogLines(spoutName, TimeData::fromJson);
+        final List<TimeDataWindow> allBoltLogLines = topo.getDeserializedDecoratedLogLines(boltName, TimeDataWindow::fromJson);
+        Assert.assertTrue(allBoltLogLines.size() >= minBoltEmits,
+                "Expecting min " + minBoltEmits + " bolt emits, found: " + allBoltLogLines.size() + " \n\t" + allBoltLogLines);
+        
+        final DateTime firstWindowEndTime = TimeUtil.ceil(new DateTime(allSpoutLogLines.get(0).getDate()).withZone(DateTimeZone.UTC), slideSec);
+        final int numberOfWindows = allBoltLogLines.size();
+        /*
+         * Windows should be aligned to the slide size, starting at firstWindowEndTime - windowSec.
+         * Because all windows are aligned to the slide size, we can partition the spout emitted timestamps by which window they should fall in.
+         * This checks that the partitioned spout emits fall in the expected windows, based on the logs from the spout and bolt.
+         */
+        for (int i = 0; i < numberOfWindows; ++i) {
+            final DateTime windowEnd = firstWindowEndTime.plusSeconds(i * slideSec);
+            final DateTime  windowStart =  windowEnd.minusSeconds(windowSec);
+            LOG.info("Comparing window: " + windowStart + " to " + windowEnd + " iter " + (i+1) + "/" + numberOfWindows);
+            
+            final List<TimeData> expectedSpoutEmitsInWindow = allSpoutLogLines.stream()
+                .filter(spoutLog -> {
+                    DateTime spoutLogTime = new DateTime(spoutLog.getDate());
+                    //The window boundaries are )windowStart, windowEnd)
+                    return spoutLogTime.isAfter(windowStart) && spoutLogTime.isBefore(windowEnd.plusMillis(1));
+                }).collect(Collectors.toList());
+            TimeDataWindow expectedWindow = new TimeDataWindow(expectedSpoutEmitsInWindow);
+            
+            final TimeDataWindow actualWindow = allBoltLogLines.get(i);
+            LOG.info("Actual window: " + actualWindow.getDescription());
+            LOG.info("Expected window: " + expectedWindow.getDescription());
+            for (TimeData oneLog : expectedWindow.getTimeData()) {
+                Assert.assertTrue(actualWindow.getTimeData().contains(oneLog),
+                        String.format("Missing: '%s' \n\tActual: '%s' \n\tComputed window: '%s'", oneLog, actualWindow, expectedWindow));
+            }
+            for (TimeData oneLog : actualWindow.getTimeData()) {
+                Assert.assertTrue(expectedWindow.getTimeData().contains(oneLog),
+                        String.format("Extra: '%s' \n\tActual: '%s' \n\tComputed window: '%s'", oneLog, actualWindow, expectedWindow));
+            }
+        }
+    }
+    
+}

--- a/integration-test/src/test/java/org/apache/storm/st/wrapper/DecoratedLogLine.java
+++ b/integration-test/src/test/java/org/apache/storm/st/wrapper/DecoratedLogLine.java
@@ -27,32 +27,33 @@ import org.apache.storm.st.utils.StringDecorator;
 import java.util.Arrays;
 import java.util.List;
 
-public class LogData implements Comparable<LogData> {
+/**
+ * Convenience class splitting log lines decorated with {@link StringDecorator}.
+ * This provides easy access to the log line timestamp and data.
+ */
+public class DecoratedLogLine implements Comparable<DecoratedLogLine> {
     private final DateTime logDate;
     private final String data;
-    private static final int dateLen = "2016-05-04 23:38:10.702".length(); //format of date in worker logs
-    private static final DateTimeFormatter dateFormat = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS");
+    private static final int DATE_LEN = "2016-05-04 23:38:10.702".length(); //format of date in worker logs
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
-    public LogData(String logLine) {
-        DateTime tempDate;
-        final String[] pair = StringDecorator.split2(StringUtils.strip(logLine));
-        final List<String> pairList = Arrays.asList(pair);
-        AssertUtil.assertTwoElements(pairList);
-        tempDate = dateFormat.parseDateTime(pairList.get(0).substring(0, dateLen));
-        this.logDate = tempDate;
-        this.data = pairList.get(1);
+    public DecoratedLogLine(String logLine) {
+        final List<String> splitOnDecorator = Arrays.asList(StringDecorator.split2(StringUtils.strip(logLine)));
+        AssertUtil.assertTwoElements(splitOnDecorator);
+        this.logDate = DATE_FORMAT.parseDateTime(splitOnDecorator.get(0).substring(0, DATE_LEN));
+        this.data = splitOnDecorator.get(1);
     }
 
     @Override
     public String toString() {
         return "LogData{" +
-                "logDate=" + dateFormat.print(logDate) +
+                "logDate=" + DATE_FORMAT.print(logDate) +
                 ", data='" + getData() + '\'' +
                 '}';
     }
 
     @Override
-    public int compareTo(LogData that) {
+    public int compareTo(DecoratedLogLine that) {
         return this.logDate.compareTo(that.logDate);
     }
 


### PR DESCRIPTION
… readable

https://issues.apache.org/jira/browse/STORM-3136

* Deduplicated the test spouts and bolts a bit. 
* Made sure all test spouts are waiting a reasonable amount of time between emits. If the log rolls during the tests, the tests will fail. I think this is the reason for the flakiness. It was fixed for some tests in an earlier PR, but I missed that the spout code had so many duplicates. 
* Added some documentation
* Replaced a bunch of Guava code with streams. Deleted unused code. Simplified some classes, e.g. TimeDataWindow