### PR TITLE
[STORM-3278] Fix permissions issue on logviewer downloading for heap dump

### DIFF
--- a/bin/flight.bash
+++ b/bin/flight.bash
@@ -69,6 +69,7 @@ function jstack_record {
 function jmap_record {
     FILENAME=recording-$1-${NOW}.bin
     $BINPATH/jmap -dump:format=b,file="$2/${FILENAME}" $1
+    /bin/chmod g+r "$2/${FILENAME}"
 }
 
 function stop_record {


### PR DESCRIPTION

https://issues.apache.org/jira/browse/STORM-3278

Without the change, the permission on the heap dump file is `-rw-------`. And it belongs to the topology submitter. Logviewer is not able to read it.