### PR TITLE
STORM-3147: Port ClusterSummary as metrics to StormMetricsRegistry

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/ConsolePreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/ConsolePreparableReporter.java
@@ -52,7 +52,6 @@ public class ConsolePreparableReporter implements PreparableReporter<ConsoleRepo
     public void start() {
         if (reporter != null) {
             LOG.debug("Starting...");
-            //TODO: will we make the period customizable?
             reporter.start(10, TimeUnit.SECONDS);
         } else {
             throw new IllegalStateException("Attempt to start without preparing " + getClass().getSimpleName());

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/ConsolePreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/ConsolePreparableReporter.java
@@ -52,6 +52,7 @@ public class ConsolePreparableReporter implements PreparableReporter<ConsoleRepo
     public void start() {
         if (reporter != null) {
             LOG.debug("Starting...");
+            //TODO: will we make the period customizable?
             reporter.start(10, TimeUnit.SECONDS);
         } else {
             throw new IllegalStateException("Attempt to start without preparing " + getClass().getSimpleName());

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2891,13 +2891,12 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                                         }
                                     });
 
-            //Be cautious using method reference instead of lambda. subexpression preceding :: will be evaluated only upon evaluation
             // Num supervisor, and fragmented resources have been included in cluster summary
-            StormMetricsRegistry.registerGauge("nimbus:total-available-memory (nonegative)", () -> nodeIdToResources.get().values()
+            StormMetricsRegistry.registerGauge("nimbus:total-available-memory-non-negative", () -> nodeIdToResources.get().values()
                 .parallelStream()
                 .mapToDouble(supervisorResources -> Math.max(supervisorResources.getAvailableMem(), 0))
                 .sum());
-            StormMetricsRegistry.registerGauge("nimbus:available-cpu (nonnegative)", () -> nodeIdToResources.get().values()
+            StormMetricsRegistry.registerGauge("nimbus:available-cpu-non-negative", () -> nodeIdToResources.get().values()
                 .parallelStream()
                 .mapToDouble(supervisorResources -> Math.max(supervisorResources.getAvailableCpu(), 0))
                 .sum());
@@ -4778,9 +4777,9 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         private final Histogram supervisorsNumWorkers = registerHistogram.apply("supervisors:num-workers");
         private final Histogram supervisorsNumUsedWorkers = registerHistogram.apply("supervisors:num-used-workers");
         private final Histogram supervisorsUsedMem = registerHistogram.apply("supervisors:used-mem");
-        private final Histogram supervisorsUsedCpu = registerHistogram.apply("supervisors:used-CPU");
+        private final Histogram supervisorsUsedCpu = registerHistogram.apply("supervisors:used-cpu");
         private final Histogram supervisorsFragmentedMem = registerHistogram.apply("supervisors:fragmented-mem");
-        private final Histogram supervisorsFragmentedCpu = registerHistogram.apply("supervisors:fragmented-CPU");
+        private final Histogram supervisorsFragmentedCpu = registerHistogram.apply("supervisors:fragmented-cpu");
 
         //Topology metrics distribution
         private final Histogram topologiesNumTasks = registerHistogram.apply("topologies:num-tasks");
@@ -4790,10 +4789,10 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         private final Histogram topologiesReplicationCount = registerHistogram.apply("topologies:replication-count");
         private final Histogram topologiesRequestedMemOnHeap = registerHistogram.apply("topologies:requested-mem-on-heap");
         private final Histogram topologiesRequestedMemOffHeap = registerHistogram.apply("topologies:requested-mem-off-heap");
-        private final Histogram topologiesRequestedCpu = registerHistogram.apply("topologies:requested-CPU");
+        private final Histogram topologiesRequestedCpu = registerHistogram.apply("topologies:requested-cpu");
         private final Histogram topologiesAssignedMemOnHeap = registerHistogram.apply("topologies:assigned-mem-on-heap");
         private final Histogram topologiesAssignedMemOffHeap = registerHistogram.apply("topologies:assigned-mem-off-heap");
-        private final Histogram topologiesAssignedCpu = registerHistogram.apply("topologies:assigned-CPU");
+        private final Histogram topologiesAssignedCpu = registerHistogram.apply("topologies:assigned-cpu");
 
         ClusterSummaryMetricSet() {
             //Break the code if out of sync to thrift protocol
@@ -4859,7 +4858,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                     return clusterSummary.get_supervisors().stream().mapToInt(SupervisorSummary::get_num_used_workers).sum();
                 }
             });
-            ported.put("cluster:total-fragmented-memory (nonnegative)", new DerivativeGauge<ClusterSummary, Double>(cachedSummary) {
+            ported.put("cluster:total-fragmented-memory-non-negative", new DerivativeGauge<ClusterSummary, Double>(cachedSummary) {
                 @Override
                 protected Double transform(ClusterSummary clusterSummary) {
                     return clusterSummary.get_supervisors().stream()
@@ -4867,7 +4866,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                         .mapToDouble(supervisorSummary -> Math.max(supervisorSummary.get_fragmented_mem(), 0)).sum();
                 }
             });
-            ported.put("cluster:total-fragmented-CPU (nonnegative)", new DerivativeGauge<ClusterSummary, Double>(cachedSummary) {
+            ported.put("cluster:total-fragmented-cpu-non-negative", new DerivativeGauge<ClusterSummary, Double>(cachedSummary) {
                 @Override
                 protected Double transform(ClusterSummary clusterSummary) {
                     return clusterSummary.get_supervisors().stream()

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -22,7 +22,6 @@ import com.codahale.metrics.CachedGauge;
 import com.codahale.metrics.DerivativeGauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
 import com.codahale.metrics.SlidingTimeWindowReservoir;
 import com.codahale.metrics.Timer;
@@ -4819,7 +4818,9 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             clusterSummaryMetrics.put("cluster:num-nimbus-leaders", new DerivativeGauge<ClusterSummary, Long>(cachedSummary) {
                 @Override
                 protected Long transform(ClusterSummary clusterSummary) {
-                    return clusterSummary.get_nimbuses().stream().filter(NimbusSummary::is_isLeader).count();
+                    return clusterSummary.get_nimbuses().stream()
+                            .filter(NimbusSummary::is_isLeader)
+                            .count();
                 }
             });
             clusterSummaryMetrics.put("cluster:num-nimbuses", new DerivativeGauge<ClusterSummary, Integer>(cachedSummary) {
@@ -4843,29 +4844,35 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             clusterSummaryMetrics.put("cluster:num-total-workers", new DerivativeGauge<ClusterSummary, Integer>(cachedSummary) {
                 @Override
                 protected Integer transform(ClusterSummary clusterSummary) {
-                    return clusterSummary.get_supervisors().stream().mapToInt(SupervisorSummary::get_num_workers).sum();
+                    return clusterSummary.get_supervisors().stream()
+                            .mapToInt(SupervisorSummary::get_num_workers)
+                            .sum();
                 }
             });
             clusterSummaryMetrics.put("cluster:num-total-used-workers", new DerivativeGauge<ClusterSummary, Integer>(cachedSummary) {
                 @Override
                 protected Integer transform(ClusterSummary clusterSummary) {
-                    return clusterSummary.get_supervisors().stream().mapToInt(SupervisorSummary::get_num_used_workers).sum();
+                    return clusterSummary.get_supervisors().stream()
+                            .mapToInt(SupervisorSummary::get_num_used_workers)
+                            .sum();
                 }
             });
             clusterSummaryMetrics.put("cluster:total-fragmented-memory-non-negative", new DerivativeGauge<ClusterSummary, Double>(cachedSummary) {
                 @Override
                 protected Double transform(ClusterSummary clusterSummary) {
                     return clusterSummary.get_supervisors().stream()
-                        //Filtered negative value
-                        .mapToDouble(supervisorSummary -> Math.max(supervisorSummary.get_fragmented_mem(), 0)).sum();
+                            //Filtered negative value
+                            .mapToDouble(supervisorSummary -> Math.max(supervisorSummary.get_fragmented_mem(), 0))
+                            .sum();
                 }
             });
             clusterSummaryMetrics.put("cluster:total-fragmented-cpu-non-negative", new DerivativeGauge<ClusterSummary, Double>(cachedSummary) {
                 @Override
                 protected Double transform(ClusterSummary clusterSummary) {
                     return clusterSummary.get_supervisors().stream()
-                        //Filtered negative value
-                        .mapToDouble(supervisorSummary -> Math.max(supervisorSummary.get_fragmented_cpu(), 0)).sum();
+                            //Filtered negative value
+                            .mapToDouble(supervisorSummary -> Math.max(supervisorSummary.get_fragmented_cpu(), 0))
+                            .sum();
                 }
             });
         }

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -4919,7 +4919,6 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         //This is not thread safe
         void setActive(final boolean active) {
             if (this.active != active) {
-                this.active = active;
                 if (active) {
                     StormMetricsRegistry.registerMetricSet(this);
                 } else {
@@ -4927,6 +4926,8 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                     // https://github.com/dropwizard/metrics/pull/1280
                     StormMetricsRegistry.unregisterMetricSet(this);
                 }
+                //Update this.active after metricSet is unregistered to avoid cacheSummary loading null value
+                this.active = active;
             }
         }
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -4807,18 +4807,14 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 @Override
                 protected ClusterSummary loadValue() {
                     try {
-                        if (active) {
-                            ClusterSummary newSummary = getClusterInfoImpl();
-                            LOG.debug("the new summary is {}", newSummary);
-                            //Force update histogram upon each cache refresh
-                            //This behavior relies on the fact that most common implementation of Reporter
-                            // reports Gauges before Histograms. Because DerivativeGauge will trigger cache
-                            // refresh upon reporter's query, histogram will also be updated before query
-                            updateHistogram(newSummary);
-                            return newSummary;
-                        } else {
-                            return null;
-                        }
+                        ClusterSummary newSummary = getClusterInfoImpl();
+                        LOG.debug("the new summary is {}", newSummary);
+                        //Force update histogram upon each cache refresh
+                        //This behavior relies on the fact that most common implementation of Reporter
+                        // reports Gauges before Histograms. Because DerivativeGauge will trigger cache
+                        // refresh upon reporter's query, histogram will also be updated before query
+                        updateHistogram(newSummary);
+                        return newSummary;
                     } catch (Exception e) {
                         LOG.warn("Get cluster info exception.", e);
                         throw new RuntimeException(e);
@@ -4919,6 +4915,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         //This is not thread safe
         void setActive(final boolean active) {
             if (this.active != active) {
+                this.active = active;
                 if (active) {
                     StormMetricsRegistry.registerMetricSet(this);
                 } else {
@@ -4926,8 +4923,6 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                     // https://github.com/dropwizard/metrics/pull/1280
                     StormMetricsRegistry.unregisterMetricSet(this);
                 }
-                //Update this.active after metricSet is unregistered to avoid cacheSummary loading null value
-                this.active = active;
             }
         }
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -4764,7 +4764,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         private final Map<String, com.codahale.metrics.Metric> ported = new HashMap<>(PORTED_METRICS);
         private final Function<String, Histogram> registerHistogram = (name) -> {
             final Histogram histogram = new Histogram(new SlidingTimeWindowReservoir(CACHING_WINDOW / 2, TimeUnit.SECONDS));
-            ported.put(name, histogram);
+            ported.put(MetricRegistry.name(SUMMARY, name), histogram);
             return histogram;
         };
         private volatile boolean active = false;


### PR DESCRIPTION
This PR depends on #2771  
The implementation is kind of ugly right now due to caching and synchronization in metrics update. I hope you can give out some advice in improvement. @revans2 @HeartSaVioR @srdo 

@kishorvpatil I've listed out all metrics I think worth implementing from ClusterSummay in Measured enum. I'm not sure if there's value in SUPERVISOR_TOTAL_RESOURCE, TOPOLOGY_STATUS, and TOPOLOGY_SCHED_STATUS. I'd like to hear what you think.

I have also discovered a potential bug of scheduler when working on this [STORM-3151](https://issues.apache.org/jira/browse/STORM-3151), can you help confirm it?