### PR TITLE
STORM-3301: Fix case where KafkaSpout could emit tuples that were alr…

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/internal/OffsetManager.java
@@ -129,6 +129,7 @@ public class OffsetManager {
                     if (nextEmittedOffset != null && currOffset == nextEmittedOffset) {
                         LOG.debug("Found committable offset: [{}] after missing offset: [{}], skipping to the committable offset",
                             currOffset, nextCommitOffset);
+                        found = true;
                         nextCommitOffset = currOffset + 1;
                     } else {
                         LOG.debug("Topic-partition [{}] has non-sequential offset [{}]."

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutLogCompactionSupportTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutLogCompactionSupportTest.java
@@ -217,5 +217,42 @@ public class KafkaSpoutLogCompactionSupportTest {
             assertThat("The first partition should have committed all offsets", committed.get(partition).offset(), is(3L));
         }
     }
+    
+    @Test
+    public void testCommitTupleAfterCompactionGap() {
+        //If there is an acked tupled after a compaction gap, the spout should commit it immediately
+        try (SimulatedTime simulatedTime = new SimulatedTime()) {
+            KafkaSpout<String, String> spout = SpoutWithMockedConsumerSetupHelper.setupSpout(spoutConfig, conf, contextMock, collectorMock, consumerMock, partition);
+            
+            List<KafkaSpoutMessageId> firstMessage = SpoutWithMockedConsumerSetupHelper
+                .pollAndEmit(spout, consumerMock, 1, collectorMock, partition, 0);
+            reset(collectorMock);
+            
+            List<KafkaSpoutMessageId> messageAfterGap = SpoutWithMockedConsumerSetupHelper.pollAndEmit(spout, consumerMock, 1, collectorMock, partition, 2);
+            reset(collectorMock);
+            
+            spout.ack(firstMessage.get(0));
+            
+            Time.advanceTime(KafkaSpout.TIMER_DELAY_MS + offsetCommitPeriodMs);
+            spout.nextTuple();
+            verify(consumerMock).commitSync(commitCapture.capture());
+            Map<TopicPartition, OffsetAndMetadata> committed = commitCapture.getValue();
+            assertThat(committed.keySet(), is(Collections.singleton(partition)));
+            assertThat("The consumer should have committed the offset before the gap",
+                committed.get(partition).offset(), is(1L));
+            reset(consumerMock);
+            
+            spout.ack(messageAfterGap.get(0));
+            
+            Time.advanceTime(KafkaSpout.TIMER_DELAY_MS + offsetCommitPeriodMs);
+            spout.nextTuple();
+            
+            verify(consumerMock).commitSync(commitCapture.capture());
+            committed = commitCapture.getValue();
+            assertThat(committed.keySet(), is(Collections.singleton(partition)));
+            assertThat("The consumer should have committed the offset after the gap, since offset 1 wasn't emitted and both 0 and 2 are acked",
+                committed.get(partition).offset(), is(3L));
+        }
+    }
 
 }


### PR DESCRIPTION
…eady committed

https://issues.apache.org/jira/browse/STORM-3301

I made a slight change to log compaction handling, the spout will now commit an acked offset after a gap, even if it's the only one. Previously there had to be at least 2 acked offsets after the gap before commit.