### PR TITLE
STORM-3159: Fixed a potential file resource leak.

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
@@ -636,15 +636,14 @@ public class ServerUtils {
      * @throws IOException
      */
     public static long zipFileSize(File myFile) throws IOException {
-        RandomAccessFile raf = new RandomAccessFile(myFile, "r");
-        raf.seek(raf.length() - 4);
-        long b4 = raf.read();
-        long b3 = raf.read();
-        long b2 = raf.read();
-        long b1 = raf.read();
-        long val = (b1 << 24) | (b2 << 16) + (b3 << 8) + b4;
-        raf.close();
-        return val;
+        try (RandomAccessFile raf = new RandomAccessFile(myFile, "r")) {
+            raf.seek(raf.length() - 4);
+            long b4 = raf.read();
+            long b3 = raf.read();
+            long b2 = raf.read();
+            long b1 = raf.read();
+            return (b1 << 24) | (b2 << 16) + (b3 << 8) + b4;
+        }
     }
 
     private static boolean downloadResourcesAsSupervisorAttempt(ClientBlobStore cb, String key, String localFile) {


### PR DESCRIPTION
The file is not properly put in the try-with-resource/try-finally block.