### PR TITLE
[MINOR] Update release verify script - 'sha' to 'sha512'

### DIFF
--- a/dev-tools/rc/verify-release-file.sh
+++ b/dev-tools/rc/verify-release-file.sh
@@ -50,12 +50,12 @@ else
 fi
 
 # checking SHA
-GPG_SHA_FILE="/tmp/${TARGET_FILE}_GPG.sha"
+GPG_SHA_FILE="/tmp/${TARGET_FILE}_GPG.sha512"
 gpg --print-md SHA512 ${TARGET_FILE} > ${GPG_SHA_FILE}
-SHA_TARGET_FILE="${TARGET_FILE}.sha"
+SHA_TARGET_FILE="${TARGET_FILE}.sha512"
 
 echo ">> checking SHA file... (${SHA_TARGET_FILE})"
-diff /tmp/${TARGET_FILE}_GPG.sha ${SHA_TARGET_FILE}
+diff /tmp/${TARGET_FILE}_GPG.sha512 ${SHA_TARGET_FILE}
 
 if [ $? -eq 0 ];
 then


### PR DESCRIPTION
Apache Storm's release process has changed to use sha512 instead of sha, but it is not reflected to release verify script. This patch applies to the change.