### PR TITLE
[STORM-3235] Fix WorkerToken renewal criteria and refactor

### DIFF
--- a/storm-server/src/test/java/org/apache/storm/security/auth/workertoken/WorkerTokenTest.java
+++ b/storm-server/src/test/java/org/apache/storm/security/auth/workertoken/WorkerTokenTest.java
@@ -143,17 +143,11 @@ public class WorkerTokenTest {
             } catch (IllegalArgumentException ia) {
                 //What we want...
             }
-        }
-    }
 
-    @Test
-    public void testRenewalTimeDefault() {
-        try (Time.SimulatedTime sim = new Time.SimulatedTime()) {
-            IStormClusterState mockState = mock(IStormClusterState.class);
-            Map<String, Object> conf = new HashMap<>();
-            WorkerTokenManager wtm = new WorkerTokenManager(conf, mockState);
-
-            assertEquals(ONE_DAY_MILLIS/2, wtm.getMaxExpirationTimeForRenewal());
+            //Verify if WorkerTokenManager recognizes the expired WorkerToken.
+            Map<String, String> creds = new HashMap<>();
+            ClientAuthUtils.setWorkerToken(creds, wt);
+            assertTrue("Expired WorkerToken should be eligible for renewal", wtm.shouldRenewWorkerToken(creds, type));
         }
     }
 }


### PR DESCRIPTION
- Fix broken condition to validate if new `WorkerToken` should be added.
- Refactor code out of `Nimbus` into `WorkerTokenManager`
- Updated `WorkerTokenTest` to ensure `WorkerTokenManager` recognizes token ready for renewal.