### PR TITLE
STORM-3363: Migrate Aether to maven-resolver as Aether is donated to ASF

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -198,8 +198,8 @@ def resolve_dependencies(artifacts, artifact_repositories, maven_local_repos_dir
         JAVA_CMD, "-client", "-cp", classpath, "org.apache.storm.submit.command.DependencyResolverMain"
     ]
 
-    command.extend(["--artifacts", ",".join(artifacts)])
-    command.extend(["--artifactRepositories", ",".join(artifact_repositories)])
+    command.extend(["--artifacts", artifacts])
+    command.extend(["--artifactRepositories", artifact_repositories])
 
     if maven_local_repos_dir is not None:
         command.extend(["--mavenLocalRepositoryDirectory", maven_local_repos_dir])

--- a/pom.xml
+++ b/pom.xml
@@ -320,9 +320,8 @@
         <clojure.test.set>!integration.*</clojure.test.set>
         <skipITs>true</skipITs>
 
-        <aetherVersion>1.1.0</aetherVersion>
-        <mavenVersion>3.1.0</mavenVersion>
-        <wagonVersion>1.0</wagonVersion>
+        <maven-resolver.version>1.3.3</maven-resolver.version>
+        <maven.version>3.6.0</maven.version>
         <azure-eventhubs.version>0.13.1</azure-eventhubs.version>
         <jersey.version>2.27</jersey.version>
         <dropwizard.version>1.3.5</dropwizard.version>

--- a/storm-submit-tools/pom.xml
+++ b/storm-submit-tools/pom.xml
@@ -45,89 +45,52 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
 
-        <!-- Aether :: maven dependency resolution -->
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-api</artifactId>
-            <version>${aetherVersion}</version>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+            <version>${maven-resolver.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-spi</artifactId>
-            <version>${aetherVersion}</version>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-spi</artifactId>
+            <version>${maven-resolver.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-util</artifactId>
-            <version>${aetherVersion}</version>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+            <version>${maven-resolver.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-impl</artifactId>
-            <version>${aetherVersion}</version>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-impl</artifactId>
+            <version>${maven-resolver.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-connector-basic</artifactId>
-            <version>${aetherVersion}</version>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-connector-basic</artifactId>
+            <version>${maven-resolver.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-file</artifactId>
-            <version>${aetherVersion}</version>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-file</artifactId>
+            <version>${maven-resolver.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-http</artifactId>
-            <version>${aetherVersion}</version>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-http</artifactId>
+            <version>${maven-resolver.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-aether-provider</artifactId>
-            <version>${mavenVersion}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>3.1.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.sisu</groupId>
-            <artifactId>org.eclipse.sisu.plexus</artifactId>
-            <version>0.1.1</version>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.enterprise</groupId>
-                    <artifactId>cdi-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.sonatype.sisu</groupId>
-            <artifactId>sisu-guice</artifactId>
-            <version>3.1.6</version>
-            <classifier>no_aop</classifier>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>aopalliance</groupId>
-                    <artifactId>aopalliance</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>jsr305</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>maven-resolver-provider</artifactId>
+            <version>${maven.version}</version>
         </dependency>
 
         <!-- storm-client is needed only for test (surefire) -->

--- a/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/RepositorySystemFactory.java
+++ b/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/RepositorySystemFactory.java
@@ -18,14 +18,15 @@
 
 package org.apache.storm.submit.dependency;
 
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
 import org.eclipse.aether.impl.DefaultServiceLocator;
-import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
-import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
 import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 
 /**
  * Get maven repository instance.


### PR DESCRIPTION
Please refer [STORM-3363](https://issues.apache.org/jira/browse/STORM-3363) for more details.

Other than migrating Aether to maven-resolver, this patch also contains a minor fix which storm cli incorrectly parses `artifacts` and `artifactRepositories`. Looks like STORM-3274 changed the behavior but not tested the case.
(Oddly my local dev. cannot run tests because of somewhat issue with `mock` and `python3`. I'll see whether the change breaks cli test in Travis CI build, and fix it if any.)