### PR TITLE
STORM-3342: Add license-maven-plugin configuration, and describe how …

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -306,9 +306,14 @@ You can also run tests selectively with `-Dtest=<test_name>`.  This works for bo
 
 Unfortunately you might experience failures in clojure tests which are wrapped in the `maven-clojure-plugin` and thus doesn't provide too much useful output at first sight - you might end up with a maven test failure with an error message as unhelpful as `Clojure failed.`. In this case it's recommended to look into `target/test-reports` of the failed project to see what actual tests have failed or scroll through the maven output looking for obvious issues like missing binaries.
 
-By default integration tests are not run in the test phase. To run Java and Clojure integration tests you must enable the profile
+By default integration tests are not run in the test phase. To run Java and Clojure integration tests you must enable the profile `integration-tests-only`, or `all-tests`.
  
+## Listing dependency licenses
 
+You can generate a list of dependencies and their licenses by running `mvn generate-resources -Dlicense.skipAggregateAddThirdParty=false` in the project root.
+The list will be put in target/generated-sources/license/THIRD-PARTY.txt.
+
+The license aggregation plugin will use the license listed in a dependency's POM. If the license is missing, or incomplete (e.g. due to multiple licenses), you can override the license by describing the dependency in the THIRD-PARTY.properties file in the project root.
 
 <a name="packaging"></a>
 

--- a/THIRD-PARTY.properties
+++ b/THIRD-PARTY.properties
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+classworlds--classworlds--1.1-alpha-2=Apache License version 2.0
+com.twitter--carbonite--1.5.0=Apache License version 2.0
+commons-beanutils--commons-beanutils--1.7.0=Apache License version 2.0
+commons-logging--commons-logging--1.0.3=Apache License version 2.0
+io.confluent--kafka-avro-serializer--1.0=Apache License version 2.0
+io.confluent--kafka-schema-registry-client--1.0=Apache License version 2.0
+org.apache.zookeeper--zookeeper--3.4.6=Apache License version 2.0
+org.codehaus.jettison--jettison--1.1=Apache License version 2.0
+org.codehaus.plexus--plexus-container-default--1.0-alpha-9-stable-1=Apache License version 2.0
+org.jdom--jdom--1.1=Apache License version 2.0
+oro--oro--2.0.8=Apache License version 2.0
+
+asm--asm--3.1=BSD 3-Clause License
+asm--asm-commons--3.1=BSD 3-Clause License
+asm--asm-tree--3.1=BSD 3-Clause License
+
+javax.jms--jms--1.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
+javax.servlet--jsp-api--2.0=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
+javax.servlet--servlet-api--2.4=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
+javax.servlet--servlet-api--2.5=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
+javax.servlet.jsp--jsp-api--2.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
+javax.transaction--jta--1.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
+javax.transaction--transaction-api--1.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
+org.glassfish.jersey--jersey-bom--2.27=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <test.extra.args>-Djava.net.preferIPv4Stack=true</test.extra.args>
+        <license.skipAggregateAddThirdParty>true</license.skipAggregateAddThirdParty>
 
         <!-- dependency versions -->
         <clojure.version>1.7.0</clojure.version>
@@ -1279,6 +1280,92 @@
                                 </bannedDependencies>
                             </rules>    
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>1.17</version>
+                <inherited>false</inherited>
+                <configuration>
+                    <useMissingFile>true</useMissingFile>
+                    <missingFile>${project.basedir}/THIRD-PARTY.properties</missingFile>
+                    <aggregateMissingLicensesFile>${project.basedir}/THIRD-PARTY.properties</aggregateMissingLicensesFile>
+                    <failOnMissing>true</failOnMissing>
+                    <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                    <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByMultiLicense.ftl</fileTemplate>
+                    <excludedScopes>system,test</excludedScopes>
+                    <licenseMerges>
+                        <licenseMerge>
+                            Apache License, Version 2.0 |
+                            Apache License, version 2.0 |
+                            Apache License Version 2 |
+                            Apache License Version 2.0 |
+                            Apache License version 2.0 |
+                            Apache 2 |
+                            Apache 2.0 |
+                            Apache License, 2.0 |
+                            Apache License 2 |
+                            Apache License 2.0 |
+                            Apache Public License 2.0 |
+                            Apache Software License - Version 2.0 |
+                            Apache v2 |
+                            ASL, version 2 |
+                            The Apache License, Version 2.0 |
+                            The Apache Software License, Version 2.0
+                        </licenseMerge>
+                        <licenseMerge>
+                            BSD 3-Clause License |
+                            BSD 3-Clause |
+                            BSD 3-clause |
+                            The BSD 3-Clause License
+                        </licenseMerge>
+                        <licenseMerge>
+                            Common Development and Distribution License (CDDL) v1.0 |
+                            COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 |
+                            CDDL 1.0
+                        </licenseMerge>
+                        <licenseMerge>
+                            Common Development and Distribution License (CDDL) v1.1 | 
+                            COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 |
+                            CDDL 1.1 |
+                            Common Development and Distribution License (CDDL), Version 1.1
+                        </licenseMerge>
+                        <licenseMerge>
+                            Eclipse Public License, Version 1.0 |
+                            Eclipse Public License 1.0 |
+                            Eclipse Public License - v 1.0
+                        </licenseMerge>
+                        <licenseMerge>
+                            MIT License |
+                            The MIT License |
+                            MIT license |
+                            MIT X11 License |
+                            MIT
+                        </licenseMerge>
+                        <licenseMerge>
+                            The GNU General Public License (GPL), Version 2, With Classpath Exception |
+                            GPL2 w/ CPE
+                        </licenseMerge>
+                        <licenseMerge>
+                            GNU Lesser General Public License (LGPL), Version 2.1 |
+                            LGPL, version 2.1 |
+                            GNU Lesser General Public License Version 2.1 |
+                            GNU Lesser General Public License, version 2.1
+                        </licenseMerge>
+                        <licenseMerge>
+                            Common Public License Version 1.0 |
+                            Common Public License - v 1.0
+                        </licenseMerge>
+                    </licenseMerges>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-and-check-licenses</id>
+                        <goals>
+                            <goal>aggregate-add-third-party</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
…to use it

https://jira.apache.org/jira/browse/STORM-3342

The plugin is set to fail if a dependency is added without a license. The error message is very readable, e.g. 
```
[WARNING] There is 1 dependency with no license :
[WARNING]  - org.apache.zookeeper--zookeeper--3.4.8
```

It also warns if licenses are listed in THIRD-PARTY.properties, but not used in the build:

```
[WARNING] dependency [org.restlet.jee--org.restlet.ext.servlet--2.3.0] does not exist in project, remove it from the missing file.
```

While the plugin supports banning specific licenses, I think we should do the check manually. License names aren't guaranteed to be uniform across different dependencies (e.g. it might be "GPL" in one dependency and "GPLv3" in another), so I think checking manually when we vote on releases is probably necessary either way.