### PR TITLE
Doc clarification on returning `null` from RecordTranslator.apply()

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/RecordTranslator.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/RecordTranslator.java
@@ -36,7 +36,8 @@ public interface RecordTranslator<K, V> extends Serializable, Func<ConsumerRecor
      * @param record the record to translate
      * @return the objects in the tuple.  Return a {@link KafkaTuple}
      *     if you want to route the tuple to a non-default stream.
-     *     Return null to discard an invalid {@link ConsumerRecord} if {@link Builder#setEmitNullTuples(boolean)} is set to true
+     *     Return {@code null} to discard an invalid {@link ConsumerRecord}
+     *     if {@link Builder#setEmitNullTuples(boolean)} is set to {@code false}.
      */
     List<Object> apply(ConsumerRecord<K,V> record);
     


### PR DESCRIPTION
According to KafkaSpout implementation, record is discarded if
Builder.setEmitNullTuples is set to `false`, instead of `true`.