### PR TITLE
STORM-3203: add back in the permission updates

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -139,13 +139,13 @@ public class AsyncLocalizer implements AutoCloseable {
     }
 
     @VisibleForTesting
-    LocallyCachedBlob getTopoJar(final String topologyId, LocalAssignment assignment) {
+    LocallyCachedBlob getTopoJar(final String topologyId, String owner) {
         return topologyBlobs.computeIfAbsent(ConfigUtils.masterStormJarKey(topologyId),
                                              (tjk) -> {
                                                  try {
                                                      return new LocallyCachedTopologyBlob(topologyId, isLocalMode, conf, fsOps,
                                                                                           LocallyCachedTopologyBlob.TopologyBlobType
-                                                                                              .TOPO_JAR, assignment);
+                                                                                              .TOPO_JAR, owner);
                                                  } catch (IOException e) {
                                                      throw new RuntimeException(e);
                                                  }
@@ -153,13 +153,13 @@ public class AsyncLocalizer implements AutoCloseable {
     }
 
     @VisibleForTesting
-    LocallyCachedBlob getTopoCode(final String topologyId, LocalAssignment assignment) {
+    LocallyCachedBlob getTopoCode(final String topologyId, String owner) {
         return topologyBlobs.computeIfAbsent(ConfigUtils.masterStormCodeKey(topologyId),
                                              (tck) -> {
                                                  try {
                                                      return new LocallyCachedTopologyBlob(topologyId, isLocalMode, conf, fsOps,
                                                                                           LocallyCachedTopologyBlob.TopologyBlobType
-                                                                                              .TOPO_CODE, assignment);
+                                                                                              .TOPO_CODE, owner);
                                                  } catch (IOException e) {
                                                      throw new RuntimeException(e);
                                                  }
@@ -167,13 +167,13 @@ public class AsyncLocalizer implements AutoCloseable {
     }
 
     @VisibleForTesting
-    LocallyCachedBlob getTopoConf(final String topologyId, LocalAssignment assignment) {
+    LocallyCachedBlob getTopoConf(final String topologyId, String owner) {
         return topologyBlobs.computeIfAbsent(ConfigUtils.masterStormConfKey(topologyId),
                                              (tck) -> {
                                                  try {
                                                      return new LocallyCachedTopologyBlob(topologyId, isLocalMode, conf, fsOps,
                                                                                           LocallyCachedTopologyBlob.TopologyBlobType
-                                                                                              .TOPO_CONF, assignment);
+                                                                                              .TOPO_CONF, owner);
                                                  } catch (IOException e) {
                                                      throw new RuntimeException(e);
                                                  }
@@ -231,13 +231,13 @@ public class AsyncLocalizer implements AutoCloseable {
     CompletableFuture<Void> requestDownloadBaseTopologyBlobs(PortAndAssignment pna, BlobChangingCallback cb) {
         final String topologyId = pna.getToplogyId();
 
-        final LocallyCachedBlob topoJar = getTopoJar(topologyId, pna.getAssignment());
+        final LocallyCachedBlob topoJar = getTopoJar(topologyId, pna.getAssignment().get_owner());
         topoJar.addReference(pna, cb);
 
-        final LocallyCachedBlob topoCode = getTopoCode(topologyId, pna.getAssignment());
+        final LocallyCachedBlob topoCode = getTopoCode(topologyId, pna.getAssignment().get_owner());
         topoCode.addReference(pna, cb);
 
-        final LocallyCachedBlob topoConf = getTopoConf(topologyId, pna.getAssignment());
+        final LocallyCachedBlob topoConf = getTopoConf(topologyId, pna.getAssignment().get_owner());
         topoConf.addReference(pna, cb);
 
         return topologyBasicDownloaded.computeIfAbsent(topologyId,
@@ -402,13 +402,13 @@ public class AsyncLocalizer implements AutoCloseable {
         final PortAndAssignment pna = new PortAndAssignmentImpl(port, currentAssignment);
         final String topologyId = pna.getToplogyId();
 
-        LocallyCachedBlob topoJar = getTopoJar(topologyId, pna.getAssignment());
+        LocallyCachedBlob topoJar = getTopoJar(topologyId, pna.getAssignment().get_owner());
         topoJar.addReference(pna, cb);
 
-        LocallyCachedBlob topoCode = getTopoCode(topologyId, pna.getAssignment());
+        LocallyCachedBlob topoCode = getTopoCode(topologyId, pna.getAssignment().get_owner());
         topoCode.addReference(pna, cb);
 
-        LocallyCachedBlob topoConf = getTopoConf(topologyId, pna.getAssignment());
+        LocallyCachedBlob topoConf = getTopoConf(topologyId, pna.getAssignment().get_owner());
         topoConf.addReference(pna, cb);
 
         CompletableFuture<Void> localResource = blobPending.computeIfAbsent(topologyId, (tid) -> ALL_DONE_FUTURE);

--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -139,13 +139,13 @@ public class AsyncLocalizer implements AutoCloseable {
     }
 
     @VisibleForTesting
-    LocallyCachedBlob getTopoJar(final String topologyId) {
+    LocallyCachedBlob getTopoJar(final String topologyId, LocalAssignment assignment) {
         return topologyBlobs.computeIfAbsent(ConfigUtils.masterStormJarKey(topologyId),
                                              (tjk) -> {
                                                  try {
                                                      return new LocallyCachedTopologyBlob(topologyId, isLocalMode, conf, fsOps,
                                                                                           LocallyCachedTopologyBlob.TopologyBlobType
-                                                                                              .TOPO_JAR);
+                                                                                              .TOPO_JAR, assignment);
                                                  } catch (IOException e) {
                                                      throw new RuntimeException(e);
                                                  }
@@ -153,13 +153,13 @@ public class AsyncLocalizer implements AutoCloseable {
     }
 
     @VisibleForTesting
-    LocallyCachedBlob getTopoCode(final String topologyId) {
+    LocallyCachedBlob getTopoCode(final String topologyId, LocalAssignment assignment) {
         return topologyBlobs.computeIfAbsent(ConfigUtils.masterStormCodeKey(topologyId),
                                              (tck) -> {
                                                  try {
                                                      return new LocallyCachedTopologyBlob(topologyId, isLocalMode, conf, fsOps,
                                                                                           LocallyCachedTopologyBlob.TopologyBlobType
-                                                                                              .TOPO_CODE);
+                                                                                              .TOPO_CODE, assignment);
                                                  } catch (IOException e) {
                                                      throw new RuntimeException(e);
                                                  }
@@ -167,13 +167,13 @@ public class AsyncLocalizer implements AutoCloseable {
     }
 
     @VisibleForTesting
-    LocallyCachedBlob getTopoConf(final String topologyId) {
+    LocallyCachedBlob getTopoConf(final String topologyId, LocalAssignment assignment) {
         return topologyBlobs.computeIfAbsent(ConfigUtils.masterStormConfKey(topologyId),
                                              (tck) -> {
                                                  try {
                                                      return new LocallyCachedTopologyBlob(topologyId, isLocalMode, conf, fsOps,
                                                                                           LocallyCachedTopologyBlob.TopologyBlobType
-                                                                                              .TOPO_CONF);
+                                                                                              .TOPO_CONF, assignment);
                                                  } catch (IOException e) {
                                                      throw new RuntimeException(e);
                                                  }
@@ -231,13 +231,13 @@ public class AsyncLocalizer implements AutoCloseable {
     CompletableFuture<Void> requestDownloadBaseTopologyBlobs(PortAndAssignment pna, BlobChangingCallback cb) {
         final String topologyId = pna.getToplogyId();
 
-        final LocallyCachedBlob topoJar = getTopoJar(topologyId);
+        final LocallyCachedBlob topoJar = getTopoJar(topologyId, pna.getAssignment());
         topoJar.addReference(pna, cb);
 
-        final LocallyCachedBlob topoCode = getTopoCode(topologyId);
+        final LocallyCachedBlob topoCode = getTopoCode(topologyId, pna.getAssignment());
         topoCode.addReference(pna, cb);
 
-        final LocallyCachedBlob topoConf = getTopoConf(topologyId);
+        final LocallyCachedBlob topoConf = getTopoConf(topologyId, pna.getAssignment());
         topoConf.addReference(pna, cb);
 
         return topologyBasicDownloaded.computeIfAbsent(topologyId,
@@ -402,13 +402,13 @@ public class AsyncLocalizer implements AutoCloseable {
         final PortAndAssignment pna = new PortAndAssignmentImpl(port, currentAssignment);
         final String topologyId = pna.getToplogyId();
 
-        LocallyCachedBlob topoJar = getTopoJar(topologyId);
+        LocallyCachedBlob topoJar = getTopoJar(topologyId, pna.getAssignment());
         topoJar.addReference(pna, cb);
 
-        LocallyCachedBlob topoCode = getTopoCode(topologyId);
+        LocallyCachedBlob topoCode = getTopoCode(topologyId, pna.getAssignment());
         topoCode.addReference(pna, cb);
 
-        LocallyCachedBlob topoConf = getTopoConf(topologyId);
+        LocallyCachedBlob topoConf = getTopoConf(topologyId, pna.getAssignment());
         topoConf.addReference(pna, cb);
 
         CompletableFuture<Void> localResource = blobPending.computeIfAbsent(topologyId, (tid) -> ALL_DONE_FUTURE);

--- a/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedTopologyBlob.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedTopologyBlob.java
@@ -62,16 +62,16 @@ public class LocallyCachedTopologyBlob extends LocallyCachedBlob {
      * Create a new LocallyCachedBlob.
      *  @param topologyId the ID of the topology.
      * @param type the type of the blob.
-     * @param assignment the assignment, mostly to know who the owner is.
+     * @param owner the name of the user that owns this blob.
      */
     protected LocallyCachedTopologyBlob(final String topologyId, final boolean isLocalMode, final Map<String, Object> conf,
-                                        final AdvancedFSOps fsOps, final TopologyBlobType type, LocalAssignment assignment) throws IOException {
+                                        final AdvancedFSOps fsOps, final TopologyBlobType type, String owner) throws IOException {
         super(topologyId + " " + type.getFileName(), type.getKey(topologyId));
         this.topologyId = topologyId;
         this.type = type;
         this.isLocalMode = isLocalMode;
         this.fsOps = fsOps;
-        this.owner = assignment.get_owner();
+        this.owner = owner;
         topologyBasicBlobsRootDir = Paths.get(ConfigUtils.supervisorStormDistRoot(conf, topologyId));
         readVersion();
         updateSizeOnDisk();

--- a/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
@@ -119,19 +119,19 @@ public class AsyncLocalizerTest {
 
         AsyncLocalizer bl = spy(new AsyncLocalizer(conf, ops, getTestLocalizerRoot()));
         LocallyCachedTopologyBlob jarBlob = mock(LocallyCachedTopologyBlob.class);
-        doReturn(jarBlob).when(bl).getTopoJar(topoId);
+        doReturn(jarBlob).when(bl).getTopoJar(topoId, la);
         when(jarBlob.getLocalVersion()).thenReturn(-1L);
         when(jarBlob.getRemoteVersion(any())).thenReturn(100L);
         when(jarBlob.fetchUnzipToTemp(any())).thenReturn(100L);
 
         LocallyCachedTopologyBlob codeBlob = mock(LocallyCachedTopologyBlob.class);
-        doReturn(codeBlob).when(bl).getTopoCode(topoId);
+        doReturn(codeBlob).when(bl).getTopoCode(topoId, la);
         when(codeBlob.getLocalVersion()).thenReturn(-1L);
         when(codeBlob.getRemoteVersion(any())).thenReturn(200L);
         when(codeBlob.fetchUnzipToTemp(any())).thenReturn(200L);
 
         LocallyCachedTopologyBlob confBlob = mock(LocallyCachedTopologyBlob.class);
-        doReturn(confBlob).when(bl).getTopoConf(topoId);
+        doReturn(confBlob).when(bl).getTopoConf(topoId, la);
         when(confBlob.getLocalVersion()).thenReturn(-1L);
         when(confBlob.getRemoteVersion(any())).thenReturn(300L);
         when(confBlob.fetchUnzipToTemp(any())).thenReturn(300L);

--- a/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
@@ -119,19 +119,19 @@ public class AsyncLocalizerTest {
 
         AsyncLocalizer bl = spy(new AsyncLocalizer(conf, ops, getTestLocalizerRoot()));
         LocallyCachedTopologyBlob jarBlob = mock(LocallyCachedTopologyBlob.class);
-        doReturn(jarBlob).when(bl).getTopoJar(topoId, la);
+        doReturn(jarBlob).when(bl).getTopoJar(topoId, la.get_owner());
         when(jarBlob.getLocalVersion()).thenReturn(-1L);
         when(jarBlob.getRemoteVersion(any())).thenReturn(100L);
         when(jarBlob.fetchUnzipToTemp(any())).thenReturn(100L);
 
         LocallyCachedTopologyBlob codeBlob = mock(LocallyCachedTopologyBlob.class);
-        doReturn(codeBlob).when(bl).getTopoCode(topoId, la);
+        doReturn(codeBlob).when(bl).getTopoCode(topoId, la.get_owner());
         when(codeBlob.getLocalVersion()).thenReturn(-1L);
         when(codeBlob.getRemoteVersion(any())).thenReturn(200L);
         when(codeBlob.fetchUnzipToTemp(any())).thenReturn(200L);
 
         LocallyCachedTopologyBlob confBlob = mock(LocallyCachedTopologyBlob.class);
-        doReturn(confBlob).when(bl).getTopoConf(topoId, la);
+        doReturn(confBlob).when(bl).getTopoConf(topoId, la.get_owner());
         when(confBlob.getLocalVersion()).thenReturn(-1L);
         when(confBlob.getRemoteVersion(any())).thenReturn(300L);
         when(confBlob.fetchUnzipToTemp(any())).thenReturn(300L);


### PR DESCRIPTION
This adds back in some permission updates and a directory creation that was missed previously.

I have manually tested it and it works.

The old code is at

https://github.com/apache/storm/blob/d2d6f40344e6cc92ab07f3a462d577ef6b61f8b1/storm-core/src/jvm/org/apache/storm/localizer/AsyncLocalizer.java#L101-L165