### PR TITLE
STORM-3268: Improve integration test stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ sudo: required
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk10
 before_install:
   - rvm reload
   - rvm use 2.4.2 --install

--- a/integration-test/src/main/java/org/apache/storm/ExclamationTopology.java
+++ b/integration-test/src/main/java/org/apache/storm/ExclamationTopology.java
@@ -17,19 +17,26 @@
 
 package org.apache.storm;
 
+import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
-import org.apache.storm.testing.TestWordSpout;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
-import org.apache.storm.utils.Utils;
 
 import java.util.Map;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.st.topology.TestableTopology;
+import org.apache.storm.st.utils.TimeUtil;
+import org.apache.storm.topology.base.BaseRichSpout;
 
 /**
  * This is a basic example of a Storm topology.
@@ -39,8 +46,11 @@ public class ExclamationTopology {
   public static final String WORD = "word";
   public static final String EXCLAIM_1 = "exclaim1";
   public static final String EXCLAIM_2 = "exclaim2";
+  public static final int SPOUT_EXECUTORS = 10;
+  public static final int EXCLAIM_2_EXECUTORS = 2;
 
   public static class ExclamationBolt extends BaseRichBolt {
+
     OutputCollector _collector;
 
     @Override
@@ -60,6 +70,38 @@ public class ExclamationTopology {
     }
   }
 
+  public static class FixedOrderWordSpout extends BaseRichSpout {
+
+    public static final List<String> WORDS = Collections.unmodifiableList(Arrays.asList("nathan", "mike", "jackson", "golda", "bertels"));
+
+    private SpoutOutputCollector collector;
+    private int currentIndex = 0;
+    private int numEmitted = 0;
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+      declarer.declare(new Fields("word"));
+    }
+
+    @Override
+    public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
+      this.collector = collector;
+    }
+
+    @Override
+    public void nextTuple() {
+      if (numEmitted >= TestableTopology.MAX_SPOUT_EMITS) {
+        //Stop emitting at a certain point, because log rolling breaks the tests.
+        return;
+      }
+      //Sleep a bit to avoid hogging the CPU.
+      TimeUtil.sleepMilliSec(1);
+      collector.emit(new Values(WORDS.get((currentIndex++) % WORDS.size())));
+      ++numEmitted;
+    }
+
+  }
+
   public static void main(String[] args) throws Exception {
     StormTopology topology = getStormTopology();
 
@@ -67,7 +109,7 @@ public class ExclamationTopology {
     conf.setDebug(true);
     String topoName = "test";
     if (args.length > 0) {
-        topoName = args[0];
+      topoName = args[0];
     }
 
     conf.setNumWorkers(3);
@@ -76,9 +118,9 @@ public class ExclamationTopology {
 
   public static StormTopology getStormTopology() {
     TopologyBuilder builder = new TopologyBuilder();
-    builder.setSpout(WORD, new TestWordSpout(), 10);
+    builder.setSpout(WORD, new FixedOrderWordSpout(), SPOUT_EXECUTORS);
     builder.setBolt(EXCLAIM_1, new ExclamationTopology.ExclamationBolt(), 3).shuffleGrouping(WORD);
-    builder.setBolt(EXCLAIM_2, new ExclamationTopology.ExclamationBolt(), 2).shuffleGrouping(EXCLAIM_1);
+    builder.setBolt(EXCLAIM_2, new ExclamationTopology.ExclamationBolt(), EXCLAIM_2_EXECUTORS).shuffleGrouping(EXCLAIM_1);
     return builder.createTopology();
   }
 }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/TestableTopology.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/TestableTopology.java
@@ -17,14 +17,18 @@
 
 package org.apache.storm.st.topology;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.storm.generated.StormTopology;
 
 public interface TestableTopology {
     String DUMMY_FIELD = "dummy";
-    //Some tests rely on reading the worker log. If emits are too close together and too much is logged, the log might roll, breaking the test.
-    int MIN_SLEEP_BETWEEN_EMITS_MS = 10;
-    int MAX_SLEEP_BETWEEN_EMITS_MS = 100;
+    int TIMEDATA_SLEEP_BETWEEN_EMITS_MS = 20;
+    //Some tests rely on reading the worker log. If there are too many emits and too much is logged, the log might roll, breaking the test.
+    //Ensure the time based windowing tests can emit for 5 minutes
+    long MAX_SPOUT_EMITS = TimeUnit.MINUTES.toMillis(5)/TIMEDATA_SLEEP_BETWEEN_EMITS_MS; 
     StormTopology newTopology();
     String getBoltName();
+    int getBoltExecutors();
     String getSpoutName();
+    int getSpoutExecutors();
 }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/SlidingWindowCorrectness.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/SlidingWindowCorrectness.java
@@ -38,7 +38,9 @@ public class SlidingWindowCorrectness implements TestableTopology {
     private final int windowSize;
     private final int slideSize;
     private final String spoutName;
+    private final int spoutExecutors = 1;
     private final String boltName;
+    private final int boltExecutors = 1;
 
     public SlidingWindowCorrectness(int windowSize, int slideSize) {
         this.windowSize = windowSize;
@@ -57,15 +59,25 @@ public class SlidingWindowCorrectness implements TestableTopology {
     public String getSpoutName() {
         return spoutName;
     }
+    
+    @Override
+    public int getBoltExecutors() {
+        return boltExecutors;
+    }
+
+    @Override
+    public int getSpoutExecutors() {
+        return spoutExecutors;
+    }
 
     @Override
     public StormTopology newTopology() {
         TopologyBuilder builder = new TopologyBuilder();
-        builder.setSpout(getSpoutName(), new IncrementingSpout(), 1);
+        builder.setSpout(getSpoutName(), new IncrementingSpout(), spoutExecutors);
         builder.setBolt(getBoltName(),
                 new VerificationBolt()
                         .withWindow(new BaseWindowedBolt.Count(windowSize), new BaseWindowedBolt.Count(slideSize)),
-                1)
+                boltExecutors)
                 .shuffleGrouping(getSpoutName());
         return builder.createTopology();
     }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/TumblingTimeCorrectness.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/TumblingTimeCorrectness.java
@@ -37,7 +37,9 @@ public class TumblingTimeCorrectness implements TestableTopology {
     private static final Logger LOG = LoggerFactory.getLogger(TumblingTimeCorrectness.class);
     private final int tumbleSec;
     private final String spoutName;
+    private final int spoutExecutors = 2;
     private final String boltName;
+    private final int boltExecutors = 1;
 
     public TumblingTimeCorrectness(int tumbleSec) {
         this.tumbleSec = tumbleSec;
@@ -55,17 +57,27 @@ public class TumblingTimeCorrectness implements TestableTopology {
     public String getSpoutName() {
         return spoutName;
     }
+    
+    @Override
+    public int getBoltExecutors() {
+        return boltExecutors;
+    }
+
+    @Override
+    public int getSpoutExecutors() {
+        return spoutExecutors;
+    }
 
     @Override
     public StormTopology newTopology() {
         TopologyBuilder builder = new TopologyBuilder();
-        builder.setSpout(getSpoutName(), new TimeDataIncrementingSpout(), 2);
+        builder.setSpout(getSpoutName(), new TimeDataIncrementingSpout(), spoutExecutors);
         builder.setBolt(getBoltName(),
                 new TimeDataVerificationBolt()
                         .withTumblingWindow(new BaseWindowedBolt.Duration(tumbleSec, TimeUnit.SECONDS))
                         .withLag(new BaseWindowedBolt.Duration(10, TimeUnit.SECONDS))
                         .withTimestampField(TimeData.getTimestampFieldName()),
-                1)
+                boltExecutors)
                 .globalGrouping(getSpoutName());
         return builder.createTopology();
     }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/TumblingWindowCorrectness.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/TumblingWindowCorrectness.java
@@ -37,7 +37,9 @@ public class TumblingWindowCorrectness implements TestableTopology {
     private static final String STRING_FIELD = "numAsStr";
     private final int tumbleSize;
     private final String spoutName;
+    private final int spoutExecutors = 1;
     private final String boltName;
+    private final int boltExecutors = 1;
 
     public TumblingWindowCorrectness(final int tumbleSize) {
         this.tumbleSize = tumbleSize;
@@ -55,14 +57,24 @@ public class TumblingWindowCorrectness implements TestableTopology {
     public String getSpoutName() {
         return spoutName;
     }
+    
+    @Override
+    public int getBoltExecutors() {
+        return boltExecutors;
+    }
+
+    @Override
+    public int getSpoutExecutors() {
+        return spoutExecutors;
+    }
 
     @Override
     public StormTopology newTopology() {
         TopologyBuilder builder = new TopologyBuilder();
-        builder.setSpout(getSpoutName(), new IncrementingSpout(), 1);
+        builder.setSpout(getSpoutName(), new IncrementingSpout(), spoutExecutors);
         builder.setBolt(getBoltName(),
                 new VerificationBolt()
-                        .withTumblingWindow(new BaseWindowedBolt.Count(tumbleSize)), 1)
+                        .withTumblingWindow(new BaseWindowedBolt.Count(tumbleSize)), boltExecutors)
                 .shuffleGrouping(getSpoutName());
         return builder.createTopology();
     }

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/VerificationBolt.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/VerificationBolt.java
@@ -20,6 +20,7 @@ import static org.apache.storm.st.topology.TestableTopology.DUMMY_FIELD;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.storm.st.utils.StringDecorator;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -52,7 +53,9 @@ public class VerificationBolt extends BaseWindowedBolt {
         LOG.info("tuplesInWindow.size() = " + tuplesInWindow.size());
         LOG.info("newTuples.size() = " + newTuples.size());
         LOG.info("expiredTuples.size() = " + expiredTuples.size());
-        LOG.info(StringDecorator.decorate(componentId, "tuplesInWindow = " + tuplesInWindow.toString()));
+        LOG.info(StringDecorator.decorate(componentId, "tuplesInWindow = " + tuplesInWindow.stream()
+            .map(t -> t.getValues())
+            .collect(Collectors.toList())));
         collector.emit(new Values("dummyValue"));
     }
 

--- a/integration-test/src/main/java/org/apache/storm/st/topology/window/data/TimeDataWindow.java
+++ b/integration-test/src/main/java/org/apache/storm/st/topology/window/data/TimeDataWindow.java
@@ -20,32 +20,30 @@ package org.apache.storm.st.topology.window.data;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.TreeSet;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
 public class TimeDataWindow {
     private static final Type LIST_TYPE = new TypeToken<List<TimeData>>() {}.getType(); 
     
-    private final List<TimeData> data;
+    private final TreeSet<TimeData> data;
 
     public TimeDataWindow(List<TimeData> data) {
-        this.data = data.stream()
-            .sorted()
-            .collect(Collectors.toList());
+        this.data = new TreeSet<>(data);
     }
 
     public String getDescription() {
         final int size = data.size();
         if (size > 0) {
-            final TimeData first = data.get(0);
-            final TimeData last = data.get(data.size() - 1);
+            final TimeData first = data.first();
+            final TimeData last = data.last();
             return "Total " + size + " items: " + first + " to " + last;
         }
         return "Total " + size + " items.";
     }
     
-    public List<TimeData> getTimeData() {
+    public TreeSet<TimeData> getTimeData() {
         return data;
     }
 

--- a/integration-test/src/main/java/org/apache/storm/st/utils/StringDecorator.java
+++ b/integration-test/src/main/java/org/apache/storm/st/utils/StringDecorator.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.StringUtils;
 /**
  * This class provides a method to pass data from the test bolts and spouts to the test method, via the worker log.
  * Test components can use {@link #decorate(java.lang.String, java.lang.String) } to create a string containing a unique prefix. 
- * Such prefixed log lines can be retrieved from the worker logs, and recognized via {@link #isDecorated(java.lang.String) }.
+ * Such prefixed log lines can be retrieved from the worker logs, and recognized via {@link #isDecorated(java.lang.String, java.lang.String) }.
  */
 public class StringDecorator {
 
@@ -32,8 +32,8 @@ public class StringDecorator {
         return componentId + UNIQUE_PREFIX + decorate;
     }
 
-    public static boolean isDecorated(String str) {
-        return str != null && str.contains(UNIQUE_PREFIX);
+    public static boolean isDecorated(String componentId, String str) {
+        return str != null && str.contains(componentId + UNIQUE_PREFIX);
     }
 
     public static String[] split2(String decoratedString) {

--- a/integration-test/src/test/java/org/apache/storm/st/tests/window/SlidingWindowTest.java
+++ b/integration-test/src/test/java/org/apache/storm/st/tests/window/SlidingWindowTest.java
@@ -56,7 +56,7 @@ public final class SlidingWindowTest extends AbstractTest {
     @Test(dataProvider = "generateCountWindows")
     public void testWindowCount(int windowSize, int slideSize) throws Exception {
         final SlidingWindowCorrectness testable = new SlidingWindowCorrectness(windowSize, slideSize);
-        final String topologyName = this.getClass().getSimpleName() + "-window" + windowSize + "-slide" + slideSize;
+        final String topologyName = this.getClass().getSimpleName() + "-size-window" + windowSize + "-slide" + slideSize;
         if (windowSize <= 0 || slideSize <= 0) {
             try {
                 testable.newTopology();
@@ -90,7 +90,7 @@ public final class SlidingWindowTest extends AbstractTest {
     @Test(dataProvider = "generateTimeWindows")
     public void testTimeWindow(int windowSec, int slideSec) throws Exception {
         final SlidingTimeCorrectness testable = new SlidingTimeCorrectness(windowSec, slideSec);
-        final String topologyName = this.getClass().getSimpleName() + "-window" + windowSec + "-slide" + slideSec;
+        final String topologyName = this.getClass().getSimpleName() + "-sec-window" + windowSec + "-slide" + slideSec;
         if (windowSec <= 0 || slideSec <= 0) {
             try {
                 testable.newTopology();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3268

Basically the integration test can't handle logs rolling during the test. To fix this we added a bit of time between spout emits, but I don't think it was enough. I've put a limit on how many tuples the spouts will emit during the tests, which should prevent the logs from growing too much.

Some tests use multiple bolt/spout tasks, and don't wait for all executors to be started. In some cases tests could fail because e.g. two spout instances were supposed to run, but one executor was slow to start so the log for that executor wasn't picked up when the test asked Nimbus for logs for the spout component. The tests now check that Nimbus has all expected executors listed.

The tests extract spout/bolt logs by looking for a magic string. If multiple components were running in the same worker, the log reading logic could pick up e.g. logs from the bolt while looking for logs from the spout. The magic string now includes the component id the log reader is looking for.

Some tests were slow due to building lots of useless error messages, the error messages are constructed lazily now.

The tests aren't perfectly stable, but I think this is due to an issue in Storm where tuples can be lost if the spout starts emitting before the bolt executor is ready to receive. I've seen the spout emit a bunch of tuples before the bolt worker started, and those tuples end up timing out.