### PR TITLE
STORM-3143: Fixed bug of unnecessary inclusion of empty search result

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
@@ -426,7 +426,8 @@ public class LogviewerLogSearchHandler {
 
             int newCount = matchCount + ((List<?>)theseMatches.get("matches")).size();
 
-            if (theseMatches.isEmpty()) {
+            //theseMatches is never empty! As guaranteed by the #get().size() method above
+            if (newCount == matchCount) {
                 // matches and matchCount is not changed
                 logs = rest(logs);
                 offset = 0;


### PR DESCRIPTION
`FindNMatches()` didn't correctly filter out empty match result in `substringSearch()` and hence send back an empty map to user. I don't know if this the desired behavior but a fix to current behavior will make metrics for logviewer easier to implement.

An example of current behavior:

```Json
{
    "fileOffset": 1,
    "searchString": "sdf",
    "matches": [
        {
            "searchString": "sdf",
            "fileName": "word-count-1-1530815972/6701/worker.log",
            "matches": [],
            "port": "6701",
            "isDaemon": "no",
            "startByteOffset": 0
        }
    ]
}
```
Desired behavior:

```Json
{
    "fileOffset": 1,
    "searchString": "sdf",
    "matches": []
}
```