### PR TITLE
STORM-3164: Fix usage of traceback.format_exc in multilang (BACKPORT)

### DIFF
--- a/storm-multilang/python/src/main/resources/resources/storm.py
+++ b/storm-multilang/python/src/main/resources/resources/storm.py
@@ -196,8 +196,8 @@ class Bolt(object):
                     sync()
                 else:
                     self.process(tup)
-        except Exception as e:
-            reportError(traceback.format_exc(e))
+        except Exception:
+            reportError(traceback.format_exc())
 
 class BasicBolt(object):
     def initialize(self, stormconf, context):
@@ -222,11 +222,11 @@ class BasicBolt(object):
                     try:
                         self.process(tup)
                         ack(tup)
-                    except Exception as e:
-                        reportError(traceback.format_exc(e))
+                    except Exception:
+                        reportError(traceback.format_exc())
                         fail(tup)
-        except Exception as e:
-            reportError(traceback.format_exc(e))
+        except Exception:
+            reportError(traceback.format_exc())
 
 class Spout(object):
     def initialize(self, conf, context):
@@ -266,5 +266,5 @@ class Spout(object):
                 if msg["command"] == "fail":
                     self.fail(msg["id"])
                 sync()
-        except Exception as e:
-            reportError(traceback.format_exc(e))
+        except Exception:
+            reportError(traceback.format_exc())


### PR DESCRIPTION
Backport to 1.x.