### PR TITLE
STORM-3161 Local mode should force setting min replication count to 1

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -208,6 +208,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
             conf.put(Config.STORM_CLUSTER_MODE, "local");
             conf.put(Config.BLOBSTORE_SUPERUSER, System.getProperty("user.name"));
             conf.put(Config.BLOBSTORE_DIR, nimbusTmp.getPath());
+            conf.put(Config.TOPOLOGY_MIN_REPLICATION_COUNT, 1);
 
             InProcessZookeeper zookeeper = null;
             if (!builder.daemonConf.containsKey(Config.STORM_ZOOKEEPER_SERVERS)) {


### PR DESCRIPTION
When topology.min.replication.count is set to more than 1, nimbus in local mode
never achieve condition for replication, hence stuck on handling blobs.

We should force set it to 1 in local mode to avoid this situation.

Will also submit patch for 1.x-branch.