### PR TITLE
STORM-3233 Update zookeeper client to version 3.4.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <clojure-complete.version>0.2.3</clojure-complete.version>
         <mockito.version>2.19.0</mockito.version>
         <conjure.version>2.1.3</conjure.version>
-        <zookeeper.version>3.4.6</zookeeper.version>
+        <zookeeper.version>3.4.13</zookeeper.version>
         <jline.version>0.9.94</jline.version>
         <clojure-data-codec.version>0.1.0</clojure-data-codec.version>
         <clojure-contrib.version>1.2.0</clojure-contrib.version>


### PR DESCRIPTION
Updated zookeeper client to version 3.4.13 which fixes various issues including ZOOKEEPER-2184 that prevents ZooKeeper Java clients working in dynamic IP (container / cloud) environment.