### PR TITLE
Fix Markdown errors and minor typos in the documentation.

### DIFF
--- a/docs/Kestrel-and-Storm.md
+++ b/docs/Kestrel-and-Storm.md
@@ -58,6 +58,7 @@ At first, we need to have a program that can add items to a Kestrel queue. The f
 ## Remove items from Kestrel
 
 This method dequeues items from a queue without removing them.
+
 ```
     private static void dequeueItems(KestrelClient kestrelClient, String queueName) throws IOException, ParseError
 			 {
@@ -80,6 +81,7 @@ This method dequeues items from a queue without removing them.
 ```
 
 This method dequeues items from a queue and then removes them.
+
 ```
     private static void dequeueAndRemoveItems(KestrelClient kestrelClient, String queueName)
     throws IOException, ParseError

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -506,43 +506,45 @@ nimbus.groups:
 
 ### DRPC
  
- Storm provides the Access Control List for the DRPC Authorizer.Users can see [org.apache.storm.security.auth.authorizer.DRPCSimpleACLAuthorizer](javadocs/org/apache/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer.html) for more details.
+Storm provides the Access Control List for the DRPC Authorizer.Users can see [org.apache.storm.security.auth.authorizer.DRPCSimpleACLAuthorizer](javadocs/org/apache/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer.html) for more details.
  
- There are several DRPC ACL related configurations.
+There are several DRPC ACL related configurations.
  
- | YAML Setting | Description |
- |------------|----------------------|
- | drpc.authorizer.acl | A class that will perform authorization for DRPC operations. Set this to org.apache.storm.security.auth.authorizer.DRPCSimpleACLAuthorizer when using security.|
- | drpc.authorizer.acl.filename | This is the name of a file that the ACLs will be loaded from. It is separate from storm.yaml to allow the file to be updated without bringing down a DRPC server. Defaults to drpc-auth-acl.yaml |
- | drpc.authorizer.acl.strict| It is useful to set this to false for staging where users may want to experiment, but true for production where you want users to be secure. Defaults to false. |
+| YAML Setting | Description |
+|------------|----------------------|
+| drpc.authorizer.acl | A class that will perform authorization for DRPC operations. Set this to org.apache.storm.security.auth.authorizer.DRPCSimpleACLAuthorizer when using security.|
+| drpc.authorizer.acl.filename | This is the name of a file that the ACLs will be loaded from. It is separate from storm.yaml to allow the file to be updated without bringing down a DRPC server. Defaults to drpc-auth-acl.yaml |
+| drpc.authorizer.acl.strict| It is useful to set this to false for staging where users may want to experiment, but true for production where you want users to be secure. Defaults to false. |
 
- The file pointed to by drpc.authorizer.acl.filename will have only one config in it drpc.authorizer.acl this should be of the form
+The file pointed to by drpc.authorizer.acl.filename will have only one config in it drpc.authorizer.acl this should be of the form
 
- drpc.authorizer.acl:
+```yaml
+drpc.authorizer.acl:
    "functionName1":
      "client.users":
        - "alice"
        - "bob"
      "invocation.user": "bob"
-     
- In this the users bob and alice as client.users are allowed to run DRPC requests against functionName1, but only bob as the invocation.user is allowed to run the topology that actually processes those requests.
+```
+
+In this the users bob and alice as client.users are allowed to run DRPC requests against functionName1, but only bob as the invocation.user is allowed to run the topology that actually processes those requests.
 
 
 ## Cluster Zookeeper Authentication
  
- Users can implement cluster Zookeeper authentication by setting several configurations are shown below.
- 
- | YAML Setting | Description |
- |------------|----------------------|
- | storm.zookeeper.auth.scheme | The cluster Zookeeper authentication scheme to use, e.g. "digest". Defaults to no authentication. |
- | storm.zookeeper.auth.payload | A string representing the payload for cluster Zookeeper authentication.It should only be set in the storm-cluster-auth.yaml.Users can see storm-cluster-auth.yaml.example for more details. |
- 
- 
- Also,there are several configurations for topology Zookeeper authentication:
- 
- | YAML Setting | Description |
- |------------|----------------------|
- | storm.zookeeper.topology.auth.scheme | The topology Zookeeper authentication scheme to use, e.g. "digest". It is the internal config and user shouldn't set it. |
- | storm.zookeeper.topology.auth.payload | A string representing the payload for topology Zookeeper authentication. |
- 
- Note: If storm.zookeeper.topology.auth.payload isn't set,storm will generate a ZooKeeper secret payload for MD5-digest with generateZookeeperDigestSecretPayload() method.
+Users can implement cluster Zookeeper authentication by setting several configurations are shown below.
+
+| YAML Setting | Description |
+|------------|----------------------|
+| storm.zookeeper.auth.scheme | The cluster Zookeeper authentication scheme to use, e.g. "digest". Defaults to no authentication. |
+| storm.zookeeper.auth.payload | A string representing the payload for cluster Zookeeper authentication. It should only be set in the storm-cluster-auth.yaml. Users can see storm-cluster-auth.yaml.example for more details. |
+
+
+Also, there are several configurations for topology Zookeeper authentication:
+
+| YAML Setting | Description |
+|------------|----------------------|
+| storm.zookeeper.topology.auth.scheme | The topology Zookeeper authentication scheme to use, e.g. "digest". It is the internal config and user shouldn't set it. |
+| storm.zookeeper.topology.auth.payload | A string representing the payload for topology Zookeeper authentication. |
+
+Note: If storm.zookeeper.topology.auth.payload isn't set, Storm will generate a ZooKeeper secret payload for MD5-digest with generateZookeeperDigestSecretPayload() method.

--- a/docs/Understanding-the-parallelism-of-a-Storm-topology.md
+++ b/docs/Understanding-the-parallelism-of-a-Storm-topology.md
@@ -116,7 +116,7 @@ $ storm rebalance mytopology -n 5 -e blue-spout=3 -e yellow-bolt=10
 
 * [Concepts](Concepts.html)
 * [Configuration](Configuration.html)
-* [Running topologies on a production cluster](Running-topologies-on-a-production-cluster.html)]
+* [Running topologies on a production cluster](Running-topologies-on-a-production-cluster.html)
 * [Local mode](Local-mode.html)
 * [Tutorial](Tutorial.html)
 * [Storm API documentation](javadocs/), most notably the class ``Config``

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ But small change will not affect the user experience. We will notify the user wh
 * [State Checkpointing](State-checkpointing.html)
 * [Windowing](Windowing.html)
 * [Joining Streams](Joins.html)
-* [Blobstore(Distcahce)](distcache-blobstore.html)
+* [Blobstore(Distcache)](distcache-blobstore.html)
 
 ### Debugging
 * [Dynamic Log Level Settings](dynamic-log-level-settings.html)


### PR DESCRIPTION
I stumbled across some Markdown syntax errors in the documentation and fixed them, as well as minor typos which I found. I thought this was nothing I should open an issue for first, or should I?