### PR TITLE
Add the getName() method in order to obtain the applied label to the Trident stream.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/trident/Stream.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/Stream.java
@@ -835,6 +835,15 @@ public class Stream implements IAggregatableStream, ResourceDeclarer<Stream> {
         return stateQuery(state, null, function, functionFields);
     }
 
+    /**
+     * Returns the label applied to the stream.
+     *
+     * @return the label applied to the stream.
+     */
+    public String getName() {
+	return _name;
+    }
+
     @Override
     public Stream toStream() {
         return this;


### PR DESCRIPTION
Being able to get the applied label of a Trident stream could be useful in case of complex Trident topology design. The getter returns the `String` corresponding to the `_name` attribute of the `Stream` object.