### PR TITLE
STORM-3222: Fix KafkaSpout internals to use LinkedList instead of ArrayList

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpout.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -364,7 +365,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
 
     private void setWaitingToEmit(ConsumerRecords<K, V> consumerRecords) {
         for (TopicPartition tp : consumerRecords.partitions()) {
-            waitingToEmit.put(tp, new ArrayList<>(consumerRecords.records(tp)));
+            waitingToEmit.put(tp, new LinkedList<>(consumerRecords.records(tp)));
         }
     }
 
@@ -551,7 +552,7 @@ public class KafkaSpout<K, V> extends BaseRichSpout {
                     List<ConsumerRecord<K, V>> waitingToEmitForTp = waitingToEmit.get(tp);
                     if (waitingToEmitForTp != null) {
                         //Discard the pending records that are already committed
-                        List<ConsumerRecord<K, V>> filteredRecords = new ArrayList<>();
+                        List<ConsumerRecord<K, V>> filteredRecords = new LinkedList<>();
                         for (ConsumerRecord<K, V> record : waitingToEmitForTp) {
                             if (record.offset() >= committedOffset) {
                                 filteredRecords.add(record);


### PR DESCRIPTION
KafkaSpout internally maintains a waitingToEmit list per topic partition and keeps removing the first item to emit during each nextTuple. The implementation uses an ArrayList which results in un-necessary traversal and copy for each tuple.

Also I am not sure why the nextTuple only emits a single tuple wheres ideally it should emit whatever it can emit in a single nextTuple call which is more efficient. However the logic appears too complicated to refactor.

https://github.com/apache/storm/pull/2829 for 1.x