### PR TITLE
[STORM-3257] 'storm kill' command line should be able to continue on error

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
+++ b/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
@@ -56,7 +56,7 @@ public class KillTopology {
                         if (!continueOnError) {
                             throw e;
                         } else {
-                            LOG.info(
+                            LOG.error(
                                     "Caught error killing topology '{}'; continuing as -i was passed. Exception: {}",
                                     name,
                                     e.getClass().getName()

--- a/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
+++ b/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
@@ -57,9 +57,7 @@ public class KillTopology {
                             throw e;
                         } else {
                             LOG.error(
-                                    "Caught error killing topology '{}'; continuing as -i was passed. Exception: {}",
-                                    name,
-                                    e.getClass().getName()
+                                    "Caught error killing topology '{}'; continuing as -i was passed.", name, e
                             );
                         }
                     }

--- a/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
+++ b/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
@@ -32,7 +32,7 @@ public class KillTopology {
         @SuppressWarnings("unchecked")
         final List<String> names = (List<String>) cl.get("TOPO");
 
-        // wait seconds for topology to shut down
+        // Wait this many seconds after deactivating topology before killing
         Integer wait = (Integer) cl.get("w");
 
         // if '-i' set, we'll try to kill every topology listed, even if an error occurs

--- a/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
+++ b/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
@@ -35,7 +35,7 @@ public class KillTopology {
         // Wait this many seconds after deactivating topology before killing
         Integer wait = (Integer) cl.get("w");
 
-        // if '-i' set, we'll try to kill every topology listed, even if an error occurs
+        // if '-i' is set, we'll try to kill every topology listed, even if an error occurs
         Boolean continueOnError = (Boolean) cl.get("i");
 
         final KillOptions opts = new KillOptions();

--- a/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
+++ b/storm-core/src/jvm/org/apache/storm/command/KillTopology.java
@@ -25,7 +25,7 @@ public class KillTopology {
 
     public static void main(String[] args) throws Exception {
         Map<String, Object> cl = CLI.opt("w", "wait", null, CLI.AS_INT)
-                                    .boolOpt("c", "continue-on-error")
+                                    .boolOpt("i", "ignore-errors")
                                     .arg("TOPO", CLI.INTO_LIST)
                                     .parse(args);
 
@@ -35,8 +35,8 @@ public class KillTopology {
         // wait seconds for topology to shut down
         Integer wait = (Integer) cl.get("w");
 
-        // if '-c' set, we'll try to kill every topology listed, even if an error occurs
-        Boolean continueOnError = (Boolean) cl.get("c");
+        // if '-i' set, we'll try to kill every topology listed, even if an error occurs
+        Boolean continueOnError = (Boolean) cl.get("i");
 
         final KillOptions opts = new KillOptions();
         if (wait != null) {
@@ -57,7 +57,7 @@ public class KillTopology {
                             throw e;
                         } else {
                             LOG.info(
-                                    "Caught error killing topology '{}'; continuing as -c was passed. Exception: {}",
+                                    "Caught error killing topology '{}'; continuing as -i was passed. Exception: {}",
                                     name,
                                     e.getClass().getName()
                             );


### PR DESCRIPTION
Adds a new `-i` parameter to `storm kill`. When passed, we will attempt to kill all listed topologies even if an error occurs.