### PR TITLE
STORM-3176: KafkaSpout commit offset occurs CommitFailedException which leads to worker dead

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.commons.lang.Validate;
+import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -282,7 +283,12 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                 } else if (kafkaSpoutConfig.getProcessingGuarantee() == ProcessingGuarantee.NO_GUARANTEE) {
                     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit =
                         createFetchedOffsetsMetadata(consumer.assignment());
-                    consumer.commitAsync(offsetsToCommit, null);
+                    try {
+                        consumer.commitAsync(offsetsToCommit, null);
+                    }catch (CommitFailedException e) {
+                        // catch the CommitFailedException
+                        LOG.warn("Commit offsets {} failed for group {}: {}", offsetsToCommit.toString());
+                    }
                     LOG.debug("Committed offsets {} to Kafka", offsetsToCommit);
                 }
             }
@@ -442,6 +448,8 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
             LOG.trace("Tuple for record [{}] has already been acked. Skipping", record);
         } else if (emitted.contains(msgId)) {   // has been emitted and it is pending ack or fail
             LOG.trace("Tuple for record [{}] has already been emitted. Skipping", record);
+        }else if(record.offset() <= offsetManagers.get(tp).getCommittedOffset()){
+            LOG.trace("Tuple for record [{}] has already been committed. Skipping", record);
         } else {
             final List<Object> tuple = kafkaSpoutConfig.getTranslator().apply(record);
             if (isEmitTuple(tuple)) {
@@ -512,37 +520,42 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
 
         // Commit offsets that are ready to be committed for every topic partition
         if (!nextCommitOffsets.isEmpty()) {
-            consumer.commitSync(nextCommitOffsets);
-            LOG.debug("Offsets successfully committed to Kafka [{}]", nextCommitOffsets);
-            // Instead of iterating again, it would be possible to commit and update the state for each TopicPartition
-            // in the prior loop, but the multiple network calls should be more expensive than iterating twice over a small loop
-            for (Map.Entry<TopicPartition, OffsetAndMetadata> tpOffset : nextCommitOffsets.entrySet()) {
-                //Update the OffsetManager for each committed partition, and update numUncommittedOffsets
-                final TopicPartition tp = tpOffset.getKey();
-                long position = consumer.position(tp);
-                long committedOffset = tpOffset.getValue().offset();
-                if (position < committedOffset) {
+            try {
+                consumer.commitSync(nextCommitOffsets);
+                LOG.debug("Offsets successfully committed to Kafka [{}]", nextCommitOffsets);
+                // Instead of iterating again, it would be possible to commit and update the state for each TopicPartition
+                // in the prior loop, but the multiple network calls should be more expensive than iterating twice over a small loop
+                for (Map.Entry<TopicPartition, OffsetAndMetadata> tpOffset : nextCommitOffsets.entrySet()) {
+                    //Update the OffsetManager for each committed partition, and update numUncommittedOffsets
+                    final TopicPartition tp = tpOffset.getKey();
+                    long position = consumer.position(tp);
+                    long committedOffset = tpOffset.getValue().offset();
+                    if (position < committedOffset) {
                     /*
                      * The position is behind the committed offset. This can happen in some cases, e.g. if a message failed, lots of (more
                      * than max.poll.records) later messages were acked, and the failed message then gets acked. The consumer may only be
                      * part way through "catching up" to where it was when it went back to retry the failed tuple. Skip the consumer forward
                      * to the committed offset and drop the current waiting to emit list, since it'll likely contain committed offsets.
                      */
-                    LOG.debug("Consumer fell behind committed offset. Catching up. Position was [{}], skipping to [{}]",
-                        position, committedOffset);
-                    consumer.seek(tp, committedOffset);
-                    List<ConsumerRecord<K, V>> waitingToEmitForTp = waitingToEmit.get(tp);
-                    if (waitingToEmitForTp != null) {
-                        //Discard the pending records that are already committed
-                        waitingToEmit.put(tp, waitingToEmitForTp.stream()
-                            .filter(record -> record.offset() >= committedOffset)
-                            .collect(Collectors.toList()));
+                        LOG.debug("Consumer fell behind committed offset. Catching up. Position was [{}], skipping to [{}]",
+                                position, committedOffset);
+                        consumer.seek(tp, committedOffset);
+                        List<ConsumerRecord<K, V>> waitingToEmitForTp = waitingToEmit.get(tp);
+                        if (waitingToEmitForTp != null) {
+                            //Discard the pending records that are already committed
+                            waitingToEmit.put(tp, waitingToEmitForTp.stream()
+                                    .filter(record -> record.offset() >= committedOffset)
+                                    .collect(Collectors.toList()));
+                        }
                     }
-                }
 
-                final OffsetManager offsetManager = offsetManagers.get(tp);
-                offsetManager.commit(tpOffset.getValue());
-                LOG.debug("[{}] uncommitted offsets for partition [{}] after commit", offsetManager.getNumUncommittedOffsets(), tp);
+                    final OffsetManager offsetManager = offsetManagers.get(tp);
+                    offsetManager.commit(tpOffset.getValue());
+                    LOG.debug("[{}] uncommitted offsets for partition [{}] after commit", offsetManager.getNumUncommittedOffsets(), tp);
+                }
+            } catch (CommitFailedException e) {
+                // catch the CommitFailedException
+                LOG.warn("Commit offsets {} failed for group {}: {}", nextCommitOffsets.toString());
             }
         } else {
             LOG.trace("No offsets to commit. {}", this);
@@ -594,6 +607,14 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
             LOG.debug("Received fail for tuple this spout is no longer tracking."
                 + " Partitions may have been reassigned. Ignoring message [{}]", msgId);
             return;
+        }
+        // tuple which has been committed should be ignoring
+        TopicPartition topicPartition = new TopicPartition(msgId.topic(), msgId.partition());
+        if (offsetManagers.containsKey(topicPartition)){
+            if (msgId.offset() <= offsetManagers.get(topicPartition).getCommittedOffset()){
+                LOG.debug("Received fail for tuple this spout has been ack. Ignoring message [{}]", msgId);
+                return;
+            }
         }
         Validate.isTrue(!retryService.isScheduled(msgId), "The message id " + msgId + " is queued for retry while being failed."
             + " This should never occur barring errors in the RetryService implementation or the spout code.");

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -285,9 +285,9 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                         createFetchedOffsetsMetadata(consumer.assignment());
                     try {
                         consumer.commitAsync(offsetsToCommit, null);
-                    }catch (CommitFailedException e) {
+                    } catch (CommitFailedException e) {
                         // catch the CommitFailedException
-                        LOG.warn("Commit offsets {} failed for group {}: {}", offsetsToCommit.toString());
+                        LOG.warn("Commit offsets {} failed.", offsetsToCommit.toString());
                     }
                     LOG.debug("Committed offsets {} to Kafka", offsetsToCommit);
                 }
@@ -448,7 +448,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
             LOG.trace("Tuple for record [{}] has already been acked. Skipping", record);
         } else if (emitted.contains(msgId)) {   // has been emitted and it is pending ack or fail
             LOG.trace("Tuple for record [{}] has already been emitted. Skipping", record);
-        }else if(record.offset() <= offsetManagers.get(tp).getCommittedOffset()){
+        } else if (record.offset() <= offsetManagers.get(tp).getCommittedOffset()) {
             LOG.trace("Tuple for record [{}] has already been committed. Skipping", record);
         } else {
             final List<Object> tuple = kafkaSpoutConfig.getTranslator().apply(record);
@@ -531,12 +531,12 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                     long position = consumer.position(tp);
                     long committedOffset = tpOffset.getValue().offset();
                     if (position < committedOffset) {
-                    /*
-                     * The position is behind the committed offset. This can happen in some cases, e.g. if a message failed, lots of (more
-                     * than max.poll.records) later messages were acked, and the failed message then gets acked. The consumer may only be
-                     * part way through "catching up" to where it was when it went back to retry the failed tuple. Skip the consumer forward
-                     * to the committed offset and drop the current waiting to emit list, since it'll likely contain committed offsets.
-                     */
+                        /*
+                         * The position is behind the committed offset. This can happen in some cases, e.g. if a message failed, lots of (more
+                         * than max.poll.records) later messages were acked, and the failed message then gets acked. The consumer may only be
+                         * part way through "catching up" to where it was when it went back to retry the failed tuple.  Skip the consumer forward
+                         * to the committed offset and drop the current waiting to emit list, since it'll likely contain committed offsets.
+                         */
                         LOG.debug("Consumer fell behind committed offset. Catching up. Position was [{}], skipping to [{}]",
                                 position, committedOffset);
                         consumer.seek(tp, committedOffset);
@@ -555,7 +555,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                 }
             } catch (CommitFailedException e) {
                 // catch the CommitFailedException
-                LOG.warn("Commit offsets {} failed for group {}: {}", nextCommitOffsets.toString());
+                LOG.warn("Commit offsets {} failed.", nextCommitOffsets.toString());
             }
         } else {
             LOG.trace("No offsets to commit. {}", this);
@@ -610,8 +610,8 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
         }
         // tuple which has been committed should be ignoring
         TopicPartition topicPartition = new TopicPartition(msgId.topic(), msgId.partition());
-        if (offsetManagers.containsKey(topicPartition)){
-            if (msgId.offset() <= offsetManagers.get(topicPartition).getCommittedOffset()){
+        if (offsetManagers.containsKey(topicPartition)) {
+            if (msgId.offset() <= offsetManagers.get(topicPartition).getCommittedOffset()) {
                 LOG.debug("Received fail for tuple this spout has been ack. Ignoring message [{}]", msgId);
                 return;
             }


### PR DESCRIPTION
KafkaSpout use the commitAsync api of Consumer, if the interval time between the calling of the  consumer.poll() more than `max.poll.interval.ms` or the heartbeat of consumer timeout, that will occur CommitFailedException,  and then the worker will die, the log like this:

```
2018-07-31 19:19:03.341 o.a.s.util [ERROR] Async loop died!
org.apache.mtkafka.clients.consumer.CommitFailedException: Commit cannot be completed since the group has already rebalanced and assigned the partitions to another member. This means that the time between subsequent calls to poll() was longer th
an the configured max.poll.interval.ms, which typically implies that the poll loop is spending too much time message processing. You can address this either by increasing the session timeout or by reducing the maximum size of batches returned in
poll() with max.poll.records.
at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.sendOffsetCommitRequest(ConsumerCoordinator.java:698) ~[stormjar.jar:?]
at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.commitOffsetsSync(ConsumerCoordinator.java:577) ~[stormjar.jar:?]
at org.apache.kafka.clients.consumer.KafkaConsumer.commitSync(KafkaConsumer.java:1126) ~[stormjar.jar:?]
at org.apache.kafka.clients.consumer.KafkaConsumer.commitSync(KafkaConsumer.java:XXX) ~[stormjar.jar:?]
at org.apache.storm.kafka.spout.KafkaSpout.commitOffsetsForAckedTuples(KafkaSpout.java:430) ~[stormjar.jar:?]
at org.apache.storm.kafka.spout.KafkaSpout.nextTuple(KafkaSpout.java:264) ~[stormjar.jar:?]
at org.apache.storm.daemon.executor$fn__10936$fn__10951$fn__10982.invoke(executor.clj:647) ~[storm-core-1.1.2-mt001.jar:?]
at org.apache.storm.util$async_loop$fn__553.invoke(util.clj:484) [storm-core-1.1.2-mt001.jar:?]
at clojure.lang.AFn.run(AFn.java:22) [clojure-1.7.0.jar:?]
at java.lang.Thread.run(Thread.java:745) [?:1.8.0_112]
2018-07-31 19:19:03.342 o.a.s.d.executor [ERROR]
```

I find it will catch the Exception in the auto-commit mode of consumer, the source code is:

```java
private void maybeAutoCommitOffsetsSync(long timeoutMs) {
    if (autoCommitEnabled) {
        Map<TopicPartition, OffsetAndMetadata> allConsumedOffsets = subscriptions.allConsumed();
        try {
            log.debug("Sending synchronous auto-commit of offsets {} for group {}", allConsumedOffsets, groupId);
            if (!commitOffsetsSync(allConsumedOffsets, timeoutMs))
                log.debug("Auto-commit of offsets {} for group {} timed out before completion",
                        allConsumedOffsets, groupId);
        } catch (WakeupException | InterruptException e) {
            log.debug("Auto-commit of offsets {} for group {} was interrupted before completion",
                    allConsumedOffsets, groupId);
            // rethrow wakeups since they are triggered by the user
            throw e;
        } catch (Exception e) {
            // consistent with async auto-commit failures, we do not propagate the exception
            log.warn("Auto-commit of offsets {} failed for group {}: {}", allConsumedOffsets, groupId,
                    e.getMessage());
        }
    }
}
```

I think KafkaSpout should do like this, catch the Exception avoid to worker die. And when the msg ack failed, Spout should judge the offset of the msgID is larger than the last commit offset(Spout can guarantee that these msgs which offset less than the last commit offset are all ack), if not, the msg should not retry.
