### PR TITLE
STORM-3295 allow blacklist scheduling to function properly with multi…

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/strategies/RasBlacklistStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/strategies/RasBlacklistStrategy.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import org.apache.storm.generated.InvalidTopologyException;
 import org.apache.storm.scheduler.Cluster;
@@ -106,21 +105,5 @@ public class RasBlacklistStrategy extends DefaultBlacklistStrategy {
             }
         }
         return readyToRemove;
-    }
-
-    private Map<String, Set<String>> createHostToSupervisorMap(final List<String> blacklistedNodeIds, Cluster cluster) {
-        Map<String, Set<String>> hostToSupervisorMap = new TreeMap<>();
-        for (String supervisorId : blacklistedNodeIds) {
-            String hostname = cluster.getHost(supervisorId);
-            if (hostname != null) {
-                Set<String> supervisorIds = hostToSupervisorMap.get(hostname);
-                if (supervisorIds == null) {
-                    supervisorIds = new HashSet<>();
-                    hostToSupervisorMap.put(hostname, supervisorIds);
-                }
-                supervisorIds.add(supervisorId);
-            }
-        }
-        return hostToSupervisorMap;
     }
 }


### PR DESCRIPTION
…ple supervisors on a host

If any supervisor on a host remains blacklisted, BlacklistScheduler.getBlacklistHosts() still considers the host blacklisted.  This change forces all supervisors on a supervisor to be released, which will free the host.

It may be nicer to consider blacklisting strictly based on supervisors, but that is open to discussion, and a much larger change than this.

