### PR TITLE
STORM-3300: Fix NPE in Acker that could occur if sending reset timeou…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/Acker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/Acker.java
@@ -78,9 +78,10 @@ public class Acker implements IBolt {
             pending.put(id, curr);
         } else if (ACKER_RESET_TIMEOUT_STREAM_ID.equals(streamId)) {
             resetTimeout = true;
-            if (curr != null) {
-                pending.put(id, curr);
-            } //else if it has not been added yet, there is no reason time it out later on
+            if (curr == null) {
+                curr = new AckObject();
+            }
+            pending.put(id, curr);
         } else if (Constants.SYSTEM_FLUSH_STREAM_ID.equals(streamId)) {
             collector.flush();
             return;


### PR DESCRIPTION
…t tuples

The error occurs when `int task = curr.spoutTask;` is hit during processing of a reset timeout tuple, if the acker hasn't received the ack_init tuple for the id yet.