### PR TITLE
Revert "[STORM-3233] Updated zookeeper client to version 3.4.13 which…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <metrics.version>3.2.6</metrics.version>
         <mockito.version>2.19.0</mockito.version>
-        <zookeeper.version>3.4.13</zookeeper.version>
+        <zookeeper.version>3.4.6</zookeeper.version>
         <jline.version>0.9.94</jline.version>
         <hive.version>2.3.3</hive.version>
         <hadoop.version>2.6.1</hadoop.version>


### PR DESCRIPTION
… fixes various issues including ZOOKEEPER-2184 that prevents ZooKeeper Java clients working in dynamic IP (container / cloud) environment."

This reverts commit b187971e0da0238c6beba200b01fb738a6f848d8.