### PR TITLE
[STORM-3213] fix server error on system component page on storm UI

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2772,8 +2772,9 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         ret.topoConf = tryReadTopoConf(topoId, topoCache);
         ret.topoName = (String) ret.topoConf.get(Config.TOPOLOGY_NAME);
         checkAuthorization(ret.topoName, ret.topoConf, operation);
-        ret.topology = tryReadTopology(topoId, topoCache);
-        ret.taskToComponent = StormCommon.stormTaskInfo(ret.topology, ret.topoConf);
+        StormTopology topology = tryReadTopology(topoId, topoCache);
+        ret.topology = StormCommon.systemTopology(ret.topoConf, topology);
+        ret.taskToComponent = StormCommon.stormTaskInfo(topology, ret.topoConf);
         ret.base = state.stormBase(topoId, null);
         if (ret.base != null && ret.base.is_set_launch_time_secs()) {
             ret.launchTimeSecs = ret.base.get_launch_time_secs();


### PR DESCRIPTION
Fix

```
2018-09-05 16:15:24.927 o.a.s.t.ProcessFunction pool-21-thread-55 [ERROR] Internal error processing getComponentPageInfo
java.lang.RuntimeException: java.lang.NullPointerException
        at org.apache.storm.daemon.nimbus.Nimbus.getComponentPageInfo(Nimbus.java:4238) ~[storm-server-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        at org.apache.storm.generated.Nimbus$Processor$getComponentPageInfo.getResult(Nimbus.java:4577) ~[storm-client-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        at org.apache.storm.generated.Nimbus$Processor$getComponentPageInfo.getResult(Nimbus.java:4556) ~[storm-client-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        at org.apache.storm.thrift.ProcessFunction.process(ProcessFunction.java:38) [shaded-deps-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        at org.apache.storm.thrift.TBaseProcessor.process(TBaseProcessor.java:39) [shaded-deps-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        at org.apache.storm.security.auth.SimpleTransportPlugin$SimpleWrapProcessor.process(SimpleTransportPlugin.java:169) [storm-client-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        at org.apache.storm.thrift.server.AbstractNonblockingServer$FrameBuffer.invoke(AbstractNonblockingServer.java:518) [shaded-deps-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        at org.apache.storm.thrift.server.Invocation.run(Invocation.java:18) [shaded-deps-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_131]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_131]
Caused by: java.lang.NullPointerException
        at org.apache.storm.scheduler.resource.ResourceUtils.getBoltResources(ResourceUtils.java:37) ~[storm-server-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        at org.apache.storm.daemon.nimbus.Nimbus.getComponentPageInfo(Nimbus.java:4192) ~[storm-server-2.0.0-SNAPSHOT.jar:2.0.0-SNAPSHOT]
        ... 10 more
```