### PR TITLE
STORM-3267: Disable Java 10 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ sudo: required
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk10
 before_install:
   - rvm reload
   - rvm use 2.4.2 --install


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3267

We can add Java 11 at some later point, but for now we need to disable the Java 10 build.