### PR TITLE
STORM-3315: Upgrade to Kryo 4

### DIFF
--- a/external/storm-kinesis/src/main/java/org/apache/storm/kinesis/spout/KinesisConnectionInfo.java
+++ b/external/storm-kinesis/src/main/java/org/apache/storm/kinesis/spout/KinesisConnectionInfo.java
@@ -84,6 +84,7 @@ public class KinesisConnectionInfo implements Serializable {
 
     private byte[] getKryoSerializedBytes (final Object obj) {
         final Kryo kryo = new Kryo();
+        kryo.getFieldSerializerConfig().setOptimizedGenerics(true);
         final ByteArrayOutputStream os = new ByteArrayOutputStream();
         final Output output = new Output(os);
         kryo.setInstantiatorStrategy(new StdInstantiatorStrategy());
@@ -94,6 +95,7 @@ public class KinesisConnectionInfo implements Serializable {
 
     private Object getKryoDeserializedObject (final byte[] ser) {
         final Kryo kryo = new Kryo();
+        kryo.getFieldSerializerConfig().setOptimizedGenerics(true);
         final Input input = new Input(new ByteArrayInputStream(ser));
         kryo.setInstantiatorStrategy(new StdInstantiatorStrategy());
         return kryo.readClassAndObject(input);

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,7 @@
         <jetty.version>9.4.14.v20181114</jetty.version>
         <clojure.tools.logging.version>0.2.3</clojure.tools.logging.version>
         <carbonite.version>1.5.0</carbonite.version>
+        <chill.version>0.9.3</chill.version>
         <snakeyaml.version>1.11</snakeyaml.version>
         <httpclient.version>4.5.6</httpclient.version>
         <jctools.version>2.0.1</jctools.version>
@@ -291,7 +292,7 @@
         <hadoop.version>2.8.5</hadoop.version>
         <hdfs.version>${hadoop.version}</hdfs.version>
         <hbase.version>2.1.3</hbase.version>
-        <kryo.version>3.0.3</kryo.version>
+        <kryo.version>4.0.2</kryo.version>
         <servlet.version>3.1.0</servlet.version>
         <joda-time.version>2.3</joda-time.version>
         <thrift.version>0.12.0</thrift.version>
@@ -718,6 +719,11 @@
                 <version>${kryo.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.esotericsoftware</groupId>
+                <artifactId>kryo-shaded</artifactId>
+                <version>${kryo.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
                 <version>${commons-cli.version}</version>
@@ -887,6 +893,11 @@
                 <groupId>com.twitter</groupId>
                 <artifactId>carbonite</artifactId>
                 <version>${carbonite.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.twitter</groupId>
+                <artifactId>chill-java</artifactId>
+                <version>${chill.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -390,7 +390,7 @@ public class Config extends HashMap<String, Object> {
     /**
      * Class that specifies how to create a Kryo instance for serialization. Storm will then apply topology.kryo.register and
      * topology.kryo.decorators on top of this. The default implementation implements topology.fall.back.on.java.serialization and turns
-     * references off.
+     * references off. It also enables optimized generics for compatibility with Kryo 3.x.
      */
     @isString
     public static final String TOPOLOGY_KRYO_FACTORY = "topology.kryo.factory";

--- a/storm-client/src/jvm/org/apache/storm/serialization/DefaultKryoFactory.java
+++ b/storm-client/src/jvm/org/apache/storm/serialization/DefaultKryoFactory.java
@@ -25,6 +25,7 @@ public class DefaultKryoFactory implements IKryoFactory {
         KryoSerializableDefault k = new KryoSerializableDefault();
         k.setRegistrationRequired(!((Boolean) conf.get(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION)));
         k.setReferences(false);
+        k.getFieldSerializerConfig().setOptimizedGenerics(true);
         return k;
     }
 

--- a/storm-client/src/jvm/org/apache/storm/state/DefaultStateSerializer.java
+++ b/storm-client/src/jvm/org/apache/storm/state/DefaultStateSerializer.java
@@ -41,6 +41,7 @@ public class DefaultStateSerializer<T> implements Serializer<T> {
         @Override
         protected Kryo initialValue() {
             Kryo obj = new Kryo();
+            obj.getFieldSerializerConfig().setOptimizedGenerics(true);
             if (context != null && topoConf != null) {
                 KryoTupleSerializer ser = new KryoTupleSerializer(topoConf, context);
                 KryoTupleDeserializer deser = new KryoTupleDeserializer(topoConf, context);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3315

Tested compatibility with Kryo 3.0.3 serialization by running the TVL topology for a couple of minutes with two supervisors, one using the unmodified Storm code, and one running this patch.