### PR TITLE
STORM-2972: Replace storm-kafka with storm-kafka-client in storm-sql-…

### DIFF
--- a/docs/storm-sql-internal.md
+++ b/docs/storm-sql-internal.md
@@ -18,18 +18,16 @@ Figure 1 describes the workflow of executing a SQL query in StormSQL. First, use
 <p>Figure 1: Workflow of StormSQL.</p>
 </div>
 
-Note: Trident Topology is now replaced with normal Storm topology leveraging Streams API.
-
 The next step is to compile the logical execution plan down to a physical execution plan. A physical plan consists of physical operators that describes how to execute the SQL query in *StormSQL*. Physical operators such as `Filter`, `Projection`, and `GroupBy` are directly mapped to operations in Storm topologies. StormSQL also compiles expressions in the SQL statements into Java code blocks and plugs them into the Storm Streams API functions which will be compiled once and executed in runtime.
 
-Finally, StormSQL submits created Storm topology with empty packaged JAR to the Storm cluster. Storm schedules and executes the Storm topology in the same way of it executes other Storm topologies.
+Finally, StormSQL submits created Storm topology with empty packaged JAR to the Storm cluster. Storm schedules and executes the Storm topology in the same way it executes other Storm topologies.
 
-The follow code blocks show an example query that filters and projects results from a Kafka stream.
+The following code block shows an example query that filters and projects results from a Kafka stream.
 
 ```
-CREATE EXTERNAL TABLE ORDERS (ID INT PRIMARY KEY, UNIT_PRICE INT, QUANTITY INT) LOCATION 'kafka://localhost:2181/brokers?topic=orders' ...
+CREATE EXTERNAL TABLE ORDERS (ID INT PRIMARY KEY, UNIT_PRICE INT, QUANTITY INT) LOCATION 'kafka://...' ...
 
-CREATE EXTERNAL TABLE LARGE_ORDERS (ID INT PRIMARY KEY, TOTAL INT) LOCATION 'kafka://localhost:2181/brokers?topic=large_orders' ...
+CREATE EXTERNAL TABLE LARGE_ORDERS (ID INT PRIMARY KEY, TOTAL INT) 'kafka://...' ...
 
 INSERT INTO LARGE_ORDERS SELECT ID, UNIT_PRICE * QUANTITY AS TOTAL FROM ORDERS WHERE UNIT_PRICE * QUANTITY > 50
 ```

--- a/docs/storm-sql-reference.md
+++ b/docs/storm-sql-reference.md
@@ -1194,7 +1194,7 @@ Default input format and output format are JSON. We will introduce `supported fo
 For example, the following statement specifies a Kafka spout and sink:
 
 ```
-CREATE EXTERNAL TABLE FOO (ID INT PRIMARY KEY) LOCATION 'kafka://localhost:2181/brokers?topic=test' TBLPROPERTIES '{"producer":{"bootstrap.servers":"localhost:9092","acks":"1","key.serializer":"org.apache.org.apache.storm.kafka.IntSerializer","value.serializer":"org.apache.org.apache.storm.kafka.ByteBufferSerializer"}}'
+CREATE EXTERNAL TABLE FOO (ID INT PRIMARY KEY) LOCATION 'kafka://test?bootstrap-hosts=localhost:9092' TBLPROPERTIES '{"producer":{"acks":"1","key.serializer":"org.apache.storm.kafka.IntSerializer"}}'
 ```
 
 Please note that users should use `--jars` or `--artifacts` while running Storm SQL runner to make sure UDFs are available in classpath. 
@@ -1238,7 +1238,7 @@ Please note that it supports only one letter for delimiter.
 | Data Source     | Artifact Name      | Location prefix     | Support Input data source | Support Output data source | Requires properties
 |:--------------- |:------------------ |:------------------- |:------------------------- |:-------------------------- |:-------------------
 | Socket | <built-in> | `socket://host:port` | Yes | Yes | No
-| Kafka | org.apache.storm:storm-sql-kafka | `kafka://zkhost:port/broker_path?topic=topic` | Yes | Yes | Yes
+| Kafka | org.apache.storm:storm-sql-kafka | `kafka://topic?bootstrap-servers=host1:port1,host2:port2` | Yes | Yes | Yes
 | Redis | org.apache.storm:storm-sql-redis | `redis://:[password]@host:port/[dbIdx]` | No | Yes | Yes
 | MongoDB | org.apache.stormg:storm-sql-mongodb | `mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]` | No | Yes | Yes
 | HDFS | org.apache.storm:storm-sql-hdfs | `hdfs://host:port/path-to-file` | No | Yes | Yes
@@ -1256,12 +1256,13 @@ TIP: `netcat` is a convenient tool for Socket: users can use netcat to connect S
 Kafka data source requires below properties only when its used for output data source:
 
 * `producer`: Specify Kafka Producer configuration - Please refer [Kafka producer configs](http://kafka.apache.org/documentation.html#producerconfigs) for details.
-   * `bootstrap.servers` must be described in `producer`
+   * Do not set `bootstrap.servers`. It is extracted from the URI you provide for the data source (e.g. `kafka://topic?bootstrap-servers=localhost:9092,localhost:9093` would extract to `localhost:9092,localhost:9093`).
+   * Do not set `value.serializer`. It is hardcoded to use `ByteBufferSerializer`. Instead use the `STORED AS INPUTFORMAT ... OUTPUTFORMAT ...` syntax to specify the output serializer Storm will use to create the ByteBuffer from input tuples.
 
-Please note that `storm-sql-kafka` requires users to provide `storm-kafka`, and `storm-kafka` requires users to provide `kafka` and `kafka-clients`.
+Please note that `storm-sql-kafka` requires users to provide `storm-kafka-client`, and `storm-kafka-client` requires users to provide `kafka-clients`.
 You can use below as working reference for `--artifacts` option, and change dependencies version, and see it works:
 
-`org.apache.storm:storm-sql-kafka:2.0.0-SNAPSHOT,org.apache.storm:storm-kafka:2.0.0-SNAPSHOT,org.apache.kafka:kafka_2.10:0.8.2.2^org.slf4j:slf4j-log4j12,org.apache.kafka:kafka-clients:0.8.2.2`
+`org.apache.storm:storm-sql-kafka:2.0.0-SNAPSHOT,org.apache.storm:storm-kafka-client:2.0.0-SNAPSHOT,org.apache.kafka:kafka-clients:1.1.0^org.slf4j:slf4j-log4j12`
 
 #### Redis
 

--- a/sql/storm-sql-external/storm-sql-kafka/pom.xml
+++ b/sql/storm-sql-external/storm-sql-kafka/pom.xml
@@ -57,18 +57,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>
-            <artifactId>storm-kafka</artifactId>
+            <artifactId>storm-kafka-client</artifactId>
             <version>${project.version}</version>
             <scope>${provided.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>${storm.kafka.artifact.id}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>${storm.kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/sql/storm-sql-external/storm-sql-kafka/src/jvm/org/apache/storm/sql/kafka/RecordTranslatorSchemeAdapter.java
+++ b/sql/storm-sql-external/storm-sql-kafka/src/jvm/org/apache/storm/sql/kafka/RecordTranslatorSchemeAdapter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.sql.kafka;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.storm.kafka.spout.RecordTranslator;
+import org.apache.storm.spout.Scheme;
+import org.apache.storm.tuple.Fields;
+
+/**
+ * RecordTranslator that delegates to a Scheme. 
+ */
+public class RecordTranslatorSchemeAdapter implements RecordTranslator<ByteBuffer, ByteBuffer> {
+
+    private static final long serialVersionUID = 1L;
+    private final Scheme delegate;
+
+    public RecordTranslatorSchemeAdapter(Scheme delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public List<Object> apply(ConsumerRecord<ByteBuffer, ByteBuffer> record) {
+        return this.delegate.deserialize(record.value());
+    }
+
+    @Override
+    public Fields getFieldsFor(String stream) {
+        //We ensure there is only the default stream when configuring the spout, so it should be safe to ignore the parameter here.
+        return this.delegate.getOutputFields();
+    }
+}

--- a/sql/storm-sql-external/storm-sql-kafka/src/test/org/apache/storm/sql/kafka/TestKafkaDataSourcesProvider.java
+++ b/sql/storm-sql-external/storm-sql-kafka/src/test/org/apache/storm/sql/kafka/TestKafkaDataSourcesProvider.java
@@ -18,48 +18,28 @@
 package org.apache.storm.sql.kafka;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.storm.kafka.bolt.KafkaBolt;
 import org.apache.storm.sql.runtime.DataSourcesRegistry;
 import org.apache.storm.sql.runtime.FieldInfo;
 import org.apache.storm.sql.runtime.ISqlStreamsDataSource;
-import org.apache.storm.sql.runtime.serde.json.JsonSerializer;
 import org.apache.storm.topology.IRichBolt;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
 
 import java.net.URI;
-import java.nio.ByteBuffer;
 import java.util.*;
-import java.util.concurrent.Future;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import java.lang.reflect.Field;
 
 public class TestKafkaDataSourcesProvider {
 
     private static final List<FieldInfo> FIELDS = ImmutableList.of(
         new FieldInfo("ID", int.class, true),
         new FieldInfo("val", String.class, false));
-    private static final List<String> FIELD_NAMES = ImmutableList.of("ID", "val");
-    private static final JsonSerializer SERIALIZER = new JsonSerializer(FIELD_NAMES);
     private static final Properties TBL_PROPERTIES = new Properties();
 
     static {
         Map<String, Object> map = new HashMap<>();
-        map.put("bootstrap.servers", "localhost:9092");
         map.put("acks", "1");
         map.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
-        map.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
         TBL_PROPERTIES.put("producer", map);
     }
 
@@ -67,7 +47,7 @@ public class TestKafkaDataSourcesProvider {
     @Test
     public void testKafkaSink() throws Exception {
         ISqlStreamsDataSource ds = DataSourcesRegistry.constructStreamsDataSource(
-            URI.create("kafka://mock?topic=foo"), null, null, TBL_PROPERTIES, FIELDS);
+            URI.create("kafka://foo?bootstrap-servers=foo"), null, null, TBL_PROPERTIES, FIELDS);
         Assert.assertNotNull(ds);
 
         IRichBolt consumer = ds.getConsumer();


### PR DESCRIPTION
…kafka

https://issues.apache.org/jira/browse/STORM-2972

The new kafka scheme syntax is stolen from [Apache Camel](https://github.com/apache/camel/blob/master/components/camel-kafka/src/main/docs/kafka-component.adoc), since I figure we are doing something very similar to them.

The primary limitation here compared to the storm-kafka version is that you can't include metadata (e.g. partition) in the emitted tuple, because I had to adapt the Scheme API to the RecordTranslator API used in storm-kafka-client. Emitting metadata with a Scheme in the storm-kafka spout is handled by [special case instanceof'ing the scheme](https://github.com/apache/storm/blob/af42f434f4a4c3d9087c6058b359033736d3b5e8/external/storm-kafka/src/jvm/org/apache/storm/kafka/KafkaUtils.java#L134) to see if it fits one that takes metadata, and I'd really prefer not to do that.

If we need to be able to emit metadata as well, we can just allow people to override the RecordTranslatorSchemeAdapter. I'll leave that as a task for later, unless someone objects.