### PR TITLE
STORM-3163: Make ShellBolt logger setup calls occur in-thread to support MDC

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/task/ShellBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/task/ShellBolt.java
@@ -153,7 +153,6 @@ public class ShellBolt implements IBolt {
         LOG.info("Launched subprocess with pid " + subpid);
 
         _logHandler = ShellUtils.getLogHandler(topoConf);
-        _logHandler.setUpContext(ShellBolt.class, _process, _context);
 
         // reader
         _readerThread = new Thread(new BoltReaderRunnable());
@@ -324,6 +323,7 @@ public class ShellBolt implements IBolt {
 
     private class BoltReaderRunnable implements Runnable {
         public void run() {
+            _logHandler.setUpContext(ShellBolt.class, _process, _context);
             while (_running) {
                 try {
                     ShellMsg shellMsg = _process.readShellMsg();


### PR DESCRIPTION
Prior to this the logger set up would occur in a separate thread (the
parent), to the one doing the logging. This meant that MDC values, which
are thread local, could not persist from the set up phase. By doing set
up in the same thread, MDC values are now reliably available during log
calls.

https://issues.apache.org/jira/browse/STORM-3163