### PR TITLE
STORM-3204: Upgrade Metrics to 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
         <log4j.version>2.8.2</log4j.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <metrics.version>3.1.0</metrics.version>
+        <metrics.version>4.0.3</metrics.version>
         <clojure.tools.nrepl.version>0.2.3</clojure.tools.nrepl.version>
         <clojure-complete.version>0.2.3</clojure-complete.version>
         <mockito.version>2.19.0</mockito.version>
@@ -790,6 +790,13 @@
                 <type>pom</type>
             </dependency>
             <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-bom</artifactId>
+                <version>${metrics.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>${commons-fileupload.version}</version>
@@ -972,16 +979,6 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
                 <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-core</artifactId>
-                <version>${metrics.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.dropwizard.metrics</groupId>
-                <artifactId>metrics-graphite</artifactId>
-                <version>${metrics.version}</version>
             </dependency>
             <dependency>
                 <groupId>metrics-clojure</groupId>

--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -90,6 +90,10 @@
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+        </dependency>
 
         <!-- end of transitive dependency management -->
 

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/JmxStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/JmxStormReporter.java
@@ -12,8 +12,8 @@
 
 package org.apache.storm.metrics2.reporters;
 
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.storm.daemon.metrics.ClientMetricsUtils;

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/JmxPreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/JmxPreparableReporter.java
@@ -12,8 +12,8 @@
 
 package org.apache.storm.daemon.metrics.reporters;
 
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.storm.DaemonConfig;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3204

The Metrics project has a BOM now, so we don't have to specify versions for each module or transitive dependency.  

I used the one liner described here https://grep.codeconsult.ch/2010/07/08/list-all-your-maven-dependencies/ to get the list of dependencies for the entire project. The diff between master and this branch is posted below.
```
13c13
<     ch.qos.logback:logback-classic:jar:1.1.2
---
>     ch.qos.logback:logback-classic:jar:1.2.3
184a185
>     com.rabbitmq:amqp-client:jar:4.4.1
208c209
<  Finished at: 2018-08-25T09:00:50Z
---
>  Finished at: 2018-08-25T08:57:14Z
226,236c227,237
<     io.dropwizard.metrics:metrics-annotation:jar:4.0.2
<     io.dropwizard.metrics:metrics-core:jar:3.1.0
<     io.dropwizard.metrics:metrics-graphite:jar:3.1.0
<     io.dropwizard.metrics:metrics-healthchecks:jar:4.0.2
<     io.dropwizard.metrics:metrics-jersey2:jar:4.0.2
<     io.dropwizard.metrics:metrics-jetty9:jar:4.0.2
<     io.dropwizard.metrics:metrics-jmx:jar:4.0.2
<     io.dropwizard.metrics:metrics-json:jar:4.0.2
<     io.dropwizard.metrics:metrics-jvm:jar:4.0.2
<     io.dropwizard.metrics:metrics-logback:jar:4.0.2
<     io.dropwizard.metrics:metrics-servlets:jar:4.0.2
---
>     io.dropwizard.metrics:metrics-annotation:jar:4.0.3
>     io.dropwizard.metrics:metrics-core:jar:4.0.3
>     io.dropwizard.metrics:metrics-graphite:jar:4.0.3
>     io.dropwizard.metrics:metrics-healthchecks:jar:4.0.3
>     io.dropwizard.metrics:metrics-jersey2:jar:4.0.3
>     io.dropwizard.metrics:metrics-jetty9:jar:4.0.3
>     io.dropwizard.metrics:metrics-jmx:jar:4.0.3
>     io.dropwizard.metrics:metrics-json:jar:4.0.3
>     io.dropwizard.metrics:metrics-jvm:jar:4.0.3
>     io.dropwizard.metrics:metrics-logback:jar:4.0.3
>     io.dropwizard.metrics:metrics-servlets:jar:4.0.3
386a388
>     org.apache.httpcomponents:httpasyncclient:jar:4.1.3

```
The new amqp-client dependency is through metrics-graphite. It used to be optional in 3.1.0, now it isn't in 4.0.3. The httpasyncclient is in storm-elasticsearch, I'm not sure why it shows as new rather than changed (previous version was 4.1.2). The rest are just version changes for the metrics dependencies.