### PR TITLE
[STORM-3131] Support hostname-substitution for blobstore.hdfs.principal

### DIFF
--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
@@ -137,7 +137,7 @@ public class HdfsBlobStore extends BlobStore {
         try {
             // if a HDFS keytab/principal have been supplied login, otherwise assume they are
             // logged in already or running insecure HDFS.
-            String principal = (String) conf.get(Config.BLOBSTORE_HDFS_PRINCIPAL);
+            String principal = Config.getBlobstoreHDFSPrincipal(conf);
             String keyTab = (String) conf.get(Config.BLOBSTORE_HDFS_KEYTAB);
 
             if (principal != null && keyTab != null) {

--- a/storm-client/test/jvm/org/apache/storm/utils/ConfigUtilsTest.java
+++ b/storm-client/test/jvm/org/apache/storm/utils/ConfigUtilsTest.java
@@ -12,6 +12,7 @@
 
 package org.apache.storm.utils;
 
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -88,5 +89,35 @@ public class ConfigUtilsTest {
         List<String> expectedValue = Arrays.asList("1", "2");
         Map<String, Object> map = mockMap(key, values);
         Assert.assertEquals(expectedValue, ConfigUtils.getValueAsList(key, map));
+    }
+
+    @Test
+    public void getBlobstoreHDFSPrincipal() throws UnknownHostException {
+        Map<String, Object> conf = mockMap(Config.BLOBSTORE_HDFS_PRINCIPAL, "primary/_HOST@EXAMPLE.COM");
+        Assert.assertEquals(Config.getBlobstoreHDFSPrincipal(conf), "primary/" +  Utils.localHostname() + "@EXAMPLE.COM");
+
+        String principal = "primary/_HOST_HOST@EXAMPLE.COM";
+        conf.put(Config.BLOBSTORE_HDFS_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getBlobstoreHDFSPrincipal(conf), principal);
+
+        principal = "primary/_HOST2@EXAMPLE.COM";
+        conf.put(Config.BLOBSTORE_HDFS_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getBlobstoreHDFSPrincipal(conf), principal);
+
+        principal = "_HOST/instance@EXAMPLE.COM";
+        conf.put(Config.BLOBSTORE_HDFS_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getBlobstoreHDFSPrincipal(conf), principal);
+
+        principal = "primary/instance@_HOST.COM";
+        conf.put(Config.BLOBSTORE_HDFS_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getBlobstoreHDFSPrincipal(conf), principal);
+
+        principal = "_HOST@EXAMPLE.COM";
+        conf.put(Config.BLOBSTORE_HDFS_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getBlobstoreHDFSPrincipal(conf), principal);
+
+        principal = "primary/instance@EXAMPLE.COM";
+        conf.put(Config.BLOBSTORE_HDFS_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getBlobstoreHDFSPrincipal(conf), principal);
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3131

 With this feature, we can set 
```
blobstore.hdfs.principal: <headless-user>/HOSTNAME@domain
```
on nodes(nimbi, supervisors) the `HOSTNAME` will be replaced with the actual hostname on that host.