### PR TITLE
Revert "[STORM-3233] Updated zookeeper client to version 3.4.13 which…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
         <clojure-complete.version>0.2.3</clojure-complete.version>
         <mockito.version>1.9.5</mockito.version>
         <conjure.version>2.1.3</conjure.version>
-        <zookeeper.version>3.4.13</zookeeper.version>
+        <zookeeper.version>3.4.6</zookeeper.version>
         <clojure-data-codec.version>0.1.0</clojure-data-codec.version>
         <clojure-contrib.version>1.2.0</clojure-contrib.version>
         <hive.version>0.14.0</hive.version>


### PR DESCRIPTION
… fixes various issues including ZOOKEEPER-2184 that prevents ZooKeeper Java clients working in dynamic IP (container / cloud) environment."

This reverts commit ac763b8bbd23f7fdc0aa9990bd0e61ce17706e77.