### PR TITLE
STORM-3171 Fix dependency conflict issue for org.apache.storm:storm-kafka-monitor:jar

### DIFF
--- a/external/storm-kafka-monitor/pom.xml
+++ b/external/storm-kafka-monitor/pom.xml
@@ -59,6 +59,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
+			<version>3.5.3-beta</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
[STORM-3171](https://issues.apache.org/jira/browse/STORM-3171)