### PR TITLE
STORM-3163: Make ShellBolt logger setup calls occur in-thread to support MDC (BACKPORT)

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/org/apache/storm/task/ShellBolt.java
@@ -154,7 +154,6 @@ public class ShellBolt implements IBolt {
         LOG.info("Launched subprocess with pid " + subpid);
 
         _logHandler = ShellUtils.getLogHandler(stormConf);
-        _logHandler.setUpContext(ShellBolt.class, _process, _context);
 
         // reader
         _readerThread = new Thread(new BoltReaderRunnable());
@@ -325,6 +324,7 @@ public class ShellBolt implements IBolt {
 
     private class BoltReaderRunnable implements Runnable {
         public void run() {
+            _logHandler.setUpContext(ShellBolt.class, _process, _context);
             while (_running) {
                 try {
                     ShellMsg shellMsg = _process.readShellMsg();


### PR DESCRIPTION
Backport to 1.x.