### PR TITLE
STORM-3166: Make Utils.threadDump account for threads dying before it…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -1187,6 +1187,10 @@ public class Utils {
         final java.lang.management.ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
         final java.lang.management.ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds(), 100);
         for (java.lang.management.ThreadInfo threadInfo : threadInfos) {
+            if (threadInfo == null) {
+                //Thread died before we could get the info, skip
+                continue;
+            }
             dump.append('"');
             dump.append(threadInfo.getThreadName());
             dump.append("\" ");


### PR DESCRIPTION
… can get the ThreadInfo

https://issues.apache.org/jira/browse/STORM-3166