### PR TITLE
[WIP] Make StormMetricsRegistry a regular class rather than a static utility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
         <log4j.version>2.8.2</log4j.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <metrics.version>3.1.0</metrics.version>
+        <metrics.version>3.2.6</metrics.version>
         <clojure.tools.nrepl.version>0.2.3</clojure.tools.nrepl.version>
         <clojure-complete.version>0.2.3</clojure-complete.version>
         <mockito.version>2.19.0</mockito.version>

--- a/storm-core/src/jvm/org/apache/storm/command/KillWorkers.java
+++ b/storm-core/src/jvm/org/apache/storm/command/KillWorkers.java
@@ -12,17 +12,16 @@
 
 package org.apache.storm.command;
 
-import java.io.File;
 import java.util.Map;
-import org.apache.storm.Config;
 import org.apache.storm.daemon.supervisor.StandaloneSupervisor;
 import org.apache.storm.daemon.supervisor.Supervisor;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.utils.Utils;
 
 public class KillWorkers {
     public static void main(String[] args) throws Exception {
         Map<String, Object> conf = Utils.readStormConfig();
-        try (Supervisor supervisor = new Supervisor(conf, null, new StandaloneSupervisor())) {
+        try (Supervisor supervisor = new Supervisor(conf, null, new StandaloneSupervisor(), new StormMetricsRegistry())) {
             supervisor.shutdownAllWorkers(null, null);
         }
     }

--- a/storm-core/test/clj/integration/org/apache/storm/trident/integration_test.clj
+++ b/storm-core/test/clj/integration/org/apache/storm/trident/integration_test.clj
@@ -47,7 +47,7 @@
 
 (deftest test-memory-map-get-tuples
   (with-open [cluster (LocalCluster. )]
-    (with-open [drpc (LocalDRPC.)]
+    (with-open [drpc (LocalDRPC. (.getMetricRegistry cluster))]
       (letlocals
         (bind topo (TridentTopology.))
         (bind feeder (FeederBatchSpout. ["sentence"]))
@@ -74,7 +74,7 @@
 
 (deftest test-word-count
   (with-open [cluster (LocalCluster. )]
-    (with-open [drpc (LocalDRPC.)]
+    (with-open [drpc (LocalDRPC. (.getMetricRegistry cluster))]
       (letlocals
         (bind topo (TridentTopology.))
         (bind feeder (FeederBatchSpout. ["sentence"]))
@@ -107,7 +107,7 @@
 ;; there's at least one repartitioning after the spout
 (deftest test-word-count-committer-spout
   (with-open [cluster (LocalCluster. )]
-    (with-open [drpc (LocalDRPC.)]
+    (with-open [drpc (LocalDRPC. (.getMetricRegistry cluster))]
       (letlocals
         (bind topo (TridentTopology.))
         (bind feeder (FeederCommitterBatchSpout. ["sentence"]))
@@ -146,7 +146,7 @@
 
 (deftest test-count-agg
   (with-open [cluster (LocalCluster. )]
-    (with-open [drpc (LocalDRPC.)]
+    (with-open [drpc (LocalDRPC. (.getMetricRegistry cluster))]
       (letlocals
         (bind topo (TridentTopology.))
         (-> topo
@@ -164,7 +164,7 @@
 
 (deftest test-split-merge
   (with-open [cluster (LocalCluster. )]
-    (with-open [drpc (LocalDRPC.)]
+    (with-open [drpc (LocalDRPC. (.getMetricRegistry cluster))]
       (letlocals
         (bind topo (TridentTopology.))
         (bind drpc-stream (-> topo (.newDRPCStream "splitter" drpc)))
@@ -185,7 +185,7 @@
 
 (deftest test-multiple-groupings-same-stream
   (with-open [cluster (LocalCluster. )]
-    (with-open [drpc (LocalDRPC.)]
+    (with-open [drpc (LocalDRPC. (.getMetricRegistry cluster))]
       (letlocals
         (bind topo (TridentTopology.))
         (bind drpc-stream (-> topo (.newDRPCStream "tester" drpc)
@@ -207,7 +207,7 @@
 
 (deftest test-multi-repartition
   (with-open [cluster (LocalCluster. )]
-    (with-open [drpc (LocalDRPC.)]
+    (with-open [drpc (LocalDRPC. (.getMetricRegistry cluster))]
       (letlocals
         (bind topo (TridentTopology.))
         (bind drpc-stream (-> topo (.newDRPCStream "tester" drpc)
@@ -281,7 +281,7 @@
                                          (CombinerAggStateUpdater. (Count.))
                                          (Fields. ["count"])))))
      ;; test .stateQuery
-     (with-open [drpc (LocalDRPC.)]
+     (with-open [drpc (LocalDRPC. (.getMetricRegistry cluster))]
        (is (thrown? IllegalArgumentException
                     (-> topo
                         (.newDRPCStream "words" drpc)
@@ -293,7 +293,7 @@
 
 (deftest test-set-component-resources
   (with-open [cluster (LocalCluster. )]
-    (with-open [drpc (LocalDRPC.)]
+    (with-open [drpc (LocalDRPC. (.getMetricRegistry cluster))]
       (letlocals
         (bind topo (TridentTopology.))
         (bind feeder (FeederBatchSpout. ["sentence"]))

--- a/storm-core/test/clj/org/apache/storm/drpc_test.clj
+++ b/storm-core/test/clj/org/apache/storm/drpc_test.clj
@@ -41,9 +41,9 @@
   )
 
 (deftest test-drpc-flow
-  (let [drpc (LocalDRPC.)
+  (let [cluster (LocalCluster.)
+        drpc (LocalDRPC. (.getMetricRegistry cluster))
         spout (DRPCSpout. "test" drpc)
-        cluster (LocalCluster.)
         topology (Thrift/buildTopology
                    {"1" (Thrift/prepareSpoutDetails spout)}
                    {"2" (Thrift/prepareBoltDetails
@@ -73,8 +73,8 @@
   )
 
 (deftest test-drpc-builder
-  (let [drpc (LocalDRPC.)
-        cluster (LocalCluster.)
+  (let [cluster (LocalCluster.)
+        drpc (LocalDRPC. (.getMetricRegistry cluster))
         builder (LinearDRPCTopologyBuilder. "test")
         ]
     (.addBolt builder exclamation-bolt-drpc 3)
@@ -136,8 +136,8 @@
     ))
 
 (deftest test-drpc-coordination
-  (let [drpc (LocalDRPC.)
-        cluster (LocalCluster.)
+  (let [cluster (LocalCluster.)
+        drpc (LocalDRPC. (.getMetricRegistry cluster))
         builder (LinearDRPCTopologyBuilder. "square")
         ]
     (.addBolt builder create-tuples 3)
@@ -178,8 +178,8 @@
                )))
 
 (deftest test-drpc-coordination-tricky
-  (let [drpc (LocalDRPC.)
-        cluster (LocalCluster.)
+  (let [cluster (LocalCluster.)
+        drpc (LocalDRPC. (.getMetricRegistry cluster))
         builder (LinearDRPCTopologyBuilder. "tricky")
         ]
     (.addBolt builder id-bolt 3)
@@ -210,8 +210,8 @@
                )))
 
 (deftest test-drpc-fail-finish
-  (let [drpc (LocalDRPC.)
-        cluster (LocalCluster.)
+  (let [cluster (LocalCluster.)
+        drpc (LocalDRPC. (.getMetricRegistry cluster))
         builder (LinearDRPCTopologyBuilder. "fail2")
         ]
     (.addBolt builder fail-finish-bolt 3)

--- a/storm-core/test/clj/org/apache/storm/scheduler/multitenant_scheduler_test.clj
+++ b/storm-core/test/clj/org/apache/storm/scheduler/multitenant_scheduler_test.clj
@@ -20,6 +20,8 @@
   (:import [org.apache.storm.daemon.nimbus Nimbus$StandaloneINimbus])
   (:import [org.apache.storm.scheduler Cluster SupervisorDetails WorkerSlot ExecutorDetails
             SchedulerAssignmentImpl Topologies TopologyDetails])
+  (:import [org.apache.storm.scheduler.resource.normalization ResourceMetrics])
+  (:import [org.apache.storm.metric StormMetricsRegistry])
   (:import [org.apache.storm.scheduler.multitenant Node NodePool FreePool DefaultPool
             IsolatedPool MultitenantScheduler]))
 
@@ -44,7 +46,7 @@
   (let [supers (gen-supervisors 5)
        topology1 (TopologyDetails. "topology1" {} nil 1, "user")
        topology2 (TopologyDetails. "topology2" {} nil 1, "user")
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} (Topologies. {"topology1" topology1 "topology2" topology2}) {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} (Topologies. {"topology1" topology1 "topology2" topology2}) {})
        node-map (Node/getAllNodesFrom cluster)]
     (is (= 5 (.size node-map)))
     (let [node (.get node-map "super0")]
@@ -90,7 +92,7 @@
 (deftest test-free-pool
   (let [supers (gen-supervisors 5)
        topology1 (TopologyDetails. "topology1" {} nil 1, "user")
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} (Topologies. {"topology1" topology1}) {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} (Topologies. {"topology1" topology1}) {})
        node-map (Node/getAllNodesFrom cluster)
        free-pool (FreePool. )]
     ;; assign one node so it is not in the pool
@@ -141,7 +143,7 @@
                     executor2 "bolt1"
                     executor3 "bolt2"} "user")
        topologies (Topologies. {"topology1" topology1})
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} topologies {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} topologies {})
        node-map (Node/getAllNodesFrom cluster)]
     ;; assign one node so it is not in the pool
     (.assign (.get node-map "super0") "topology1" (list executor1) cluster)
@@ -179,7 +181,7 @@
                     executor2 "bolt1"
                     executor3 "bolt2"} "user")
        topologies (Topologies. {"topology1" topology1})
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} topologies {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} topologies {})
        node-map (Node/getAllNodesFrom cluster)]
     ;; assign one node so it is not in the pool
     (.assign (.get node-map "super0") "topology1" (list executor1) cluster)
@@ -220,7 +222,7 @@
                     executor3 "bolt1"
                     executor4 "bolt1"
                     executor5 "bolt2"} "user")
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} (Topologies. {"topology1" topology1}) {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} (Topologies. {"topology1" topology1}) {})
        node-map (Node/getAllNodesFrom cluster)]
     ;; assign one node so it is not in the pool
     (.assign (.get node-map "super0") "topology1" (list executor1) cluster)
@@ -261,7 +263,7 @@
                     executor4 "bolt3"
                     executor5 "bolt4"} "user")
        topologies (Topologies. {"topology1" topology1})
-       single-cluster (Cluster. (Nimbus$StandaloneINimbus.) single-super {} topologies {})]
+       single-cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) single-super {} topologies {})]
     (let [node-map (Node/getAllNodesFrom single-cluster)
          free-pool (FreePool. )
          default-pool (DefaultPool. )]
@@ -274,7 +276,7 @@
       (is (= "Running with fewer slots than requested (4/5)" (.get (.getStatusMap single-cluster) "topology1")))
     )
 
-    (let [cluster (Cluster. (Nimbus$StandaloneINimbus.) supers (.getAssignments single-cluster) topologies {})
+    (let [cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers (.getAssignments single-cluster) topologies {})
          node-map (Node/getAllNodesFrom cluster)
          free-pool (FreePool. )
          default-pool (DefaultPool. )]
@@ -316,7 +318,7 @@
                      executor13 "bolt13"
                      executor14 "bolt14"} "user")
        topologies (Topologies. {"topology1" topology1 "topology2" topology2})
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} topologies {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} topologies {})
        node-map (Node/getAllNodesFrom cluster)]
     ;; assign one node so it is not in the pool
     (.assign (.get node-map "super0") "topology1" (list executor1) cluster)
@@ -390,7 +392,7 @@
                     executor3 "bolt2"
                     executor4 "bolt4"} "user")
        topologies (Topologies. {"topology1" topology1})
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} topologies {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} topologies {})
        node-map (Node/getAllNodesFrom cluster)]
     ;; assign one node so it is not in the pool
     (.assign (.get node-map "super0") "topology1" (list executor1) cluster)
@@ -435,7 +437,7 @@
                     executor3 "bolt2"
                     executor4 "bolt4"} "user")
        topologies (Topologies. {"topology1" topology1})
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} topologies {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} topologies {})
        node-map (Node/getAllNodesFrom cluster)]
     ;; assign one node so it is not in the pool
     (.assign (.get node-map "super0") "topology1" (list executor1) cluster)
@@ -492,7 +494,7 @@
                      executor13 "bolt13"
                      executor14 "bolt14"} "user")
        topologies (Topologies. {"topology1" topology1 "topology2" topology2})
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} topologies {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} topologies {})
        node-map (Node/getAllNodesFrom cluster)]
     ;; assign one node so it is not in the pool
     (.assign (.get node-map "super0") "topology1" (list executor1) cluster)
@@ -598,7 +600,7 @@
                      executor13 "bolt13"
                      executor14 "bolt14"} "user")
        topologies (Topologies. {"topology1" topology1 "topology2" topology2})
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} topologies {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} topologies {})
        node-map (Node/getAllNodesFrom cluster)]
     ;; assign one node so it is not in the pool
     (.assign (.get node-map "super0") "topology1" (list executor1) cluster)
@@ -666,7 +668,7 @@
                                 ["bolt23" 20 30]
                                 ["bolt24" 30 40]]) "userB")
        topologies (Topologies. (to-top-map [topology1 topology2 topology3]))
-       cluster (Cluster. (Nimbus$StandaloneINimbus.) supers {} topologies {})
+       cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers {} topologies {})
        node-map (Node/getAllNodesFrom cluster)
        conf {MULTITENANT-SCHEDULER-USER-POOLS {"userA" 5 "userB" 5}}
        scheduler (MultitenantScheduler.)]
@@ -704,7 +706,7 @@
                                                                                   (ExecutorDetails. 15 20) (WorkerSlot. "super0" 1)} nil nil)
                                }
         topologies (Topologies. (to-top-map [topology1]))
-        cluster (Cluster. (Nimbus$StandaloneINimbus.) supers existing-assignments topologies {})
+        cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers existing-assignments topologies {})
         node-map (Node/getAllNodesFrom cluster)
         conf {MULTITENANT-SCHEDULER-USER-POOLS {"userA" 5 "userB" 5}}
         scheduler (MultitenantScheduler.)]
@@ -746,7 +748,7 @@
           existing-assignments {"topology2" (SchedulerAssignmentImpl. "topology2" {(ExecutorDetails. 1 1) worker-slot-with-multiple-assignments} nil nil)
                                 "topology3" (SchedulerAssignmentImpl. "topology3" {(ExecutorDetails. 2 2) worker-slot-with-multiple-assignments} nil nil)}
           topologies (Topologies. (to-top-map [topology1 topology2 topology3]))
-          cluster (Cluster. (Nimbus$StandaloneINimbus.) supers existing-assignments topologies {})
+          cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers existing-assignments topologies {})
           conf {MULTITENANT-SCHEDULER-USER-POOLS {"userA" 2 "userB" 1}}
           scheduler (MultitenantScheduler.)]
       (.prepare scheduler conf)
@@ -773,7 +775,7 @@
                                 (SchedulerAssignmentImpl. "topology1"
                                   {(ExecutorDetails. 0 0) (WorkerSlot. "super0" port-not-reported-by-supervisor)} nil nil)}
           topologies (Topologies. (to-top-map [topology1]))
-          cluster (Cluster. (Nimbus$StandaloneINimbus.) supers existing-assignments topologies {})
+          cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers existing-assignments topologies {})
           conf {}
           scheduler (MultitenantScheduler.)]
       (.prepare scheduler conf)
@@ -811,7 +813,7 @@
                                   {(ExecutorDetails. 4 4) worker-slot-with-multiple-assignments
                                    (ExecutorDetails. 5 5) (WorkerSlot. dead-supervisor port-not-reported-by-supervisor)} nil nil)}
           topologies (Topologies. (to-top-map [topology1 topology2]))
-          cluster (Cluster. (Nimbus$StandaloneINimbus.) supers existing-assignments topologies {})
+          cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers existing-assignments topologies {})
           conf {}
           scheduler (MultitenantScheduler.)]
       (.prepare scheduler conf)
@@ -849,7 +851,7 @@
                                  (ExecutorDetails. 4 4) (WorkerSlot. "super2" 1)
                                  (ExecutorDetails. 5 5) (WorkerSlot. "super2" 2)} nil nil)}
         topologies (Topologies. (to-top-map [topology1]))
-        cluster (Cluster. (Nimbus$StandaloneINimbus.) supers existing-assignments topologies {})
+        cluster (Cluster. (Nimbus$StandaloneINimbus.) (ResourceMetrics. (StormMetricsRegistry.)) supers existing-assignments topologies {})
         conf {MULTITENANT-SCHEDULER-USER-POOLS {"userA" 2}}
         scheduler (MultitenantScheduler.)]
     (.prepare scheduler conf)

--- a/storm-core/test/clj/org/apache/storm/scheduler_test.clj
+++ b/storm-core/test/clj/org/apache/storm/scheduler_test.clj
@@ -19,6 +19,8 @@
   (:import [org.apache.storm.scheduler EvenScheduler])
   (:import [org.apache.storm.daemon.nimbus Nimbus$StandaloneINimbus])
   (:import [org.apache.storm.generated StormTopology])
+  (:import [org.apache.storm.scheduler.resource.normalization ResourceMetrics])
+  (:import [org.apache.storm.metric StormMetricsRegistry])
   (:import [org.apache.storm.scheduler Cluster SupervisorDetails WorkerSlot ExecutorDetails
             SchedulerAssignmentImpl Topologies TopologyDetails]))
 
@@ -128,6 +130,7 @@
         assignment2 (SchedulerAssignmentImpl. "topology2" executor->slot2 nil nil)
         assignment3 (SchedulerAssignmentImpl. "topology3" executor->slot3 nil nil)
         cluster (Cluster. (Nimbus$StandaloneINimbus.)
+                          (ResourceMetrics. (StormMetricsRegistry.))
                           {"supervisor1" supervisor1 "supervisor2" supervisor2}
                           {"topology1" assignment1 "topology2" assignment2 "topology3" assignment3}
                           topologies

--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -84,6 +84,7 @@ import org.apache.storm.generated.TopologyPageInfo;
 import org.apache.storm.generated.WorkerMetrics;
 import org.apache.storm.messaging.IContext;
 import org.apache.storm.messaging.local.Context;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.nimbus.ILeaderElector;
 import org.apache.storm.scheduler.INimbus;
 import org.apache.storm.scheduler.ISupervisor;
@@ -144,6 +145,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
     private final StormCommonInstaller commonInstaller;
     private final SimulatedTime time;
     private final NimbusClient.LocalOverride nimbusOverride;
+    private final StormMetricsRegistry metricRegistry;
 
     /**
      * Create a default LocalCluster.
@@ -219,6 +221,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
             this.zookeeper = zookeeper;
             conf.putAll(builder.daemonConf);
             this.daemonConf = new HashMap<>(conf);
+            this.metricRegistry = new StormMetricsRegistry();
 
             this.portCounter = new AtomicInteger(builder.supervisorSlotPortMin);
             ClusterStateContext cs = new ClusterStateContext(DaemonType.NIMBUS, daemonConf);
@@ -232,7 +235,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
             conf.put(Config.STORM_LOCAL_DIR, nimbusTmp.getPath());
             Nimbus nimbus = new Nimbus(conf, builder.inimbus == null ? new StandaloneINimbus() : builder.inimbus,
                                        this.getClusterState(), null, builder.store, builder.topoCache, builder.leaderElector,
-                                       builder.groupMapper);
+                                       builder.groupMapper, metricRegistry);
             if (builder.nimbusWrapper != null) {
                 nimbus = builder.nimbusWrapper.apply(nimbus);
             }
@@ -270,6 +273,8 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
                 this.nimbusOverride = null;
             }
             success = true;
+            
+            metricRegistry.startMetricsReporters(daemonConf);
         } finally {
             if (!success) {
                 close();
@@ -307,7 +312,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
     public static <T> T withLocalModeOverride(Callable<T> c, long ttlSec) throws Exception {
         LOG.info("\n\n\t\tSTARTING LOCAL MODE CLUSTER\n\n");
         try (LocalCluster local = new LocalCluster();
-             LocalDRPC drpc = new LocalDRPC();
+             LocalDRPC drpc = new LocalDRPC(local.metricRegistry);
              DRPCClient.LocalOverride drpcOverride = new DRPCClient.LocalOverride(drpc)) {
 
             T ret = c.call();
@@ -372,6 +377,13 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
      */
     public Nimbus getNimbus() {
         return nimbus;
+    }
+
+    /**
+     * @return The metrics registry for the local cluster.
+     */
+    public StormMetricsRegistry getMetricRegistry() {
+        return metricRegistry;
     }
 
     /**
@@ -498,6 +510,9 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
 
     @Override
     public synchronized void close() throws Exception {
+        if (metricRegistry != null) {
+            metricRegistry.stopMetricsReporters(daemonConf);
+        }
         if (nimbusOverride != null) {
             nimbusOverride.close();
         }
@@ -648,7 +663,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
             throw new IllegalArgumentException("Cannot start server in distrubuted mode!");
         }
 
-        Supervisor s = new Supervisor(superConf, sharedContext, isuper);
+        Supervisor s = new Supervisor(superConf, sharedContext, isuper, metricRegistry);
         s.launch();
         s.setLocalNimbus(this.nimbus);
         this.nimbus.addSupervisor(s);

--- a/storm-server/src/main/java/org/apache/storm/LocalDRPC.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalDRPC.java
@@ -24,6 +24,7 @@ import org.apache.storm.daemon.drpc.DRPCThrift;
 import org.apache.storm.generated.AuthorizationException;
 import org.apache.storm.generated.DRPCExecutionException;
 import org.apache.storm.generated.DRPCRequest;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.thrift.TException;
 import org.apache.storm.utils.ServiceRegistry;
 import org.apache.storm.utils.Utils;
@@ -38,9 +39,9 @@ public class LocalDRPC implements ILocalDRPC {
     private final DRPC drpc;
     private final String serviceId;
 
-    public LocalDRPC() {
+    public LocalDRPC(StormMetricsRegistry metricsRegistry) {
         Map<String, Object> conf = Utils.readStormConfig();
-        drpc = new DRPC(conf);
+        drpc = new DRPC(metricsRegistry, conf);
         serviceId = ServiceRegistry.registerService(new DRPCThrift(drpc));
     }
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/drpc/DRPC.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/drpc/DRPC.java
@@ -52,11 +52,12 @@ public class DRPC implements AutoCloseable {
     private static final DRPCExecutionException TIMED_OUT = new WrappedDRPCExecutionException("Timed Out");
     private static final DRPCExecutionException SHUT_DOWN = new WrappedDRPCExecutionException("Server Shutting Down");
     private static final DRPCExecutionException DEFAULT_FAILED = new WrappedDRPCExecutionException("Request failed");
-    private static final Meter meterServerTimedOut = StormMetricsRegistry.registerMeter("drpc:num-server-timedout-requests");
-    private static final Meter meterExecuteCalls = StormMetricsRegistry.registerMeter("drpc:num-execute-calls");
-    private static final Meter meterResultCalls = StormMetricsRegistry.registerMeter("drpc:num-result-calls");
-    private static final Meter meterFailRequestCalls = StormMetricsRegistry.registerMeter("drpc:num-failRequest-calls");
-    private static final Meter meterFetchRequestCalls = StormMetricsRegistry.registerMeter("drpc:num-fetchRequest-calls");
+    
+    private final Meter meterServerTimedOut;
+    private final Meter meterExecuteCalls;
+    private final Meter meterResultCalls;
+    private final Meter meterFailRequestCalls;
+    private final Meter meterFetchRequestCalls;
 
     static {
         TIMED_OUT.set_type(DRPCExceptionType.SERVER_TIMEOUT);
@@ -74,13 +75,18 @@ public class DRPC implements AutoCloseable {
     private final AtomicLong _ctr = new AtomicLong(0);
     private final IAuthorizer _auth;
 
-    public DRPC(Map<String, Object> conf) {
-        this(mkAuthorizationHandler((String) conf.get(DaemonConfig.DRPC_AUTHORIZER), conf),
+    public DRPC(StormMetricsRegistry metricsRegistry, Map<String, Object> conf) {
+        this(metricsRegistry, mkAuthorizationHandler((String) conf.get(DaemonConfig.DRPC_AUTHORIZER), conf),
              ObjectReader.getInt(conf.get(DaemonConfig.DRPC_REQUEST_TIMEOUT_SECS), 600) * 1000);
     }
 
-    public DRPC(IAuthorizer auth, long timeoutMs) {
+    public DRPC(StormMetricsRegistry metricsRegistry, IAuthorizer auth, long timeoutMs) {
         _auth = auth;
+        this.meterServerTimedOut = metricsRegistry.registerMeter("drpc:num-server-timedout-requests");
+        this.meterExecuteCalls = metricsRegistry.registerMeter("drpc:num-execute-calls");
+        this.meterResultCalls = metricsRegistry.registerMeter("drpc:num-result-calls");
+        this.meterFailRequestCalls = metricsRegistry.registerMeter("drpc:num-failRequest-calls");
+        this.meterFetchRequestCalls = metricsRegistry.registerMeter("drpc:num-fetchRequest-calls");
         _timer.scheduleAtFixedRate(new TimerTask() {
             @Override
             public void run() {

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/ConsolePreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/ConsolePreparableReporter.java
@@ -21,7 +21,7 @@ import org.apache.storm.daemon.metrics.ClientMetricsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConsolePreparableReporter implements PreparableReporter<ConsoleReporter> {
+public class ConsolePreparableReporter implements PreparableReporter {
     private static final Logger LOG = LoggerFactory.getLogger(ConsolePreparableReporter.class);
     ConsoleReporter reporter = null;
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/CsvPreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/CsvPreparableReporter.java
@@ -23,7 +23,7 @@ import org.apache.storm.daemon.metrics.MetricsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CsvPreparableReporter implements PreparableReporter<CsvReporter> {
+public class CsvPreparableReporter implements PreparableReporter {
     private static final Logger LOG = LoggerFactory.getLogger(CsvPreparableReporter.class);
     CsvReporter reporter = null;
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/JmxPreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/JmxPreparableReporter.java
@@ -22,7 +22,7 @@ import org.apache.storm.utils.ObjectReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JmxPreparableReporter implements PreparableReporter<JmxReporter> {
+public class JmxPreparableReporter implements PreparableReporter {
     private static final Logger LOG = LoggerFactory.getLogger(JmxPreparableReporter.class);
     JmxReporter reporter = null;
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/PreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/PreparableReporter.java
@@ -13,12 +13,10 @@
 package org.apache.storm.daemon.metrics.reporters;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Reporter;
-import java.io.Closeable;
 import java.util.Map;
 
 
-public interface PreparableReporter<T extends Reporter & Closeable> {
+public interface PreparableReporter {
     void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf);
 
     void start();

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/BasicContainer.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/BasicContainer.java
@@ -91,12 +91,13 @@ public class BasicContainer extends Container {
      * @param resourceIsolationManager used to isolate resources for a container can be null if no isolation is used.
      * @param localState               the local state of the supervisor.  May be null if partial recovery
      * @param workerId                 the id of the worker to use.  Must not be null if doing a partial recovery.
+     * @param containerMemoryTracker   The shared memory tracker for the supervisor's containers
      */
     public BasicContainer(ContainerType type, Map<String, Object> conf, String supervisorId, int supervisorPort,
                           int port, LocalAssignment assignment, ResourceIsolationInterface resourceIsolationManager,
-                          LocalState localState, String workerId) throws IOException {
+                          LocalState localState, String workerId, ContainerMemoryTracker containerMemoryTracker) throws IOException {
         this(type, conf, supervisorId, supervisorPort, port, assignment, resourceIsolationManager, localState,
-             workerId, null, null, null);
+             workerId, containerMemoryTracker, null, null, null);
     }
 
     /**
@@ -111,18 +112,19 @@ public class BasicContainer extends Container {
      * @param resourceIsolationManager used to isolate resources for a container can be null if no isolation is used.
      * @param localState               the local state of the supervisor.  May be null if partial recovery
      * @param workerId                 the id of the worker to use.  Must not be null if doing a partial recovery.
+     * @param containerMemoryTracker   The shared memory tracker for the supervisor's containers
      * @param ops                      file system operations (mostly for testing) if null a new one is made
      * @param topoConf                 the config of the topology (mostly for testing) if null and not a partial recovery the real conf is
      *                                 read.
-     * @param profileCmd               the command to use when profiling (used for testing)
+     * @param profileCmd               the command to use when profiling (used for testing) 
      * @throws IOException                on any error
      * @throws ContainerRecoveryException if the Container could not be recovered.
      */
     BasicContainer(ContainerType type, Map<String, Object> conf, String supervisorId, int supervisorPort, int port,
-                   LocalAssignment assignment, ResourceIsolationInterface resourceIsolationManager,
-                   LocalState localState, String workerId, Map<String, Object> topoConf,
-                   AdvancedFSOps ops, String profileCmd) throws IOException {
-        super(type, conf, supervisorId, supervisorPort, port, assignment, resourceIsolationManager, workerId, topoConf, ops);
+        LocalAssignment assignment, ResourceIsolationInterface resourceIsolationManager, LocalState localState, String workerId,
+        ContainerMemoryTracker containerMemoryTracker, Map<String, Object> topoConf, AdvancedFSOps ops, String profileCmd) throws IOException {
+        super(type, conf, supervisorId, supervisorPort, port, assignment,
+            resourceIsolationManager, workerId, topoConf, ops, containerMemoryTracker);
         assert (localState != null);
         _localState = localState;
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/BasicContainerLauncher.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/BasicContainerLauncher.java
@@ -27,19 +27,22 @@ public class BasicContainerLauncher extends ContainerLauncher {
     private final Map<String, Object> _conf;
     private final String _supervisorId;
     private final int _supervisorPort;
+    private final ContainerMemoryTracker _containerMemoryTracker;
 
     public BasicContainerLauncher(Map<String, Object> conf, String supervisorId, int supervisorPort,
-                                  ResourceIsolationInterface resourceIsolationManager) throws IOException {
+                                  ResourceIsolationInterface resourceIsolationManager,
+                                  ContainerMemoryTracker containerMemoryTracker) throws IOException {
         _conf = conf;
         _supervisorId = supervisorId;
         _supervisorPort = supervisorPort;
         _resourceIsolationManager = resourceIsolationManager;
+        _containerMemoryTracker = containerMemoryTracker;
     }
 
     @Override
     public Container launchContainer(int port, LocalAssignment assignment, LocalState state) throws IOException {
         Container container = new BasicContainer(ContainerType.LAUNCH, _conf, _supervisorId, _supervisorPort, port,
-                                                 assignment, _resourceIsolationManager, state, null);
+                                                 assignment, _resourceIsolationManager, state, null, _containerMemoryTracker);
         container.setup();
         container.launch();
         return container;
@@ -48,12 +51,12 @@ public class BasicContainerLauncher extends ContainerLauncher {
     @Override
     public Container recoverContainer(int port, LocalAssignment assignment, LocalState state) throws IOException {
         return new BasicContainer(ContainerType.RECOVER_FULL, _conf, _supervisorId, _supervisorPort, port, assignment,
-                                  _resourceIsolationManager, state, null);
+                                  _resourceIsolationManager, state, null, _containerMemoryTracker);
     }
 
     @Override
     public Killable recoverContainer(String workerId, LocalState localState) throws IOException {
         return new BasicContainer(ContainerType.RECOVER_PARTIAL, _conf, _supervisorId, _supervisorPort, -1, null,
-                                  _resourceIsolationManager, localState, workerId);
+                                  _resourceIsolationManager, localState, workerId, _containerMemoryTracker);
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ContainerLauncher.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ContainerLauncher.java
@@ -43,13 +43,14 @@ public abstract class ContainerLauncher {
      * @param supervisorId the ID of the supervisor
      * @param supervisorPort the parent supervisor thrift server port
      * @param sharedContext Used in local mode to let workers talk together without netty
+     * @param containerMemoryTracker The shared memory tracker for the supervisor's containers
      * @return the proper container launcher
      * @throws IOException on any error
      */
     public static ContainerLauncher make(Map<String, Object> conf, String supervisorId, int supervisorPort,
-                                         IContext sharedContext) throws IOException {
+                                         IContext sharedContext, ContainerMemoryTracker containerMemoryTracker) throws IOException {
         if (ConfigUtils.isLocalMode(conf)) {
-            return new LocalContainerLauncher(conf, supervisorId, supervisorPort, sharedContext);
+            return new LocalContainerLauncher(conf, supervisorId, supervisorPort, sharedContext, containerMemoryTracker);
         }
 
         ResourceIsolationInterface resourceIsolationManager = null;
@@ -61,9 +62,9 @@ public abstract class ContainerLauncher {
         }
 
         if (ObjectReader.getBoolean(conf.get(Config.SUPERVISOR_RUN_WORKER_AS_USER), false)) {
-            return new RunAsUserContainerLauncher(conf, supervisorId, supervisorPort, resourceIsolationManager);
+            return new RunAsUserContainerLauncher(conf, supervisorId, supervisorPort, resourceIsolationManager, containerMemoryTracker);
         }
-        return new BasicContainerLauncher(conf, supervisorId, supervisorPort, resourceIsolationManager);
+        return new BasicContainerLauncher(conf, supervisorId, supervisorPort, resourceIsolationManager, containerMemoryTracker);
     }
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ContainerMemoryTracker.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ContainerMemoryTracker.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.storm.daemon.supervisor;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.storm.metric.StormMetricsRegistry;
+
+public class ContainerMemoryTracker {
+
+    private final ConcurrentHashMap<Integer, TopoAndMemory> usedMemory =
+        new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, TopoAndMemory> reservedMemory =
+        new ConcurrentHashMap<>();
+
+    public ContainerMemoryTracker(StormMetricsRegistry metricsRegistry) {
+        metricsRegistry.registerGauge(
+            "supervisor:current-used-memory-mb",
+            () -> {
+                Long val =
+                usedMemory.values().stream().mapToLong((topoAndMem) -> topoAndMem.memory).sum();
+                int ret = val.intValue();
+                if (val > Integer.MAX_VALUE) { // Would only happen at 2 PB so we are OK for now
+                    ret = Integer.MAX_VALUE;
+                }
+                return ret;
+            });
+        metricsRegistry.registerGauge(
+            "supervisor:current-reserved-memory-mb",
+            () -> {
+                Long val =
+                reservedMemory.values().stream().mapToLong((topoAndMem) -> topoAndMem.memory).sum();
+                int ret = val.intValue();
+                if (val > Integer.MAX_VALUE) { // Would only happen at 2 PB so we are OK for now
+                    ret = Integer.MAX_VALUE;
+                }
+                return ret;
+            });
+    }
+
+    /**
+     * Get the memory used by the worker on the given port.
+     *
+     * @param port The worker port
+     * @return The memory used by the worker, or empty if no worker exists on the given port.
+     */
+    public Optional<Long> getUsedMemoryMb(int port) {
+        TopoAndMemory topoAndMemory = usedMemory.get(port);
+        if (topoAndMemory == null) {
+            return Optional.empty();
+        }
+        return Optional.of(topoAndMemory.memory);
+    }
+
+    /**
+     * Gets the memory used by the given topology across all ports on this supervisor.
+     *
+     * @param topologyId The topology id
+     * @return The memory used by the given topology id
+     */
+    public long getUsedMemoryMb(String topologyId) {
+        return usedMemory
+            .values()
+            .stream()
+            .filter((topoAndMem) -> topologyId.equals(topoAndMem.topoId))
+            .mapToLong((topoAndMem) -> topoAndMem.memory)
+            .sum();
+    }
+
+    /**
+     * Gets the memory reserved by the given topology across all ports on this supervisor.
+     *
+     * @param topologyId The topology id
+     * @return The memory reserved by the given topology id
+     */
+    public long getReservedMemoryMb(String topologyId) {
+        return reservedMemory
+            .values()
+            .stream()
+            .filter((topoAndMem) -> topologyId.equals(topoAndMem.topoId))
+            .mapToLong((topoAndMem) -> topoAndMem.memory)
+            .sum();
+    }
+
+    /**
+     * Gets the number of worker ports assigned to the given topology id on this supervisor.
+     *
+     * @param topologyId The topology id
+     * @return The number of worker ports assigned to the given topology.
+     */
+    public long getAssignedWorkerCount(String topologyId) {
+        return usedMemory
+            .values()
+            .stream()
+            .filter((topoAndMem) -> topologyId.equals(topoAndMem.topoId))
+            .count();
+    }
+
+    /**
+     * Clears the topology assignment and tracked memory for the given port.
+     *
+     * @param port The worker port
+     */
+    public void remove(int port) {
+        usedMemory.remove(port);
+        reservedMemory.remove(port);
+    }
+
+    /**
+     * Assigns the given topology id to the given port, and sets the used memory for that port and topology id.
+     *
+     * @param port The worker port
+     * @param topologyId The topology id
+     * @param usedMemoryMb The memory used by the topology
+     */
+    public void setUsedMemoryMb(int port, String topologyId, long usedMemoryMb) {
+        usedMemory.put(port, new TopoAndMemory(topologyId, usedMemoryMb));
+    }
+
+    /**
+     * Sets the reserved memory for the given port and topology id.
+     *
+     * @param port The worker port
+     * @param topologyId The topology id
+     * @param reservedMemoryMb The memory reserved by the topology
+     */
+    public void setReservedMemoryMb(int port, String topologyId, long reservedMemoryMb) {
+        reservedMemory.put(port, new TopoAndMemory(topologyId, reservedMemoryMb));
+    }
+
+    private static class TopoAndMemory {
+
+        public final String topoId;
+        public final long memory;
+
+        public TopoAndMemory(String id, long mem) {
+            topoId = id;
+            memory = mem;
+        }
+
+        @Override
+        public String toString() {
+            return "{TOPO: " + topoId + " at " + memory + " MB}";
+        }
+    }
+
+}

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/LocalContainer.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/LocalContainer.java
@@ -19,6 +19,7 @@ import org.apache.storm.daemon.worker.Worker;
 import org.apache.storm.generated.LocalAssignment;
 import org.apache.storm.generated.ProfileRequest;
 import org.apache.storm.messaging.IContext;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,8 +30,8 @@ public class LocalContainer extends Container {
     private volatile boolean _isAlive = false;
 
     public LocalContainer(Map<String, Object> conf, String supervisorId, int supervisorPort, int port,
-                          LocalAssignment assignment, IContext sharedContext) throws IOException {
-        super(ContainerType.LAUNCH, conf, supervisorId, supervisorPort, port, assignment, null, null, null, null);
+                          LocalAssignment assignment, IContext sharedContext, ContainerMemoryTracker containerMemoryTracker) throws IOException {
+        super(ContainerType.LAUNCH, conf, supervisorId, supervisorPort, port, assignment, null, null, null, null, containerMemoryTracker);
         _sharedContext = sharedContext;
         _workerId = Utils.uuid();
     }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/LocalContainerLauncher.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/LocalContainerLauncher.java
@@ -26,18 +26,21 @@ public class LocalContainerLauncher extends ContainerLauncher {
     private final String _supervisorId;
     private final int _supervisorPort;
     private final IContext _sharedContext;
+    private final ContainerMemoryTracker _containerMemoryTracker;
 
     public LocalContainerLauncher(Map<String, Object> conf, String supervisorId, int supervisorPort,
-                                  IContext sharedContext) {
+                                  IContext sharedContext, ContainerMemoryTracker containerMemoryTracker) {
         _conf = conf;
         _supervisorId = supervisorId;
         _supervisorPort = supervisorPort;
         _sharedContext = sharedContext;
+        _containerMemoryTracker = containerMemoryTracker;
     }
 
     @Override
     public Container launchContainer(int port, LocalAssignment assignment, LocalState state) throws IOException {
-        LocalContainer ret = new LocalContainer(_conf, _supervisorId, _supervisorPort, port, assignment, _sharedContext);
+        LocalContainer ret = new LocalContainer(_conf, _supervisorId, _supervisorPort,
+            port, assignment, _sharedContext, _containerMemoryTracker);
         ret.setup();
         ret.launch();
         return ret;

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
@@ -68,6 +68,7 @@ public class ReadClusterState implements Runnable, AutoCloseable {
     private final LocalState localState;
     private final AtomicReference<Map<Long, LocalAssignment>> cachedAssignments;
     private final OnlyLatestExecutor<Integer> metricsExec;
+    private final SlotMetrics slotMetrics;
     private WorkerMetricsProcessor metricsProcessor;
 
     public ReadClusterState(Supervisor supervisor) throws Exception {
@@ -81,8 +82,10 @@ public class ReadClusterState implements Runnable, AutoCloseable {
         this.localState = supervisor.getLocalState();
         this.cachedAssignments = supervisor.getCurrAssignment();
         this.metricsExec = new OnlyLatestExecutor<>(supervisor.getHeartbeatExecutor());
+        this.slotMetrics = supervisor.getSlotMetrics();
 
-        this.launcher = ContainerLauncher.make(superConf, assignmentId, supervisorPort, supervisor.getSharedContext());
+        this.launcher = ContainerLauncher.make(superConf, assignmentId, supervisorPort,
+            supervisor.getSharedContext(), supervisor.getContainerMemoryTracker());
 
         this.metricsProcessor = null;
         try {
@@ -121,7 +124,7 @@ public class ReadClusterState implements Runnable, AutoCloseable {
 
     private Slot mkSlot(int port) throws Exception {
         return new Slot(localizer, superConf, launcher, host, port,
-                        localState, stormClusterState, iSuper, cachedAssignments, metricsExec, metricsProcessor);
+                        localState, stormClusterState, iSuper, cachedAssignments, metricsExec, metricsProcessor, slotMetrics);
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/RunAsUserContainer.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/RunAsUserContainer.java
@@ -37,17 +37,17 @@ public class RunAsUserContainer extends BasicContainer {
     public RunAsUserContainer(Container.ContainerType type, Map<String, Object> conf, String supervisorId,
                               int supervisorPort, int port, LocalAssignment assignment,
                               ResourceIsolationInterface resourceIsolationManager, LocalState localState,
-                              String workerId) throws IOException {
+                              String workerId, ContainerMemoryTracker containerMemoryTracker) throws IOException {
         this(type, conf, supervisorId, supervisorPort, port, assignment, resourceIsolationManager, localState, workerId,
-             null, null, null);
+            containerMemoryTracker, null, null, null);
     }
 
     RunAsUserContainer(Container.ContainerType type, Map<String, Object> conf, String supervisorId, int supervisorPort,
                        int port, LocalAssignment assignment, ResourceIsolationInterface resourceIsolationManager,
-                       LocalState localState, String workerId, Map<String, Object> topoConf, AdvancedFSOps ops,
-                       String profileCmd) throws IOException {
+                       LocalState localState, String workerId, ContainerMemoryTracker containerMemoryTracker,
+                       Map<String, Object> topoConf, AdvancedFSOps ops, String profileCmd) throws IOException {
         super(type, conf, supervisorId, supervisorPort, port, assignment, resourceIsolationManager, localState,
-              workerId, topoConf, ops, profileCmd);
+              workerId, containerMemoryTracker, topoConf, ops, profileCmd);
         if (Utils.isOnWindows()) {
             throw new UnsupportedOperationException("ERROR: Windows doesn't support running workers as different users yet");
         }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/RunAsUserContainerLauncher.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/RunAsUserContainerLauncher.java
@@ -24,19 +24,22 @@ public class RunAsUserContainerLauncher extends ContainerLauncher {
     private final Map<String, Object> _conf;
     private final String _supervisorId;
     private final int _supervisorPort;
+    private final ContainerMemoryTracker _containerMemoryTracker;
 
     public RunAsUserContainerLauncher(Map<String, Object> conf, String supervisorId, int supervisorPort,
-                                      ResourceIsolationInterface resourceIsolationManager) throws IOException {
+                                      ResourceIsolationInterface resourceIsolationManager,
+                                      ContainerMemoryTracker containerMemoryTracker) throws IOException {
         _conf = conf;
         _supervisorId = supervisorId;
         _supervisorPort = supervisorPort;
         _resourceIsolationManager = resourceIsolationManager;
+        _containerMemoryTracker = containerMemoryTracker;
     }
 
     @Override
     public Container launchContainer(int port, LocalAssignment assignment, LocalState state) throws IOException {
         Container container = new RunAsUserContainer(ContainerType.LAUNCH, _conf, _supervisorId, _supervisorPort, port,
-                                                     assignment, _resourceIsolationManager, state, null, null, null, null);
+            assignment, _resourceIsolationManager, state, null, _containerMemoryTracker, null, null, null);
         container.setup();
         container.launch();
         return container;
@@ -45,13 +48,13 @@ public class RunAsUserContainerLauncher extends ContainerLauncher {
     @Override
     public Container recoverContainer(int port, LocalAssignment assignment, LocalState state) throws IOException {
         return new RunAsUserContainer(ContainerType.RECOVER_FULL, _conf, _supervisorId, _supervisorPort, port,
-                                      assignment, _resourceIsolationManager, state, null, null, null, null);
+                                      assignment, _resourceIsolationManager, state, null, _containerMemoryTracker, null, null, null);
     }
 
     @Override
     public Killable recoverContainer(String workerId, LocalState localState) throws IOException {
         return new RunAsUserContainer(ContainerType.RECOVER_PARTIAL, _conf, _supervisorId, _supervisorPort, -1, null,
-                                      _resourceIsolationManager, localState, workerId, null, null, null);
+                                      _resourceIsolationManager, localState, workerId, _containerMemoryTracker, null, null, null);
     }
 
 }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/SlotMetrics.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/SlotMetrics.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.daemon.supervisor;
+
+import com.codahale.metrics.Meter;
+import java.util.Map;
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.utils.EnumUtil;
+
+public class SlotMetrics {
+
+    private final Meter numWorkersLaunched;
+    private final Map<Slot.KillReason, Meter> numWorkersKilledFor;
+    private final Meter numForceKill;
+
+    public SlotMetrics(StormMetricsRegistry metricsRegistry) {
+        numWorkersLaunched = metricsRegistry.registerMeter("supervisor:num-workers-launched");
+        numWorkersKilledFor = EnumUtil.toEnumMap(Slot.KillReason.class,
+            killReason -> metricsRegistry.registerMeter("supervisor:num-workers-killed-" + killReason.toString()));
+        numForceKill = metricsRegistry.registerMeter("supervisor:num-workers-force-kill");
+    }
+
+    public Meter getWorkersLaunchedMeter() {
+        return numWorkersLaunched;
+    }
+
+    public Meter getForceKillMeter() {
+        return numForceKill;
+    }
+
+    public Meter getWorkersKilledForReasonMeter(Slot.KillReason reason) {
+        return numWorkersKilledFor.get(reason);
+    }
+
+}

--- a/storm-server/src/main/java/org/apache/storm/metricstore/MetricStore.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/MetricStore.java
@@ -12,6 +12,7 @@
 package org.apache.storm.metricstore;
 
 import java.util.Map;
+import org.apache.storm.metric.StormMetricsRegistry;
 
 public interface MetricStore extends AutoCloseable {
 
@@ -19,9 +20,10 @@ public interface MetricStore extends AutoCloseable {
      * Create metric store instance using the configurations provided via the config map.
      *
      * @param config Storm config map
+     * @param metricsRegistry The Nimbus daemon metrics registry
      * @throws MetricException on preparation error
      */
-    void prepare(Map<String, Object> config) throws MetricException;
+    void prepare(Map<String, Object> config, StormMetricsRegistry metricsRegistry) throws MetricException;
 
     /**
      * Stores a metric in the store.

--- a/storm-server/src/main/java/org/apache/storm/metricstore/MetricStoreConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/MetricStoreConfig.java
@@ -13,6 +13,7 @@ package org.apache.storm.metricstore;
 
 import java.util.Map;
 import org.apache.storm.DaemonConfig;
+import org.apache.storm.metric.StormMetricsRegistry;
 
 
 public class MetricStoreConfig {
@@ -20,15 +21,16 @@ public class MetricStoreConfig {
     /**
      * Configures metrics store (running on Nimbus) to use the class specified in the conf.
      * @param conf Storm config map
+     * @param metricsRegistry The Nimbus daemon metrics registry
      * @return MetricStore prepared store
      * @throws MetricException  on misconfiguration
      */
-    public static MetricStore configure(Map<String, Object> conf) throws MetricException {
+    public static MetricStore configure(Map<String, Object> conf, StormMetricsRegistry metricsRegistry) throws MetricException {
 
         try {
             String storeClass = (String) conf.get(DaemonConfig.STORM_METRIC_STORE_CLASS);
             MetricStore store = (MetricStore) (Class.forName(storeClass)).newInstance();
-            store.prepare(conf);
+            store.prepare(conf, metricsRegistry);
             return store;
         } catch (Exception e) {
             throw new MetricException("Failed to create metric store", e);

--- a/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/MetricsCleaner.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/MetricsCleaner.java
@@ -23,15 +23,15 @@ import org.slf4j.LoggerFactory;
  */
 public class MetricsCleaner implements Runnable, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(MetricsCleaner.class);
-    private static long DEFAULT_SLEEP_MS = 4L * 60L * 60L * 1000L;
-    private RocksDbStore store;
-    private long retentionHours;
+    private static final long DEFAULT_SLEEP_MS = 4L * 60L * 60L * 1000L;
+    private final RocksDbStore store;
+    private final long retentionHours;
+    private final Meter failureMeter;
     private volatile boolean shutdown = false;
     private long sleepMs = DEFAULT_SLEEP_MS;
-    private Meter failureMeter;
     private long purgeTimestamp = 0L;
 
-    MetricsCleaner(RocksDbStore store, int retentionHours, int hourlyPeriod, Meter failureMeter) {
+    MetricsCleaner(RocksDbStore store, int retentionHours, int hourlyPeriod, Meter failureMeter, StormMetricsRegistry metricsRegistry) {
         this.store = store;
         this.retentionHours = retentionHours;
         if (hourlyPeriod > 0) {
@@ -39,7 +39,7 @@ public class MetricsCleaner implements Runnable, AutoCloseable {
         }
         this.failureMeter = failureMeter;
 
-        StormMetricsRegistry.registerGauge("MetricsCleaner:purgeTimestamp", () -> purgeTimestamp);
+        metricsRegistry.registerGauge("MetricsCleaner:purgeTimestamp", () -> purgeTimestamp);
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/pacemaker/Pacemaker.java
+++ b/storm-server/src/main/java/org/apache/storm/pacemaker/Pacemaker.java
@@ -33,32 +33,35 @@ import org.apache.storm.utils.VersionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class Pacemaker implements IServerMessageHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(Pacemaker.class);
-    private final static Meter meterSendPulseCount = StormMetricsRegistry.registerMeter("pacemaker:send-pulse-count");
-    private final static Meter meterTotalReceivedSize = StormMetricsRegistry.registerMeter("pacemaker:total-receive-size");
-    private final static Meter meterGetPulseCount = StormMetricsRegistry.registerMeter("pacemaker:get-pulse=count");
-    private final static Meter meterTotalSentSize = StormMetricsRegistry.registerMeter("pacemaker:total-sent-size");
-    private final static Histogram histogramHeartbeatSize =
-        StormMetricsRegistry.registerHistogram("pacemaker:heartbeat-size", new ExponentiallyDecayingReservoir());
+    private final Meter meterSendPulseCount;
+    private final Meter meterTotalReceivedSize;
+    private final Meter meterGetPulseCount;
+    private final Meter meterTotalSentSize;
+    private final Histogram histogramHeartbeatSize;
     private final Map<String, byte[]> heartbeats;
     private final Map<String, Object> conf;
 
-
-    public Pacemaker(Map<String, Object> conf) {
+    public Pacemaker(Map<String, Object> conf, StormMetricsRegistry metricsRegistry) {
         heartbeats = new ConcurrentHashMap<>();
         this.conf = conf;
-        StormMetricsRegistry.registerGauge("pacemaker:size-total-keys", heartbeats::size);
-        StormMetricsRegistry.startMetricsReporters(conf);
+        this.meterSendPulseCount = metricsRegistry.registerMeter("pacemaker:send-pulse-count");
+        this.meterTotalReceivedSize = metricsRegistry.registerMeter("pacemaker:total-receive-size");
+        this.meterGetPulseCount = metricsRegistry.registerMeter("pacemaker:get-pulse=count");
+        this.meterTotalSentSize = metricsRegistry.registerMeter("pacemaker:total-sent-size");
+        this.histogramHeartbeatSize = metricsRegistry.registerHistogram("pacemaker:heartbeat-size", new ExponentiallyDecayingReservoir());
+        metricsRegistry.registerGauge("pacemaker:size-total-keys", heartbeats::size);
     }
 
     public static void main(String[] args) {
         SysOutOverSLF4J.sendSystemOutAndErrToSLF4J();
         Map<String, Object> conf = ConfigUtils.overrideLoginConfigWithSystemProperty(Utils.readStormConfig());
-        final Pacemaker serverHandler = new Pacemaker(conf);
+        StormMetricsRegistry metricsRegistry = new StormMetricsRegistry();
+        final Pacemaker serverHandler = new Pacemaker(conf, metricsRegistry);
         serverHandler.launchServer();
+        metricsRegistry.startMetricsReporters(conf);
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
@@ -39,6 +39,7 @@ import org.apache.storm.networktopography.DefaultRackDNSToSwitchMapping;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResourceOffer;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResourceRequest;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResources;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
 import org.apache.storm.shade.com.google.common.annotations.VisibleForTesting;
 import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.utils.ObjectReader;
@@ -80,17 +81,19 @@ public class Cluster implements ISchedulingState {
     private final Map<String, Map<WorkerSlot, NormalizedResourceRequest>> nodeToScheduledResourcesCache;
     private final Map<String, Set<WorkerSlot>> nodeToUsedSlotsCache;
     private final Map<String, NormalizedResourceRequest> totalResourcesPerNodeCache = new HashMap<>();
+    private final ResourceMetrics resourceMetrics;
     private SchedulerAssignmentImpl assignment;
     private Set<String> blackListedHosts = new HashSet<>();
     private INimbus inimbus;
 
     public Cluster(
         INimbus nimbus,
+        ResourceMetrics resourceMetrics,
         Map<String, SupervisorDetails> supervisors,
         Map<String, ? extends SchedulerAssignment> map,
         Topologies topologies,
         Map<String, Object> conf) {
-        this(nimbus, supervisors, map, topologies, conf, null, null, null);
+        this(nimbus, resourceMetrics, supervisors, map, topologies, conf, null, null, null);
     }
 
     /**
@@ -99,6 +102,7 @@ public class Cluster implements ISchedulingState {
     public Cluster(Cluster src) {
         this(
             src.inimbus,
+            src.resourceMetrics,
             src.supervisors,
             src.assignments,
             src.topologies,
@@ -118,6 +122,7 @@ public class Cluster implements ISchedulingState {
     public Cluster(Cluster src, Topologies topologies) {
         this(
             src.inimbus,
+            src.resourceMetrics,
             src.supervisors,
             src.assignments,
             topologies,
@@ -129,6 +134,7 @@ public class Cluster implements ISchedulingState {
 
     private Cluster(
         INimbus nimbus,
+        ResourceMetrics resourceMetrics,
         Map<String, SupervisorDetails> supervisors,
         Map<String, ? extends SchedulerAssignment> assignments,
         Topologies topologies,
@@ -137,6 +143,7 @@ public class Cluster implements ISchedulingState {
         Set<String> blackListedHosts,
         Map<String, List<String>> networkTopography) {
         this.inimbus = nimbus;
+        this.resourceMetrics = resourceMetrics;
         this.supervisors.putAll(supervisors);
         this.nodeToScheduledResourcesCache = new HashMap<>(this.supervisors.size());
         this.nodeToUsedSlotsCache = new HashMap<>(this.supervisors.size());
@@ -940,6 +947,10 @@ public class Cluster implements ISchedulingState {
         normalizedResourceRequest.addOffHeap(sharedoffHeapMemory);
         nodeToScheduledResourcesCache.computeIfAbsent(nodeId, MAKE_MAP).put(workerSlot, normalizedResourceRequest);
         nodeToUsedSlotsCache.computeIfAbsent(nodeId, MAKE_SET).add(workerSlot);
+    }
+
+    public ResourceMetrics getResourceMetrics() {
+        return resourceMetrics;
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/scheduler/SupervisorDetails.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/SupervisorDetails.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResourceOffer;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/storm-server/src/main/java/org/apache/storm/scheduler/TopologyDetails.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/TopologyDetails.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.storm.Config;
-import org.apache.storm.Constants;
-import org.apache.storm.daemon.Acker;
 import org.apache.storm.generated.Bolt;
 import org.apache.storm.generated.ComponentCommon;
 import org.apache.storm.generated.ComponentType;

--- a/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/BlacklistScheduler.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/BlacklistScheduler.java
@@ -42,6 +42,7 @@ public class BlacklistScheduler implements IScheduler {
     public static final int DEFAULT_BLACKLIST_SCHEDULER_TOLERANCE_TIME = 300;
     private static final Logger LOG = LoggerFactory.getLogger(BlacklistScheduler.class);
     private final IScheduler underlyingScheduler;
+    private final StormMetricsRegistry metricsRegistry;
     protected int toleranceTime;
     protected int toleranceCount;
     protected int resumeTime;
@@ -55,8 +56,9 @@ public class BlacklistScheduler implements IScheduler {
     protected Set<String> blacklistHost;
     private Map<String, Object> conf;
 
-    public BlacklistScheduler(IScheduler underlyingScheduler) {
+    public BlacklistScheduler(IScheduler underlyingScheduler, StormMetricsRegistry metricsRegistry) {
         this.underlyingScheduler = underlyingScheduler;
+        this.metricsRegistry = metricsRegistry;
     }
 
     @Override
@@ -89,7 +91,7 @@ public class BlacklistScheduler implements IScheduler {
         blacklistHost = new HashSet<>();
 
         //nimbus:num-blacklisted-supervisor + non-blacklisted supervisor = nimbus:num-supervisors
-        StormMetricsRegistry.registerGauge("nimbus:num-blacklisted-supervisor", () -> blacklistHost.size());
+        metricsRegistry.registerGauge("nimbus:num-blacklisted-supervisor", () -> blacklistHost.size());
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/RAS_Node.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/RAS_Node.java
@@ -445,7 +445,7 @@ public class RAS_Node {
     public NormalizedResourceOffer getTotalAvailableResources() {
         if (sup != null) {
             NormalizedResourceOffer availableResources = new NormalizedResourceOffer(sup.getTotalResources());
-            if (availableResources.remove(cluster.getAllScheduledResourcesForNode(sup.getId()))) {
+            if (availableResources.remove(cluster.getAllScheduledResourcesForNode(sup.getId()), cluster.getResourceMetrics())) {
                 if (!loggedUnderageUsage) {
                     LOG.error("Resources on {} became negative and was clamped to 0 {}.", hostname, availableResources);
                     loggedUnderageUsage = true;

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceUtils.java
@@ -39,8 +39,7 @@ public class ResourceUtils {
         return null;
     }
 
-    public static Map<String, NormalizedResourceRequest> getBoltsResources(StormTopology topology,
-                                                                           Map<String, Object> topologyConf) {
+    public static Map<String, NormalizedResourceRequest> getBoltsResources(StormTopology topology, Map<String, Object> topologyConf) {
         Map<String, NormalizedResourceRequest> boltResources = new HashMap<>();
         if (topology.get_bolts() != null) {
             for (Map.Entry<String, Bolt> bolt : topology.get_bolts().entrySet()) {
@@ -55,8 +54,8 @@ public class ResourceUtils {
         return boltResources;
     }
 
-    public static NormalizedResourceRequest getSpoutResources(StormTopology topology, Map<String, Object> topologyConf,
-                                                              String componentId) {
+    public static NormalizedResourceRequest getSpoutResources(StormTopology topology,
+        Map<String, Object> topologyConf, String componentId) {
         if (topology.get_spouts() != null) {
             SpoutSpec spout = topology.get_spouts().get(componentId);
             return new NormalizedResourceRequest(spout.get_common(), topologyConf, componentId);
@@ -65,7 +64,7 @@ public class ResourceUtils {
     }
 
     public static Map<String, NormalizedResourceRequest> getSpoutsResources(StormTopology topology,
-                                                                            Map<String, Object> topologyConf) {
+        Map<String, Object> topologyConf) {
         Map<String, NormalizedResourceRequest> spoutResources = new HashMap<>();
         if (topology.get_spouts() != null) {
             for (Map.Entry<String, SpoutSpec> spout : topology.get_spouts().entrySet()) {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOffer.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOffer.java
@@ -83,14 +83,15 @@ public class NormalizedResourceOffer implements NormalizedResourcesWithMemory {
     /**
      * Remove the resources in other from this.
      * @param other the resources to be removed.
+     * @param resourceMetrics The resource related metrics
      * @return true if one or more resources in other were larger than available resources in this, else false.
      */
-    public boolean remove(NormalizedResourcesWithMemory other) {
-        boolean negativeResources = normalizedResources.remove(other.getNormalizedResources());
+    public boolean remove(NormalizedResourcesWithMemory other, ResourceMetrics resourceMetrics) {
+        boolean negativeResources = normalizedResources.remove(other.getNormalizedResources(), resourceMetrics);
         totalMemoryMb -= other.getTotalMemoryMb();
         if (totalMemoryMb < 0.0) {
             negativeResources = true;
-            NormalizedResources.numNegativeResourceEvents.mark();
+            resourceMetrics.getNegativeResourceEventsMeter().mark();
             totalMemoryMb = 0.0;
         }
         return negativeResources;

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
@@ -43,7 +43,7 @@ public class NormalizedResourceRequest implements NormalizedResourcesWithMemory 
     private double offHeap;
 
     private NormalizedResourceRequest(Map<String, ? extends Number> resources,
-                                      Map<String, Double> defaultResources) {
+        Map<String, Double> defaultResources) {
         if (resources == null && defaultResources == null) {
             onHeap = 0.0;
             offHeap = 0.0;

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/ResourceMetrics.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/ResourceMetrics.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.scheduler.resource.normalization;
+
+import com.codahale.metrics.Meter;
+import org.apache.storm.metric.StormMetricsRegistry;
+
+public class ResourceMetrics {
+
+    private final Meter numNegativeResourceEvents;
+    
+    public ResourceMetrics(StormMetricsRegistry metricsRegistry) {
+        numNegativeResourceEvents = metricsRegistry.registerMeter("nimbus:num-negative-resource-events");
+    }
+
+    public Meter getNegativeResourceEventsMeter() {
+        return numNegativeResourceEvents;
+    }
+    
+}

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
@@ -45,6 +45,7 @@ import org.apache.storm.scheduler.resource.SchedulingResult;
 import org.apache.storm.scheduler.resource.SchedulingStatus;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResourceOffer;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResourceRequest;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
 import org.apache.storm.shade.com.google.common.annotations.VisibleForTesting;
 import org.apache.storm.shade.com.google.common.collect.Sets;
 import org.slf4j.Logger;
@@ -632,12 +633,14 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
      */
     static class AllResources {
         List<ObjectResources> objectResources = new LinkedList<>();
-        NormalizedResourceOffer availableResourcesOverall = new NormalizedResourceOffer();
-        NormalizedResourceOffer totalResourcesOverall = new NormalizedResourceOffer();
+        final NormalizedResourceOffer availableResourcesOverall;
+        final NormalizedResourceOffer totalResourcesOverall;
         String identifier;
 
         public AllResources(String identifier) {
             this.identifier = identifier;
+            this.availableResourcesOverall = new NormalizedResourceOffer();
+            this.totalResourcesOverall = new NormalizedResourceOffer();
         }
 
         public AllResources(AllResources other) {
@@ -666,12 +669,14 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
      */
     static class ObjectResources {
         public final String id;
-        public NormalizedResourceOffer availableResources = new NormalizedResourceOffer();
-        public NormalizedResourceOffer totalResources = new NormalizedResourceOffer();
+        public NormalizedResourceOffer availableResources;
+        public NormalizedResourceOffer totalResources;
         public double effectiveResources = 0.0;
 
         public ObjectResources(String id) {
             this.id = id;
+            this.availableResources = new NormalizedResourceOffer();
+            this.totalResources = new NormalizedResourceOffer();
         }
 
         public ObjectResources(ObjectResources other) {

--- a/storm-server/src/test/java/org/apache/storm/PacemakerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/PacemakerTest.java
@@ -19,6 +19,7 @@ import org.apache.storm.generated.HBMessage;
 import org.apache.storm.generated.HBMessageData;
 import org.apache.storm.generated.HBPulse;
 import org.apache.storm.generated.HBServerMessageType;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.pacemaker.Pacemaker;
 import org.apache.storm.utils.Utils;
 import org.junit.Assert;
@@ -30,15 +31,16 @@ public class PacemakerTest {
     private HBMessage hbMessage;
     private int mid;
     private Random random;
+    private Pacemaker handler;
 
     @Before
     public void init() {
         random = new Random(100);
+        handler = new Pacemaker(new ConcurrentHashMap<>(), new StormMetricsRegistry());
     }
-
+    
     @Test
     public void testServerCreatePath() {
-        Pacemaker handler = new Pacemaker(new ConcurrentHashMap());
         messageWithRandId(HBServerMessageType.CREATE_PATH, HBMessageData.path("/testpath"));
         HBMessage response = handler.handleMessage(hbMessage, true);
         Assert.assertEquals(mid, response.get_message_id());
@@ -48,7 +50,6 @@ public class PacemakerTest {
 
     @Test
     public void testServerExistsFalse() {
-        Pacemaker handler = new Pacemaker(new ConcurrentHashMap());
         messageWithRandId(HBServerMessageType.EXISTS, HBMessageData.path("/testpath"));
         HBMessage badResponse = handler.handleMessage(hbMessage, false);
         HBMessage goodResponse = handler.handleMessage(hbMessage, true);
@@ -64,7 +65,6 @@ public class PacemakerTest {
     public void testServerExistsTrue() {
         String path = "/exists_path";
         String dataString = "pulse data";
-        Pacemaker handler = new Pacemaker(new ConcurrentHashMap());
         HBPulse hbPulse = new HBPulse();
         hbPulse.set_id(path);
         hbPulse.set_details(Utils.javaSerialize(dataString));
@@ -86,7 +86,6 @@ public class PacemakerTest {
     public void testServerSendPulseGetPulse() {
         String path = "/pulsepath";
         String dataString = "pulse data";
-        Pacemaker handler = new Pacemaker(new ConcurrentHashMap());
         HBPulse hbPulse = new HBPulse();
         hbPulse.set_id(path);
         hbPulse.set_details(Utils.javaSerialize(dataString));
@@ -105,7 +104,6 @@ public class PacemakerTest {
 
     @Test
     public void testServerGetAllPulseForPath() {
-        Pacemaker handler = new Pacemaker(new ConcurrentHashMap());
         messageWithRandId(HBServerMessageType.GET_ALL_PULSE_FOR_PATH, HBMessageData.path("/testpath"));
         HBMessage badResponse = handler.handleMessage(hbMessage, false);
         HBMessage goodResponse = handler.handleMessage(hbMessage, true);
@@ -119,7 +117,6 @@ public class PacemakerTest {
 
     @Test
     public void testServerGetAllNodesForPath() {
-        Pacemaker handler = new Pacemaker(new ConcurrentHashMap());
         makeNode(handler, "/some-root-path/foo");
         makeNode(handler, "/some-root-path/bar");
         makeNode(handler, "/some-root-path/baz");
@@ -161,7 +158,6 @@ public class PacemakerTest {
 
     @Test
     public void testServerGetPulse() {
-        Pacemaker handler = new Pacemaker(new ConcurrentHashMap());
         makeNode(handler, "/some-root/GET_PULSE");
         messageWithRandId(HBServerMessageType.GET_PULSE, HBMessageData.path("/some-root/GET_PULSE"));
         HBMessage badResponse = handler.handleMessage(hbMessage, false);
@@ -179,7 +175,6 @@ public class PacemakerTest {
 
     @Test
     public void testServerDeletePath() {
-        Pacemaker handler = new Pacemaker(new ConcurrentHashMap());
         makeNode(handler, "/some-root/DELETE_PATH/foo");
         makeNode(handler, "/some-root/DELETE_PATH/bar");
         makeNode(handler, "/some-root/DELETE_PATH/baz");
@@ -201,7 +196,6 @@ public class PacemakerTest {
 
     @Test
     public void testServerDeletePulseId() {
-        Pacemaker handler = new Pacemaker(new ConcurrentHashMap());
         makeNode(handler, "/some-root/DELETE_PULSE_ID/foo");
         makeNode(handler, "/some-root/DELETE_PULSE_ID/bar");
         makeNode(handler, "/some-root/DELETE_PULSE_ID/baz");

--- a/storm-server/src/test/java/org/apache/storm/daemon/drpc/DRPCTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/drpc/DRPCTest.java
@@ -47,6 +47,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.storm.metric.StormMetricsRegistry;
+
 public class DRPCTest {
     private static final ExecutorService exec = Executors.newCachedThreadPool();
 
@@ -80,7 +82,7 @@ public class DRPCTest {
 
     @Test
     public void testGoodBlocking() throws Exception {
-        try (DRPC server = new DRPC(null, 100)) {
+        try (DRPC server = new DRPC(new StormMetricsRegistry(), null, 100)) {
             Future<String> found = exec.submit(() -> server.executeBlocking("testing", "test"));
             DRPCRequest request = getNextAvailableRequest(server, "testing");
             assertNotNull(request);
@@ -94,7 +96,7 @@ public class DRPCTest {
 
     @Test
     public void testFailedBlocking() throws Exception {
-        try (DRPC server = new DRPC(null, 100)) {
+        try (DRPC server = new DRPC(new StormMetricsRegistry(), null, 100)) {
             Future<String> found = exec.submit(() -> server.executeBlocking("testing", "test"));
             DRPCRequest request = getNextAvailableRequest(server, "testing");
             assertNotNull(request);
@@ -116,7 +118,7 @@ public class DRPCTest {
     @Test
     public void testDequeueAfterTimeout() throws Exception {
         long timeout = 1000;
-        try (DRPC server = new DRPC(null, timeout)) {
+        try (DRPC server = new DRPC(new StormMetricsRegistry(), null, timeout)) {
             long start = Time.currentTimeMillis();
             try {
                 server.executeBlocking("testing", "test");
@@ -136,7 +138,7 @@ public class DRPCTest {
 
     @Test
     public void testDeny() throws Exception {
-        try (DRPC server = new DRPC(new DenyAuthorizer(), 100)) {
+        try (DRPC server = new DRPC(new StormMetricsRegistry(), new DenyAuthorizer(), 100)) {
             assertThrows(() -> server.executeBlocking("testing", "test"), AuthorizationException.class);
             assertThrows(() -> server.fetchRequest("testing"), AuthorizationException.class);
         }

--- a/storm-server/src/test/java/org/apache/storm/daemon/supervisor/BasicContainerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/supervisor/BasicContainerTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.utils.ConfigUtils;
 
 public class BasicContainerTest {
@@ -659,7 +660,7 @@ public class BasicContainerTest {
                                   LocalState localState, String workerId, Map<String, Object> topoConf, AdvancedFSOps ops,
                                   String profileCmd) throws IOException {
             super(type, conf, supervisorId, supervisorPort, port, assignment, resourceIsolationManager, localState,
-                  workerId, topoConf, ops, profileCmd);
+                  workerId, new ContainerMemoryTracker(new StormMetricsRegistry()), topoConf, ops, profileCmd);
         }
 
         @Override

--- a/storm-server/src/test/java/org/apache/storm/daemon/supervisor/ContainerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/supervisor/ContainerTest.java
@@ -42,6 +42,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.apache.storm.metric.StormMetricsRegistry;
+
 public class ContainerTest {
     private static final Joiner PATH_JOIN = Joiner.on(File.separator).skipNulls();
     private static final String DOUBLE_SEP = File.separator + File.separator;
@@ -228,7 +230,7 @@ public class ContainerTest {
                                 int port, LocalAssignment assignment, ResourceIsolationInterface resourceIsolationManager,
                                 String workerId, Map<String, Object> topoConf, AdvancedFSOps ops) throws IOException {
             super(type, conf, supervisorId, supervisorPort, port, assignment, resourceIsolationManager, workerId,
-                  topoConf, ops);
+                  topoConf, ops, new ContainerMemoryTracker(new StormMetricsRegistry()));
         }
 
         @Override

--- a/storm-server/src/test/java/org/apache/storm/daemon/supervisor/SlotTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/supervisor/SlotTest.java
@@ -52,6 +52,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
+import org.apache.storm.metric.StormMetricsRegistry;
+
 public class SlotTest {
     private static final Logger LOG = LoggerFactory.getLogger(SlotTest.class);
 
@@ -148,7 +150,8 @@ public class SlotTest {
             ContainerLauncher containerLauncher = mock(ContainerLauncher.class);
             ISupervisor iSuper = mock(ISupervisor.class);
             StaticState staticState = new StaticState(localizer, 1000, 1000, 1000, 1000,
-                                                      containerLauncher, "localhost", 8080, iSuper, state, cb, null, null);
+                containerLauncher, "localhost", 8080, iSuper, state, cb, null, null,
+                new SlotMetrics(new StormMetricsRegistry()));
             DynamicState dynamicState = new DynamicState(null, null, null);
             DynamicState nextState = Slot.handleEmpty(dynamicState, staticState);
             assertEquals(MachineState.EMPTY, nextState.state);
@@ -180,7 +183,7 @@ public class SlotTest {
 
             ISupervisor iSuper = mock(ISupervisor.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null);
+                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null, new SlotMetrics(new StormMetricsRegistry()));
             DynamicState dynamicState = new DynamicState(null, null, null)
                 .withNewAssignment(newAssignment);
 
@@ -249,7 +252,7 @@ public class SlotTest {
             ISupervisor iSuper = mock(ISupervisor.class);
             LocalState state = mock(LocalState.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null);
+                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null, new SlotMetrics(new StormMetricsRegistry()));
             DynamicState dynamicState = new DynamicState(assignment, container, assignment);
 
             DynamicState nextState = Slot.stateMachineStep(dynamicState, staticState);
@@ -310,7 +313,7 @@ public class SlotTest {
 
             ISupervisor iSuper = mock(ISupervisor.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null);
+                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null, new SlotMetrics(new StormMetricsRegistry()));
             DynamicState dynamicState = new DynamicState(cAssignment, cContainer, nAssignment);
 
             DynamicState nextState = Slot.stateMachineStep(dynamicState, staticState);
@@ -391,7 +394,7 @@ public class SlotTest {
             ISupervisor iSuper = mock(ISupervisor.class);
             LocalState state = mock(LocalState.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null);
+                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null, new SlotMetrics(new StormMetricsRegistry()));
             DynamicState dynamicState = new DynamicState(cAssignment, cContainer, null);
 
             DynamicState nextState = Slot.stateMachineStep(dynamicState, staticState);
@@ -452,7 +455,7 @@ public class SlotTest {
             ISupervisor iSuper = mock(ISupervisor.class);
             LocalState state = mock(LocalState.class);
             StaticState staticState = new StaticState(localizer, 5000, 120000, 1000, 1000,
-                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null);
+                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null, new SlotMetrics(new StormMetricsRegistry()));
             Set<TopoProfileAction> profileActions = new HashSet<>();
             ProfileRequest request = new ProfileRequest();
             request.set_action(ProfileAction.JPROFILE_STOP);
@@ -534,7 +537,7 @@ public class SlotTest {
             ISupervisor iSuper = mock(ISupervisor.class);
             long heartbeatTimeoutMs = 5000;
             StaticState staticState = new StaticState(localizer, heartbeatTimeoutMs, 120_000, 1000, 1000,
-                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null);
+                                                      containerLauncher, "localhost", port, iSuper, state, cb, null, null, new SlotMetrics(new StormMetricsRegistry()));
 
             Set<Slot.BlobChanging> changing = new HashSet<>();
 

--- a/storm-server/src/test/java/org/apache/storm/metricstore/rocksdb/RocksDbStoreTest.java
+++ b/storm-server/src/test/java/org/apache/storm/metricstore/rocksdb/RocksDbStoreTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.storm.metric.StormMetricsRegistry;
 
 public class RocksDbStoreTest {
     private final static Logger LOG = LoggerFactory.getLogger(RocksDbStoreTest.class);
@@ -57,7 +58,7 @@ public class RocksDbStoreTest {
         conf.put(DaemonConfig.STORM_ROCKSDB_CREATE_IF_MISSING, true);
         conf.put(DaemonConfig.STORM_ROCKSDB_METADATA_STRING_CACHE_CAPACITY, 4000);
         conf.put(DaemonConfig.STORM_ROCKSDB_METRIC_RETENTION_HOURS, 240);
-        store = MetricStoreConfig.configure(conf);
+        store = MetricStoreConfig.configure(conf, new StormMetricsRegistry());
     }
 
     @AfterClass
@@ -307,7 +308,7 @@ public class RocksDbStoreTest {
         Assert.assertTrue(list.size() >= 2);
 
         // delete anything older than an hour
-        MetricsCleaner cleaner = new MetricsCleaner((RocksDbStore)store, 1, 1, null);
+        MetricsCleaner cleaner = new MetricsCleaner((RocksDbStore)store, 1, 1, null, new StormMetricsRegistry());
         cleaner.purgeMetrics();
         list = getMetricsFromScan(filter);
         Assert.assertEquals(1, list.size());

--- a/storm-server/src/test/java/org/apache/storm/scheduler/blacklist/FaultGenerateUtils.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/blacklist/FaultGenerateUtils.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
 
 public class FaultGenerateUtils {
 
@@ -58,6 +60,6 @@ public class FaultGenerateUtils {
         } else {
             assignment = TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments());
         }
-        return new Cluster(iNimbus, supervisors, assignment, topologies, config);
+        return new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supervisors, assignment, topologies, config);
     }
 }

--- a/storm-server/src/test/java/org/apache/storm/scheduler/blacklist/TestBlacklistScheduler.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/blacklist/TestBlacklistScheduler.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.List;
 import java.util.ArrayList;
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
 
 public class TestBlacklistScheduler {
 
@@ -67,15 +69,17 @@ public class TestBlacklistScheduler {
         topoMap.put(topo1.getId(), topo1);
 
         Topologies topologies = new Topologies(topoMap);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
-        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler());
+        StormMetricsRegistry metricsRegistry = new StormMetricsRegistry();
+        ResourceMetrics resourceMetrics = new ResourceMetrics(metricsRegistry);
+        Cluster cluster = new Cluster(iNimbus, resourceMetrics, supMap, new HashMap<>(), topologies, config);
+        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler(), metricsRegistry);
         bs.prepare(config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, supMap, TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, supMap, TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
         Assert.assertEquals("blacklist", Collections.singleton("host-0"), cluster.getBlacklistedHosts());
     }
@@ -98,16 +102,18 @@ public class TestBlacklistScheduler {
         topoMap.put(topo1.getId(), topo1);
 
         Topologies topologies = new Topologies(topoMap);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
-        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler());
+        StormMetricsRegistry metricsRegistry = new StormMetricsRegistry();
+        ResourceMetrics resourceMetrics = new ResourceMetrics(metricsRegistry);
+        Cluster cluster = new Cluster(iNimbus, resourceMetrics, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler(), metricsRegistry);
         bs.prepare(config);
         bs.schedule(topologies, cluster);
 
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removePortFromSupervisors(supMap, "sup-0", 0), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removePortFromSupervisors(supMap, "sup-0", 0), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removePortFromSupervisors(supMap, "sup-0", 0), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removePortFromSupervisors(supMap, "sup-0", 0), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
         bs.schedule(topologies, cluster);
         Assert.assertEquals("blacklist", Collections.singleton("host-0"), cluster.getBlacklistedHosts());
     }
@@ -130,15 +136,17 @@ public class TestBlacklistScheduler {
         topoMap.put(topo1.getId(), topo1);
 
         Topologies topologies = new Topologies(topoMap);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
-        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler());
+        StormMetricsRegistry metricsRegistry = new StormMetricsRegistry();
+        ResourceMetrics resourceMetrics = new ResourceMetrics(metricsRegistry);
+        Cluster cluster = new Cluster(iNimbus, resourceMetrics, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler(), metricsRegistry);
         bs.prepare(config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
         bs.schedule(topologies, cluster);
         Assert.assertEquals("blacklist", Collections.singleton("host-0"), cluster.getBlacklistedHosts());
         for (int i = 0; i < 300 / 10 - 2; i++) {
@@ -170,22 +178,24 @@ public class TestBlacklistScheduler {
         topoMap.put(topo1.getId(), topo1);
 
         Topologies topologies = new Topologies(topoMap);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
-        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler());
+        StormMetricsRegistry metricsRegistry = new StormMetricsRegistry();
+        ResourceMetrics resourceMetrics = new ResourceMetrics(metricsRegistry);
+        Cluster cluster = new Cluster(iNimbus, resourceMetrics, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler(), metricsRegistry);
         bs.prepare(config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap, "sup-0"), TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
-        cluster = new Cluster(iNimbus, supMap, TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, supMap, TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
         Assert.assertEquals("blacklist", Collections.singleton("host-0"), cluster.getBlacklistedHosts());
         topoMap.put(topo2.getId(), topo2);
         topoMap.put(topo3.getId(), topo3);
         topoMap.put(topo4.getId(), topo4);
         topologies = new Topologies(topoMap);
-        cluster = new Cluster(iNimbus, supMap, TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, supMap, TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         bs.schedule(topologies, cluster);
         Assert.assertEquals("blacklist", Collections.emptySet(), cluster.getBlacklistedHosts());
     }
@@ -205,7 +215,7 @@ public class TestBlacklistScheduler {
         topoMap.put(topo1.getId(), topo1);
         topoMap.put(topo2.getId(), topo2);
         Topologies topologies = new Topologies(topoMap);
-        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler());
+        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler(), new StormMetricsRegistry());
         bs.prepare(config);
 
         List<Map<Integer, List<Integer>>> faultList = new ArrayList<>();
@@ -292,11 +302,13 @@ public class TestBlacklistScheduler {
         topoMap.put(topo1.getId(), topo1);
 
         Topologies topologies = new Topologies(topoMap);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
-        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler());
+        StormMetricsRegistry metricsRegistry = new StormMetricsRegistry();
+        ResourceMetrics resourceMetrics = new ResourceMetrics(metricsRegistry);
+        Cluster cluster = new Cluster(iNimbus, resourceMetrics, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        BlacklistScheduler bs = new BlacklistScheduler(new DefaultScheduler(), metricsRegistry);
         bs.prepare(config);
         bs.schedule(topologies,cluster);
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap,"sup-0"),TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removeSupervisorFromSupervisors(supMap,"sup-0"),TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         for (int i = 0 ; i < 20 ; i++){
             bs.schedule(topologies,cluster);
         }
@@ -304,9 +316,9 @@ public class TestBlacklistScheduler {
         cached.add("sup-1");
         cached.add("sup-2");
         Assert.assertEquals(cached,bs.cachedSupervisors.keySet());
-        cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
         bs.schedule(topologies,cluster);
-        cluster = new Cluster(iNimbus, TestUtilsForBlacklistScheduler.removePortFromSupervisors(supMap,"sup-0",0),TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
+        cluster = new Cluster(iNimbus, resourceMetrics, TestUtilsForBlacklistScheduler.removePortFromSupervisors(supMap,"sup-0",0),TestUtilsForBlacklistScheduler.assignmentMapToImpl(cluster.getAssignments()), topologies, config);
         for (int i = 0 ;i < 20 ; i++){
             bs.schedule(topologies, cluster);
         }

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestResourceAwareScheduler.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestResourceAwareScheduler.java
@@ -62,6 +62,9 @@ import org.slf4j.LoggerFactory;
 import static org.apache.storm.scheduler.resource.TestUtilsForResourceAwareScheduler.*;
 import static org.junit.Assert.*;
 
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
+
 public class TestResourceAwareScheduler {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestResourceAwareScheduler.class);
@@ -86,7 +89,7 @@ public class TestResourceAwareScheduler {
         TopologyDetails topology1 = genTopology("topology1", config, 1, 0, 2, 0, 0, 0, "user");
         TopologyDetails topology2 = genTopology("topology2", config, 1, 0, 2, 0, 0, 0, "user");
         Topologies topologies = new Topologies(topology1, topology2);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         Map<String, RAS_Node> nodes = RAS_Nodes.getAllNodesFrom(cluster);
         assertEquals(5, nodes.size());
         RAS_Node node = nodes.get("r000s000");
@@ -156,7 +159,7 @@ public class TestResourceAwareScheduler {
         TopologyDetails topology1 = genTopology("topology1", config, 1, 1, 1, 1, 0, 0, "user");
 
         Topologies topologies = new Topologies(topology1);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
 
         rs.prepare(config);
         rs.schedule(topologies, cluster);
@@ -205,7 +208,7 @@ public class TestResourceAwareScheduler {
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
         Topologies topologies = new Topologies(topology1, topology2);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
 
         rs.prepare(config);
         rs.schedule(topologies, cluster);
@@ -254,7 +257,7 @@ public class TestResourceAwareScheduler {
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         Topologies topologies = new Topologies(topology1);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
 
         rs.prepare(config);
         rs.schedule(topologies, cluster);
@@ -298,7 +301,7 @@ public class TestResourceAwareScheduler {
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         Topologies topologies = new Topologies(topology1);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
 
         rs.prepare(config);
         rs.schedule(topologies, cluster);
@@ -394,7 +397,7 @@ public class TestResourceAwareScheduler {
         // Test1: When a worker fails, RAS does not alter existing assignments on healthy workers
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         Topologies topologies = new Topologies(topology2);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config1);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config1);
 
         rs.prepare(config1);
         rs.schedule(topologies, cluster);
@@ -439,7 +442,7 @@ public class TestResourceAwareScheduler {
         supMap1.remove("r000s000"); // mock the supervisor r000s000 as a failed supervisor
 
         topologies = new Topologies(topology1);
-        Cluster cluster1 = new Cluster(iNimbus, supMap1, existingAssignments, topologies, config1);
+        Cluster cluster1 = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap1, existingAssignments, topologies, config1);
         rs.schedule(topologies, cluster1);
 
         newAssignment = cluster1.getAssignmentById(topology1.getId());
@@ -468,7 +471,7 @@ public class TestResourceAwareScheduler {
         supMap1.remove("r000s000"); // mock the supervisor r000s000 as a failed supervisor
 
         topologies = new Topologies(topology1);
-        cluster1 = new Cluster(iNimbus, supMap1, existingAssignments, topologies, config1);
+        cluster1 = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap1, existingAssignments, topologies, config1);
         rs.schedule(topologies, cluster1);
 
         newAssignment = cluster1.getAssignmentById(topology1.getId());
@@ -482,14 +485,14 @@ public class TestResourceAwareScheduler {
 
         // Test4: Scheduling a new topology does not disturb other assignments unnecessarily
         topologies = new Topologies(topology1);
-        cluster1 = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config1);
+        cluster1 = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config1);
         rs.schedule(topologies, cluster1);
         assignment = cluster1.getAssignmentById(topology1.getId());
         executorToSlot = assignment.getExecutorToSlot();
         copyOfOldMapping = new HashMap<>(executorToSlot);
 
         topologies = addTopologies(topologies, topology2);
-        cluster1 = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config1);
+        cluster1 = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config1);
         rs.schedule(topologies, cluster1);
 
         newAssignment = cluster1.getAssignmentById(topology1.getId());
@@ -575,7 +578,7 @@ public class TestResourceAwareScheduler {
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         LOG.info("\n\n\t\tScheduling topologies 1, 2 and 3");
         Topologies topologies = new Topologies(topology1, topology2, topology3);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config1);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config1);
         rs.prepare(config1);
         rs.schedule(topologies, cluster);
 
@@ -602,7 +605,7 @@ public class TestResourceAwareScheduler {
         // Test2: Launch topo 1, 2 and 4, they together request a little more mem than available, so one of the 3 topos will not be
         // scheduled
         topologies = new Topologies(topology1, topology2, topology4);
-        cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config1);
+        cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config1);
         rs.prepare(config1);
         rs.schedule(topologies, cluster);
         int numTopologiesAssigned = 0;
@@ -624,7 +627,7 @@ public class TestResourceAwareScheduler {
         LOG.info("\n\n\t\tScheduling just topo 5");
         //Test3: "Launch topo5 only, both mem and cpu should be exactly used up"
         topologies = new Topologies(topology5);
-        cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config1);
+        cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config1);
         rs.prepare(config1);
         rs.schedule(topologies, cluster);
         superToCpu = getSupervisorToCpuUsage(cluster, topologies);
@@ -668,7 +671,7 @@ public class TestResourceAwareScheduler {
         TopologyDetails topology1 = new TopologyDetails("topology1", config1, stormTopology1, 1, executorMap1, 0, "user");
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         Topologies topologies = new Topologies(topology1);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config1);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config1);
         rs.prepare(config1);
         rs.schedule(topologies, cluster);
         assertEquals("Running - Fully Scheduled by DefaultResourceAwareStrategy", cluster.getStatusMap().get(topology1.getId()));
@@ -688,7 +691,7 @@ public class TestResourceAwareScheduler {
         Map<ExecutorDetails, String> executorMap2 = genExecsAndComps(stormTopology2);
         TopologyDetails topology2 = new TopologyDetails("topology2", config2, stormTopology2, 1, executorMap2, 0, "user");
         topologies = new Topologies(topology2);
-        cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config2);
+        cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config2);
         rs.prepare(config2);
         rs.schedule(topologies, cluster);
         String status = cluster.getStatusMap().get(topology2.getId());
@@ -719,7 +722,7 @@ public class TestResourceAwareScheduler {
             genTopology("topo-3", config, 1, 0, 1, 0, currentTime - 2, 20, "jerry"),
             genTopology("topo-4", config, 1, 0, 1, 0, currentTime - 2, 10, "bobby"),
             genTopology("topo-5", config, 1, 0, 1, 0, currentTime - 2, 20, "bobby"));
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         rs.prepare(config);
@@ -755,7 +758,7 @@ public class TestResourceAwareScheduler {
             genTopology("topo-13", config, 5, 15, 1, 1, currentTime - 16, 29, "derek"),
             genTopology("topo-14", config, 5, 15, 1, 1, currentTime - 16, 20, "derek"),
             genTopology("topo-15", config, 5, 15, 1, 1, currentTime - 24, 29, "derek"));
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
@@ -779,7 +782,7 @@ public class TestResourceAwareScheduler {
         Topologies topologies = new Topologies(
             genTopology("topo-1", config, 5, 15, 1, 1, currentTime - 2, 20, "jerry"),
             genTopology("topo-2", config, 5, 15, 1, 1, currentTime - 8, 29, "jerry"));
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
         rs.prepare(config);
@@ -810,7 +813,7 @@ public class TestResourceAwareScheduler {
             genTopology("topo-4", config, 1, 0, 1, 0, currentTime - 2, 10, "bobby"),
             genTopology("topo-5", config, 1, 0, 1, 0, currentTime - 2, 29, "derek"),
             genTopology("topo-6", config, 1, 0, 1, 0, currentTime - 2, 10, "derek"));
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
         rs.prepare(config);
@@ -838,7 +841,7 @@ public class TestResourceAwareScheduler {
         }
         Map<String, String> statusMap = cluster.getStatusMap();
         LOG.warn("Rescheduling with removed Supervisor....");
-        cluster = new Cluster(iNimbus, supMap, newAssignments, topologies, config);
+        cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, newAssignments, topologies, config);
         cluster.setStatusMap(statusMap);
         rs.schedule(topologies, cluster);
 
@@ -858,7 +861,7 @@ public class TestResourceAwareScheduler {
         Topologies topologies = new Topologies(
             genTopology("topo-1", config, 1, 0, 2, 0, currentTime - 2, 29, "user"),
             genTopology("topo-2", config, 1, 0, 2, 0, currentTime - 2, 10, "user"));
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
         rs.prepare(config);
@@ -900,7 +903,7 @@ public class TestResourceAwareScheduler {
         TopologyDetails topo3 = genTopology("topo-3", config, 1, 2, 1, 1, currentTime - 2, 20, "jerry");
 
         Topologies topologies = new Topologies(topo1, topo2, topo3);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
         rs.prepare(config);
@@ -941,7 +944,7 @@ public class TestResourceAwareScheduler {
                                                    0, genExecsAndComps(stormTopology), 0, "jerry");
 
         Topologies topologies = new Topologies(topo);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
         rs.prepare(config);
@@ -1026,7 +1029,7 @@ public class TestResourceAwareScheduler {
             }
         }
         Topologies topologies = new Topologies(topologyDetailsMap);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
 
         long startTime = Time.currentTimeMillis();
         rs.prepare(config);

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestUser.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestUser.java
@@ -35,6 +35,9 @@ import static org.apache.storm.scheduler.resource.TestUtilsForResourceAwareSched
 import static org.apache.storm.scheduler.resource.TestUtilsForResourceAwareScheduler.userRes;
 import static org.apache.storm.scheduler.resource.TestUtilsForResourceAwareScheduler.userResourcePool;
 
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
+
 public class TestUser {
     private static final Logger LOG = LoggerFactory.getLogger(TestUser.class);
 
@@ -50,7 +53,7 @@ public class TestUser {
         TopologyDetails topo1 = genTopology("topo-1", config, 1, 1, 2, 1, Time.currentTimeSecs() - 24, 9, "user1");
         Topologies topologies = new Topologies(topo1);
 
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         User user1 = new User("user1", toDouble(resourceUserPool.get("user1")));
         WorkerSlot slot = cluster.getAvailableSlots().get(0);
         cluster.assign(slot, topo1.getId(), topo1.getExecutors());

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOfferTest.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceOfferTest.java
@@ -21,6 +21,7 @@ package org.apache.storm.scheduler.resource.normalization;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.storm.Constants;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,7 +30,7 @@ public class NormalizedResourceOfferTest {
     public void testNodeOverExtendedCpu() {
         NormalizedResourceOffer availableResources = createOffer(100.0, 0.0);
         NormalizedResourceOffer scheduledResources = createOffer(110.0, 0.0);
-        availableResources.remove(scheduledResources);
+        availableResources.remove(scheduledResources, new ResourceMetrics(new StormMetricsRegistry()));
         Assert.assertEquals(0.0, availableResources.getTotalCpu(), 0.001);
     }
 
@@ -37,7 +38,7 @@ public class NormalizedResourceOfferTest {
     public void testNodeOverExtendedMemory() {
         NormalizedResourceOffer availableResources = createOffer(0.0, 5.0);
         NormalizedResourceOffer scheduledResources = createOffer(0.0, 10.0);
-        availableResources.remove(scheduledResources);
+        availableResources.remove(scheduledResources, new ResourceMetrics(new StormMetricsRegistry()));
         Assert.assertEquals(0.0, availableResources.getTotalMemoryMb(), 0.001);
     }
 

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourcesTest.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourcesTest.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import org.apache.storm.Constants;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -94,7 +95,7 @@ public class NormalizedResourcesTest {
         NormalizedResources resources = new NormalizedResources(normalize(Collections.singletonMap(gpuResourceName, 1)));
         NormalizedResources removedResources = new NormalizedResources(normalize(Collections.singletonMap(gpuResourceName, 2)));
 
-        resources.remove(removedResources);
+        resources.remove(removedResources, new ResourceMetrics(new StormMetricsRegistry()));
         Map<String, Double> normalizedMap = resources.toNormalizedMap();
         assertThat(normalizedMap.get(gpuResourceName), is(0.0));
     }
@@ -104,7 +105,7 @@ public class NormalizedResourcesTest {
         NormalizedResources resources = new NormalizedResources(normalize(Collections.singletonMap(Constants.COMMON_CPU_RESOURCE_NAME, 1)));
         NormalizedResources removedResources = new NormalizedResources(normalize(Collections.singletonMap(Constants.COMMON_CPU_RESOURCE_NAME, 2)));
 
-        resources.remove(removedResources);
+        resources.remove(removedResources, new ResourceMetrics(new StormMetricsRegistry()));
         assertThat(resources.getTotalCpu(), is(0.0));
     }
     
@@ -113,7 +114,7 @@ public class NormalizedResourcesTest {
         NormalizedResources resources = new NormalizedResources(normalize(Collections.singletonMap(Constants.COMMON_CPU_RESOURCE_NAME, 2)));
         NormalizedResources removedResources = new NormalizedResources(normalize(Collections.singletonMap(Constants.COMMON_CPU_RESOURCE_NAME, 1)));
         
-        resources.remove(removedResources);
+        resources.remove(removedResources, new ResourceMetrics(new StormMetricsRegistry()));
         
         Map<String, Double> normalizedMap = resources.toNormalizedMap();
         assertThat(normalizedMap.get(Constants.COMMON_CPU_RESOURCE_NAME), is(1.0));
@@ -125,7 +126,7 @@ public class NormalizedResourcesTest {
         NormalizedResources resources = new NormalizedResources(normalize(Collections.singletonMap(gpuResourceName, 15)));
         NormalizedResources removedResources = new NormalizedResources(normalize(Collections.singletonMap(gpuResourceName, 1)));
         
-        resources.remove(removedResources);
+        resources.remove(removedResources, new ResourceMetrics(new StormMetricsRegistry()));
         
         Map<String, Double> normalizedMap = resources.toNormalizedMap();
         assertThat(normalizedMap.get(gpuResourceName), is(14.0));

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/eviction/TestDefaultEvictionStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/eviction/TestDefaultEvictionStrategy.java
@@ -33,6 +33,9 @@ import java.util.Map;
 
 import static org.apache.storm.scheduler.resource.TestUtilsForResourceAwareScheduler.*;
 
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
+
 public class TestDefaultEvictionStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(TestDefaultEvictionStrategy.class);
     private static int currentTime = 1450418597;
@@ -57,7 +60,7 @@ public class TestDefaultEvictionStrategy {
             genTopology("topo-3", config, 1, 0, 1, 0, currentTime - 2, 20, "bobby"),
             genTopology("topo-4", config, 1, 0, 1, 0, currentTime - 2, 29, "derek"));
 
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         rs.prepare(config);
         rs.schedule(topologies, cluster);
@@ -89,7 +92,7 @@ public class TestDefaultEvictionStrategy {
             genTopology("topo-3", config, 1, 0, 1, 0, currentTime - 2, 20, "bobby"),
             genTopology("topo-4", config, 1, 0, 1, 0, currentTime - 2, 29, "derek"),
             genTopology("topo-5", config, 1, 0, 1, 0, currentTime - 2, 29, "derek"));
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         rs.prepare(config);
         LOG.info("\n\n\t\tScheduling topos 2 to 5...");
@@ -123,7 +126,7 @@ public class TestDefaultEvictionStrategy {
             genTopology("topo-3", config, 1, 0, 1, 0, currentTime - 2, 20, "bobby"),
             genTopology("topo-4", config, 1, 0, 1, 0, currentTime - 2, 29, "derek"),
             genTopology("topo-5", config, 1, 0, 1, 0, currentTime - 15, 29, "derek"));
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         rs.prepare(config);
         rs.schedule(topologies, cluster);
@@ -179,7 +182,7 @@ public class TestDefaultEvictionStrategy {
             genTopology("topo-2", config, 1, 0, 1, 0, currentTime - 2, 20, "jerry"),
             genTopology("topo-5", config, 1, 0, 1, 0, currentTime - 2, 10, "bobby"),
             genTopology("topo-6", config, 1, 0, 1, 0, currentTime - 2, 29, "derek"));
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         rs.prepare(config);
         LOG.info("\n\n\t\tScheduling topos 1,2,5,6");
@@ -231,7 +234,7 @@ public class TestDefaultEvictionStrategy {
             genTopology("topo-3", config, 1, 0, 1, 0, currentTime - 2, 10, "bobby"),
             genTopology("topo-4", config, 1, 0, 1, 0, currentTime - 2, 10, "bobby"),
             genTopology("topo-5", config, 1, 0, 1, 0, currentTime - 2, 29, "derek"));
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         rs.prepare(config);
         LOG.info("\n\n\t\tScheduling topos 1,3,4,5");

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/priority/TestFIFOSchedulingPriorityStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/priority/TestFIFOSchedulingPriorityStrategy.java
@@ -35,6 +35,9 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.storm.scheduler.resource.TestUtilsForResourceAwareScheduler.*;
 
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
+
 public class TestFIFOSchedulingPriorityStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(TestFIFOSchedulingPriorityStrategy.class);
 
@@ -53,7 +56,7 @@ public class TestFIFOSchedulingPriorityStrategy {
                 genTopology("topo-2-bobby", config, 1, 0, 1, 0,Time.currentTimeSecs() - 200,10, "bobby"),
                 genTopology("topo-3-bobby", config, 1, 0, 1, 0,Time.currentTimeSecs() - 300,20, "bobby"),
                 genTopology("topo-4-derek", config, 1, 0, 1, 0,Time.currentTimeSecs() - 201,29, "derek"));
-            Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+            Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
 
             ResourceAwareScheduler rs = new ResourceAwareScheduler();
             rs.prepare(config);
@@ -67,7 +70,7 @@ public class TestFIFOSchedulingPriorityStrategy {
             topologies = addTopologies(topologies,
                 genTopology("topo-5-derek", config, 1, 0, 1, 0,Time.currentTimeSecs() - 15,29, "derek"));
 
-            cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+            cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
             rs.schedule(topologies, cluster);
 
             assertTopologiesFullyScheduled(cluster, "topo-1-jerry", "topo-2-bobby", "topo-4-derek", "topo-5-derek");
@@ -79,7 +82,7 @@ public class TestFIFOSchedulingPriorityStrategy {
             topologies = addTopologies(topologies,
                 genTopology("topo-6-bobby", config, 1, 0, 1, 0,Time.currentTimeSecs() - 10,29, "bobby"));
 
-            cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+            cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
             rs.schedule(topologies, cluster);
 
             assertTopologiesFullyScheduled(cluster, "topo-1-jerry", "topo-2-bobby", "topo-5-derek", "topo-6-bobby");

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
@@ -49,6 +49,9 @@ import java.util.Map;
 
 import static org.apache.storm.scheduler.resource.TestUtilsForResourceAwareScheduler.*;
 
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
+
 public class TestConstraintSolverStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(TestConstraintSolverStrategy.class);
     private static final int MAX_TRAVERSAL_DEPTH = 2000;
@@ -86,7 +89,7 @@ public class TestConstraintSolverStrategy {
     public Cluster makeCluster(TopologyDetails topo) {
         Topologies topologies = new Topologies(topo);
         Map<String, SupervisorDetails> supMap = genSupervisors(4, 2, 120, 1200);
-        return new Cluster(new INimbusTest(), supMap, new HashMap<>(), topologies, new Config());
+        return new Cluster(new INimbusTest(), new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, new Config());
     }
 
     public void basicUnitTestWithKillAndRecover(ConstraintSolverStrategy cs, int boltParallel) {
@@ -214,10 +217,10 @@ public class TestConstraintSolverStrategy {
         config.put(Config.TOPOLOGY_COMPONENT_RESOURCES_OFFHEAP_MEMORY_MB, 0.0);
 
         TopologyDetails topo = genTopology("testTopo", config, 2, 3, 30, 300, 0, 0, "user");
-        Map<String, TopologyDetails> topoMap = new HashMap<String, TopologyDetails>();
+        Map<String, TopologyDetails> topoMap = new HashMap<>();
         topoMap.put(topo.getId(), topo);
         Topologies topologies = new Topologies(topoMap);
-        Cluster cluster = new Cluster(new INimbusTest(), supMap, new HashMap<String, SchedulerAssignmentImpl>(), topologies, config);
+        Cluster cluster = new Cluster(new INimbusTest(), new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
         rs.prepare(config);
         rs.schedule(topologies, cluster);

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -62,6 +62,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeSet;
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
 
 public class TestDefaultResourceAwareStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(TestDefaultResourceAwareStrategy.class);
@@ -128,7 +130,7 @@ public class TestDefaultResourceAwareStrategy {
                 genExecsAndComps(stormToplogy), CURRENT_TIME, "user");
 
         Topologies topologies = new Topologies(topo);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, conf);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, conf);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
@@ -195,7 +197,7 @@ public class TestDefaultResourceAwareStrategy {
                 genExecsAndComps(stormToplogy), CURRENT_TIME, "user");
 
         Topologies topologies = new Topologies(topo);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, conf);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, conf);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
@@ -264,7 +266,7 @@ public class TestDefaultResourceAwareStrategy {
         TopologyDetails topo2 = genTopology("topo-2", config, 8, 0, 2, 0, CURRENT_TIME - 2, 10, "user");
         
         Topologies topologies = new Topologies(topo1, topo2);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         
         List<String> supHostnames = new LinkedList<>();
         for (SupervisorDetails sup : supMap.values()) {
@@ -388,7 +390,7 @@ public class TestDefaultResourceAwareStrategy {
         TopologyDetails topo2 = genTopology("topo-2", t2Conf, 8, 0, 2, 0, CURRENT_TIME - 2, 10, "user");
 
         Topologies topologies = new Topologies(topo1, topo2);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
 
         List<String> supHostnames = new LinkedList<>();
         for (SupervisorDetails sup : supMap.values()) {

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
@@ -52,6 +52,9 @@ import org.slf4j.LoggerFactory;
 import static org.apache.storm.scheduler.resource.TestUtilsForResourceAwareScheduler.*;
 import static org.junit.Assert.*;
 
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
+
 public class TestGenericResourceAwareStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(TestGenericResourceAwareStrategy.class);
 
@@ -99,7 +102,7 @@ public class TestGenericResourceAwareStrategy {
 
         Topologies topologies = new Topologies(topo);
 
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, conf);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, conf);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
@@ -187,7 +190,7 @@ public class TestGenericResourceAwareStrategy {
                 genExecsAndComps(stormToplogy), currentTime, "user");
 
         Topologies topologies = new Topologies(topo);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, conf);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, conf);
 
         ResourceAwareScheduler rs = new ResourceAwareScheduler();
 
@@ -241,7 +244,7 @@ public class TestGenericResourceAwareStrategy {
 
         //Schedule the simple topology first
         Topologies topologies = new Topologies(tdSimple);
-        Cluster cluster = new Cluster(iNimbus, supMap, new HashMap<>(), topologies, config);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, config);
         rs.schedule(topologies, cluster);
 
         TopologyBuilder builder = topologyBuilder(1, 5, 100, 300);

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 
 public class DRPCServer implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(DRPCServer.class);
-    private static final Meter meterShutdownCalls = StormMetricsRegistry.registerMeter("drpc:num-shutdown-calls");
+    private final Meter meterShutdownCalls;
    
     //TODO in the future this might be better in a common webapp location
 
@@ -81,7 +81,7 @@ public class DRPCServer implements AutoCloseable {
                 ThriftConnectionType.DRPC_INVOCATIONS);
     }
     
-    private static Server mkHttpServer(Map<String, Object> conf, DRPC drpc) {
+    private static Server mkHttpServer(StormMetricsRegistry metricsRegistry, Map<String, Object> conf, DRPC drpc) {
         Integer drpcHttpPort = (Integer) conf.get(DaemonConfig.DRPC_HTTP_PORT);
         Server ret = null;
         if (drpcHttpPort != null && drpcHttpPort >= 0) {
@@ -103,7 +103,7 @@ public class DRPCServer implements AutoCloseable {
             final Boolean httpsNeedClientAuth = (Boolean) (conf.get(DaemonConfig.DRPC_HTTPS_NEED_CLIENT_AUTH));
 
             //TODO a better way to do this would be great.
-            DRPCApplication.setup(drpc);
+            DRPCApplication.setup(drpc, metricsRegistry);
             ret = UIHelpers.jettyCreateServer(drpcHttpPort, null, httpsPort);
             
             UIHelpers.configSsl(ret, httpsPort, httpsKsPath, httpsKsPassword, httpsKsType, httpsKeyPassword,
@@ -133,13 +133,15 @@ public class DRPCServer implements AutoCloseable {
     /**
      * Constructor.
      * @param conf Drpc conf for the servers
+     * @param metricsRegistry The metrics registry
      */
-    public DRPCServer(Map<String, Object> conf) {
-        drpc = new DRPC(conf);
+    public DRPCServer(Map<String, Object> conf, StormMetricsRegistry metricsRegistry) {
+        meterShutdownCalls = metricsRegistry.registerMeter("drpc:num-shutdown-calls");
+        drpc = new DRPC(metricsRegistry, conf);
         DRPCThrift thrift = new DRPCThrift(drpc);
         handlerServer = mkHandlerServer(thrift, ObjectReader.getInt(conf.get(Config.DRPC_PORT), null), conf);
         invokeServer = mkInvokeServer(thrift, ObjectReader.getInt(conf.get(Config.DRPC_INVOCATIONS_PORT), 3773), conf);
-        httpServer = mkHttpServer(conf, drpc);
+        httpServer = mkHttpServer(metricsRegistry, conf, drpc);
     }
 
     @VisibleForTesting
@@ -222,9 +224,10 @@ public class DRPCServer implements AutoCloseable {
     public static void main(String [] args) throws Exception {
         Utils.setupDefaultUncaughtExceptionHandler();
         Map<String, Object> conf = Utils.readStormConfig();
-        try (DRPCServer server = new DRPCServer(conf)) {
+        StormMetricsRegistry metricsRegistry = new StormMetricsRegistry();
+        try (DRPCServer server = new DRPCServer(conf, metricsRegistry)) {
             Utils.addShutdownHookWithForceKillIn1Sec(() -> server.close());
-            StormMetricsRegistry.startMetricsReporters(conf);
+            metricsRegistry.startMetricsReporters(conf);
             server.start();
             server.awaitTermination();
         }

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCApplication.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCApplication.java
@@ -26,10 +26,12 @@ import javax.ws.rs.core.Application;
 
 import org.apache.storm.daemon.common.AuthorizationExceptionMapper;
 import org.apache.storm.daemon.drpc.DRPC;
+import org.apache.storm.metric.StormMetricsRegistry;
 
 @ApplicationPath("")
 public class DRPCApplication extends Application {
     private static DRPC _drpc;
+    private static StormMetricsRegistry metricsRegistry;
     private final Set<Object> singletons = new HashSet<Object>();
 
     /**
@@ -38,7 +40,7 @@ public class DRPCApplication extends Application {
      * and adds them to a set which can be retrieved later.
      */
     public DRPCApplication() {
-        singletons.add(new DRPCResource(_drpc));
+        singletons.add(new DRPCResource(_drpc, metricsRegistry));
         singletons.add(new DRPCExceptionMapper());
         singletons.add(new AuthorizationExceptionMapper());
     }
@@ -48,7 +50,8 @@ public class DRPCApplication extends Application {
         return singletons;
     }
 
-    public static void setup(DRPC drpc) {
+    public static void setup(DRPC drpc, StormMetricsRegistry metricsRegistry) {
         _drpc = drpc;
+        DRPCApplication.metricsRegistry = metricsRegistry;
     }
 }

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCResource.java
@@ -33,11 +33,12 @@ import org.apache.storm.thrift.TException;
 
 @Path("/drpc/")
 public class DRPCResource {
-    private static final Meter meterHttpRequests = StormMetricsRegistry.registerMeter("drpc:num-execute-http-requests");
+    private final Meter meterHttpRequests;
     private final DRPC drpc;
 
-    public DRPCResource(DRPC drpc) {
+    public DRPCResource(DRPC drpc, StormMetricsRegistry metricsRegistry) {
         this.drpc = drpc;
+        this.meterHttpRequests = metricsRegistry.registerMeter("drpc:num-execute-http-requests");
     }
     
     //TODO put in some better exception mapping...

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerApplication.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerApplication.java
@@ -39,6 +39,7 @@ import org.apache.storm.daemon.logviewer.handler.LogviewerLogSearchHandler;
 import org.apache.storm.daemon.logviewer.handler.LogviewerProfileHandler;
 import org.apache.storm.daemon.logviewer.utils.ResourceAuthorizer;
 import org.apache.storm.daemon.logviewer.utils.WorkerLogs;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.security.auth.IHttpCredentialsPlugin;
 import org.apache.storm.security.auth.ServerAuthUtils;
 import org.apache.storm.utils.ConfigUtils;
@@ -47,7 +48,8 @@ import org.apache.storm.utils.ObjectReader;
 @ApplicationPath("")
 public class LogviewerApplication extends Application {
     private static Map<String, Object> stormConf;
-    private final Set<Object> singletons = new HashSet<Object>();
+    private static StormMetricsRegistry metricsRegistry;
+    private final Set<Object> singletons = new HashSet<>();
 
     /**
      * Constructor.
@@ -67,7 +69,8 @@ public class LogviewerApplication extends Application {
                 resourceAuthorizer);
         IHttpCredentialsPlugin httpCredsHandler = ServerAuthUtils.getUiHttpCredentialsPlugin(stormConf);
 
-        singletons.add(new LogviewerResource(logviewer, profileHandler, logDownloadHandler, logSearchHandler, httpCredsHandler));
+        singletons.add(new LogviewerResource(logviewer, profileHandler, logDownloadHandler, logSearchHandler,
+            httpCredsHandler, metricsRegistry));
         singletons.add(new AuthorizationExceptionMapper());
     }
     
@@ -80,9 +83,11 @@ public class LogviewerApplication extends Application {
      * Spot to inject storm configuration before initializing LogviewerApplication instance.
      *
      * @param stormConf storm configuration
+     * @param metricRegistry The metrics registry
      */
-    public static void setup(Map<String, Object> stormConf) {
+    public static void setup(Map<String, Object> stormConf, StormMetricsRegistry metricRegistry) {
         LogviewerApplication.stormConf = stormConf;
+        LogviewerApplication.metricsRegistry = metricRegistry;
     }
 
     /**

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerResource.java
@@ -53,14 +53,11 @@ import org.slf4j.LoggerFactory;
 public class LogviewerResource {
     private static final Logger LOG = LoggerFactory.getLogger(LogviewerResource.class);
 
-    private static final Meter meterLogPageHttpRequests = StormMetricsRegistry.registerMeter("logviewer:num-log-page-http-requests");
-    private static final Meter meterDaemonLogPageHttpRequests = StormMetricsRegistry.registerMeter(
-            "logviewer:num-daemonlog-page-http-requests");
-    private static final Meter meterDownloadLogFileHttpRequests = StormMetricsRegistry.registerMeter(
-            "logviewer:num-download-log-file-http-requests");
-    private static final Meter meterDownloadLogDaemonFileHttpRequests = StormMetricsRegistry.registerMeter(
-            "logviewer:num-download-log-daemon-file-http-requests");
-    private static final Meter meterListLogsHttpRequests = StormMetricsRegistry.registerMeter("logviewer:num-list-logs-http-requests");
+    private final Meter meterLogPageHttpRequests;
+    private final Meter meterDaemonLogPageHttpRequests;
+    private final Meter meterDownloadLogFileHttpRequests;
+    private final Meter meterDownloadLogDaemonFileHttpRequests;
+    private final Meter meterListLogsHttpRequests;
 
     private final LogviewerLogPageHandler logviewer;
     private final LogviewerProfileHandler profileHandler;
@@ -76,10 +73,19 @@ public class LogviewerResource {
      * @param logDownloadHandler {@link LogviewerLogDownloadHandler}
      * @param logSearchHandler {@link LogviewerLogSearchHandler}
      * @param httpCredsHandler {@link IHttpCredentialsPlugin}
+     * @param metricsRegistry The metrics registry
      */
     public LogviewerResource(LogviewerLogPageHandler logviewerParam, LogviewerProfileHandler profileHandler,
                              LogviewerLogDownloadHandler logDownloadHandler, LogviewerLogSearchHandler logSearchHandler,
-                             IHttpCredentialsPlugin httpCredsHandler) {
+                             IHttpCredentialsPlugin httpCredsHandler, StormMetricsRegistry metricsRegistry) {
+        this.meterLogPageHttpRequests = metricsRegistry.registerMeter("logviewer:num-log-page-http-requests");
+        this.meterDaemonLogPageHttpRequests = metricsRegistry.registerMeter(
+            "logviewer:num-daemonlog-page-http-requests");
+        this.meterDownloadLogFileHttpRequests = metricsRegistry.registerMeter(
+            "logviewer:num-download-log-file-http-requests");
+        this.meterDownloadLogDaemonFileHttpRequests = metricsRegistry.registerMeter(
+            "logviewer:num-download-log-daemon-file-http-requests");
+        this.meterListLogsHttpRequests = metricsRegistry.registerMeter("logviewer:num-list-logs-http-requests");
         this.logviewer = logviewerParam;
         this.profileHandler = profileHandler;
         this.logDownloadHandler = logDownloadHandler;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIServer.java
@@ -50,6 +50,8 @@ import org.slf4j.LoggerFactory;
 import static org.apache.storm.utils.ConfigUtils.FILE_SEPARATOR;
 import static org.apache.storm.utils.ConfigUtils.STORM_HOME;
 
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
 /**
  * Main class.
  *
@@ -85,18 +87,26 @@ public class UIServer {
         connector.setPort((Integer) conf.get(DaemonConfig.UI_PORT));
         jettyServer.addConnector(connector);
 
+        StormMetricsRegistry metricsRegistry = new StormMetricsRegistry();
+
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
         context.setContextPath("/");
         jettyServer.setHandler(context);
 
         ResourceConfig resourceConfig =
-                new ResourceConfig()
-                        .packages("org.apache.storm.daemon.ui.resources")
-                        .register(AuthorizedUserFilter.class)
-                        .register(HeaderResponseFilter.class)
-                        .register(AuthorizationExceptionMapper.class)
-                        .register(NotAliveExceptionMapper.class)
-                        .register(DefaultExceptionMapper.class);
+            new ResourceConfig()
+                .packages("org.apache.storm.daemon.ui.resources")
+                .registerInstances(new AbstractBinder() {
+                    @Override
+                    protected void configure() {
+                        super.bind(metricsRegistry).to(StormMetricsRegistry.class);
+                    }
+                })
+                .register(AuthorizedUserFilter.class)
+                .register(HeaderResponseFilter.class)
+                .register(AuthorizationExceptionMapper.class)
+                .register(NotAliveExceptionMapper.class)
+                .register(DefaultExceptionMapper.class);
 
         ServletHolder jerseyServlet = new ServletHolder(new ServletContainer(resourceConfig));
         jerseyServlet.setInitOrder(0);
@@ -128,7 +138,7 @@ public class UIServer {
 
         holderHome.setInitParameter("dirAllowed","true");
         holderHome.setInitParameter("pathInfoOnly","true");
-        context.addFilter(new FilterHolder(new HeaderResponseServletFilter()), "/*", EnumSet.allOf(DispatcherType.class));
+        context.addFilter(new FilterHolder(new HeaderResponseServletFilter(metricsRegistry)), "/*", EnumSet.allOf(DispatcherType.class));
         context.addServlet(holderHome,"/*");
 
 
@@ -137,7 +147,7 @@ public class UIServer {
         holderPwd.setInitParameter("dirAllowed","true");
         context.addServlet(holderPwd,"/");
 
-        StormMetricsRegistry.startMetricsReporters(conf);
+        metricsRegistry.startMetricsReporters(conf);
         try {
             jettyServer.start();
             jettyServer.join();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/HeaderResponseFilter.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/HeaderResponseFilter.java
@@ -20,6 +20,7 @@ package org.apache.storm.daemon.ui.filters;
 
 import com.codahale.metrics.Meter;
 import java.io.IOException;
+import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
@@ -33,8 +34,12 @@ import org.slf4j.LoggerFactory;
 public class HeaderResponseFilter implements ContainerResponseFilter {
     public static final Logger LOG = LoggerFactory.getLogger(HeaderResponseFilter.class);
 
-    public static Meter webRequestMeter =
-            StormMetricsRegistry.registerMeter("num-web-requests");
+    private final Meter webRequestMeter;
+    
+    @Inject
+    public HeaderResponseFilter(StormMetricsRegistry metricsRegistry) {
+        this.webRequestMeter = metricsRegistry.registerMeter("num-web-requests");
+    }
 
     @Override
     public void filter(ContainerRequestContext containerRequestContext,

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/HeaderResponseServletFilter.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/HeaderResponseServletFilter.java
@@ -35,11 +35,14 @@ import org.slf4j.LoggerFactory;
 public class HeaderResponseServletFilter implements Filter {
     public static final Logger LOG = LoggerFactory.getLogger(HeaderResponseServletFilter.class);
 
-    public static Meter webRequestMeter =
-            StormMetricsRegistry.registerMeter("num-web-requests");
+    private final Meter webRequestMeter;
 
-    public static Meter mainPageRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-main-page-http-requests");
+    private final Meter mainPageRequestMeter;
+    
+    public HeaderResponseServletFilter(StormMetricsRegistry metricsRegistry) {
+        this.webRequestMeter = metricsRegistry.registerMeter("num-web-requests");
+        this.mainPageRequestMeter = metricsRegistry.registerMeter("ui:num-main-page-http-requests");
+    }
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/resources/StormApiResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/resources/StormApiResource.java
@@ -21,6 +21,7 @@ package org.apache.storm.daemon.ui.resources;
 import com.codahale.metrics.Meter;
 import java.net.URLDecoder;
 import java.util.Map;
+import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
@@ -59,63 +60,48 @@ public class StormApiResource {
 
     public static Map<String, Object> config = Utils.readStormConfig();
 
-    public static Meter clusterConfigurationRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-cluster-configuration-http-requests");
+    private final Meter clusterConfigurationRequestMeter;
+    private final Meter clusterSummaryRequestMeter;
+    private final Meter nimbusSummaryRequestMeter;
+    private final Meter supervisorRequestMeter;
+    private final Meter supervisorSummaryRequestMeter;
+    private final Meter allTopologiesSummaryRequestMeter;
+    private final Meter topologyPageRequestMeter;
+    private final Meter topologyMetricRequestMeter;
+    private final Meter buildVisualizationRequestMeter;
+    private final Meter mkVisualizationDataRequestMeter;
+    private final Meter componentPageRequestMeter;
+    private final Meter logConfigRequestMeter;
+    private final Meter activateTopologyRequestMeter;
+    private final Meter deactivateTopologyRequestMeter;
+    private final Meter debugTopologyRequestMeter;
+    private final Meter componentOpResponseRequestMeter;
+    private final Meter topologyOpResponseMeter;
+    private final Meter topologyLagRequestMeter;
+    private final Meter getOwnerResourceSummariesMeter;
 
-    public static Meter clusterSummaryRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-cluster-summary-http-requests");
-
-    public static Meter nimbusSummaryRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-nimbus-summary-http-requests");
-
-    public static Meter supervisorRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-supervisor-http-requests");
-
-    public static Meter supervisorSummaryRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-supervisor-summary-http-requests");
-
-    public static Meter allTopologiesSummaryRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-all-topologies-summary-http-requests");
-
-    public static Meter topologyPageRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-topology-page-http-requests");
-
-    public static Meter topologyMetricRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-topology-metric-http-requests");
-
-    public static Meter buildVisualizationRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-build-visualization-http-requests");
-
-    public static Meter mkVisualizationDataRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-mk-visualization-data-http-requests");
-
-    public static Meter componentPageRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-component-page-http-requests");
-
-    public static Meter logConfigRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-log-config-http-requests");
-
-    public static Meter activateTopologyRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-activate-topology-http-requests");
-
-    public static Meter deactivateTopologyRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-deactivate-topology-http-requests");
-
-    public static Meter debugTopologyRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-debug-topology-http-requests");
-
-    public static Meter componentOpResponseRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-component-op-response-http-requests");
-
-    public static Meter topologyOpResponseMeter =
-            StormMetricsRegistry.registerMeter("ui:num-topology-op-response-http-requests");
-
-    public static Meter topologyLagRequestMeter =
-            StormMetricsRegistry.registerMeter("ui:num-topology-lag-http-requests");
-
-    public static Meter getOwnerResourceSummariesMeter =
-            StormMetricsRegistry.registerMeter("ui:num-get-owner-resource-summaries-http-request");
-
+    @Inject
+    public StormApiResource(StormMetricsRegistry metricsRegistry) {
+        this.clusterConfigurationRequestMeter = metricsRegistry.registerMeter("ui:num-cluster-configuration-http-requests");
+        this.clusterSummaryRequestMeter = metricsRegistry.registerMeter("ui:num-cluster-summary-http-requests");
+        this.nimbusSummaryRequestMeter = metricsRegistry.registerMeter("ui:num-nimbus-summary-http-requests");
+        this.supervisorRequestMeter = metricsRegistry.registerMeter("ui:num-supervisor-http-requests");
+        this.supervisorSummaryRequestMeter = metricsRegistry.registerMeter("ui:num-supervisor-summary-http-requests");
+        this.allTopologiesSummaryRequestMeter = metricsRegistry.registerMeter("ui:num-all-topologies-summary-http-requests");
+        this.topologyPageRequestMeter = metricsRegistry.registerMeter("ui:num-topology-page-http-requests");
+        this.topologyMetricRequestMeter = metricsRegistry.registerMeter("ui:num-topology-metric-http-requests");
+        this.buildVisualizationRequestMeter = metricsRegistry.registerMeter("ui:num-build-visualization-http-requests");
+        this.mkVisualizationDataRequestMeter = metricsRegistry.registerMeter("ui:num-mk-visualization-data-http-requests");
+        this.componentPageRequestMeter = metricsRegistry.registerMeter("ui:num-component-page-http-requests");
+        this.logConfigRequestMeter = metricsRegistry.registerMeter("ui:num-log-config-http-requests");
+        this.activateTopologyRequestMeter = metricsRegistry.registerMeter("ui:num-activate-topology-http-requests");
+        this.deactivateTopologyRequestMeter = metricsRegistry.registerMeter("ui:num-deactivate-topology-http-requests");
+        this.debugTopologyRequestMeter = metricsRegistry.registerMeter("ui:num-debug-topology-http-requests");
+        this.componentOpResponseRequestMeter = metricsRegistry.registerMeter("ui:num-component-op-response-http-requests");
+        this.topologyOpResponseMeter = metricsRegistry.registerMeter("ui:num-topology-op-response-http-requests");
+        this.topologyLagRequestMeter = metricsRegistry.registerMeter("ui:num-topology-lag-http-requests");
+        this.getOwnerResourceSummariesMeter = metricsRegistry.registerMeter("ui:num-get-owner-resource-summaries-http-request");
+    }
 
     /**
      * /api/v1/cluster/configuration -> nimbus configuration.

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/drpc/DRPCServerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/drpc/DRPCServerTest.java
@@ -37,6 +37,7 @@ import org.apache.storm.DaemonConfig;
 import org.apache.storm.drpc.DRPCInvocationsClient;
 import org.apache.storm.generated.DRPCExecutionException;
 import org.apache.storm.generated.DRPCRequest;
+import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.security.auth.SimpleTransportPlugin;
 import org.apache.storm.utils.DRPCClient;
 import org.junit.AfterClass;
@@ -88,7 +89,7 @@ public class DRPCServerTest {
     @Test
     public void testGoodThrift() throws Exception {
         Map<String, Object> conf = getConf(0, 0, null);
-        try (DRPCServer server = new DRPCServer(conf)) {
+        try (DRPCServer server = new DRPCServer(conf, new StormMetricsRegistry())) {
             server.start();
             try (DRPCClient client = new DRPCClient(conf, "localhost", server.getDrpcPort());
                 DRPCInvocationsClient invoke = new DRPCInvocationsClient(conf, "localhost", server.getDrpcInvokePort())) {
@@ -107,7 +108,7 @@ public class DRPCServerTest {
     @Test
     public void testFailedThrift() throws Exception {
         Map<String, Object> conf = getConf(0, 0, null);
-        try (DRPCServer server = new DRPCServer(conf)) {
+        try (DRPCServer server = new DRPCServer(conf, new StormMetricsRegistry())) {
             server.start();
             try (DRPCClient client = new DRPCClient(conf, "localhost", server.getDrpcPort());
                     DRPCInvocationsClient invoke = new DRPCInvocationsClient(conf, "localhost", server.getDrpcInvokePort())) {
@@ -146,7 +147,7 @@ public class DRPCServerTest {
     public void testGoodHttpGet() throws Exception {
         LOG.info("STARTING HTTP GET TEST...");
         Map<String, Object> conf = getConf(0, 0, 0);
-        try (DRPCServer server = new DRPCServer(conf)) {
+        try (DRPCServer server = new DRPCServer(conf, new StormMetricsRegistry())) {
             server.start();
             //TODO need a better way to do this
             Thread.sleep(2000);
@@ -167,7 +168,7 @@ public class DRPCServerTest {
     public void testFailedHttpGet() throws Exception {
         LOG.info("STARTING HTTP GET (FAIL) TEST...");
         Map<String, Object> conf = getConf(0, 0, 0);
-        try (DRPCServer server = new DRPCServer(conf)) {
+        try (DRPCServer server = new DRPCServer(conf, new StormMetricsRegistry())) {
             server.start();
             //TODO need a better way to do this
             Thread.sleep(2000);


### PR DESCRIPTION
I'd like to put this up for discussion before spending more time on it, in case this solution is a no go. 

As mentioned on https://github.com/apache/storm/pull/2714, I think we can solve the issue with unintended metrics registration by making StormMetricsRegistry a regular class rather than a static utility. We can probably do something similar with StormMetricRegistry (the worker metrics registry) if this makes sense.

The basic idea here is to initialize the metrics registry in each daemon's main method, and pass it around to the classes using it from there, rather than having the registry be a statically available tool. Metrics registration is moved from static initializers to regular instance fields. I also bumped the Metrics library version, since they've added the ability to get or add metrics, so we don't have to handle duplicate registrations by hand anymore.

I've based this on the Java migration of Storm UI to avoid some likely conflicts, so please ignore everything except the last commit. 

@zd-project If you have a chance, I'd appreciate your input on this since you've been working a lot with the metrics system recently.