### PR TITLE
STORM-3354: Fix Nimbus not reentering leadership election in some cas…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/StormServerHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/StormServerHandler.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 public class StormServerHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(StormServerHandler.class);
-    private static final Set<Class> ALLOWED_EXCEPTIONS = new HashSet<>(Arrays.asList(new Class[]{ IOException.class }));
+    private static final Set<Class<?>> ALLOWED_EXCEPTIONS = new HashSet<>(Arrays.asList(new Class<?>[]{ IOException.class }));
     private final IServer server;
     private final AtomicInteger failure_count;
 

--- a/storm-client/src/jvm/org/apache/storm/nimbus/ILeaderElector.java
+++ b/storm-client/src/jvm/org/apache/storm/nimbus/ILeaderElector.java
@@ -12,7 +12,6 @@
 
 package org.apache.storm.nimbus;
 
-import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -21,7 +20,7 @@ import org.apache.storm.shade.com.google.common.annotations.VisibleForTesting;
 /**
  * The interface for leader election.
  */
-public interface ILeaderElector extends Closeable {
+public interface ILeaderElector extends AutoCloseable {
 
     /**
      * Method guaranteed to be called as part of initialization of leader elector instance.
@@ -37,11 +36,11 @@ public interface ILeaderElector extends Closeable {
     void addToLeaderLockQueue() throws Exception;
 
     /**
-     * Removes the caller from the leader lock queue. If the caller is leader
-     * also releases the lock. This method can be called multiple times so it needs
-     * to be idempotent.
+     * Removes the caller from leadership election, relinquishing leadership if acquired, then requeues for leadership after the specified
+     * delay.
+     * @param delayMs The delay to wait before re-entering the election
      */
-    void removeFromLeaderLockQueue() throws Exception;
+    void quitElectionFor(int delayMs) throws Exception;
 
     /**
      * Decide if the caller currently has the leader lock.
@@ -51,7 +50,7 @@ public interface ILeaderElector extends Closeable {
 
     /**
      * Get the current leader's address.
-     * @return the current leader's address , may return null if no one has the lock.
+     * @return the current leader's address, may return null if no one has the lock.
      */
     NimbusInfo getLeader();
     
@@ -71,9 +70,9 @@ public interface ILeaderElector extends Closeable {
     List<NimbusInfo> getAllNimbuses() throws Exception;
 
     /**
-     * Method called to allow for cleanup. once close this object can not be reused.
+     * Method called to allow for cleanup. Relinquishes leadership if owned by the caller.
      */
     @Override
-    void close();
+    void close() throws Exception;
 }
 

--- a/storm-core/src/jvm/org/apache/storm/testing/MockLeaderElector.java
+++ b/storm-core/src/jvm/org/apache/storm/testing/MockLeaderElector.java
@@ -47,7 +47,7 @@ public class MockLeaderElector implements ILeaderElector {
     }
 
     @Override
-    public void removeFromLeaderLockQueue() throws Exception {
+    public void quitElectionFor(int delayMs) throws Exception {
         //NOOP
     }
 

--- a/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStore.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStore.java
@@ -171,7 +171,7 @@ public class LocalFsBlobStore extends BlobStore {
                 sync.setZookeeperKeySet(zkKeys);
                 sync.setZkClient(zkClient);
                 sync.syncBlobs();
-            } //else not leader (NOOP)
+            } //else leader (NOOP)
         } //else local (NOOP)
     }
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -455,7 +455,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     private MetricStore metricsStore;
     private IAuthorizer authorizationHandler;
     //Cached CuratorFramework, mainly used for BlobStore.
-    private CuratorFramework zkClient;
+    private final CuratorFramework zkClient;
     //Cached topology -> executor ids, used for deciding timeout workers of heartbeatsCache.
     private AtomicReference<Map<String, Set<List<Integer>>>> idToExecutors;
     //May be null if worker tokens are not supported by the thrift transport.
@@ -4625,9 +4625,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             if (actionNotifier != null) {
                 actionNotifier.cleanup();
             }
-            if (zkClient != null) {
-                zkClient.close();
-            }
+            zkClient.close();
             if (metricsStore != null) {
                 metricsStore.close();
             }

--- a/storm-server/src/main/java/org/apache/storm/nimbus/LeaderListenerCallback.java
+++ b/storm-server/src/main/java/org/apache/storm/nimbus/LeaderListenerCallback.java
@@ -23,6 +23,7 @@ import javax.security.auth.Subject;
 import com.codahale.metrics.Meter;
 import org.apache.commons.io.IOUtils;
 import org.apache.storm.Config;
+import org.apache.storm.DaemonConfig;
 import org.apache.storm.blobstore.BlobStore;
 import org.apache.storm.blobstore.InputStreamWithMeta;
 import org.apache.storm.cluster.ClusterUtils;
@@ -39,6 +40,7 @@ import org.apache.storm.shade.org.apache.curator.framework.CuratorFramework;
 import org.apache.storm.shade.org.apache.curator.framework.recipes.leader.LeaderLatch;
 import org.apache.storm.shade.org.apache.zookeeper.CreateMode;
 import org.apache.storm.shade.org.apache.zookeeper.data.ACL;
+import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.zookeeper.ClientZookeeper;
 import org.slf4j.Logger;
@@ -60,31 +62,35 @@ public class LeaderListenerCallback {
     private final TopoCache tc;
     private final IStormClusterState clusterState;
     private final CuratorFramework zk;
-    private final LeaderLatch leaderLatch;
+    private final ILeaderElector leaderElector;
     private final Map conf;
     private final List<ACL> acls;
+    private final int requeueDelayMs;
 
     /**
      * Constructor for {@LeaderListenerCallback}.
      * @param conf config
      * @param zk zookeeper CuratorFramework client
-     * @param leaderLatch LeaderLatch
      * @param blobStore BlobStore
+     * @param leaderElector Leader elector
      * @param tc TopoCache
      * @param clusterState IStormClusterState
      * @param acls zookeeper acls
      */
-    public LeaderListenerCallback(Map conf, CuratorFramework zk, LeaderLatch leaderLatch, BlobStore blobStore,
+    public LeaderListenerCallback(Map conf, CuratorFramework zk, BlobStore blobStore, ILeaderElector leaderElector,
                                   TopoCache tc, IStormClusterState clusterState, List<ACL> acls, StormMetricsRegistry metricsRegistry) {
         this.blobStore = blobStore;
         this.tc = tc;
         this.clusterState = clusterState;
         this.zk = zk;
-        this.leaderLatch = leaderLatch;
+        this.leaderElector = leaderElector;
         this.conf = conf;
         this.acls = acls;
         this.numGainedLeader = metricsRegistry.registerMeter("nimbus:num-gained-leadership");
         this.numLostLeader = metricsRegistry.registerMeter("nimbus:num-lost-leadership");
+        //Since we only give up leadership if we're waiting for blobs to sync,
+        //it makes sense to wait a full sync cycle before trying for leadership again.
+        this.requeueDelayMs = ObjectReader.getInt(conf.get(DaemonConfig.NIMBUS_CODE_SYNC_FREQ_SECS))*1000;
     }
 
     /**
@@ -129,11 +135,11 @@ public class LeaderListenerCallback {
             } else {
                 LOG.info("Code for all active topologies is available locally, but some dependencies are not found locally, "
                          + "giving up leadership.");
-                closeLatch();
+                surrenderLeadership();
             }
         } else {
             LOG.info("code for all active topologies not available locally, giving up leadership.");
-            closeLatch();
+            surrenderLeadership();
         }
     }
 
@@ -218,11 +224,11 @@ public class LeaderListenerCallback {
         return activeTopologyDependencies;
     }
 
-    private void closeLatch() {
+    private void surrenderLeadership() {
         try {
-            leaderLatch.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            leaderElector.quitElectionFor(requeueDelayMs);
+        } catch (Exception e) {
+            throw Utils.wrapInRuntime(e);
         }
     }
 

--- a/storm-server/src/main/java/org/apache/storm/zookeeper/LeaderListenerCallbackFactory.java
+++ b/storm-server/src/main/java/org/apache/storm/zookeeper/LeaderListenerCallbackFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.zookeeper;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
+import org.apache.storm.blobstore.BlobStore;
+import org.apache.storm.cluster.IStormClusterState;
+import org.apache.storm.daemon.nimbus.TopoCache;
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.nimbus.ILeaderElector;
+import org.apache.storm.nimbus.LeaderListenerCallback;
+import org.apache.storm.shade.org.apache.curator.framework.CuratorFramework;
+import org.apache.storm.shade.org.apache.curator.framework.recipes.leader.LeaderLatchListener;
+import org.apache.storm.shade.org.apache.zookeeper.data.ACL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LeaderListenerCallbackFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LeaderListenerCallbackFactory.class);
+    
+    private final Map<String, Object> conf;
+    private final CuratorFramework zk;
+    private final BlobStore blobStore;
+    private final TopoCache tc;
+    private final IStormClusterState clusterState;
+    private final List<ACL> acls;
+    private final StormMetricsRegistry metricsRegistry;
+
+    public LeaderListenerCallbackFactory(Map<String, Object> conf, CuratorFramework zk, BlobStore blobStore, TopoCache tc,
+        IStormClusterState clusterState, List<ACL> acls, StormMetricsRegistry metricsRegistry) {
+        this.conf = conf;
+        this.zk = zk;
+        this.blobStore = blobStore;
+        this.tc = tc;
+        this.clusterState = clusterState;
+        this.acls = acls;
+        this.metricsRegistry = metricsRegistry;
+    }
+    
+    public LeaderLatchListener create(ILeaderElector elector) throws UnknownHostException {
+        final LeaderListenerCallback callback = new LeaderListenerCallback(conf, zk, blobStore, elector,
+            tc, clusterState, acls, metricsRegistry);
+        final String hostName = InetAddress.getLocalHost().getCanonicalHostName();
+        return new LeaderLatchListener() {
+
+            @Override
+            public void isLeader() {
+                callback.leaderCallBack();
+                LOG.info("{} gained leadership.", hostName);
+            }
+
+            @Override
+            public void notLeader() {
+                LOG.info("{} lost leadership.", hostName);
+                //Just to be sure
+                callback.notLeaderCallback();
+            }
+        };
+    }
+    
+}


### PR DESCRIPTION
…es, and quit leadership election cleanly when Nimbus shuts down

https://issues.apache.org/jira/browse/STORM-3354

There are two issues here. 

First that the LeaderElectorImp doesn't close the LeaderLatch when closed, which can cause a crash during Nimbus shutdown. 

Second that if LeaderListenerCallback.leaderCallback decides not to be leader due to missing blobs, I believe Nimbus will stop trying to acquire leadership entirely. I haven't seen this happen, but I can't find any code that restarts the LeaderLatch.