### PR TITLE
[STORM-3206] validate topoConf only against Config.java during submission

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -308,10 +308,10 @@ public class StormSubmitter {
             }
             LOG.info("Finished submitting topology: {}", name);
         } catch (InvalidTopologyException e) {
-            LOG.warn("Topology submission exception: {}", e.get_msg());
+            LOG.error("Topology submission exception: {}", e.get_msg());
             throw e;
         } catch (AlreadyAliveException e) {
-            LOG.warn("Topology already alive exception", e);
+            LOG.error("Topology already alive exception", e);
             throw e;
         }
     }
@@ -512,7 +512,7 @@ public class StormSubmitter {
 
     private static void validateConfs(Map<String, Object> topoConf, StormTopology topology) throws IllegalArgumentException,
         InvalidTopologyException, AuthorizationException {
-        ConfigValidation.validateFields(topoConf);
+        ConfigValidation.validateTopoConf(topoConf);
         Utils.validateTopologyBlobStoreMap(topoConf);
     }
 

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -171,6 +171,14 @@ public class ConfigValidation {
     }
 
     /**
+     * Validate topology conf.
+     * @param topoConf The topology conf.
+     */
+    public static void validateTopoConf(Map<String, Object> topoConf) {
+        validateFields(topoConf, Arrays.asList(Config.class));
+    }
+
+    /**
      * Validate all confs in map.
      *
      * @param conf map of configs

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2968,7 +2968,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             @SuppressWarnings("unchecked")
             Map<String, Object> topoConf = (Map<String, Object>) JSONValue.parse(jsonConf);
             try {
-                ConfigValidation.validateFields(topoConf);
+                ConfigValidation.validateTopoConf(topoConf);
             } catch (IllegalArgumentException ex) {
                 throw new WrappedInvalidTopologyException(ex.getMessage());
             }


### PR DESCRIPTION
Storm should only validate client-side conf when user submits a topology. 

Otherwise settings like `logviewer.https.port=-1` will fail the submission.
