### PR TITLE
STORM-3349: Upgrade Hadoop, Hive, HDFS, HBase to latest compatible ve…

### DIFF
--- a/examples/storm-hbase-examples/src/main/java/org/apache/storm/hbase/topology/WordCountClient.java
+++ b/examples/storm-hbase-examples/src/main/java/org/apache/storm/hbase/topology/WordCountClient.java
@@ -14,9 +14,11 @@ package org.apache.storm.hbase.topology;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 
 /**
@@ -32,7 +34,7 @@ public class WordCountClient {
             config.set("hbase.rootdir", args[0]);
         }
 
-        HTable table = new HTable(config, "WordCount");
+        Table table = ConnectionFactory.createConnection(config).getTable(TableName.valueOf("WordCount"));
 
 
         for (String word : WordSpout.words) {

--- a/examples/storm-jms-examples/pom.xml
+++ b/examples/storm-jms-examples/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>storm-jms-examples</artifactId>
 
     <properties>
-        <spring.version>5.0.4.RELEASE</spring.version>
+        <spring.version>5.1.5.RELEASE</spring.version>
     </properties>
     <dependencies>
         <dependency>

--- a/external/storm-autocreds/pom.xml
+++ b/external/storm-autocreds/pom.xml
@@ -108,6 +108,22 @@
             </exclusions>
         </dependency>
         <dependency>
+            <!-- Needed for TokenUtil, which moved here from hbase-client -->
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-server</artifactId>
+            <version>${hbase.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hive.hcatalog</groupId>
             <artifactId>hive-hcatalog-streaming</artifactId>
             <version>${hive.version}</version>

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/common/HBaseClient.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/common/HBaseClient.java
@@ -22,13 +22,13 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.storm.hbase.bolt.mapper.HBaseProjectionCriteria;
 import org.apache.storm.hbase.security.HBaseSecurityUtil;
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public class HBaseClient implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(HBaseClient.class);
 
-    private HTable table;
+    private Table table;
 
     public HBaseClient(Map<String, Object> map, final Configuration configuration, final String tableName) {
         try {
@@ -60,14 +60,14 @@ public class HBaseClient implements Closeable {
             put.setDurability(durability);
             for (ColumnList.Column col : cols.getColumns()) {
                 if (col.getTs() > 0) {
-                    put.add(
+                    put.addColumn(
                         col.getFamily(),
                         col.getQualifier(),
                         col.getTs(),
                         col.getValue()
                     );
                 } else {
-                    put.add(
+                    put.addColumn(
                         col.getFamily(),
                         col.getQualifier(),
                         col.getValue()
@@ -82,9 +82,9 @@ public class HBaseClient implements Closeable {
             inc.setDurability(durability);
             for (ColumnList.Counter cnt : cols.getCounters()) {
                 inc.addColumn(
-                    cnt.getFamily(),
-                    cnt.getQualifier(),
-                    cnt.getIncrement()
+                        cnt.getFamily(),
+                        cnt.getQualifier(),
+                        cnt.getIncrement()
                 );
             }
             mutations.add(inc);

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/common/Utils.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/common/Utils.java
@@ -16,7 +16,9 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.security.PrivilegedExceptionAction;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -31,7 +33,7 @@ public class Utils {
 
     private Utils() {}
 
-    public static HTable getTable(UserProvider provider, Configuration config, String tableName)
+    public static Table getTable(UserProvider provider, Configuration config, String tableName)
         throws IOException, InterruptedException {
         UserGroupInformation ugi;
         if (provider != null) {
@@ -74,10 +76,10 @@ public class Utils {
             }
         }
 
-        return ugi.doAs(new PrivilegedExceptionAction<HTable>() {
+        return ugi.doAs(new PrivilegedExceptionAction<Table>() {
             @Override
-            public HTable run() throws IOException {
-                return new HTable(config, tableName);
+            public Table run() throws IOException {
+                return ConnectionFactory.createConnection(config).getTable(TableName.valueOf(tableName));
             }
         });
     }

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/state/HBaseMapState.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/state/HBaseMapState.java
@@ -28,10 +28,10 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.storm.hbase.common.Utils;
 import org.apache.storm.hbase.security.HBaseSecurityUtil;
@@ -72,7 +72,7 @@ public class HBaseMapState<T> implements IBackingMap<T> {
     private int partitionNum;
     private Options<T> options;
     private Serializer<T> serializer;
-    private HTable table;
+    private Table table;
 
     /**
      * Constructor.
@@ -183,7 +183,7 @@ public class HBaseMapState<T> implements IBackingMap<T> {
                      new Object[]{ this.partitionNum, new String(hbaseKey), new String(this.serializer.serialize(values.get(i))) });
             Put put = new Put(hbaseKey);
             T val = values.get(i);
-            put.add(this.options.columnFamily.getBytes(),
+            put.addColumn(this.options.columnFamily.getBytes(),
                     qualifier.getBytes(),
                     this.serializer.serialize(val));
 

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -154,6 +154,7 @@
         <artifactId>java-hamcrest</artifactId>
     </dependency>
     <dependency>
+        <!-- Needed in this version by hive -->
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
       <version>0.9.3</version>

--- a/flux/flux-examples/src/main/java/org/apache/storm/flux/examples/WordCountClient.java
+++ b/flux/flux-examples/src/main/java/org/apache/storm/flux/examples/WordCountClient.java
@@ -23,9 +23,11 @@ import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.util.Bytes;
 
 /**
@@ -61,7 +63,7 @@ public class WordCountClient {
             System.exit(1);
         }
 
-        HTable table = new HTable(config, "WordCount");
+        Table table = ConnectionFactory.createConnection(config).getTable(TableName.valueOf("WordCount"));
         String[] words = new String[] {"nathan", "mike", "jackson", "golda", "bertels"};
 
         for (String word : words) {

--- a/pom.xml
+++ b/pom.xml
@@ -287,10 +287,10 @@
         <mockito.version>2.19.0</mockito.version>
         <zookeeper.version>3.4.6</zookeeper.version>
         <jline.version>0.9.94</jline.version>
-        <hive.version>2.3.3</hive.version>
-        <hadoop.version>2.6.1</hadoop.version>
+        <hive.version>2.3.4</hive.version>
+        <hadoop.version>2.8.5</hadoop.version>
         <hdfs.version>${hadoop.version}</hdfs.version>
-        <hbase.version>1.4.4</hbase.version>
+        <hbase.version>2.1.3</hbase.version>
         <kryo.version>3.0.3</kryo.version>
         <servlet.version>3.1.0</servlet.version>
         <joda-time.version>2.3</joda-time.version>
@@ -301,7 +301,6 @@
         <hdrhistogram.version>2.1.10</hdrhistogram.version>
         <hamcrest.version>2.0.0.0</hamcrest.version>
         <cassandra.version>2.1.7</cassandra.version>
-        <druid.version>0.8.2</druid.version>
         <elasticsearch.version>5.2.2</elasticsearch.version>
         <calcite.version>1.14.0</calcite.version>
         <mongodb.version>3.2.0</mongodb.version>
@@ -1083,6 +1082,62 @@
                        <artifactId>log4j</artifactId>
                    </exclusion>
                 </exclusions>
+           </dependency>
+           <!-- Hadoop dependencies. Specified here so HDFS/HBase don't import older versions of these jars in their projects-->
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-auth</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-hdfs</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-common</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-annotations</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-mapreduce-client-core</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-yarn-common</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-yarn-server-applicationhistoryservice</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-yarn-server-web-proxy</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-yarn-registry</artifactId>
+               <version>${hadoop.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>org.apache.hadoop</groupId>
+               <artifactId>hadoop-archives</artifactId>
+               <version>${hadoop.version}</version>
            </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
…rsions

https://jira.apache.org/jira/browse/STORM-3349

Testing is limited to the unit tests. I went by the compatibility table at http://hbase.apache.org/book.html#hadoop. Hive docs indicate that 2.3.4 is compatible with all 2.x versions of Hadoop.

I bumped the Spring version in an example as well.

I saw a test failure in JCQueueTest due to a timeout. I don't think we need the test to run 100 times, and if we do we should use `@RepeatedTest` to do it. Removed the repeat runs.