### PR TITLE
STORM-3133: Extend metrics on Nimbus and LogViewer

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/scheduler/WorkerSlot.java
+++ b/storm-client/src/jvm/org/apache/storm/scheduler/WorkerSlot.java
@@ -12,6 +12,9 @@
 
 package org.apache.storm.scheduler;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class WorkerSlot {
     private final String nodeId;
     private final int port;
@@ -37,6 +40,10 @@ public class WorkerSlot {
 
     public String getId() {
         return getNodeId() + ":" + getPort();
+    }
+
+    public List<Object> toList() {
+        return Arrays.asList(nodeId, (long) port);
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/SupervisorUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/SupervisorUtils.java
@@ -114,20 +114,17 @@ public class SupervisorUtils {
      * @param conf
      * @return
      *
-     * @throws Exception
      */
-    public static Map<String, LSWorkerHeartbeat> readWorkerHeartbeats(Map<String, Object> conf) throws Exception {
+    public static Map<String, LSWorkerHeartbeat> readWorkerHeartbeats(Map<String, Object> conf) {
         return _instance.readWorkerHeartbeatsImpl(conf);
     }
 
     /**
-     * get worker heartbeat by workerId
+     * get worker heartbeat by workerId.
      *
      * @param conf
      * @param workerId
      * @return
-     *
-     * @throws IOException
      */
     private static LSWorkerHeartbeat readWorkerHeartbeat(Map<String, Object> conf, String workerId) {
         return _instance.readWorkerHeartbeatImpl(conf, workerId);
@@ -137,7 +134,7 @@ public class SupervisorUtils {
         return _instance.isWorkerHbTimedOutImpl(now, whb, conf);
     }
 
-    public Map<String, LSWorkerHeartbeat> readWorkerHeartbeatsImpl(Map<String, Object> conf) throws Exception {
+    public Map<String, LSWorkerHeartbeat> readWorkerHeartbeatsImpl(Map<String, Object> conf) {
         Map<String, LSWorkerHeartbeat> workerHeartbeats = new HashMap<>();
 
         Collection<String> workerIds = SupervisorUtils.supervisorWorkerIds(conf);

--- a/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedBlob.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedBlob.java
@@ -52,8 +52,7 @@ public abstract class LocallyCachedBlob {
     private long lastUsed = Time.currentTimeMillis();
     private CompletableFuture<Void> doneUpdating = null;
 
-    private static final Histogram fetchingRate = StormMetricsRegistry.registerHistogram(
-            "supervisor:blob-fetching-rate-MB/s", new ExponentiallyDecayingReservoir());
+    private static final Histogram fetchingRate = StormMetricsRegistry.registerHistogram("supervisor:blob-fetching-rate-MB/s");
 
     /**
      * Create a new LocallyCachedBlob.

--- a/storm-server/src/main/java/org/apache/storm/nimbus/LeaderListenerCallback.java
+++ b/storm-server/src/main/java/org/apache/storm/nimbus/LeaderListenerCallback.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.security.auth.Subject;
+
+import com.codahale.metrics.Meter;
 import org.apache.commons.io.IOUtils;
 import org.apache.storm.Config;
 import org.apache.storm.blobstore.BlobStore;
@@ -29,6 +31,7 @@ import org.apache.storm.daemon.nimbus.TopoCache;
 import org.apache.storm.generated.AuthorizationException;
 import org.apache.storm.generated.KeyNotFoundException;
 import org.apache.storm.generated.StormTopology;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.security.auth.ReqContext;
 import org.apache.storm.shade.com.google.common.base.Joiner;
 import org.apache.storm.shade.com.google.common.collect.Sets;
@@ -45,6 +48,8 @@ import org.slf4j.LoggerFactory;
  * A callback function when nimbus gains leadership.
  */
 public class LeaderListenerCallback {
+    private static final Meter numGainedLeader = StormMetricsRegistry.registerMeter("nimbus:num-gained-leadership");
+    private static final Meter numLostLeader = StormMetricsRegistry.registerMeter("nimbus:num-lost-leadership");
     private static final Logger LOG = LoggerFactory.getLogger(LeaderListenerCallback.class);
     private static final String STORM_JAR_SUFFIX = "-stormjar.jar";
     private static final String STORM_CODE_SUFFIX = "-stormcode.ser";
@@ -82,6 +87,7 @@ public class LeaderListenerCallback {
      * Invoke when gains leadership.
      */
     public void leaderCallBack() {
+        numGainedLeader.mark();
         //set up nimbus-info to zk
         setUpNimbusInfo(acls);
         //sync zk assignments/id-info to local
@@ -131,6 +137,7 @@ public class LeaderListenerCallback {
      * Invoke when lost leadership.
      */
     public void notLeaderCallback() {
+        numLostLeader.mark();
         tc.clear();
     }
 

--- a/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
@@ -145,11 +145,7 @@ public class Cluster implements ISchedulingState {
             String nodeId = entry.getKey();
             SupervisorDetails supervisor = entry.getValue();
             String host = supervisor.getHost();
-            List<String> ids = hostToId.get(host);
-            if (ids == null) {
-                ids = new ArrayList<>();
-                hostToId.put(host, ids);
-            }
+            List<String> ids = hostToId.computeIfAbsent(host, k -> new ArrayList<>());
             ids.add(nodeId);
         }
         this.conf = conf;
@@ -173,11 +169,7 @@ public class Cluster implements ISchedulingState {
             for (Map.Entry<String, String> entry : resolvedSuperVisors.entrySet()) {
                 String hostName = entry.getKey();
                 String rack = entry.getValue();
-                List<String> nodesForRack = this.networkTopography.get(rack);
-                if (nodesForRack == null) {
-                    nodesForRack = new ArrayList<>();
-                    this.networkTopography.put(rack, nodesForRack);
-                }
+                List<String> nodesForRack = this.networkTopography.computeIfAbsent(rack, k -> new ArrayList<>());
                 nodesForRack.add(hostName);
             }
         } else {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/ExecutorDetails.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/ExecutorDetails.java
@@ -18,6 +18,9 @@
 
 package org.apache.storm.scheduler;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class ExecutorDetails {
     public final int startTask;
     public final int endTask;
@@ -35,9 +38,13 @@ public class ExecutorDetails {
         return endTask;
     }
 
+    public List<Long> toList() {
+        return Arrays.asList((long) startTask, (long) endTask);
+    }
+
     @Override
     public boolean equals(Object other) {
-        if (other == null || !(other instanceof ExecutorDetails)) {
+        if (!(other instanceof ExecutorDetails)) {
             return false;
         }
 

--- a/storm-server/src/test/java/org/apache/storm/metric/StormMetricsRegistryTest.java
+++ b/storm-server/src/test/java/org/apache/storm/metric/StormMetricsRegistryTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.metric;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.Timer;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.junit.jupiter.api.Assertions.*;
+
+class StormMetricsRegistryTest {
+    private static final Logger LOG = LoggerFactory.getLogger(StormMetricsRegistryTest.class);
+
+    private static final String OUTER_METER = "outerMeter";
+    private static final String INNER_SET = "innerSet";
+    private static final String OUTER_TIMER = "outerTimer";
+    private static final String INNER_METER = "innerMeter";
+    private static final String INNER_TIMER = "innerTimer";
+    private static final MetricSet OUTER = newMetricSetInstance();
+
+    @Test
+    void registerMetricSet() {
+        Meter existingInnerMeter = StormMetricsRegistry.registerMeter(name(INNER_SET, INNER_METER));
+
+        LOG.info("register outer set");
+        StormMetricsRegistry.registerMetricSet(OUTER);
+        assertSame(OUTER.getMetrics().get(OUTER_TIMER), StormMetricsRegistry.REGISTRY.getMetrics().get(OUTER_TIMER));
+        assertSame(OUTER.getMetrics().get(OUTER_METER), StormMetricsRegistry.REGISTRY.getMetrics().get(OUTER_METER));
+        assertSame(((MetricSet) OUTER.getMetrics().get(INNER_SET)).getMetrics().get(INNER_TIMER),
+            StormMetricsRegistry.REGISTRY.getMetrics().get(name(INNER_SET, INNER_TIMER)));
+
+        assertNotSame(((MetricSet) OUTER.getMetrics().get(INNER_SET)).getMetrics().get(INNER_METER),
+            StormMetricsRegistry.REGISTRY.getMetrics().get(name(INNER_SET, INNER_METER)));
+        assertSame(existingInnerMeter, StormMetricsRegistry.REGISTRY.getMetrics().get(name(INNER_SET, INNER_METER)));
+
+        //Ensure idempotency
+        LOG.info("twice register outer set");
+        MetricSet newOuter = newMetricSetInstance();
+        StormMetricsRegistry.registerMetricSet(newOuter);
+        assertSame(OUTER.getMetrics().get(OUTER_TIMER), StormMetricsRegistry.REGISTRY.getMetrics().get(OUTER_TIMER));
+        assertSame(OUTER.getMetrics().get(OUTER_METER), StormMetricsRegistry.REGISTRY.getMetrics().get(OUTER_METER));
+        assertSame(((MetricSet) OUTER.getMetrics().get(INNER_SET)).getMetrics().get(INNER_TIMER),
+            StormMetricsRegistry.REGISTRY.getMetrics().get(name(INNER_SET, INNER_TIMER)));
+        assertSame(existingInnerMeter, StormMetricsRegistry.REGISTRY.getMetrics().get(name(INNER_SET, INNER_METER)));
+
+        LOG.info("name collision");
+        assertThrows(IllegalArgumentException.class, () -> StormMetricsRegistry.registerGauge(name(INNER_SET, INNER_METER), () -> 0));
+    }
+
+    @Test
+    void unregisterMetricSet() {
+        StormMetricsRegistry.registerMetricSet(OUTER);
+        StormMetricsRegistry.unregisterMetricSet(OUTER);
+        assertTrue(StormMetricsRegistry.REGISTRY.getMetrics().isEmpty());
+
+    }
+
+    private static MetricSet newMetricSetInstance() {
+        return new MetricSet() {
+            private final MetricSet inner = new MetricSet() {
+                private final Map<String, Metric> map = new HashMap<>();
+
+                {
+                    map.put(INNER_METER, new Meter());
+                    map.put(INNER_TIMER, new Timer());
+                }
+
+                @Override
+                public Map<String, Metric> getMetrics() {
+                    return map;
+                }
+            };
+            private final Map<String, Metric> outerMap = new HashMap<>();
+
+            {
+                outerMap.put(OUTER_METER, new Meter());
+                outerMap.put(INNER_SET, inner);
+                outerMap.put(OUTER_TIMER, new Timer());
+            }
+
+            @Override
+            public Map<String, Metric> getMetrics() {
+                return outerMap;
+            }
+        };
+    }
+}

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
@@ -21,6 +21,8 @@ package org.apache.storm.daemon.logviewer;
 import static org.apache.storm.DaemonConfig.UI_HEADER_BUFFER_BYTES;
 
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.io.File;
@@ -31,6 +33,7 @@ import java.util.Map;
 
 import org.apache.storm.DaemonConfig;
 import org.apache.storm.daemon.logviewer.utils.DirectoryCleaner;
+import org.apache.storm.daemon.logviewer.utils.ExceptionMeters;
 import org.apache.storm.daemon.logviewer.utils.LogCleaner;
 import org.apache.storm.daemon.logviewer.utils.WorkerLogs;
 import org.apache.storm.daemon.logviewer.webapp.LogviewerApplication;
@@ -126,6 +129,7 @@ public class LogviewerServer implements AutoCloseable {
     void start() throws Exception {
         LOG.info("Starting Logviewer...");
         if (httpServer != null) {
+            StormMetricsRegistry.registerMetricSet(ExceptionMeters::getMetrics);
             httpServer.start();
         }
     }
@@ -165,7 +169,7 @@ public class LogviewerServer implements AutoCloseable {
 
         try (LogviewerServer server = new LogviewerServer(conf);
              LogCleaner logCleaner = new LogCleaner(conf, workerLogs, directoryCleaner, logRootDir)) {
-            Utils.addShutdownHookWithForceKillIn1Sec(() -> server.close());
+            Utils.addShutdownHookWithForceKillIn1Sec(server::close);
             logCleaner.start();
             StormMetricsRegistry.startMetricsReporters(conf);
             server.start();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
@@ -25,6 +25,10 @@ import static org.apache.storm.daemon.utils.ListFunctionalSupport.last;
 import static org.apache.storm.daemon.utils.ListFunctionalSupport.rest;
 import static org.apache.storm.daemon.utils.PathUtil.truncatePathToLastElements;
 
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -46,6 +50,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
 import javax.ws.rs.core.Response;
@@ -56,12 +61,14 @@ import org.apache.storm.DaemonConfig;
 import org.apache.storm.daemon.common.JsonResponseBuilder;
 import org.apache.storm.daemon.logviewer.LogviewerConstant;
 import org.apache.storm.daemon.logviewer.utils.DirectoryCleaner;
+import org.apache.storm.daemon.logviewer.utils.ExceptionMeters;
 import org.apache.storm.daemon.logviewer.utils.LogviewerResponseBuilder;
 import org.apache.storm.daemon.logviewer.utils.ResourceAuthorizer;
 import org.apache.storm.daemon.logviewer.utils.WorkerLogs;
 import org.apache.storm.daemon.ui.InvalidRequestException;
 import org.apache.storm.daemon.utils.StreamUtil;
 import org.apache.storm.daemon.utils.UrlBuilder;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.ServerUtils;
 import org.apache.storm.utils.Utils;
@@ -71,6 +78,9 @@ import org.slf4j.LoggerFactory;
 
 public class LogviewerLogSearchHandler {
     private static final Logger LOG = LoggerFactory.getLogger(LogviewerLogSearchHandler.class);
+    private static final Meter numDeepSearchNoResult = StormMetricsRegistry.registerMeter("logviewer:num-deep-search-no-result");
+    private static final Histogram numFileScanned = StormMetricsRegistry.registerHistogram("logviewer:num-files-scanned-per-deep-search");
+    private static final Meter numSearchRequestNoResult = StormMetricsRegistry.registerMeter("logviewer:num-search-request-no-result");
 
     public static final int GREP_MAX_SEARCH_SIZE = 1024;
     public static final int GREP_BUF_SIZE = 2048;
@@ -124,6 +134,8 @@ public class LogviewerLogSearchHandler {
     public Response searchLogFile(String fileName, String user, boolean isDaemon, String search,
                                   String numMatchesStr, String offsetStr, String callback, String origin)
             throws IOException, InvalidRequestException {
+        boolean noResult = true;
+
         String rootDir = isDaemon ? daemonLogRoot : logRoot;
         File file = new File(rootDir, fileName).getCanonicalFile();
         Response response;
@@ -136,7 +148,9 @@ public class LogviewerLogSearchHandler {
                     if (StringUtils.isNotEmpty(search) && search.getBytes("UTF-8").length <= GREP_MAX_SEARCH_SIZE) {
                         Map<String, Object> entity = new HashMap<>();
                         entity.put("isDaemon", isDaemon ? "yes" : "no");
-                        entity.putAll(substringSearch(file, search, isDaemon, numMatchesInt, offsetInt));
+                        Map<String, Object> res = substringSearch(file, search, isDaemon, numMatchesInt, offsetInt);
+                        entity.putAll(res);
+                        noResult = ((List) res.get("matches")).isEmpty();
 
                         response = LogviewerResponseBuilder.buildSuccessJsonResponse(entity, callback, origin);
                     } else {
@@ -159,16 +173,20 @@ public class LogviewerLogSearchHandler {
             response = new JsonResponseBuilder().setData(entity).setCallback(callback).setStatus(404).build();
         }
 
+        if (noResult) {
+            numSearchRequestNoResult.mark();
+        }
         return response;
     }
 
     /**
-     * Deep search across worker log files in a topology.
+     * Advanced search across worker log files in a topology.
      *
      * @param topologyId topology ID
      * @param user username
      * @param search search string
-     * @param numMatchesStr the count of maximum matches
+     * @param numMatchesStr the count of maximum matches. Note that this number is with respect to
+     *                      each port, not to each log or each search request
      * @param portStr worker port, null or '*' if the request wants to search from all worker logs
      * @param fileOffsetStr index (offset) of the log files
      * @param offsetStr start offset for log file
@@ -180,6 +198,9 @@ public class LogviewerLogSearchHandler {
     public Response deepSearchLogsForTopology(String topologyId, String user, String search,
                                               String numMatchesStr, String portStr, String fileOffsetStr, String offsetStr,
                                               Boolean searchArchived, String callback, String origin) {
+        int numMatchedFiles = 0;
+        int numScannedFiles = 0;
+
         String rootDir = logRoot;
         Object returnValue;
         File topologyDir = new File(rootDir, topologyId);
@@ -200,24 +221,24 @@ public class LogviewerLogSearchHandler {
 
             if (StringUtils.isEmpty(portStr) || portStr.equals("*")) {
                 // check for all ports
-                List<List<File>> filteredLogs = portDirs.stream()
-                        .map(portDir -> logsForPort(user, portDir))
-                        .filter(logs -> logs != null && !logs.isEmpty())
-                        .collect(toList());
+                Stream<List<File>> portsOfLogs = portDirs.stream()
+                    .map(portDir -> logsForPort(user, portDir))
+                    .filter(logs -> logs != null && !logs.isEmpty());
 
-                if (BooleanUtils.isTrue(searchArchived)) {
-                    returnValue = filteredLogs.stream()
-                            .map(fl -> findNMatches(fl, numMatches, 0, 0, search))
-                            .collect(toList());
-                } else {
-                    returnValue = filteredLogs.stream()
-                            .map(fl -> Collections.singletonList(first(fl)))
-                            .map(fl -> findNMatches(fl, numMatches, 0, 0, search))
-                            .collect(toList());
+                if (BooleanUtils.isNotTrue(searchArchived)) {
+                    portsOfLogs = portsOfLogs.map(fl -> Collections.singletonList(first(fl)));
                 }
+
+                final List<Matched> matchedList = portsOfLogs
+                        .map(logs -> findNMatches(logs, numMatches, 0, 0, search))
+                        .collect(toList());
+                numMatchedFiles = matchedList.stream().mapToInt(match -> match.getMatches().size()).sum();
+                numScannedFiles = matchedList.stream().mapToInt(match -> match.openedFiles).sum();
+                returnValue = matchedList;
             } else {
                 int port = Integer.parseInt(portStr);
                 // check just the one port
+                @SuppressWarnings("unchecked")
                 List<Integer> slotsPorts = (List<Integer>) stormConf.getOrDefault(DaemonConfig.SUPERVISOR_SLOTS_PORTS,
                         new ArrayList<>());
                 boolean containsPort = slotsPorts.stream()
@@ -232,17 +253,22 @@ public class LogviewerLogSearchHandler {
                         returnValue = new ArrayList<>();
                     } else {
                         List<File> filteredLogs = logsForPort(user, portDir);
-                        if (BooleanUtils.isTrue(searchArchived)) {
-                            returnValue = findNMatches(filteredLogs, numMatches, fileOffset, offset, search);
-                        } else {
-                            returnValue = findNMatches(Collections.singletonList(first(filteredLogs)),
-                                    numMatches, 0, offset, search);
+                        if (BooleanUtils.isNotTrue(searchArchived)) {
+                            filteredLogs = Collections.singletonList(first(filteredLogs));
+                            fileOffset = 0;
                         }
+                        returnValue = findNMatches(filteredLogs, numMatches, fileOffset, offset, search);
+                        numMatchedFiles = ((Matched) returnValue).getMatches().size();
+                        numScannedFiles = ((Matched) returnValue).openedFiles;
                     }
                 }
             }
         }
 
+        if (numMatchedFiles == 0) {
+            numDeepSearchNoResult.mark();
+        }
+        numFileScanned.update(numScannedFiles);
         return LogviewerResponseBuilder.buildSuccessJsonResponse(returnValue, callback, origin);
     }
 
@@ -271,26 +297,21 @@ public class LogviewerLogSearchHandler {
 
     private Map<String,Object> substringSearch(File file, String searchString, boolean isDaemon, Integer numMatches,
                                                Integer startByteOffset) throws InvalidRequestException {
-        try {
-            if (StringUtils.isEmpty(searchString)) {
-                throw new IllegalArgumentException("Precondition fails: search string should not be empty.");
-            }
-            if (searchString.getBytes(StandardCharsets.UTF_8).length > GREP_MAX_SEARCH_SIZE) {
-                throw new IllegalArgumentException("Precondition fails: the length of search string should be less than "
-                    + GREP_MAX_SEARCH_SIZE);
-            }
+        if (StringUtils.isEmpty(searchString)) {
+            throw new IllegalArgumentException("Precondition fails: search string should not be empty.");
+        }
+        if (searchString.getBytes(StandardCharsets.UTF_8).length > GREP_MAX_SEARCH_SIZE) {
+            throw new IllegalArgumentException("Precondition fails: the length of search string should be less than "
+                + GREP_MAX_SEARCH_SIZE);
+        }
 
-            boolean isZipFile = file.getName().endsWith(".gz");
-            try (InputStream fis = Files.newInputStream(file.toPath());
-                InputStream gzippedInputStream = isZipFile ? new GZIPInputStream(fis) : fis;
-                BufferedInputStream stream = new BufferedInputStream(gzippedInputStream)) {
+        boolean isZipFile = file.getName().endsWith(".gz");
+        try (InputStream fis = Files.newInputStream(file.toPath())) {
+            try (InputStream gzippedInputStream = isZipFile ? new GZIPInputStream(fis) : fis;
+                 BufferedInputStream stream = new BufferedInputStream(gzippedInputStream)) {
 
-                int fileLength;
-                if (isZipFile) {
-                    fileLength = (int) ServerUtils.zipFileSize(file);
-                } else {
-                    fileLength = (int) file.length();
-                }
+                //It's more likely to be a file read exception here, so we don't differentiate
+                int fileLength = isZipFile ? (int) ServerUtils.zipFileSize(file) : (int) file.length();
 
                 ByteBuffer buf = ByteBuffer.allocate(GREP_BUF_SIZE);
                 final byte[] bufArray = buf.array();
@@ -311,7 +332,7 @@ public class LogviewerLogSearchHandler {
                 Arrays.fill(bufArray, (byte) 0);
 
                 int totalBytesRead = 0;
-                int bytesRead = stream.read(bufArray, 0, Math.min((int) fileLength, GREP_BUF_SIZE));
+                int bytesRead = stream.read(bufArray, 0, Math.min(fileLength, GREP_BUF_SIZE));
                 buf.limit(bytesRead);
                 totalBytesRead += bytesRead;
 
@@ -335,7 +356,7 @@ public class LogviewerLogSearchHandler {
                         // buffer on the previous read.
                         final int newBufOffset = Math.min(buf.limit(), GREP_MAX_SEARCH_SIZE) - searchBytes.length;
 
-                        totalBytesRead = rotateGrepBuffer(buf, stream, totalBytesRead, file, fileLength);
+                        totalBytesRead = rotateGrepBuffer(buf, stream, totalBytesRead, fileLength);
                         if (totalBytesRead < 0) {
                             throw new InvalidRequestException("Cannot search past the end of the file");
                         }
@@ -358,8 +379,14 @@ public class LogviewerLogSearchHandler {
                     }
                 }
                 return ret;
+            } catch (UnknownHostException | UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            } catch (IOException e) {
+                ExceptionMeters.NUM_FILE_READ_EXCEPTIONS.mark();
+                throw new RuntimeException(e);
             }
         } catch (IOException e) {
+            ExceptionMeters.NUM_FILE_OPEN_EXCEPTIONS.mark();
             throw new RuntimeException(e);
         }
     }
@@ -388,32 +415,46 @@ public class LogviewerLogSearchHandler {
         }
     }
 
+    /**
+     * Find the first N matches of target string in files.
+     * @param logs all candidate log files to search
+     * @param numMatches number of matches expected
+     * @param fileOffset number of log files to skip initially
+     * @param startByteOffset number of byte to be ignored in each log file
+     * @param targetStr searched string
+     * @return all matched results
+     */
     @VisibleForTesting
-    Matched findNMatches(List<File> logs, int numMatches, int fileOffset, int offset, String search) {
+    Matched findNMatches(List<File> logs, int numMatches, int fileOffset, int startByteOffset, String targetStr) {
         logs = drop(logs, fileOffset);
+        LOG.debug("{} files to scan", logs.size());
 
         List<Map<String, Object>> matches = new ArrayList<>();
         int matchCount = 0;
+        int scannedFiles = 0;
 
         while (true) {
             if (logs.isEmpty()) {
+                //fileOffset = one past last scanned file
                 break;
             }
 
             File firstLog = logs.get(0);
-            Map<String, Object> theseMatches;
+            Map<String, Object> matchInLog;
             try {
                 LOG.debug("Looking through {}", firstLog);
-                theseMatches = substringSearch(firstLog, search, numMatches - matchCount, offset);
+                matchInLog = substringSearch(firstLog, targetStr, numMatches - matchCount, startByteOffset);
+                scannedFiles++;
             } catch (InvalidRequestException e) {
                 LOG.error("Can't search past end of file.", e);
-                theseMatches = new HashMap<>();
+                matchInLog = new HashMap<>();
             }
 
             String fileName = WorkerLogs.getTopologyPortWorkerLog(firstLog);
 
+            //This section simply put the formatted log filename and corresponding port in the matching.
             final List<Map<String, Object>> newMatches = new ArrayList<>(matches);
-            Map<String, Object> currentFileMatch = new HashMap<>(theseMatches);
+            Map<String, Object> currentFileMatch = new HashMap<>(matchInLog);
             currentFileMatch.put("fileName", fileName);
             Path firstLogAbsPath;
             try {
@@ -424,27 +465,27 @@ public class LogviewerLogSearchHandler {
             currentFileMatch.put("port", truncatePathToLastElements(firstLogAbsPath, 2).getName(0).toString());
             newMatches.add(currentFileMatch);
 
-            int newCount = matchCount + ((List<?>)theseMatches.get("matches")).size();
-
-            //theseMatches is never empty! As guaranteed by the #get().size() method above
+            int newCount = matchCount + ((List<?>)matchInLog.get("matches")).size();
             if (newCount == matchCount) {
                 // matches and matchCount is not changed
                 logs = rest(logs);
-                offset = 0;
+                startByteOffset = 0;
                 fileOffset = fileOffset + 1;
             } else if (newCount >= numMatches) {
                 matches = newMatches;
+                //fileOffset = the index of last scanned file
                 break;
             } else {
                 matches = newMatches;
                 logs = rest(logs);
-                offset = 0;
+                startByteOffset = 0;
                 fileOffset = fileOffset + 1;
                 matchCount = newCount;
             }
         }
 
-        return new Matched(fileOffset, search, matches);
+        LOG.debug("scanned {} files", scannedFiles);
+        return new Matched(fileOffset, targetStr, matches, scannedFiles);
     }
 
 
@@ -502,8 +543,7 @@ public class LogviewerLogSearchHandler {
         return new SubstringSearchResult(matches, newByteOffset, newBeforeBytes);
     }
 
-    private int rotateGrepBuffer(ByteBuffer buf, BufferedInputStream stream, int totalBytesRead, File file,
-                                 int fileLength) throws IOException {
+    private int rotateGrepBuffer(ByteBuffer buf, BufferedInputStream stream, int totalBytesRead, int fileLength) throws IOException {
         byte[] bufArray = buf.array();
 
         // Copy the 2nd half of the buffer to the first half.
@@ -513,7 +553,7 @@ public class LogviewerLogSearchHandler {
         Arrays.fill(bufArray, GREP_MAX_SEARCH_SIZE, bufArray.length, (byte) 0);
 
         // Fill the 2nd half with new bytes from the stream.
-        int bytesRead = stream.read(bufArray, GREP_MAX_SEARCH_SIZE, Math.min((int) fileLength, GREP_MAX_SEARCH_SIZE));
+        int bytesRead = stream.read(bufArray, GREP_MAX_SEARCH_SIZE, Math.min(fileLength, GREP_MAX_SEARCH_SIZE));
         buf.limit(GREP_MAX_SEARCH_SIZE + bytesRead);
         return totalBytesRead + bytesRead;
     }
@@ -693,18 +733,21 @@ public class LogviewerLogSearchHandler {
         private int fileOffset;
         private String searchString;
         private List<Map<String, Object>> matches;
+        @JsonIgnore
+        private final int openedFiles;
 
         /**
          * Constructor.
-         *
-         * @param fileOffset offset (index) of the files
+         *  @param fileOffset offset (index) of the files
          * @param searchString search string
          * @param matches map representing matched search result
+         * @param openedFiles number of files scanned, used for metrics only
          */
-        public Matched(int fileOffset, String searchString, List<Map<String, Object>> matches) {
+        public Matched(int fileOffset, String searchString, List<Map<String, Object>> matches, int openedFiles) {
             this.fileOffset = fileOffset;
             this.searchString = searchString;
             this.matches = matches;
+            this.openedFiles = openedFiles;
         }
 
         public int getFileOffset() {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/DeletionMeta.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/DeletionMeta.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.daemon.logviewer.utils;
+
+class DeletionMeta {
+    static final DeletionMeta EMPTY = new DeletionMeta(0, 0);
+
+    final long deletedSize;
+    final int deletedFiles;
+
+    DeletionMeta(long deletedSize, int deletedFiles) {
+        this.deletedSize = deletedSize;
+        this.deletedFiles = deletedFiles;
+    }
+}

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/ExceptionMeters.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/ExceptionMeters.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.storm.daemon.logviewer.utils;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ExceptionMeters {
+    //Operation level IO Exceptions
+    NUM_FILE_OPEN_EXCEPTIONS("logviewer:num-file-open-exceptions"),
+    NUM_FILE_READ_EXCEPTIONS("logviewer:num-file-read-exceptions"),
+    NUM_FILE_REMOVAL_EXCEPTIONS("logviewer:num-file-removal-exceptions"),
+    NUM_FILE_DOWNLOAD_EXCEPTIONS("logviewer:num-file-download-exceptions"),
+    NUM_SET_PERMISSION_EXCEPTIONS("logviewer:num-set-permission-exceptions"),
+
+    //Routine level
+    NUM_CLEANUP_EXCEPTIONS("logviewer:num-other-cleanup-exceptions"),
+    NUM_READ_LOG_EXCEPTIONS("logviewer:num-read-log-exceptions"),
+    NUM_READ_DAEMON_LOG_EXCEPTIONS("logviewer:num-read-daemon-log-exceptions"),
+    NUM_LIST_LOG_EXCEPTIONS("logviewer:num-search-log-exceptions"),
+    NUM_LIST_DUMP_EXCEPTIONS("logviewer:num-list-dump-files-exceptions"),
+    NUM_DOWNLOAD_DUMP_EXCEPTIONS("logviewer:num-download-dump-exceptions"),
+    NUM_DOWNLOAD_LOG_EXCEPTIONS("logviewer:num-download-log-exceptions"),
+    NUM_DOWNLOAD_DAEMON_LOG_EXCEPTIONS("logviewer:num-download-daemon-log-exceptions"),
+    NUM_SEARCH_EXCEPTIONS("logviewer:num-search-exceptions");
+
+    private static final Map<String, Metric> metrics = new HashMap<>();
+
+    static {
+        for (ExceptionMeters e : ExceptionMeters.values()) {
+            metrics.put(e.name, e.meter);
+        }
+    }
+
+    private final String name;
+    private final Meter meter;
+
+    public static Map<String, Metric> getMetrics() {
+        return metrics;
+    }
+
+    ExceptionMeters(String name) {
+        this.name = name;
+        meter = new Meter();
+    }
+
+    public void mark() {
+        this.meter.mark();
+    }
+}

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogviewerResponseBuilder.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogviewerResponseBuilder.java
@@ -76,13 +76,18 @@ public class LogviewerResponseBuilder {
      * @param file file to download
      */
     public static Response buildDownloadFile(File file) throws IOException {
-        // do not close this InputStream in method: it will be used from jetty server
-        InputStream is = new FileInputStream(file);
-        return Response.status(OK)
-                .entity(wrapWithStreamingOutput(is))
-                .type(MediaType.APPLICATION_OCTET_STREAM_TYPE)
-                .header("Content-Disposition", "attachment; filename=\"" + file.getName() + "\"")
-                .build();
+        try {
+            // do not close this InputStream in method: it will be used from jetty server
+            InputStream is = new FileInputStream(file);
+            return Response.status(OK)
+                    .entity(wrapWithStreamingOutput(is))
+                    .type(MediaType.APPLICATION_OCTET_STREAM_TYPE)
+                    .header("Content-Disposition", "attachment; filename=\"" + file.getName() + "\"")
+                    .build();
+        } catch (IOException e) {
+            ExceptionMeters.NUM_FILE_DOWNLOAD_EXCEPTIONS.mark();
+            throw e;
+        }
     }
 
     /**

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandlerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandlerTest.java
@@ -627,6 +627,7 @@ public class LogviewerLogSearchHandlerTest {
 
     public static class TestDeepSearchLogs {
 
+        public static final int METRIC_SCANNED_FILES = 0;
         private List<File> logFiles;
         private String topoPath;
 
@@ -857,7 +858,7 @@ public class LogviewerLogSearchHandlerTest {
                 int fileOffset = (Integer) arguments[2];
                 String search = (String) arguments[4];
 
-                return new LogviewerLogSearchHandler.Matched(fileOffset, search, Collections.emptyList());
+                return new LogviewerLogSearchHandler.Matched(fileOffset, search, Collections.emptyList(), METRIC_SCANNED_FILES);
             }).when(handler).findNMatches(any(), anyInt(), anyInt(), anyInt(), any());
 
             return handler;

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/utils/LogCleanerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/utils/LogCleanerTest.java
@@ -159,7 +159,10 @@ public class LogCleanerTest {
             WorkerLogs workerLogs = new WorkerLogs(conf, rootDir);
             LogCleaner logCleaner = new LogCleaner(conf, workerLogs, mockDirectoryCleaner, rootDir);
 
-            List<Integer> deletedFiles = logCleaner.perWorkerDirCleanup(1200);
+            List<Integer> deletedFiles = logCleaner.perWorkerDirCleanup(1200)
+                .stream()
+                .map(deletionMeta -> deletionMeta.deletedFiles)
+                .collect(toList());
             assertEquals(Integer.valueOf(4), deletedFiles.get(0));
             assertEquals(Integer.valueOf(4), deletedFiles.get(1));
             assertEquals(Integer.valueOf(4), deletedFiles.get(deletedFiles.size() - 1));
@@ -218,13 +221,13 @@ public class LogCleanerTest {
             Map<String, Object> conf = Utils.readStormConfig();
             WorkerLogs stubbedWorkerLogs = new WorkerLogs(conf, rootDir) {
                 @Override
-                public SortedSet<String> getAliveWorkerDirs() throws Exception {
+                public SortedSet<String> getAliveWorkerDirs() {
                     return new TreeSet<>(Collections.singletonList("/workers-artifacts/topo1/port1"));
                 }
             };
 
             LogCleaner logCleaner = new LogCleaner(conf, stubbedWorkerLogs, mockDirectoryCleaner, rootDir);
-            int deletedFiles = logCleaner.globalLogCleanup(2400);
+            int deletedFiles = logCleaner.globalLogCleanup(2400).deletedFiles;
             assertEquals(18, deletedFiles);
         } finally {
             Utils.setInstance(prevUtils);


### PR DESCRIPTION
This PR is based on #2743, #2771 , #2787 , and #2788 and implements the following metrics:

LogViewer:
- [x] Time to complete one clean up loop Time. (timing on blocking calls)
- [x] Search request Cnt: By category - search (non-archived only) vs deep search (archived/non-archived)
- [x] Search Request - Response time - search vs deep search (both timing on blocking calls)
- [x] Search Request - 0 result Cnt - search vs deep search
	- [x] Search Result - open files (scanned files, deep search only, manually tested)
- [x] File Download request Cnt/ And Size served (round to MB)
- [x] Failures/exceptions.
	- Does not track common IO exceptions thrown by File#getCanonicalFile/File#getCanonicalPath(), as it's common but does not actually try to open or read file content
	- Does not track meta file IO exception
- [x] File partial read count
- [x] Disk usage by worker logs
- [x] Disk free-up from each LogCleaner routine


Nimbus:
- [x] File upload time.
- [x] Nimbus launch/relaunch count
- [x] Nimbus loss of leadership
	- [x] meter marking when a nimbus node gains or loses leadership
- [x] Scheduling latency (both distribution (as histogram) and maximum (as gauge, including current scheduling iteration))
- [x] Scheduling throughput