### PR TITLE
STORM-3330: Migrate some of storm-webapp to Files API and reduce use …

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
@@ -166,11 +166,11 @@ public class LogviewerServer implements AutoCloseable {
         String logRoot = ConfigUtils.workerArtifactsRoot(conf);
         File logRootDir = new File(logRoot);
         logRootDir.mkdirs();
-        WorkerLogs workerLogs = new WorkerLogs(conf, logRootDir, metricsRegistry);
+        WorkerLogs workerLogs = new WorkerLogs(conf, logRootDir.toPath(), metricsRegistry);
         DirectoryCleaner directoryCleaner = new DirectoryCleaner(metricsRegistry);
 
         try (LogviewerServer server = new LogviewerServer(conf, metricsRegistry);
-             LogCleaner logCleaner = new LogCleaner(conf, workerLogs, directoryCleaner, logRootDir, metricsRegistry)) {
+             LogCleaner logCleaner = new LogCleaner(conf, workerLogs, directoryCleaner, logRootDir.toPath(), metricsRegistry)) {
             metricsRegistry.startMetricsReporters(conf);
             Utils.addShutdownHookWithForceKillIn1Sec(() -> {
                 server.meterShutdownCalls.mark();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandler.java
@@ -33,6 +33,7 @@ import j2html.tags.DomContent;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import javax.ws.rs.core.Response;
 
@@ -42,7 +43,6 @@ import org.apache.storm.daemon.logviewer.utils.ExceptionMeterNames;
 import org.apache.storm.daemon.logviewer.utils.LogviewerResponseBuilder;
 import org.apache.storm.daemon.logviewer.utils.ResourceAuthorizer;
 import org.apache.storm.metric.StormMetricsRegistry;
-import org.apache.storm.utils.ServerUtils;
 
 public class LogviewerProfileHandler {
 
@@ -139,8 +139,10 @@ public class LogviewerProfileHandler {
     }
 
     private List<String> getProfilerDumpFiles(File dir) throws IOException {
-        List<File> filesForDir = directoryCleaner.getFilesForDir(dir);
-        return filesForDir.stream().filter(file -> {
+        List<Path> filesForDir = directoryCleaner.getFilesForDir(dir.toPath());
+        return filesForDir.stream()
+            .map(path -> path.toFile())
+            .filter(file -> {
             String fileName = file.getName();
             return StringUtils.isNotEmpty(fileName)
                     && (fileName.endsWith(".txt") || fileName.endsWith(".jfr") || fileName.endsWith(".bin"));

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/WorkerLogs.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/WorkerLogs.java
@@ -19,18 +19,16 @@
 package org.apache.storm.daemon.logviewer.utils;
 
 import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toMap;
 import static org.apache.storm.Config.SUPERVISOR_RUN_WORKER_AS_USER;
 import static org.apache.storm.Config.TOPOLOGY_SUBMITTER_USER;
 
 import com.codahale.metrics.Meter;
 import com.google.common.collect.Lists;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,6 +37,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.storm.daemon.supervisor.ClientSupervisorUtils;
@@ -63,7 +62,7 @@ public class WorkerLogs {
     private final Meter numSetPermissionsExceptions;
     
     private final Map<String, Object> stormConf;
-    private final File logRootDir;
+    private final Path logRootDir;
     private final DirectoryCleaner directoryCleaner;
 
     /**
@@ -73,7 +72,7 @@ public class WorkerLogs {
      * @param logRootDir the log root directory
      * @param metricsRegistry The logviewer metrics registry
      */
-    public WorkerLogs(Map<String, Object> stormConf, File logRootDir, StormMetricsRegistry metricsRegistry) {
+    public WorkerLogs(Map<String, Object> stormConf, Path logRootDir, StormMetricsRegistry metricsRegistry) {
         this.stormConf = stormConf;
         this.logRootDir = logRootDir;
         this.numSetPermissionsExceptions = metricsRegistry.registerMeter(ExceptionMeterNames.NUM_SET_PERMISSION_EXCEPTIONS);
@@ -86,19 +85,19 @@ public class WorkerLogs {
      * @param fileName log file
      */
     public void setLogFilePermission(String fileName) throws IOException {
-        File file = new File(logRootDir, fileName).getCanonicalFile();
+        Path file = logRootDir.resolve(fileName).toAbsolutePath().normalize();
         boolean runAsUser = ObjectReader.getBoolean(stormConf.get(SUPERVISOR_RUN_WORKER_AS_USER), false);
-        File parent = new File(logRootDir, fileName).getParentFile();
-        Optional<File> mdFile = (parent == null) ? Optional.empty() : getMetadataFileForWorkerLogDir(parent);
+        Path parent = logRootDir.resolve(fileName).getParent();
+        Optional<Path> mdFile = (parent == null) ? Optional.empty() : getMetadataFileForWorkerLogDir(parent);
         Optional<String> topoOwner = mdFile.isPresent()
-                ? Optional.of(getTopologyOwnerFromMetadataFile(mdFile.get().getCanonicalPath()))
+                ? Optional.of(getTopologyOwnerFromMetadataFile(mdFile.get().toAbsolutePath().normalize()))
                 : Optional.empty();
 
-        if (runAsUser && topoOwner.isPresent() && file.exists() && !Files.isReadable(file.toPath())) {
+        if (runAsUser && topoOwner.isPresent() && file.toFile().exists() && !Files.isReadable(file)) {
             LOG.debug("Setting permissions on file {} with topo-owner {}", fileName, topoOwner);
             try {
                 ClientSupervisorUtils.processLauncherAndWait(stormConf, topoOwner.get(),
-                        Lists.newArrayList("blob", file.getCanonicalPath()), null,
+                        Lists.newArrayList("blob", file.toAbsolutePath().normalize().toString()), null,
                         "setup group read permissions for file: " + fileName);
             } catch (IOException e) {
                 numSetPermissionsExceptions.mark();
@@ -110,39 +109,39 @@ public class WorkerLogs {
     /**
      * Return a list of all log files from worker directories in root log directory.
      */
-    public List<File> getAllLogsForRootDir() throws IOException {
-        List<File> files = new ArrayList<>();
-        Set<File> topoDirFiles = getAllWorkerDirs();
+    public List<Path> getAllLogsForRootDir() throws IOException {
+        List<Path> files = new ArrayList<>();
+        Set<Path> topoDirFiles = getAllWorkerDirs();
         if (topoDirFiles != null) {
-            for (File portDir : topoDirFiles) {
+            for (Path portDir : topoDirFiles) {
                 files.addAll(directoryCleaner.getFilesForDir(portDir));
             }
         }
 
         return files;
     }
-
+    
     /**
      * Return a set of all worker directories in root log directory.
      */
-    public Set<File> getAllWorkerDirs() {
-        File[] rootDirFiles = logRootDir.listFiles();
-        if (rootDirFiles != null) {
-            return Arrays.stream(rootDirFiles).flatMap(topoDir -> {
-                File[] topoFiles = topoDir.listFiles();
-                return topoFiles != null ? Arrays.stream(topoFiles) : Stream.empty();
-            }).collect(toCollection(TreeSet::new));
+    public Set<Path> getAllWorkerDirs() {
+        try (Stream<Path> topoDirs = Files.list(logRootDir)) {
+            return topoDirs
+                .filter(Files::isDirectory)
+                .flatMap(Unchecked.function(Files::list)) //Worker dirs
+                .filter(Files::isDirectory)
+                .collect(Collectors.toCollection(TreeSet::new));
+        } catch (IOException e) {
+            throw Utils.wrapInRuntime(e);
         }
-
-        return new TreeSet<>();
     }
 
     /**
-     * Return a sorted set of java.io.Files that were written by workers that are now active.
+     * Return a sorted set of paths that were written by workers that are now active.
      */
-    public SortedSet<File> getAliveWorkerDirs() {
+    public SortedSet<Path> getAliveWorkerDirs() throws IOException {
         Set<String> aliveIds = getAliveIds(Time.currentTimeSecs());
-        Set<File> logDirs = getAllWorkerDirs();
+        Set<Path> logDirs = getAllWorkerDirs();
         return getLogDirs(logDirs, (wid) -> aliveIds.contains(wid));
     }
 
@@ -150,12 +149,12 @@ public class WorkerLogs {
      * Return a metadata file (worker.yaml) for given worker log directory.
      * @param logDir worker log directory
      */
-    public Optional<File> getMetadataFileForWorkerLogDir(File logDir) throws IOException {
-        File metaFile = new File(logDir, WORKER_YAML);
-        if (metaFile.exists()) {
+    public Optional<Path> getMetadataFileForWorkerLogDir(Path logDir) throws IOException {
+        Path metaFile = logDir.resolve(WORKER_YAML);
+        if (metaFile.toFile().exists()) {
             return Optional.of(metaFile);
         } else {
-            LOG.warn("Could not find {} to clean up for {}", metaFile.getCanonicalPath(), logDir);
+            LOG.warn("Could not find {} to clean up for {}", metaFile.toAbsolutePath().normalize(), logDir);
             return Optional.empty();
         }
     }
@@ -165,8 +164,8 @@ public class WorkerLogs {
      *
      * @param metaFile metadata file
      */
-    public String getWorkerIdFromMetadataFile(String metaFile) {
-        Map<String, Object> map = (Map<String, Object>) Utils.readYamlFile(metaFile);
+    public String getWorkerIdFromMetadataFile(Path metaFile) {
+        Map<String, Object> map = (Map<String, Object>) Utils.readYamlFile(metaFile.toString());
         return ObjectReader.getString(map == null ? null : map.get("worker-id"), null);
     }
 
@@ -175,8 +174,8 @@ public class WorkerLogs {
      *
      * @param metaFile metadata file
      */
-    public String getTopologyOwnerFromMetadataFile(String metaFile) {
-        Map<String, Object> map = (Map<String, Object>) Utils.readYamlFile(metaFile);
+    public String getTopologyOwnerFromMetadataFile(Path metaFile) {
+        Map<String, Object> map = (Map<String, Object>) Utils.readYamlFile(metaFile.toString());
         return ObjectReader.getString(map.get(TOPOLOGY_SUBMITTER_USER), null);
     }
 
@@ -185,7 +184,7 @@ public class WorkerLogs {
      *
      * @param nowSecs current time in seconds
      */
-    public Set<String> getAliveIds(int nowSecs) {
+    public Set<String> getAliveIds(int nowSecs) throws IOException {
         return SupervisorUtils.readWorkerHeartbeats(stormConf).entrySet().stream()
                 .filter(entry -> Objects.nonNull(entry.getValue())
                         && !SupervisorUtils.isWorkerHbTimedOut(nowSecs, entry.getValue(), stormConf))
@@ -200,15 +199,15 @@ public class WorkerLogs {
      * @param predicate a check on a worker id to see if the log dir should be included
      * @return directories that can be cleaned up.
      */
-    public SortedSet<File> getLogDirs(Set<File> logDirs, Predicate<String> predicate) {
+    public SortedSet<Path> getLogDirs(Set<Path> logDirs, Predicate<String> predicate) {
         // we could also make this static, but not to do it due to mock
-        TreeSet<File> ret = new TreeSet<>();
-        for (File logDir: logDirs) {
+        TreeSet<Path> ret = new TreeSet<>();
+        for (Path logDir: logDirs) {
             String workerId = "";
             try {
-                Optional<File> metaFile = getMetadataFileForWorkerLogDir(logDir);
+                Optional<Path> metaFile = getMetadataFileForWorkerLogDir(logDir);
                 if (metaFile.isPresent()) {
-                    workerId = getWorkerIdFromMetadataFile(metaFile.get().getCanonicalPath());
+                    workerId = getWorkerIdFromMetadataFile(metaFile.get().toAbsolutePath().normalize());
                     if (workerId == null) {
                         workerId = "";
                     }
@@ -228,12 +227,8 @@ public class WorkerLogs {
      *
      * @param file worker log
      */
-    public static String getTopologyPortWorkerLog(File file) {
-        try {
-            return PathUtil.truncatePathToLastElements(file.getCanonicalFile().toPath(), 3).toString();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    public static String getTopologyPortWorkerLog(Path file) {
+        return PathUtil.truncatePathToLastElements(file.toAbsolutePath().normalize(), 3).toString();
     }
 
 }

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerApplication.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerApplication.java
@@ -21,6 +21,7 @@ package org.apache.storm.daemon.logviewer.webapp;
 import static org.apache.storm.DaemonConfig.LOGVIEWER_APPENDER_NAME;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -59,14 +60,14 @@ public class LogviewerApplication extends Application {
         String daemonLogRoot = logRootDir(ObjectReader.getString(stormConf.get(LOGVIEWER_APPENDER_NAME)));
 
         ResourceAuthorizer resourceAuthorizer = new ResourceAuthorizer(stormConf);
-        WorkerLogs workerLogs = new WorkerLogs(stormConf, new File(logRoot), metricsRegistry);
+        WorkerLogs workerLogs = new WorkerLogs(stormConf, Paths.get(logRoot), metricsRegistry);
 
         LogviewerLogPageHandler logviewer = new LogviewerLogPageHandler(logRoot, daemonLogRoot, workerLogs, resourceAuthorizer,
             metricsRegistry);
         LogviewerProfileHandler profileHandler = new LogviewerProfileHandler(logRoot, resourceAuthorizer, metricsRegistry);
         LogviewerLogDownloadHandler logDownloadHandler = new LogviewerLogDownloadHandler(logRoot, daemonLogRoot,
                 workerLogs, resourceAuthorizer, metricsRegistry);
-        LogviewerLogSearchHandler logSearchHandler = new LogviewerLogSearchHandler(stormConf, logRoot, daemonLogRoot,
+        LogviewerLogSearchHandler logSearchHandler = new LogviewerLogSearchHandler(stormConf, Paths.get(logRoot), Paths.get(daemonLogRoot),
                 resourceAuthorizer, metricsRegistry);
         IHttpCredentialsPlugin httpCredsHandler = ServerAuthUtils.getUiHttpCredentialsPlugin(stormConf);
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerResource.java
@@ -314,7 +314,7 @@ public class LogviewerResource {
     @GET
     @Path("/deepSearch/{topoId}")
     public Response deepSearch(@PathParam("topoId") String topologyId,
-                               @Context HttpServletRequest request) {
+                               @Context HttpServletRequest request) throws IOException {
         String user = httpCredsHandler.getUserName(request);
         String searchString = request.getParameter("search-string");
         String numMatchesStr = request.getParameter("num-matches");

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandlerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandlerTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class LogviewerLogPageHandlerTest {
         Map<String, Object> stormConf = Utils.readStormConfig();
         StormMetricsRegistry metricsRegistry = new StormMetricsRegistry();
         LogviewerLogPageHandler handler = new LogviewerLogPageHandler(rootPath, null,
-                new WorkerLogs(stormConf, new File(rootPath), metricsRegistry), new ResourceAuthorizer(stormConf), metricsRegistry);
+                new WorkerLogs(stormConf, Paths.get(rootPath), metricsRegistry), new ResourceAuthorizer(stormConf), metricsRegistry);
 
         final Response expectedAll = LogviewerResponseBuilder.buildSuccessJsonResponse(
                 Lists.newArrayList("topoA/port1/worker.log", "topoA/port2/worker.log", "topoB/port1/worker.log"),

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandlerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandlerTest.java
@@ -40,6 +40,8 @@ import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -183,7 +185,7 @@ public class LogviewerLogSearchHandlerTest {
                 expected.put("matches", matches);
 
                 LogviewerLogSearchHandler handler = getSearchHandlerWithPort(expectedPort);
-                Map<String, Object> searchResult = handler.substringSearch(file, pattern);
+                Map<String, Object> searchResult = handler.substringSearch(file.toPath(), pattern);
 
                 assertEquals(expected, searchResult);
             } finally {
@@ -220,7 +222,7 @@ public class LogviewerLogSearchHandlerTest {
                 expected.put("matches", matches);
 
                 LogviewerLogSearchHandler handler = getSearchHandlerWithPort(expectedPort);
-                Map<String, Object> searchResult = handler.substringSearch(file, pattern);
+                Map<String, Object> searchResult = handler.substringSearch(file.toPath(), pattern);
                 
                 assertEquals(expected, searchResult);
             } finally {
@@ -256,7 +258,7 @@ public class LogviewerLogSearchHandlerTest {
                 expected.put("matches", matches);
 
                 LogviewerLogSearchHandler handler = getSearchHandlerWithPort(expectedPort);
-                Map<String, Object> searchResult = handler.substringSearchDaemonLog(file, pattern);
+                Map<String, Object> searchResult = handler.substringSearchDaemonLog(file.toPath(), pattern);
 
                 assertEquals(expected, searchResult);
             } finally {
@@ -294,8 +296,8 @@ public class LogviewerLogSearchHandlerTest {
                 expected.put("matches", matches);
 
                 LogviewerLogSearchHandler handler = getSearchHandlerWithPort(expectedPort);
-                Map<String, Object> searchResult = handler.substringSearch(file, pattern);
-                Map<String, Object> searchResult2 = handler.substringSearch(file, pattern, 1);
+                Map<String, Object> searchResult = handler.substringSearch(file.toPath(), pattern);
+                Map<String, Object> searchResult2 = handler.substringSearch(file.toPath(), pattern, 1);
 
                 assertEquals(expected, searchResult);
                 assertEquals(expected, searchResult2);
@@ -336,7 +338,7 @@ public class LogviewerLogSearchHandlerTest {
                 dataAndExpected.add(new Tuple3<>(13, 12, null));
 
                 dataAndExpected.forEach(Unchecked.consumer(data -> {
-                    Map<String, Object> result = handler.substringSearch(file, pattern, data.v1());
+                    Map<String, Object> result = handler.substringSearch(file.toPath(), pattern, data.v1());
                     assertEquals(data.v3(), result.get("nextByteOffset"));
                     assertEquals(data.v2().intValue(), ((List) result.get("matches")).size());
                 }));
@@ -407,7 +409,7 @@ public class LogviewerLogSearchHandlerTest {
 
                 expected.put("matches", matches);
 
-                Map<String, Object> searchResult = handler.substringSearch(file, pattern, 7);
+                Map<String, Object> searchResult = handler.substringSearch(file.toPath(), pattern, 7);
 
                 assertEquals(expected, searchResult);
             } finally {
@@ -449,7 +451,7 @@ public class LogviewerLogSearchHandlerTest {
                 expected.put("matches", matches);
 
                 LogviewerLogSearchHandler handler = getSearchHandlerWithPort(expectedPort);
-                Map<String, Object> searchResult = handler.substringSearch(file, pattern, 1, startByteOffset);
+                Map<String, Object> searchResult = handler.substringSearch(file.toPath(), pattern, 1, startByteOffset);
 
                 assertEquals(expected, searchResult);
             } finally {
@@ -499,7 +501,7 @@ public class LogviewerLogSearchHandlerTest {
                 expected.put("matches", matches);
 
                 LogviewerLogSearchHandler handler = getSearchHandlerWithPort(expectedPort);
-                Map<String, Object> searchResult = handler.substringSearch(file, pattern, 2);
+                Map<String, Object> searchResult = handler.substringSearch(file.toPath(), pattern, 2);
 
                 assertEquals(expected, searchResult);
             } finally {
@@ -540,7 +542,7 @@ public class LogviewerLogSearchHandlerTest {
                 expected.put("matches", matches);
 
                 LogviewerLogSearchHandler handler = getSearchHandlerWithPort(expectedPort);
-                Map<String, Object> searchResult = handler.substringSearch(file, pattern, 1);
+                Map<String, Object> searchResult = handler.substringSearch(file.toPath(), pattern, 1);
 
                 assertEquals(expected, searchResult);
             } finally {
@@ -570,7 +572,7 @@ public class LogviewerLogSearchHandlerTest {
                 expected.put("matches", Collections.emptyList());
 
                 LogviewerLogSearchHandler handler = getSearchHandlerWithPort(expectedPort);
-                Map<String, Object> searchResult = handler.substringSearch(file, pattern);
+                Map<String, Object> searchResult = handler.substringSearch(file.toPath(), pattern);
 
                 assertEquals(expected, searchResult);
             } finally {
@@ -600,11 +602,11 @@ public class LogviewerLogSearchHandlerTest {
          */
         @Test
         public void testFindNMatches() {
-            List<File> files = new ArrayList<>();
+            List<Path> files = new ArrayList<>();
             files.add(new File(String.join(File.separator, "src", "test", "resources"),
-                    "logviewer-search-context-tests.log.test"));
+                    "logviewer-search-context-tests.log.test").toPath());
             files.add(new File(String.join(File.separator, "src", "test", "resources"),
-                    "logviewer-search-context-tests.log.gz"));
+                    "logviewer-search-context-tests.log.gz").toPath());
 
             final LogviewerLogSearchHandler handler = getSearchHandler();
 
@@ -629,8 +631,8 @@ public class LogviewerLogSearchHandlerTest {
     public static class TestDeepSearchLogs {
 
         public static final int METRIC_SCANNED_FILES = 0;
-        private List<File> logFiles;
-        private String topoPath;
+        private List<Path> logFiles;
+        private Path topoPath;
 
         /**
          * Setup test environment for each test.
@@ -638,17 +640,15 @@ public class LogviewerLogSearchHandlerTest {
         @Before
         public void setUp() throws IOException {
             logFiles = new ArrayList<>();
-            logFiles.add(new File(String.join(File.separator, "src", "test", "resources"),
-                    "logviewer-search-context-tests.log.test"));
-            logFiles.add(new File(String.join(File.separator, "src", "test", "resources"),
-                    "logviewer-search-context-tests.log.gz"));
+            logFiles.add(Paths.get("src/test/resources/logviewer-search-context-tests.log.test"));
+            logFiles.add(Paths.get("src/test/resources/logviewer-search-context-tests.log.gz"));
 
             FileAttribute[] attrs = new FileAttribute[0];
-            topoPath = Files.createTempDirectory("topoA", attrs).toFile().getCanonicalPath();
-            new File(topoPath, "6400").createNewFile();
-            new File(topoPath, "6500").createNewFile();
-            new File(topoPath, "6600").createNewFile();
-            new File(topoPath, "6700").createNewFile();
+            topoPath = Files.createTempDirectory("topoA", attrs).toAbsolutePath().normalize();
+            new File(topoPath.toFile(), "6400").createNewFile();
+            new File(topoPath.toFile(), "6500").createNewFile();
+            new File(topoPath.toFile(), "6600").createNewFile();
+            new File(topoPath.toFile(), "6700").createNewFile();
         }
 
         /**
@@ -656,9 +656,9 @@ public class LogviewerLogSearchHandlerTest {
          */
         @After
         public void tearDown() {
-            if (StringUtils.isNotEmpty(topoPath)) {
+            if (topoPath != null) {
                 try {
-                    Utils.forceDelete(topoPath);
+                    Utils.forceDelete(topoPath.toString());
                 } catch (IOException e) {
                     // ignore...
                 }
@@ -679,7 +679,7 @@ public class LogviewerLogSearchHandlerTest {
 
             verify(handler, times(4)).findNMatches(files.capture(), numMatches.capture(), fileOffset.capture(),
                     offset.capture(), search.capture());
-            verify(handler, times(4)).logsForPort(isNull(), any(File.class));
+            verify(handler, times(4)).logsForPort(isNull(), any());
 
             // File offset and byte offset should always be zero when searching multiple workers (multiple ports).
             assertEquals(logFiles, files.getAllValues().get(0));
@@ -721,7 +721,7 @@ public class LogviewerLogSearchHandlerTest {
 
             verify(handler, times(4)).findNMatches(files.capture(), numMatches.capture(), fileOffset.capture(),
                     offset.capture(), search.capture());
-            verify(handler, times(4)).logsForPort(isNull(), any(File.class));
+            verify(handler, times(4)).logsForPort(isNull(), any());
 
             // File offset and byte offset should always be zero when searching multiple workers (multiple ports).
             assertEquals(Collections.singletonList(logFiles.get(0)), files.getAllValues().get(0));
@@ -763,7 +763,7 @@ public class LogviewerLogSearchHandlerTest {
 
             verify(handler, times(1)).findNMatches(files.capture(), numMatches.capture(), fileOffset.capture(),
                     offset.capture(), search.capture());
-            verify(handler, times(2)).logsForPort(isNull(), any(File.class));
+            verify(handler, times(2)).logsForPort(isNull(), any());
 
             assertEquals(logFiles, files.getAllValues().get(0));
             assertEquals(Integer.valueOf(20), numMatches.getAllValues().get(0));
@@ -786,7 +786,7 @@ public class LogviewerLogSearchHandlerTest {
 
             verify(handler, times(1)).findNMatches(files.capture(), numMatches.capture(), fileOffset.capture(),
                     offset.capture(), search.capture());
-            verify(handler, times(2)).logsForPort(isNull(), any(File.class));
+            verify(handler, times(2)).logsForPort(isNull(), any());
 
             assertEquals(logFiles, files.getAllValues().get(0));
             assertEquals(Integer.valueOf(20), numMatches.getAllValues().get(0));
@@ -809,7 +809,7 @@ public class LogviewerLogSearchHandlerTest {
 
             verify(handler, times(1)).findNMatches(files.capture(), numMatches.capture(), fileOffset.capture(),
                     offset.capture(), search.capture());
-            verify(handler, times(2)).logsForPort(isNull(), any(File.class));
+            verify(handler, times(2)).logsForPort(isNull(), any());
 
             // File offset should be zero, since search-archived is false.
             assertEquals(Collections.singletonList(logFiles.get(0)), files.getAllValues().get(0));
@@ -826,7 +826,7 @@ public class LogviewerLogSearchHandlerTest {
             handler.deepSearchLogsForTopology("", null, "search", "20", "6700", "1", "100", true, null, null);
 
             verify(handler, times(1)).findNMatches(anyList(), anyInt(), anyInt(), anyInt(), anyString());
-            verify(handler, times(2)).logsForPort(isNull(), any(File.class));
+            verify(handler, times(2)).logsForPort(isNull(), any());
         }
 
         @Test
@@ -844,7 +844,7 @@ public class LogviewerLogSearchHandlerTest {
             // Called with a bad port (not in the config) No searching should be done.
             verify(handler, never()).findNMatches(files.capture(), numMatches.capture(), fileOffset.capture(),
                     offset.capture(), search.capture());
-            verify(handler, never()).logsForPort(anyString(), any(File.class));
+            verify(handler, never()).logsForPort(anyString(), any());
         }
 
         private LogviewerLogSearchHandler getStubbedSearchHandler() {

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/utils/WorkerLogsTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/utils/WorkerLogsTest.java
@@ -19,22 +19,23 @@
 package org.apache.storm.daemon.logviewer.utils;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
 import java.util.SortedSet;
 import java.util.TreeSet;
-import org.apache.storm.daemon.logviewer.testsupport.MockDirectoryBuilder;
-import org.apache.storm.daemon.logviewer.testsupport.MockFileBuilder;
 import org.apache.storm.daemon.supervisor.SupervisorUtils;
 import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.testing.TmpPath;
 import org.apache.storm.utils.Utils;
 import org.junit.Test;
 
@@ -45,31 +46,30 @@ public class WorkerLogsTest {
      */
     @Test
     public void testIdentifyWorkerLogDirs() throws Exception {
-        File port1Dir = new MockDirectoryBuilder().setDirName("/workers-artifacts/topo1/port1").build();
-        File mockMetaFile = new MockFileBuilder().setFileName("worker.yaml").build();
+        try (TmpPath testDir = new TmpPath()) {
+            Path port1Dir = Files.createDirectories(testDir.getFile().toPath().resolve("workers-artifacts/topo1/port1"));
+            Path metaFile = Files.createFile(testDir.getFile().toPath().resolve("worker.yaml"));
 
-        String expId = "id12345";
-        SortedSet<File> expected = new TreeSet<>();
-        expected.add(port1Dir);
-
-        try {
+            String expId = "id12345";
+            SortedSet<Path> expected = new TreeSet<>();
+            expected.add(port1Dir);
             SupervisorUtils mockedSupervisorUtils = mock(SupervisorUtils.class);
             SupervisorUtils.setInstance(mockedSupervisorUtils);
 
             Map<String, Object> stormConf = Utils.readStormConfig();
             WorkerLogs workerLogs = new WorkerLogs(stormConf, port1Dir, new StormMetricsRegistry()) {
                 @Override
-                public Optional<File> getMetadataFileForWorkerLogDir(File logDir) throws IOException {
-                    return Optional.of(mockMetaFile);
+                public Optional<Path> getMetadataFileForWorkerLogDir(Path logDir) throws IOException {
+                    return Optional.of(metaFile);
                 }
 
                 @Override
-                public String getWorkerIdFromMetadataFile(String metaFile) {
+                public String getWorkerIdFromMetadataFile(Path metaFile) {
                     return expId;
                 }
             };
 
-            when(mockedSupervisorUtils.readWorkerHeartbeatsImpl(anyMapOf(String.class, Object.class))).thenReturn(null);
+            when(mockedSupervisorUtils.readWorkerHeartbeatsImpl(anyMap())).thenReturn(null);
             assertEquals(expected, workerLogs.getLogDirs(Collections.singleton(port1Dir), (wid) -> true));
         } finally {
             SupervisorUtils.resetInstance();


### PR DESCRIPTION
…of mocking for test files

https://issues.apache.org/jira/browse/STORM-3330

This shouldn't contain many functional changes, it's mainly replacing Strings and Files with Path. The only real logic change should be that file modification timestamps are loaded up front rather than on demand when sorting log files. The sort algorithm could act weird if timestamps change while sorting is happening.