### PR TITLE
STORM-3317 fix upload credentials when using a differing path for jav…

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/command/UploadCredentials.java
+++ b/storm-core/src/jvm/org/apache/storm/command/UploadCredentials.java
@@ -107,6 +107,10 @@ public class UploadCredentials {
                 }
             }
         }
+
+        // use the local setting for the login config rather than the topology's
+        topologyConf.remove("java.security.auth.login.config");
+
         StormSubmitter.pushCredentials(topologyName, topologyConf, credentialsMap, (String) cl.get("u"));
         LOG.info("Uploaded new creds to topology: {}", topologyName);
     }


### PR DESCRIPTION
…a.security.auth.login.config

If the launcher has a java.security.auth.login.config file locally specified that differs from the system property in the topology conf, we need to honor that setting for upload credentials to work properly.



