### PR TITLE
bugfix ConfigurableTopology completely overwrites preexisting config

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/topology/ConfigurableTopology.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/ConfigurableTopology.java
@@ -86,7 +86,7 @@ public abstract class ConfigurableTopology {
             if (ret.size() == 1) {
                 Object confNode = ret.get("config");
                 if (confNode != null && confNode instanceof Map) {
-                    ret = (Map<String, Object>) ret;
+                    ret = (Map<String, Object>) confNode;
                 }
             }
         }


### PR DESCRIPTION
The ConfigurableTopology can take configuration files where the values are put under a single config element to be compatible with Flux. This PR fixes a bug when multiple configs are set, the last one will overwrite any preexisting value as everything is put under the same key 'config'