### PR TITLE
STORM-3309: Fix flaky tick tuple test

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/Executor.java
@@ -344,8 +344,10 @@ public abstract class Executor implements Callable, JCQueue.Consumer {
         final Integer tickTimeSecs = ObjectReader.getInt(topoConf.get(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS), null);
         if (tickTimeSecs != null) {
             boolean enableMessageTimeout = (Boolean) topoConf.get(Config.TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS);
-            if ((!Acker.ACKER_COMPONENT_ID.equals(componentId) && Utils.isSystemId(componentId))
-                || (!enableMessageTimeout && isSpout)) {
+            boolean isAcker = Acker.ACKER_COMPONENT_ID.equals(componentId);
+            if ((!isAcker && Utils.isSystemId(componentId))
+                || (!enableMessageTimeout && isSpout)
+                || (!enableMessageTimeout && isAcker)) {
                 LOG.info("Timeouts disabled for executor {}:{}", componentId, executorId);
             } else {
                 StormTimer timerTask = workerData.getUserTimer();

--- a/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
@@ -100,7 +100,7 @@ public class BoltExecutor extends Executor {
     public void init(ArrayList<Task> idToTask, int idToTaskBase) {
         executorTransfer.initLocalRecvQueues();
         while (!stormActive.get()) {
-            Utils.sleep(100);
+            Utils.sleepNoSimulation(100);
         }
 
         if (!componentId.equals(StormCommon.SYSTEM_STREAM_ID)) { // System bolt doesn't call reportError()

--- a/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/spout/SpoutExecutor.java
@@ -98,7 +98,7 @@ public class SpoutExecutor extends Executor {
         this.threadId = Thread.currentThread().getId();
         executorTransfer.initLocalRecvQueues();
         while (!stormActive.get()) {
-            Utils.sleep(100);
+            Utils.sleepNoSimulation(100);
         }
 
         LOG.info("Opening spout {}:{}", componentId, taskIds);

--- a/storm-client/src/jvm/org/apache/storm/utils/InprocMessaging.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/InprocMessaging.java
@@ -66,7 +66,7 @@ public class InprocMessaging {
         long start = Time.currentTimeMillis();
         while (!ab.get()) {
             if (Time.isSimulating()) {
-                Time.advanceTime(100);
+                Time.advanceTime(10);
             }
             try {
                 Thread.sleep(10);

--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -659,6 +659,15 @@ public class Utils {
         return des;
     }
 
+    public static void sleepNoSimulation(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+    
     public static void sleep(long millis) {
         try {
             Time.sleep(millis);

--- a/storm-client/src/jvm/org/apache/storm/zookeeper/ClientZookeeper.java
+++ b/storm-client/src/jvm/org/apache/storm/zookeeper/ClientZookeeper.java
@@ -314,7 +314,7 @@ public class ClientZookeeper {
                 watcher.execute(event.getState(), event.getType(), event.getPath());
             }
         });
-        LOG.info("Staring ZK Curator");
+        LOG.info("Starting ZK Curator");
         fk.start();
         return fk;
     }

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -49,6 +49,14 @@
             <artifactId>storm-server</artifactId>
             <version>${project.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-server</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
 
         <!--Hadoop Mini Cluster cannot use log4j2 bridge,
         Surefire has a way to exclude the conflicting log4j API jar

--- a/storm-core/test/jvm/org/apache/storm/integration/TestingTest.java
+++ b/storm-core/test/jvm/org/apache/storm/integration/TestingTest.java
@@ -16,11 +16,8 @@
 
 package org.apache.storm.integration;
 
-import static org.apache.storm.integration.AssertLoop.assertAcked;
-import static org.apache.storm.integration.AssertLoop.assertFailed;
-
-import org.apache.storm.LocalCluster;
-
+import static org.apache.storm.AssertLoop.assertAcked;
+import static org.apache.storm.AssertLoop.assertFailed;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -30,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.storm.Config;
+import org.apache.storm.LocalCluster;
 import org.apache.storm.Testing;
 import org.apache.storm.Thrift;
 import org.apache.storm.generated.GlobalStreamId;

--- a/storm-core/test/jvm/org/apache/storm/integration/TopologyIntegrationTest.java
+++ b/storm-core/test/jvm/org/apache/storm/integration/TopologyIntegrationTest.java
@@ -16,8 +16,8 @@
 
 package org.apache.storm.integration;
 
-import static org.apache.storm.integration.AssertLoop.assertAcked;
-import static org.apache.storm.integration.AssertLoop.assertFailed;
+import static org.apache.storm.AssertLoop.assertAcked;
+import static org.apache.storm.AssertLoop.assertFailed;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -97,6 +97,11 @@
             <artifactId>java-hamcrest</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -720,6 +720,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
 
     /**
      * Wait for the cluster to be idle.  This is intended to be used with Simulated time and is for internal testing.
+     * Note that this does not wait for spout or bolt executors to be idle.
      *
      * @throws InterruptedException if interrupted while waiting.
      * @throws AssertionError       if the cluster did not come to an idle point with a timeout.
@@ -730,6 +731,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
 
     /**
      * Wait for the cluster to be idle.  This is intended to be used with Simulated time and is for internal testing.
+     * Note that this does not wait for spout or bolt executors to be idle.
      *
      * @param timeoutMs the number of ms to wait before throwing an error.
      * @throws InterruptedException if interrupted while waiting.

--- a/storm-server/src/test/java/org/apache/storm/AssertLoop.java
+++ b/storm-server/src/test/java/org/apache/storm/AssertLoop.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.apache.storm.integration;
+package org.apache.storm;
 
 import static org.apache.storm.utils.PredicateMatcher.matchesPredicate;
 import static org.hamcrest.CoreMatchers.everyItem;
@@ -27,13 +27,13 @@ import org.apache.storm.testing.AckFailMapTracker;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 
-class AssertLoop {
+public class AssertLoop {
 
     public static void assertLoop(Predicate<Object> condition, Object... conditionParams) {
         try {
             Awaitility.with()
                 .pollInterval(1, TimeUnit.MILLISECONDS)
-                .atMost(10, TimeUnit.SECONDS)
+                .atMost(Testing.TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 .untilAsserted(() -> assertThat(Arrays.asList(conditionParams), everyItem(matchesPredicate(condition))));
         } catch (ConditionTimeoutException e) {
             throw new AssertionError(e.getMessage());

--- a/storm-server/src/test/java/org/apache/storm/TickTupleTest.java
+++ b/storm-server/src/test/java/org/apache/storm/TickTupleTest.java
@@ -13,97 +13,130 @@
 package org.apache.storm;
 
 import java.util.Map;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.storm.ILocalCluster.ILocalTopology;
-import org.apache.storm.generated.StormTopology;
-import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.TopologyBuilder;
 import org.apache.storm.topology.base.BaseRichBolt;
-import org.apache.storm.topology.base.BaseRichSpout;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.Time;
 import org.apache.storm.utils.TupleUtils;
-import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.storm.testing.AckFailMapTracker;
+import org.apache.storm.testing.FeederSpout;
+import org.apache.storm.tuple.Values;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public class TickTupleTest {
     private final static Logger LOG = LoggerFactory.getLogger(TickTupleTest.class);
-    private static LinkedBlockingQueue<Long> tickTupleTimes = new LinkedBlockingQueue<>();
-    private static AtomicReference<Tuple> nonTickTuple = new AtomicReference<>(null);
+    private static final AtomicInteger tickTupleCount = new AtomicInteger();
+    private static final AtomicReference<Tuple> nonTickTuple = new AtomicReference<>(null);
+    private static final AtomicBoolean receivedAnyTuple = new AtomicBoolean();
+    //This needs to be appropriately large to drown out any time advances performed during topology boot
+    private static final int TICK_INTERVAL_SECS = 30;
+    
+    @AfterEach
+    public void cleanUp() {
+        tickTupleCount.set(0);
+        nonTickTuple.set(null);
+        receivedAnyTuple.set(false);
+    }
 
     @Test
     public void testTickTupleWorksWithSystemBolt() throws Exception {
-        try (ILocalCluster cluster = new LocalCluster.Builder().withSimulatedTime().build()) {
-            StormTopology topology = createNoOpTopology();
+        try (ILocalCluster cluster = new LocalCluster.Builder()
+            .withSimulatedTime()
+            .build()) {
+            
+            TopologyBuilder builder = new TopologyBuilder();
+            FeederSpout feeder = new FeederSpout(new Fields("field1"));
+            AckFailMapTracker tracker = new AckFailMapTracker();
+            feeder.setAckFailDelegate(tracker);
+            
+            builder.setSpout("Spout", feeder);
+            builder.setBolt("Bolt", new NoopBolt())
+                .shuffleGrouping("Spout");
+            
             Config topoConf = new Config();
-            topoConf.put(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS, 1);
-            try (ILocalTopology topo = cluster.submitTopology("test", topoConf, topology)) {
-                //Give the topology some time to come up
-                long time = 0;
-                int timeout = Math.max(Testing.TEST_TIMEOUT_MS, 100_000);
-                while (tickTupleTimes.size() <= 0) {
-                    assert time <= timeout : "took over " + time + " ms of simulated time to get a message back...";
-                    cluster.advanceClusterTime(10);
-                    time += 10_000;
+            topoConf.put(Config.TOPOLOGY_TICK_TUPLE_FREQ_SECS, TICK_INTERVAL_SECS);
+            
+            try (ILocalTopology topo = cluster.submitTopology("test", topoConf, builder.createTopology())) {
+                //Use a bootstrap tuple to wait for topology to be running
+                feeder.feed(new Values("val"), 1);
+                AssertLoop.assertAcked(tracker, 1);
+                /*
+                 * Verify that some ticks are received. The interval between ticks is validated by the bolt.
+                 * Too few and the checks will time out. Too many and the bolt may crash (not reliably, but the test should become flaky).
+                 */
+                try {
+                    cluster.advanceClusterTime(TICK_INTERVAL_SECS);
+                    waitForTicks(1);
+                    cluster.advanceClusterTime(TICK_INTERVAL_SECS);
+                    waitForTicks(2);
+                    cluster.advanceClusterTime(TICK_INTERVAL_SECS);
+                    waitForTicks(3);
+                } catch (ConditionTimeoutException e) {
+                    throw new AssertionError(e.getMessage());
                 }
-                tickTupleTimes.clear();
-                for (int i = 0; i < 5; i++) {
-                    cluster.advanceClusterTime(1);
-                    time += 1_000;
-                    assertEquals("Iteration " + i, (Long) time, tickTupleTimes.poll(100, TimeUnit.MILLISECONDS));
-                }
+                assertNull("The bolt got a tuple that is not a tick tuple " + nonTickTuple.get(), nonTickTuple.get());
             }
-            assertNull("The bolt got a tuple that is not a tick tuple " + nonTickTuple.get(), nonTickTuple.get());
         }
     }
-
-    private StormTopology createNoOpTopology() {
-        TopologyBuilder builder = new TopologyBuilder();
-        builder.setSpout("Spout", new NoopSpout());
-        builder.setBolt("Bolt", new NoopBolt()).fieldsGrouping("Spout", new Fields("tuple"));
-        return builder.createTopology();
-    }
-
-    private static class NoopSpout extends BaseRichSpout {
-        @Override
-        public void declareOutputFields(OutputFieldsDeclarer declarer) {
-            declarer.declare(new Fields("tuple"));
-        }
-
-        @Override
-        public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
-        }
-
-        @Override
-        public void nextTuple() {
+    
+    private void waitForTicks(int minTicks) {
+        try {
+            Awaitility.with()
+                .pollInterval(1, TimeUnit.MILLISECONDS)
+                .atMost(Testing.TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(tickTupleCount.get(), Matchers.greaterThanOrEqualTo(minTicks)));
+        } catch (ConditionTimeoutException e) {
+            throw new AssertionError(e.getMessage());
         }
     }
 
     private static class NoopBolt extends BaseRichBolt {
+        private OutputCollector collector;
+        
         @Override
-        public void prepare(Map<String, Object> conf, TopologyContext topologyContext, OutputCollector outputCollector) {}
+        public void prepare(Map<String, Object> conf, TopologyContext topologyContext, OutputCollector outputCollector) {
+            collector = outputCollector;
+        }
 
         @Override
         public void execute(Tuple tuple) {
-            LOG.info("GOT {}", tuple);
+            LOG.info("GOT {} at time {}", tuple, Time.currentTimeMillis());
+            if (!receivedAnyTuple.get() && Time.currentTimeSecs() > TICK_INTERVAL_SECS) {
+                throw new RuntimeException("Simulated time was higher than " + TICK_INTERVAL_SECS + " at start of test."
+                    + " Increase the interval until this no longer occurs, but keep an eye on Storm's timeouts for e.g. worker heartbeat.");
+            }
+            receivedAnyTuple.set(true);
+            if (tickTupleCount.get() > 3) {
+                throw new RuntimeException("Unexpectedly many tick tuples");
+            }
             if (TupleUtils.isTick(tuple)) {
-                try {
-                    tickTupleTimes.put(Time.currentTimeMillis());
-                } catch (InterruptedException e) {
-                    //Ignored
-                }
+                tickTupleCount.incrementAndGet();
+                collector.ack(tuple);
             } else {
-                nonTickTuple.set(tuple);
+                if (tuple.getValues().size() == 1 && "val".equals(tuple.getValue(0))) {
+                    collector.ack(tuple);
+                } else {
+                    nonTickTuple.set(tuple);
+                }
             }
         }
 

--- a/storm-server/src/test/resources/log4j2.xml
+++ b/storm-server/src/test/resources/log4j2.xml
@@ -16,15 +16,17 @@
  limitations under the License.
 -->
 <Configuration>
-  <Appenders>
-    <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
-    </Console>
-  </Appenders>
-  <Loggers>
-    <Root level="INFO">
-      <appender-ref ref="console" />
-    </Root>
-  </Loggers>
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.apache.storm.shade.org.apache.zookeeper" level="WARN"/>
+        <Logger name="org.apache.storm.shade.org.apache.curator" level="WARN"/>
+        <Root level="INFO">
+            <appender-ref ref="console" />
+        </Root>
+    </Loggers>
 </Configuration>
       


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3309

I've made the following changes:
* When message timeout is disabled, the acker shouldn't time out tuples. Disable ticks for the acker if message timeouts are disabled
* The spout and bolt executors don't integrate with time simulation, in the sense that they don't require simulated time to increment in order to run. This is fine, but if they aren't going to pause for simulated time to increase, they also shouldn't potentially pause during initialization, waiting for Nimbus to activate the topology.
* InProcMessaging (used by the FeederSpout) will wait for the receiver to show up when sending the initial message. It waits at most 20 seconds, but if time simulation is enabled, it only waits 2. This is not enough for the topology/spout to start most of the time. I set the simulated time increment to match the real time spent waiting.
* The Zookeeper log drowns out any useful logging, set its level to WARN in storm-server

The TickTupleTest has been amended a bit. The problem with the current code is that LocalCluster.waitForIdle doesn't cover spout and bolt executor async loops, so we can end up in a situations where the test fails spuriously.

Example:
The test starts by incrementing cluster time until the bolt receives a tick tuple. Starting from t=0, it is possible that the test sets cluster time to 10 and waits until the tick thread has added some tuples. The bolt thread runs independently of time simulation, and will consume the first tick at some arbitrary time. If we are unlucky, we can get the following sequence:

* 10 ticks are added by tick thread
* Bolt consumes first tick
* All threads covered by LocalCluster.waitForIdle (but not the bolt thread) are now idle, so the test exits the loop waiting for ticks
* The received ticks list is cleared
* The test stores what time the list was cleared at, advances cluster time by 1 and checks that a tick is received
* The bolt may just now be processing some of the previously queued ticks. This will cause the test to fail, because the bolt may receive multiple ticks at the same simulated time.

The replacement test instead uses a bootstrap tuple to verify that the executor (and tick thread) have started, and then increments the full tick interval. The tick interval is chosen so the tick thread will not produce any ticks until the test advances time enough to trigger one. This allows the test to verify that exactly one tick is received per second.