### PR TITLE
STORM-3184: Mask the plaintext passwords from the logs

### DIFF
--- a/external/storm-autocreds/src/main/java/org/apache/storm/common/AbstractHadoopNimbusPluginAutoCreds.java
+++ b/external/storm-autocreds/src/main/java/org/apache/storm/common/AbstractHadoopNimbusPluginAutoCreds.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.storm.security.INimbusCredentialPlugin;
 import org.apache.storm.security.auth.ICredentialsRenewer;
+import org.apache.storm.utils.ConfigUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,8 @@ public abstract class AbstractHadoopNimbusPluginAutoCreds
 
     protected void fillHadoopConfiguration(Map topologyConf, String configKey, Configuration configuration) {
         Map<String, Object> config = (Map<String, Object>) topologyConf.get(configKey);
-        LOG.info("TopoConf {}, got config {}, for configKey {}", topologyConf, config, configKey);
+        LOG.info("TopoConf {}, got config {}, for configKey {}", ConfigUtils.maskPasswords(topologyConf),
+                ConfigUtils.maskPasswords(config), configKey);
         if (config != null) {
             List<String> resourcesToLoad = new ArrayList<>();
             for (Map.Entry<String, Object> entry : config.entrySet()) {

--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -97,12 +97,6 @@
 
         <!-- end of transitive dependency management -->
 
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-
         <!-- test -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -97,6 +97,12 @@
 
         <!-- end of transitive dependency management -->
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
         <!-- test -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -36,6 +36,7 @@ import org.apache.storm.validation.ConfigValidation.MetricRegistryValidator;
 import org.apache.storm.validation.ConfigValidation.MetricReportersValidator;
 import org.apache.storm.validation.ConfigValidationAnnotations.CustomValidator;
 import org.apache.storm.validation.ConfigValidationAnnotations.NotNull;
+import org.apache.storm.validation.ConfigValidationAnnotations.Password;
 import org.apache.storm.validation.ConfigValidationAnnotations.isBoolean;
 import org.apache.storm.validation.ConfigValidationAnnotations.isImplementationOfClass;
 import org.apache.storm.validation.ConfigValidationAnnotations.isInteger;
@@ -1146,6 +1147,7 @@ public class Config extends HashMap<String, Object> {
      * authentication.
      */
     @isString
+    @Password
     public static final String STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD = "storm.zookeeper.topology.auth.payload";
     /**
      * The cluster Zookeeper authentication scheme to use, e.g. "digest". Defaults to no authentication.

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -278,8 +278,7 @@ public class Worker implements Shutdownable, DaemonCommon {
         setupFlushTupleTimer(topologyConf, newExecutors);
         setupBackPressureCheckTimer(topologyConf);
 
-        LOG.info("Worker has topology config {}", Utils.redactValue(ConfigUtils.maskPasswords(topologyConf),
-                Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
+        LOG.info("Worker has topology config {}", ConfigUtils.maskPasswords(topologyConf));
         LOG.info("Worker {} for storm {} on {}:{}  has finished loading", workerId, topologyId, assignmentId, port);
         return this;
     }

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -278,8 +278,8 @@ public class Worker implements Shutdownable, DaemonCommon {
         setupFlushTupleTimer(topologyConf, newExecutors);
         setupBackPressureCheckTimer(topologyConf);
 
-        LOG.info("Worker has topology config {}", ConfigUtils.maskPasswords(Utils.redactValue(topologyConf,
-                Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD)));
+        LOG.info("Worker has topology config {}", Utils.redactValue(ConfigUtils.maskPasswords(topologyConf),
+                Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
         LOG.info("Worker {} for storm {} on {}:{}  has finished loading", workerId, topologyId, assignmentId, port);
         return this;
     }

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -132,7 +132,7 @@ public class Worker implements Shutdownable, DaemonCommon {
 
     public void start() throws Exception {
         LOG.info("Launching worker for {} on {}:{} with id {} and conf {}", topologyId, assignmentId, port, workerId,
-                 conf);
+                 ConfigUtils.maskPasswords(conf));
         // because in local mode, its not a separate
         // process. supervisor will register it in this case
         // if ConfigUtils.isLocalMode(conf) returns false then it is in distributed mode.
@@ -278,7 +278,8 @@ public class Worker implements Shutdownable, DaemonCommon {
         setupFlushTupleTimer(topologyConf, newExecutors);
         setupBackPressureCheckTimer(topologyConf);
 
-        LOG.info("Worker has topology config {}", Utils.redactValue(topologyConf, Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
+        LOG.info("Worker has topology config {}", Utils.redactValue(ConfigUtils.maskPasswords(topologyConf),
+                Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
         LOG.info("Worker {} for storm {} on {}:{}  has finished loading", workerId, topologyId, assignmentId, port);
         return this;
     }

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -278,8 +278,8 @@ public class Worker implements Shutdownable, DaemonCommon {
         setupFlushTupleTimer(topologyConf, newExecutors);
         setupBackPressureCheckTimer(topologyConf);
 
-        LOG.info("Worker has topology config {}", Utils.redactValue(ConfigUtils.maskPasswords(topologyConf),
-                Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
+        LOG.info("Worker has topology config {}", ConfigUtils.maskPasswords(Utils.redactValue(topologyConf,
+                Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD)));
         LOG.info("Worker {} for storm {} on {}:{}  has finished loading", workerId, topologyId, assignmentId, port);
         return this;
     }

--- a/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
@@ -14,6 +14,8 @@ package org.apache.storm.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Collection;
@@ -22,18 +24,43 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
+
+import com.google.common.collect.Maps;
 import org.apache.storm.Config;
 import org.apache.storm.daemon.supervisor.AdvancedFSOps;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.shade.org.apache.commons.io.FileUtils;
 import org.apache.storm.validation.ConfigValidation;
+import org.apache.storm.validation.ConfigValidationAnnotations;
 
 public class ConfigUtils {
     public static final String FILE_SEPARATOR = File.separator;
     public static final String STORM_HOME = "storm.home";
     public final static String RESOURCES_SUBDIR = "resources";
+
+    private static final Set<String> passwordConfigKeys = new HashSet<>();
+
+    static {
+        for (Class<?> clazz: ConfigValidation.getConfigClasses()) {
+            for (Field field : clazz.getFields()) {
+                for (Annotation annotation : field.getAnnotations()) {
+                    boolean isPassword = annotation.annotationType().getName().equals(
+                            ConfigValidationAnnotations.Password.class.getName());
+                    if (isPassword) {
+                        try {
+                            passwordConfigKeys.add((String) field.get(null));
+                        } catch (IllegalAccessException e) {
+                            // ignore
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 
     // A singleton instance allows us to mock delegated static methods in our
     // tests by subclassing.
@@ -50,6 +77,16 @@ public class ConfigUtils {
         ConfigUtils oldInstance = _instance;
         _instance = u;
         return oldInstance;
+    }
+
+    public static Map<String, Object> maskPasswords(final Map<String, Object> conf) {
+        Maps.EntryTransformer<String, Object, Object> maskPasswords =
+                new Maps.EntryTransformer<String, Object, Object>() {
+                    public Object transformEntry(String key, Object value) {
+                        return passwordConfigKeys.contains(key) ? "*****" : value;
+                    }
+                };
+        return Maps.transformEntries(conf, maskPasswords);
     }
 
     public static boolean isLocalMode(Map<String, Object> conf) {

--- a/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.Maps;
+import org.apache.storm.shade.com.google.common.collect.Maps;
 import org.apache.storm.Config;
 import org.apache.storm.daemon.supervisor.AdvancedFSOps;
 import org.apache.storm.generated.StormTopology;

--- a/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
@@ -26,9 +26,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.Maps;
 import org.apache.storm.Config;
 import org.apache.storm.daemon.supervisor.AdvancedFSOps;
 import org.apache.storm.generated.StormTopology;
@@ -79,34 +79,14 @@ public class ConfigUtils {
         return oldInstance;
     }
 
-    private static class MaskedConf implements Supplier<Map<String, Object>> {
-        private final Map<String, Object> conf;
-
-        MaskedConf(Map<String, Object> conf) {
-            this.conf = conf;
-        }
-
-        @Override
-        public Map<String, Object> get() {
-            Map<String, Object> res = new HashMap<>();
-            for (Map.Entry<String, Object> e : conf.entrySet()) {
-                if (passwordConfigKeys.contains(e.getKey())) {
-                    res.put(e.getKey(), "*****");
-                } else {
-                    res.put(e.getKey(), e.getValue());
-                }
-            }
-            return res;
-        }
-
-        @Override
-        public String toString() {
-            return get().toString();
-        }
-    }
-
-    public static Supplier<Map<String, Object>> maskPasswords(Map<String, Object> conf) {
-        return new MaskedConf(conf);
+    public static Map<String, Object> maskPasswords(final Map<String, Object> conf) {
+        Maps.EntryTransformer<String, Object, Object> maskPasswords =
+                new Maps.EntryTransformer<String, Object, Object>() {
+                    public Object transformEntry(String key, Object value) {
+                        return passwordConfigKeys.contains(key) ? "*****" : value;
+                    }
+                };
+        return Maps.transformEntries(conf, maskPasswords);
     }
 
     public static boolean isLocalMode(Map<String, Object> conf) {

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -62,7 +62,7 @@ public class ConfigValidation {
         validateField(fieldName, conf, getConfigClasses());
     }
 
-    private static synchronized List<Class<?>> getConfigClasses() {
+    public static synchronized List<Class<?>> getConfigClasses() {
         if (configClasses == null) {
             List<Class<?>> ret = new ArrayList<>();
             Set<String> classesToScan = new HashSet<>();

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidationAnnotations.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidationAnnotations.java
@@ -197,6 +197,12 @@ public class ConfigValidationAnnotations {
         Class<?> validatorClass();
     }
 
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface Password {
+        Class validatorClass() default ConfigValidation.NotNullValidator.class;
+    }
+
     /**
      * Field names for annotations
      */

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -44,6 +44,7 @@ import static org.apache.storm.validation.ConfigValidationAnnotations.isPositive
 import static org.apache.storm.validation.ConfigValidationAnnotations.isString;
 import static org.apache.storm.validation.ConfigValidationAnnotations.isStringList;
 import static org.apache.storm.validation.ConfigValidationAnnotations.isStringOrStringList;
+import static org.apache.storm.validation.ConfigValidationAnnotations.Password;
 
 /**
  * Storm configs are specified as a plain old map. This class provides constants for all the configurations possible on a Storm cluster.
@@ -374,6 +375,7 @@ public class DaemonConfig implements Validated {
      * Password for the keystore for HTTPS for Storm Logviewer.
      */
     @isString
+    @Password
     public static final String LOGVIEWER_HTTPS_KEYSTORE_PASSWORD = "logviewer.https.keystore.password";
 
     /**
@@ -387,6 +389,7 @@ public class DaemonConfig implements Validated {
      * Password to the private key in the keystore for setting up HTTPS (SSL).
      */
     @isString
+    @Password
     public static final String LOGVIEWER_HTTPS_KEY_PASSWORD = "logviewer.https.key.password";
 
     /**
@@ -399,6 +402,7 @@ public class DaemonConfig implements Validated {
      * Password for the truststore for HTTPS for Storm Logviewer.
      */
     @isString
+    @Password
     public static final String LOGVIEWER_HTTPS_TRUSTSTORE_PASSWORD = "logviewer.https.truststore.password";
 
     /**
@@ -477,6 +481,7 @@ public class DaemonConfig implements Validated {
      * Password to the keystore used by Storm UI for setting up HTTPS (SSL).
      */
     @isString
+    @Password
     public static final String UI_HTTPS_KEYSTORE_PASSWORD = "ui.https.keystore.password";
 
     /**
@@ -491,6 +496,7 @@ public class DaemonConfig implements Validated {
      * Password to the private key in the keystore for setting up HTTPS (SSL).
      */
     @isString
+    @Password
     public static final String UI_HTTPS_KEY_PASSWORD = "ui.https.key.password";
 
     /**
@@ -503,6 +509,7 @@ public class DaemonConfig implements Validated {
      * Password to the truststore used by Storm UI setting up HTTPS (SSL).
      */
     @isString
+    @Password
     public static final String UI_HTTPS_TRUSTSTORE_PASSWORD = "ui.https.truststore.password";
 
     /**
@@ -559,6 +566,7 @@ public class DaemonConfig implements Validated {
      * Password to the keystore used by Storm DRPC for setting up HTTPS (SSL).
      */
     @isString
+    @Password
     public static final String DRPC_HTTPS_KEYSTORE_PASSWORD = "drpc.https.keystore.password";
 
     /**
@@ -573,6 +581,7 @@ public class DaemonConfig implements Validated {
      * Password to the private key in the keystore for setting up HTTPS (SSL).
      */
     @isString
+    @Password
     public static final String DRPC_HTTPS_KEY_PASSWORD = "drpc.https.key.password";
 
     /**
@@ -585,6 +594,7 @@ public class DaemonConfig implements Validated {
      * Password to the truststore used by Storm DRPC setting up HTTPS (SSL).
      */
     @isString
+    @Password
     public static final String DRPC_HTTPS_TRUSTSTORE_PASSWORD = "drpc.https.truststore.password";
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3074,8 +3074,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 throw new IllegalArgumentException("The cluster is configured for zookeeper authentication, but no payload was provided.");
             }
             LOG.info("Received topology submission for {} (storm-{} JDK-{}) with conf {}", topoName,
-                     topoVersionString, topology.get_jdk_version(),
-                     Utils.redactValue(ConfigUtils.maskPasswords(topoConf), Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
+                     topoVersionString, topology.get_jdk_version(), ConfigUtils.maskPasswords(topoConf));
 
             // lock protects against multiple topologies being submitted at once and
             // cleanup thread killing topology in b/w assignment and starting the topology

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3075,7 +3075,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             }
             LOG.info("Received topology submission for {} (storm-{} JDK-{}) with conf {}", topoName,
                      topoVersionString, topology.get_jdk_version(),
-                     Utils.redactValue(ConfigUtils.maskPasswords(topoConf), Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
+                    ConfigUtils.maskPasswords(Utils.redactValue(topoConf, Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD)));
 
             // lock protects against multiple topologies being submitted at once and
             // cleanup thread killing topology in b/w assignment and starting the topology

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3075,7 +3075,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             }
             LOG.info("Received topology submission for {} (storm-{} JDK-{}) with conf {}", topoName,
                      topoVersionString, topology.get_jdk_version(),
-                    ConfigUtils.maskPasswords(Utils.redactValue(topoConf, Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD)));
+                     Utils.redactValue(ConfigUtils.maskPasswords(topoConf), Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
 
             // lock protects against multiple topologies being submitted at once and
             // cleanup thread killing topology in b/w assignment and starting the topology

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2798,7 +2798,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             IStormClusterState state = stormClusterState;
             NimbusInfo hpi = nimbusHostPortInfo;
 
-            LOG.info("Starting Nimbus with conf {}", conf);
+            LOG.info("Starting Nimbus with conf {}", ConfigUtils.maskPasswords(conf));
             validator.prepare(conf);
 
             //add to nimbuses
@@ -3075,7 +3075,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             }
             LOG.info("Received topology submission for {} (storm-{} JDK-{}) with conf {}", topoName,
                      topoVersionString, topology.get_jdk_version(),
-                     Utils.redactValue(topoConf, Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
+                     Utils.redactValue(ConfigUtils.maskPasswords(topoConf), Config.STORM_ZOOKEEPER_TOPOLOGY_AUTH_PAYLOAD));
 
             // lock protects against multiple topologies being submitted at once and
             // cleanup thread killing topology in b/w assignment and starting the topology

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -268,7 +268,7 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
      * Launch the supervisor.
      */
     public void launch() throws Exception {
-        LOG.info("Starting Supervisor with conf {}", conf);
+        LOG.info("Starting Supervisor with conf {}", ConfigUtils.maskPasswords(conf));
         String path = ServerConfigUtils.supervisorTmpDir(conf);
         FileUtils.cleanDirectory(new File(path));
 

--- a/storm-server/src/test/java/org/apache/storm/DaemonConfigTest.java
+++ b/storm-server/src/test/java/org/apache/storm/DaemonConfigTest.java
@@ -18,6 +18,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+
+import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.validation.ConfigValidation;
 import org.junit.Assert;
 import org.junit.Test;
@@ -88,5 +90,15 @@ public class DaemonConfigTest {
     public void testSupervisorChildoptsIsStringOrStringList() throws InvocationTargetException, NoSuchMethodException, NoSuchFieldException,
         InstantiationException, IllegalAccessException {
         stringOrStringListTest(DaemonConfig.SUPERVISOR_CHILDOPTS);
+    }
+
+    @Test
+    public void testMaskPasswords() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(DaemonConfig.LOGVIEWER_HTTPS_KEY_PASSWORD, "pass1");
+        conf.put(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS, 100);
+        Map result = ConfigUtils.maskPasswords(conf);
+        Assert.assertEquals("*****", result.get(DaemonConfig.LOGVIEWER_HTTPS_KEY_PASSWORD));
+        Assert.assertEquals(100, result.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
     }
 }

--- a/storm-server/src/test/java/org/apache/storm/DaemonConfigTest.java
+++ b/storm-server/src/test/java/org/apache/storm/DaemonConfigTest.java
@@ -97,7 +97,7 @@ public class DaemonConfigTest {
         Map<String, Object> conf = new HashMap<>();
         conf.put(DaemonConfig.LOGVIEWER_HTTPS_KEY_PASSWORD, "pass1");
         conf.put(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS, 100);
-        Map result = ConfigUtils.maskPasswords(conf);
+        Map result = ConfigUtils.maskPasswords(conf).get();
         Assert.assertEquals("*****", result.get(DaemonConfig.LOGVIEWER_HTTPS_KEY_PASSWORD));
         Assert.assertEquals(100, result.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
     }

--- a/storm-server/src/test/java/org/apache/storm/DaemonConfigTest.java
+++ b/storm-server/src/test/java/org/apache/storm/DaemonConfigTest.java
@@ -97,7 +97,7 @@ public class DaemonConfigTest {
         Map<String, Object> conf = new HashMap<>();
         conf.put(DaemonConfig.LOGVIEWER_HTTPS_KEY_PASSWORD, "pass1");
         conf.put(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS, 100);
-        Map result = ConfigUtils.maskPasswords(conf).get();
+        Map result = ConfigUtils.maskPasswords(conf);
         Assert.assertEquals("*****", result.get(DaemonConfig.LOGVIEWER_HTTPS_KEY_PASSWORD));
         Assert.assertEquals(100, result.get(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS));
     }


### PR DESCRIPTION
Introduce a `Password` config annotation and use it to mark configs that are
sensitive and mask the values while logging.


Master port of https://github.com/apache/storm/pull/2798