### PR TITLE
Clarify spout non-serializable field exception message

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -64,7 +64,7 @@ At time of writing, you can't emit to multiple output streams from Trident -- se
 
 ### Why am I getting a NotSerializableException/IllegalStateException when my topology is being started up?
 
-Within the Storm lifecycle, the topology is instantiated and then serialized to byte format to be stored in ZooKeeper, prior to the topology being executed. Within this step, if a spout or bolt within the topology has an initialized unserializable property, serialization will fail. If there is a need for a field that is unserializable, initialize it within the bolt or spout's prepare method, which is run after the topology is delivered to the worker.
+Within the Storm lifecycle, the topology is instantiated and then serialized to byte format to be stored in ZooKeeper, prior to the topology being executed. Within this step, if a spout or bolt within the topology has an initialized unserializable property, serialization will fail. If there is a need for a field that is unserializable, initialize it within the bolt's `prepare` or spout's `open` method, which is run after the topology is delivered to the worker.
 
 ## Spouts
 

--- a/storm-client/src/jvm/org/apache/storm/topology/TopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/TopologyBuilder.java
@@ -134,7 +134,7 @@ public class TopologyBuilder {
                     throw new IllegalStateException(
                         "Spout '" + spoutId + "' contains a non-serializable field of type " + wrapperCause.getCause().getMessage() + ", " +
                         "which was instantiated prior to topology creation. " + wrapperCause.getCause().getMessage() + " " +
-                        "should be instantiated within the prepare method of '" + spoutId + " at the earliest.", wrapperCause);
+                        "should be instantiated within the open method of '" + spoutId + " at the earliest.", wrapperCause);
                 }
                 throw wrapperCause;
             }


### PR DESCRIPTION
ISpout has an `open` method instead of a `prepare` method.