### PR TITLE
STORM-3352: Lock Netty versions using Netty BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -946,8 +946,10 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-all</artifactId>
+                <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3352

The dependency tree for storm-cassandra previously showed
```
org.apache.storm:storm-cassandra:jar:2.0.1-SNAPSHOT
[INFO] +- com.datastax.cassandra:cassandra-driver-core:jar:3.1.2:provided
[INFO] |  +- io.netty:netty-handler:jar:4.0.37.Final:provided
[INFO] |  |  +- io.netty:netty-buffer:jar:4.0.37.Final:provided
[INFO] |  |  |  \- io.netty:netty-common:jar:4.0.37.Final:provided
[INFO] |  |  +- io.netty:netty-transport:jar:4.0.37.Final:provided
[INFO] |  |  \- io.netty:netty-codec:jar:4.0.37.Final:provided
...
- io.netty:netty-all:jar:4.1.30.Final:test
```
which is likely to cause issues.