### PR TITLE
STORM-3272 allow worker-launcher to delete dead symlinks

### DIFF
--- a/storm-core/src/native/worker-launcher/impl/worker-launcher.c
+++ b/storm-core/src/native/worker-launcher/impl/worker-launcher.c
@@ -593,14 +593,17 @@ int recursive_delete(const char *path, int supervisor_owns_dir) {
     return UNABLE_TO_BUILD_PATH;
   }
 
+  struct stat file_stat;
+
   if(access(path, F_OK) != 0) {
     if(errno == ENOENT) {
-      return 0;
-    }
-    // Can probably return here, but we'll try to lstat anyway.
-  }
+       // we need to handle symlinks that target missing files.
+       if((lstat(path, &file_stat) != 0) || ((file_stat.st_mode & S_IFMT) != S_IFLNK)) {
+         return 0;
+       }
+     }
+   }
 
-  struct stat file_stat;
   if(lstat(path, &file_stat) != 0) {
     fprintf(LOGFILE, "Failed to delete %s: %s", path, strerror(errno));
     return UNABLE_TO_STAT_FILE;

--- a/storm-core/src/native/worker-launcher/impl/worker-launcher.c
+++ b/storm-core/src/native/worker-launcher/impl/worker-launcher.c
@@ -597,8 +597,12 @@ int recursive_delete(const char *path, int supervisor_owns_dir) {
 
   if(access(path, F_OK) != 0) {
     if(errno == ENOENT) {
+       if(lstat(path, &file_stat) != 0) {
+         fprintf(LOGFILE, "Failed to stat %s: %s", path, strerror(errno));
+         return 0;
+       }
        // we need to handle symlinks that target missing files.
-       if((lstat(path, &file_stat) != 0) || ((file_stat.st_mode & S_IFMT) != S_IFLNK)) {
+       if((file_stat.st_mode & S_IFMT) != S_IFLNK) {
          return 0;
        }
      }


### PR DESCRIPTION
When a topology folder contains a symlink to a missing file, the worker-launcher would not remove the symlink.  This prevents force delete from deleting the folder when cleaning up a topology.  

When a cluster is short on resources, this can cause all sorts of issues on the supervisor when rescheduling the same topology when this folder still exists.