### PR TITLE
STORM-3321: Fix race in LocalCluster regarding Nimbus leadership, red…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/metric/cgroup/CGroupMetricsBase.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/cgroup/CGroupMetricsBase.java
@@ -39,7 +39,7 @@ public abstract class CGroupMetricsBase<T> implements IMetric {
         enabled = false;
         CgroupCenter center = CgroupCenter.getInstance();
         if (center == null) {
-            LOG.warn("{} is diabled. cgroups do not appear to be enabled on this system", simpleName);
+            LOG.warn("{} is disabled. cgroups do not appear to be enabled on this system", simpleName);
             return;
         }
         if (!center.isSubSystemEnabled(type)) {

--- a/storm-client/src/jvm/org/apache/storm/nimbus/ILeaderElector.java
+++ b/storm-client/src/jvm/org/apache/storm/nimbus/ILeaderElector.java
@@ -15,6 +15,8 @@ package org.apache.storm.nimbus;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.storm.shade.com.google.common.annotations.VisibleForTesting;
 
 /**
  * The interface for leader election.
@@ -52,6 +54,15 @@ public interface ILeaderElector extends Closeable {
      * @return the current leader's address , may return null if no one has the lock.
      */
     NimbusInfo getLeader();
+    
+    /**
+     * Wait for the caller to gain leadership. This should only be used in single-Nimbus clusters, and is only useful to allow testing
+     * code to wait for a LocalCluster's Nimbus to gain leadership before trying to submit topologies.
+     *
+     * @return true is leadership was acquired, false otherwise
+     */
+    @VisibleForTesting
+    boolean awaitLeadership(long timeout, TimeUnit timeUnit) throws InterruptedException;
 
     /**
      * Get list of current nimbus addresses.

--- a/storm-client/src/jvm/org/apache/storm/testing/FixedTupleSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/FixedTupleSpout.java
@@ -22,7 +22,6 @@ import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.IRichSpout;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
-import org.apache.storm.utils.Utils;
 
 import static org.apache.storm.utils.Utils.get;
 
@@ -131,8 +130,6 @@ public class FixedTupleSpout implements IRichSpout, CompletableSpout {
             String id = UUID.randomUUID().toString();
             _pending.put(id, ft);
             _collector.emit(ft.stream, ft.values, id);
-        } else {
-            Utils.sleep(100);
         }
     }
 

--- a/storm-core/src/jvm/org/apache/storm/testing/MockLeaderElector.java
+++ b/storm-core/src/jvm/org/apache/storm/testing/MockLeaderElector.java
@@ -15,6 +15,7 @@ package org.apache.storm.testing;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.storm.nimbus.ILeaderElector;
 import org.apache.storm.nimbus.NimbusInfo;
 
@@ -52,6 +53,11 @@ public class MockLeaderElector implements ILeaderElector {
 
     @Override
     public boolean isLeader() throws Exception {
+        return isLeader;
+    }
+
+    @Override
+    public boolean awaitLeadership(long timeout, TimeUnit timeUnit) throws InterruptedException {
         return isLeader;
     }
 

--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -30,6 +30,7 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
 import org.apache.storm.blobstore.BlobStore;
@@ -91,6 +92,7 @@ import org.apache.storm.scheduler.ISupervisor;
 import org.apache.storm.security.auth.IGroupMappingServiceProvider;
 import org.apache.storm.security.auth.ThriftConnectionType;
 import org.apache.storm.security.auth.ThriftServer;
+import org.apache.storm.shade.org.apache.zookeeper.server.ServerConfig;
 import org.apache.storm.task.IBolt;
 import org.apache.storm.testing.InProcessZookeeper;
 import org.apache.storm.testing.NonRichBoltTracker;
@@ -231,6 +233,10 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
             } else {
                 this.clusterState = builder.clusterState;
             }
+            if (!Time.isSimulating()) {
+                //Ensure Nimbus assigns topologies as quickly as possible
+                conf.put(DaemonConfig.NIMBUS_MONITOR_FREQ_SECS, 1);
+            }
             //Set it for nimbus only
             conf.put(Config.STORM_LOCAL_DIR, nimbusTmp.getPath());
             Nimbus nimbus = new Nimbus(conf, builder.inimbus == null ? new StandaloneINimbus() : builder.inimbus,
@@ -241,6 +247,10 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
             }
             this.nimbus = nimbus;
             this.nimbus.launchServer();
+            if (!this.nimbus.awaitLeadership(Testing.TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                //Ensure Nimbus has leadership, otherwise topology submission will fail.
+                throw new RuntimeException("LocalCluster Nimbus failed to gain leadership.");
+            }
             IContext context = null;
             if (!ObjectReader.getBoolean(this.daemonConf.get(Config.STORM_LOCAL_MODE_ZMQ), false)) {
                 context = new Context();
@@ -690,6 +700,10 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
         }
         superConf.put(Config.STORM_LOCAL_DIR, tmpDir.getPath());
         superConf.put(DaemonConfig.SUPERVISOR_SLOTS_PORTS, portNumbers);
+        if (!Time.isSimulating()) {
+            //Monitor for assignment changes as often as possible, so e.g. shutdown happens as fast as possible.
+            superConf.put(DaemonConfig.SUPERVISOR_MONITOR_FREQUENCY_SECS, 1);
+        }
 
         final String superId = id == null ? Utils.uuid() : id;
         ISupervisor isuper = new StandaloneSupervisor() {

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2835,7 +2835,6 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     @VisibleForTesting
     public void launchServer() throws Exception {
         try {
-            BlobStore store = blobStore;
             IStormClusterState state = stormClusterState;
             NimbusInfo hpi = nimbusHostPortInfo;
 
@@ -2956,6 +2955,11 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             LOG.error("Error on initialization of nimbus", e);
             Utils.exitProcess(13, "Error on initialization of nimbus");
         }
+    }
+    
+    @VisibleForTesting
+    public boolean awaitLeadership(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return leaderElector.awaitLeadership(timeout, timeUnit);
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import org.apache.commons.io.FileUtils;
 import org.apache.storm.Config;
 import org.apache.storm.DaemonConfig;
@@ -529,7 +530,7 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
         }
     }
 
-    public void shutdownAllWorkers(UniFunc<Slot> onWarnTimeout, UniFunc<Slot> onErrorTimeout) {
+    public void shutdownAllWorkers(BiConsumer<Slot, Long> onWarnTimeout, UniFunc<Slot> onErrorTimeout) {
         if (readState != null) {
             readState.shutdownAllWorkers(onWarnTimeout, onErrorTimeout);
         } else {

--- a/storm-server/src/main/java/org/apache/storm/zookeeper/LeaderElectorImp.java
+++ b/storm-server/src/main/java/org/apache/storm/zookeeper/LeaderElectorImp.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.storm.blobstore.BlobStore;
 import org.apache.storm.cluster.IStormClusterState;
@@ -24,6 +25,7 @@ import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.nimbus.ILeaderElector;
 import org.apache.storm.nimbus.LeaderListenerCallback;
 import org.apache.storm.nimbus.NimbusInfo;
+import org.apache.storm.shade.com.google.common.annotations.VisibleForTesting;
 import org.apache.storm.shade.org.apache.curator.framework.CuratorFramework;
 import org.apache.storm.shade.org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.storm.shade.org.apache.curator.framework.recipes.leader.LeaderLatchListener;
@@ -105,6 +107,12 @@ public class LeaderElectorImp implements ILeaderElector {
     @Override
     public boolean isLeader() throws Exception {
         return leaderLatch.get().hasLeadership();
+    }
+
+    @Override
+    @VisibleForTesting
+    public boolean awaitLeadership(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return leaderLatch.get().await(timeout, timeUnit);
     }
 
     @Override

--- a/storm-server/src/test/java/org/apache/storm/TestingTest.java
+++ b/storm-server/src/test/java/org/apache/storm/TestingTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test that the testing class does what it should do.
  */
+@IntegrationTest
 public class TestingTest {
 
     private static final TestJob COMPLETE_TOPOLOGY_TESTJOB = (cluster) -> {
@@ -87,7 +88,6 @@ public class TestingTest {
     };
 
     @Test
-    @IntegrationTest
     public void testCompleteTopologyNettySimulated() throws Exception {
         Config daemonConf = new Config();
         daemonConf.put(Config.STORM_LOCAL_MODE_ZMQ, true);
@@ -99,7 +99,6 @@ public class TestingTest {
     }
 
     @Test
-    @IntegrationTest
     public void testCompleteTopologyNetty() throws Exception {
         Config daemonConf = new Config();
         daemonConf.put(Config.STORM_LOCAL_MODE_ZMQ, true);
@@ -111,7 +110,6 @@ public class TestingTest {
     }
 
     @Test
-    @IntegrationTest
     public void testCompleteTopologyLocalSimulated() throws Exception {
         MkClusterParam param = new MkClusterParam();
         param.setSupervisors(4);
@@ -120,7 +118,6 @@ public class TestingTest {
     }
 
     @Test
-    @IntegrationTest
     public void testCompleteTopologyLocal() throws Exception {
         MkClusterParam param = new MkClusterParam();
         param.setSupervisors(4);


### PR DESCRIPTION
…uce poll timers for Nimbus and supervisor to speed up tests and avoid timeouts

https://issues.apache.org/jira/browse/STORM-3321

I also updated an error message to print how long Slots take to shut down, previously it would print 1000ms no matter how long the shutdown took.

The timer interval reductions in LocalCluster are set to only happen if time simulation is disabled. There are some tests (e.g. nimbus_test.clj) that use time simulation and want those timers to be longer, so it seemed easier to just leave it alone for them.