### PR TITLE
STORM-3242: Adds "examples" and "externals" profiles

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -262,6 +262,8 @@ The following commands must be run from the top-level directory.
 
 If you wish to skip the unit tests you can do this by adding `-DskipTests` to the command line. 
 
+If you wish to skip the examples and external modules, you can do this by adding `-P '!examples,!externals'` to the command line.
+
 In case you modified `storm.thrift`, you have to regenerate thrift code as java and python code before compiling whole project.
 
 ```sh

--- a/dev-tools/travis/travis-install.sh
+++ b/dev-tools/travis/travis-install.sh
@@ -28,7 +28,7 @@ then
 fi
 
 cd ${STORM_SRC_ROOT_DIR}
-python ${TRAVIS_SCRIPT_DIR}/save-logs.py "install.txt" mvn clean install -DskipTests -Pnative '-P!include-shaded-deps' --batch-mode
+python ${TRAVIS_SCRIPT_DIR}/save-logs.py "install.txt" mvn clean install -DskipTests -Pnative,examples,externals '-P!include-shaded-deps' --batch-mode
 BUILD_RET_VAL=$?
 
 if [[ "$BUILD_RET_VAL" != "0" ]];

--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -50,7 +50,7 @@ export STORM_TEST_TIMEOUT_MS=150000
 # Travis only has 3GB of memory, lets use 1GB for build, and 1.5GB for forked JVMs
 export MAVEN_OPTS="-Xmx1024m"
 
-mvn --batch-mode test -fae -Pnative,all-tests '-P!include-shaded-deps' -Prat -pl "$TEST_MODULES"
+mvn --batch-mode test -fae -Pnative,all-tests,examples,externals '-P!include-shaded-deps' -Prat -pl "$TEST_MODULES"
 BUILD_RET_VAL=$?
 
 for dir in `find . -type d -and -wholename \*/target/\*-reports`;
@@ -60,5 +60,3 @@ do
 done
 
 exit ${BUILD_RET_VAL}
-fi
-

--- a/pom.xml
+++ b/pom.xml
@@ -355,53 +355,6 @@
         <module>storm-clojure</module>
         <module>storm-clojure-test</module>
         <module>storm-submit-tools</module>
-        <module>flux</module>
-        <module>sql</module>
-
-        <!-- externals -->
-        <module>external/storm-autocreds</module>
-        <module>external/storm-hdfs</module>
-        <module>external/storm-hdfs-blobstore</module>
-        <module>external/storm-hbase</module>
-        <module>external/storm-hive</module>
-        <module>external/storm-jdbc</module>
-        <module>external/storm-redis</module>
-        <module>external/storm-eventhubs</module>
-        <module>external/storm-elasticsearch</module>
-        <module>external/storm-solr</module>
-        <module>external/storm-metrics</module>
-        <module>external/storm-cassandra</module>
-        <module>external/storm-mqtt</module>
-        <module>external/storm-mongodb</module>
-        <module>external/storm-kafka-client</module>
-        <module>external/storm-kafka-migration</module>
-        <module>external/storm-opentsdb</module>
-        <module>external/storm-kafka-monitor</module>
-        <module>external/storm-kinesis</module>
-        <module>external/storm-jms</module>
-        <module>external/storm-pmml</module>
-        <module>external/storm-rocketmq</module>
-        <module>external/storm-blobstore-migration</module>
-        <module>integration-test</module>
-
-        <!-- examples -->
-        <module>examples/storm-starter</module>
-        <module>examples/storm-loadgen</module>
-        <module>examples/storm-mongodb-examples</module>
-        <module>examples/storm-redis-examples</module>
-        <module>examples/storm-opentsdb-examples</module>
-        <module>examples/storm-solr-examples</module>
-        <module>examples/storm-kafka-client-examples</module>
-        <module>examples/storm-jdbc-examples</module>
-        <module>examples/storm-hdfs-examples</module>
-        <module>examples/storm-hbase-examples</module>
-        <module>examples/storm-hive-examples</module>
-        <module>examples/storm-elasticsearch-examples</module>
-        <module>examples/storm-mqtt-examples</module>
-        <module>examples/storm-pmml-examples</module>
-        <module>examples/storm-jms-examples</module>
-        <module>examples/storm-rocketmq-examples</module>
-        <module>examples/storm-perf</module>
     </modules>
 
     <dependencies>
@@ -653,6 +606,67 @@
                 <clojure.test.set>integration.*</clojure.test.set>
                 <clojure.test.declared.namespace.only>true</clojure.test.declared.namespace.only>
             </properties>
+        </profile>
+        <profile>
+            <id>externals</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>external/storm-autocreds</module>
+                <module>external/storm-hdfs</module>
+                <module>external/storm-hdfs-blobstore</module>
+                <module>external/storm-hbase</module>
+                <module>external/storm-hive</module>
+                <module>external/storm-jdbc</module>
+                <module>external/storm-redis</module>
+                <module>external/storm-eventhubs</module>
+                <module>external/storm-elasticsearch</module>
+                <module>external/storm-solr</module>
+                <module>external/storm-metrics</module>
+                <module>external/storm-cassandra</module>
+                <module>external/storm-mqtt</module>
+                <module>external/storm-mongodb</module>
+                <module>external/storm-kafka-client</module>
+                <module>external/storm-kafka-migration</module>
+                <module>external/storm-opentsdb</module>
+                <module>external/storm-kafka-monitor</module>
+                <module>external/storm-kinesis</module>
+                <module>external/storm-jms</module>
+                <module>external/storm-pmml</module>
+                <module>external/storm-rocketmq</module>
+                <module>external/storm-blobstore-migration</module>
+                <module>integration-test</module>
+
+                <!-- The following modules have dependencies on external modules. -->
+                <module>flux</module>
+                <module>sql</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>examples</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>examples/storm-starter</module>
+                <module>examples/storm-loadgen</module>
+                <module>examples/storm-mongodb-examples</module>
+                <module>examples/storm-redis-examples</module>
+                <module>examples/storm-opentsdb-examples</module>
+                <module>examples/storm-solr-examples</module>
+                <module>examples/storm-kafka-client-examples</module>
+                <module>examples/storm-jdbc-examples</module>
+                <module>examples/storm-hdfs-examples</module>
+                <module>examples/storm-hbase-examples</module>
+                <module>examples/storm-hive-examples</module>
+                <module>examples/storm-elasticsearch-examples</module>
+                <module>examples/storm-mqtt-examples</module>
+                <module>examples/storm-pmml-examples</module>
+                <module>examples/storm-jms-examples</module>
+                <module>examples/storm-rocketmq-examples</module>
+                <module>examples/storm-perf</module>
+            </modules>
         </profile>
     </profiles>
 


### PR DESCRIPTION
The existing modules have been moved into like-named Maven profiles that
are enabled by default.

They can be disabled, for example, with:
```
mvn clean install -DskipTests=true -P '!examples,!externals'
```