### PR TITLE
(1.x) STORM-3121: Fix flaky metrics tests in storm-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,7 @@
         <joda-time.version>2.3</joda-time.version>
         <thrift.version>0.9.3</thrift.version>
         <junit.version>4.11</junit.version>
+        <awaitility.version>3.1.0</awaitility.version>
         <metrics-clojure.version>2.5.1</metrics-clojure.version>
         <hdrhistogram.version>2.1.7</hdrhistogram.version>
         <hamcrest.version>1.3</hamcrest.version>
@@ -942,6 +943,12 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -280,6 +280,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>

--- a/storm-core/test/resources/log4j2-test.xml
+++ b/storm-core/test/resources/log4j2-test.xml
@@ -26,6 +26,7 @@
         <!-- suppress ERROR org.apache.storm.blobstore.BlobStoreUtils - Could not update the blob with key: key when testing -->
         <Logger name="org.apache.storm.blobstore" level="FATAL" />
         <Logger name="org.apache.zookeeper" level="WARN"/>
+        <Logger name="org.apache.curator" level="WARN"/>
         <Root level="${env:LOG_LEVEL:-INFO}">
             <AppenderRef ref="Console"/>
         </Root>


### PR DESCRIPTION
This ports back #2735 to 1.x-branch since I can see flaky metrics tests from 1.x-branch.

https://travis-ci.org/apache/storm/jobs/408847970#L1079-L1082

I also fixed merge conflict so would like to review rather than pushing the change without notice.

@srdo Could you take a look? Thanks in advance!