### PR TITLE
Bug fix for BaseResourceAwareStrategy to avoid NullPointerException

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
@@ -357,9 +357,12 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
             ObjectResources rack = new ObjectResources(rackId);
             racks.add(rack);
             for (String nodeHost : nodeHosts) {
-                for (RAS_Node node : hostnameToNodes(nodeHost)) {
-                    rack.availableResources.add(node.getTotalAvailableResources());
-                    rack.totalResources.add(node.getTotalAvailableResources());
+                List<RAS_Node> nodes = hostnameToNodes(nodeHost);
+                if(nodes != null) {
+                    for (RAS_Node node : nodes) {
+                        rack.availableResources.add(node.getTotalAvailableResources());
+                        rack.totalResources.add(node.getTotalAvailableResources());
+                    }
                 }
             }
 


### PR DESCRIPTION
Bug fix for BaseResourceAwareStrategy to avoid NullPointerException, when a supervisor is in bad list but alive.