### PR TITLE
STORM-3180 Total executors in Cluster Summary in main UI page is not …

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -571,7 +571,7 @@ public class UIHelpers {
         result.put("slotsTotal", totalSlots);
         result.put("slotsFree", totalSlots - usedSlots);
         result.put("tasksTotal", totalTasks);
-        result.put("totalExecutors", totalExecutors);
+        result.put("executorsTotal", totalExecutors);
 
         result.put("totalMem", supervisorTotalMemory);
         result.put("totalCpu", supervisorTotalCpu);


### PR DESCRIPTION
…exposed even a topology is running

* rename the field of /cluster/summary output: `totalExecutors` to `executorsTotal`

Please compare with doc regarding the output format of API:
https://github.com/apache/storm/blob/master/docs/STORM-UI-REST-API.md#apiv1clustersummary-get
