### PR TITLE
[STORM-3152]Storm has supported ipv6 but Troubleshooting.md didn't update

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -27,7 +27,6 @@ Possible symptoms:
 
 Solutions:
 
- * Storm doesn't work with ipv6. You can force ipv4 by adding `-Djava.net.preferIPv4Stack=true` to the supervisor child options and restarting the supervisor. 
  * You may have a misconfigured subnet. See the solutions for `Worker processes are crashing on startup with no stack trace`
 
 ### Topology stops processing tuples after awhile


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/STORM-3152](https://issues.apache.org/jira/browse/STORM-3152)
As storm's socket get inetaddress by java's InetAddress class,I think there is no difficulty to run Topology on ipv6.And I have test it on ipv6,all socket can be established on ipv6's ip.