### PR TITLE
STORM-3270: Build Storm with Java 11, excluding some incompatible mod…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ sudo: required
 language: java
 jdk:
   - oraclejdk8
+  - openjdk11
 before_install:
   - rvm reload
   - rvm use 2.4.2 --install

--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -38,9 +38,9 @@ then
   TEST_MODULES=storm-core
 elif [ "$2" == "External" ]
 then
-  if [ "$TRAVIS_JDK_VERSION" == "oraclejdk10" ]
+  if [ "$TRAVIS_JDK_VERSION" == "openjdk11" ]
   then 
-    TEST_MODULES='!storm-client,!storm-server,!storm-core,!external/storm-cassandra,!external/storm-hive'
+    TEST_MODULES='!storm-client,!storm-server,!storm-core,!external/storm-cassandra,!external/storm-hive,!external/storm-hdfs,!external/storm-hbase,!sql/storm-sql-external/storm-sql-hdfs,!external/storm-hdfs-blobstore'
   else
     TEST_MODULES='!storm-client,!storm-server,!storm-core'
   fi

--- a/examples/storm-mqtt-examples/pom.xml
+++ b/examples/storm-mqtt-examples/pom.xml
@@ -71,7 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.4</version>
         <configuration>
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <filters>

--- a/examples/storm-perf/pom.xml
+++ b/examples/storm-perf/pom.xml
@@ -72,7 +72,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -220,7 +220,6 @@
         <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.2.1</version>
         <executions>
           <execution>
             <goals>

--- a/external/storm-blobstore-migration/pom.xml
+++ b/external/storm-blobstore-migration/pom.xml
@@ -77,7 +77,6 @@ limitations under the License.
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -97,7 +96,6 @@ limitations under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/external/storm-hdfs-blobstore/pom.xml
+++ b/external/storm-hdfs-blobstore/pom.xml
@@ -213,7 +213,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -224,7 +223,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.5</version>
                 <executions>
                     <execution>
                         <id>cleanup</id>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -232,7 +232,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -243,7 +242,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.5</version>
                 <executions>
                     <execution>
                         <id>cleanup</id>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -177,7 +177,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>2.5</version>
         <executions>
           <execution>
             <id>cleanup</id>
@@ -199,7 +198,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.2</version>
         <executions>
           <execution>
             <goals>

--- a/external/storm-jdbc/pom.xml
+++ b/external/storm-jdbc/pom.xml
@@ -78,7 +78,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
                 <executions>
                     <execution>
                         <goals>

--- a/external/storm-jms/pom.xml
+++ b/external/storm-jms/pom.xml
@@ -72,7 +72,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>

--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -159,7 +159,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
                 <executions>
                     <execution>
                         <goals>

--- a/external/storm-metrics/pom.xml
+++ b/external/storm-metrics/pom.xml
@@ -68,7 +68,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.6</version>
         <executions>
           <execution>
             <id>prepare</id>

--- a/external/storm-solr/pom.xml
+++ b/external/storm-solr/pom.xml
@@ -109,7 +109,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.5</version>
                 <executions>
                     <execution>
                         <goals>

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -21,19 +21,21 @@ Following describes how we can run individual tests against this vagrant cluster
 
 Configs for running
 -------------------
-The supplied configuration will run tests against vagrant setup. However, it can be changed to use a different cluster.
-Change `integration-test/src/test/resources/storm.yaml` as necessary.
+Configuration for the Storm cluster in Vagrant can be found in `integration-test/config/storm.yaml`. The configuration for the tests when running against Vagrant can be found in `src/test/resources/storm-conf/`, which is used if you run Maven with the `intellij` profile.
+Outside Vagrant, you will need to configure your cluster as normal through your cluster's storm.yaml file. You can configure the tests by pointing to a storm.yaml by adding "-Dstorm.conf.file=/your/path/to/storm.yaml". This file needs to contain `nimbus.seeds` pointing to your Nimbus URL(s).
+
+If you're running against a cluster outside Vagrant, the test needs access to Nimbus and the test must be able to hit the Logviewer URLs at port 8000 on each Supervisor. 
 
 Running all tests manually
 --------------------------
 To run all tests:
 ```sh
-mvn clean package -DskipTests && mvn test
+mvn clean package -DskipTests && mvn test -DskipTests=false
 ```
 
 To run a single test:
 ```sh
-mvn clean package -DskipTests && mvn test -Dtest=SlidingWindowCountTest
+mvn clean package -DskipTests && mvn test -DskipTests=false -Dtest=SlidingWindowCountTest#testWindowCount
 ```
 
 Running tests from IDE
@@ -41,7 +43,7 @@ Running tests from IDE
 You might have to enable intellij profile to make your IDE happy.
 Make sure that the following is run before tests are launched.
 ```sh
-mvn package -DskipTests
+mvn package
 ```
 
 Running tests with custom storm version
@@ -49,7 +51,7 @@ Running tests with custom storm version
 You can supply custom storm version using `-Dstorm.version=<storm-version>` property to all the maven commands.
 ```sh
 mvn clean package -DskipTests -Dstorm.version=<storm-version>
-mvn test -Dtest=DemoTest -Dstorm.version=<storm-version>
+mvn test -DskipTests=false -Dtest=DemoTest -Dstorm.version=<storm-version>
 ```
 
 To find version of the storm that you are running run `storm version` command.

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -74,10 +74,12 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.storm</groupId>
-            <artifactId>storm-server</artifactId>
-            <version>${project.version}</version>
-            <scope>${provided.scope}</scope>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/integration-test/run-it.sh
+++ b/integration-test/run-it.sh
@@ -30,7 +30,7 @@ function list_storm_processes() {
     (ps -ef | grep -i -e zookeeper | grep -v grep) && (ps -ef | grep -i -e storm.home  | grep -v grep)
 }
 
-if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk10" ]]
+if [[ "$TRAVIS_JDK_VERSION" == "openjdk11" ]]
 then
   #Work around https://github.com/travis-ci/travis-ci/issues/9784
   chmod o+rx /home/travis
@@ -41,20 +41,19 @@ sudo dd if=/dev/zero of=/swapfile.img bs=4096 count=1M
 sudo mkswap /swapfile.img
 sudo swapon /swapfile.img
 
-if [[ "${USER}" == "vagrant" ]]; then # install oracle jdk8 or jdk10
+if [[ "${USER}" == "vagrant" ]]; then # install oracle jdk8 or openjdk11
     sudo apt-get update
     sudo apt-get -y install python-software-properties
-    if [[ "${JDK_VERSION}" -ne "10" ]]
+    if [[ "${JDK_VERSION}" -ne "11" ]]
     then
       sudo apt-add-repository -y ppa:webupd8team/java
       sudo apt-get update
       echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
       sudo apt-get install -y oracle-java8-installer
     else 
-      sudo add-apt-repository ppa:linuxuprising/java
+      sudo add-apt-repository ppa:openjdk-r/ppa
       sudo apt-get update
-      echo "oracle-java10-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
-      sudo apt-get install -y oracle-java10-installer
+      sudo apt-get install -y openjdk-11-jdk
     fi
     sudo apt-get -y install maven
     sudo apt-get install unzip
@@ -78,7 +77,7 @@ echo "Using storm version:" ${STORM_VERSION}
 list_storm_processes || true
 sudo bash "${SCRIPT_DIR}/config/common.sh"
 sudo bash "${SCRIPT_DIR}/config/install-storm.sh" "$storm_binary_zip"
-if [[ "$TRAVIS_JDK_VERSION" == "oraclejdk10" ]] || [[ "${JDK_VERSION}" == "10" ]]
+if [[ "$TRAVIS_JDK_VERSION" == "openjdk11" ]] || [[ "${JDK_VERSION}" == "11" ]]
 then
   cat "${SCRIPT_DIR}/config/storm-java9.yaml" | sudo tee -a /usr/share/storm/conf/storm.yaml
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>18</version>
+        <version>21</version>
     </parent>
 
     <groupId>org.apache.storm</groupId>
@@ -268,7 +268,7 @@
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>16.0.1</guava.version>
         <auto-service.version>1.0-rc3</auto-service.version>
-        <netty.version>4.1.25.Final</netty.version>
+        <netty.version>4.1.30.Final</netty.version>
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
         <log4j.version>2.11.1</log4j.version>
@@ -1009,6 +1009,11 @@
                 <version>1.1.1</version>
             </dependency>
             <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+            </dependency>
+            <dependency>
                 <groupId>org.rocksdb</groupId>
                 <artifactId>rocksdbjni</artifactId>
                 <version>${rocksdb-version}</version>
@@ -1192,9 +1197,9 @@
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.4.1</version>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.6.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -66,11 +66,15 @@
             <version>${project.version}</version>
         </dependency>
 
-	<!-- JAXB on JDK8 and below this is a part of java,
-	     but JDK9+ it is not there by default. -->
+        <!-- Java EE packages. On JDK8 and below this is a part of java,
+        but JDK9+ it is not there by default. -->
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
         </dependency>
 
         <!-- kryo -->
@@ -215,7 +219,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -229,7 +232,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <goals>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -328,7 +328,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -377,7 +376,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -391,7 +389,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <goals>
@@ -414,7 +411,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
-                        <version>1.7</version>
                         <executions>
                             <execution>
                                 <id>pre-test-jacoco-clean</id>
@@ -484,7 +480,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.6.0</version>
                         <executions>
                             <execution>
                                 <phase>generate-sources</phase>
@@ -532,7 +527,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-resources-plugin</artifactId>
-                        <version>3.0.2</version>
                         <executions>
                             <execution>
                                 <id>copy-build-scripts</id>

--- a/storm-core/test/clj/integration/org/apache/storm/trident/integration_test.clj
+++ b/storm-core/test/clj/integration/org/apache/storm/trident/integration_test.clj
@@ -21,7 +21,7 @@
   (:import [org.apache.storm.trident.state StateSpec])
   (:import [org.apache.storm.trident TridentTopology]
            [org.apache.storm.trident.operation.impl CombinerAggStateUpdater]
-           [org.apache.storm.trident.operation BaseFunction]
+           [org.apache.storm.trident.operation Function]
            [org.apache.storm.trident.operation.builtin Count Sum Equals MapGet Debug FilterNull FirstN TupleCollectionGet]
            [org.apache.storm.tuple Fields]
            [org.json.simple.parser JSONParser]
@@ -297,8 +297,8 @@
       (letlocals
         (bind topo (TridentTopology.))
         (bind feeder (FeederBatchSpout. ["sentence"]))
-        (bind add-bang (proxy [BaseFunction] []
-                         (execute [tuple collector]
+        (bind add-bang (reify Function
+                         (execute [_ tuple collector]
                            (. collector emit (str (. tuple getString 0) "!")))))
         (bind word-counts
           (.. topo

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -175,7 +175,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -189,7 +188,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <goals>

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1018,7 +1018,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         long topologyDeletionDelay = ObjectReader.getInt(
                 conf.get(DaemonConfig.NIMBUS_TOPOLOGY_BLOBSTORE_DELETION_DELAY_MS), 5 * 60 * 1000);
         for (String topologyId : toposToClean) {
-            if (Time.currentTimeMillis() - getTopologyCleanupDetectedTime(topologyId) >= topologyDeletionDelay) {
+            if (Math.max(0, Time.currentTimeMillis() - getTopologyCleanupDetectedTime(topologyId)) >= topologyDeletionDelay) {
                 idleTopologies.add(topologyId);
             }
         }

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestResourceAwareScheduler.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestResourceAwareScheduler.java
@@ -991,7 +991,7 @@ public class TestResourceAwareScheduler {
     }
     
     @Category(PerformanceTest.class)
-    @Test(timeout=60_000)
+    @Test(timeout=75_000)
     public void testLargeTopologiesOnLargeClustersGras() {
         testLargeTopologiesCommon(GenericResourceAwareStrategy.class.getName(), true, 1);
     }

--- a/storm-webapp/pom.xml
+++ b/storm-webapp/pom.xml
@@ -314,7 +314,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -334,7 +333,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -348,7 +346,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <goals>
@@ -360,7 +357,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.6.0</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
…ules

https://issues.apache.org/jira/browse/STORM-3270

All Hadoop-related modules are excluded from tests, since Hadoop doesn't work with Java 11 yet. Same for Cassandra.

Libraries I'm aware of that need to be updated, other than Netty which is bumped in this PR:
* Clojure to 1.10 (not released yet, currently going through RCs)
* Hadoop/Hive/HBase need to be updated once https://issues.apache.org/jira/browse/HADOOP-15338 is resolved and released.
* Cassandra needs to be updated to 4.0.0. This update should be easy, since we only depend on it in tests, the production code only relies on the Datastax driver, which should be compatible with most Cassandra versions.
* Dropwizard Metrics should probably be updated to 4.x, but we're blocked by https://issues.apache.org/jira/browse/CASSANDRA-14667. I'm not sure how critical the fixes for Metrics are.
* Kafka should probably be upgraded to 2.1.0. I don't think it is an issue for storm-kafka-client, since users can just specify another client library version, but for storm-kafka-monitor it might be necessary for us to upgrade.