### PR TITLE
[STORM-3365] Configuration to disable Topology Lag Monitoring

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -98,6 +98,7 @@ ui.header.buffer.bytes: 4096
 ui.http.creds.plugin: org.apache.storm.security.auth.DefaultHttpCredentialsPlugin
 ui.pagination: 20
 ui.disable.http.binding: true
+ui.disable.spout.lag.monitoring: true
 
 logviewer.port: 8000
 logviewer.childopts: "-Xmx128m"

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -317,6 +317,12 @@ public class DaemonConfig implements Validated {
     public static final String UI_DISABLE_HTTP_BINDING = "ui.disable.http.binding";
 
     /**
+     * This controls whether Storm UI would not monitor Spout lag.
+     */
+    @isBoolean
+    public static final String UI_DISABLE_SPOUT_LAG_MONITORING = "ui.disable.spout.lag.monitoring";
+
+    /**
      * This controls wheather Storm Logviewer should bind to http port even if logviewer.port is > 0.
      */
     @isBoolean

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -317,7 +317,7 @@ public class DaemonConfig implements Validated {
     public static final String UI_DISABLE_HTTP_BINDING = "ui.disable.http.binding";
 
     /**
-     * This controls whether Storm UI would not monitor Spout lag.
+     * This controls whether Storm UI displays spout lag for the Kafka spout.
      */
     @isBoolean
     public static final String UI_DISABLE_SPOUT_LAG_MONITORING = "ui.disable.spout.lag.monitoring";

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -1619,7 +1619,7 @@ public class UIHelpers {
      * @return getTopologyLag.
      */
     public static Map<String, Map<String, Object>> getTopologyLag(StormTopology userTopology, Map<String,Object> config) {
-        Boolean disableLagMonitoring = ObjectReader.getBoolean(config.get(DaemonConfig.UI_DISABLE_SPOUT_LAG_MONITORING), false);
+        Boolean disableLagMonitoring = (Boolean)(config.get(DaemonConfig.UI_DISABLE_SPOUT_LAG_MONITORING));
         return disableLagMonitoring ? Collections.EMPTY_MAP : TopologySpoutLag.lag(userTopology, config);
     }
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -1618,7 +1619,8 @@ public class UIHelpers {
      * @return getTopologyLag.
      */
     public static Map<String, Map<String, Object>> getTopologyLag(StormTopology userTopology, Map<String,Object> config) {
-        return TopologySpoutLag.lag(userTopology, config);
+        Boolean disableLagMonitoring = ObjectReader.getBoolean(config.get(DaemonConfig.UI_DISABLE_SPOUT_LAG_MONITORING), false);
+        return disableLagMonitoring ? Collections.EMPTY_MAP : TopologySpoutLag.lag(userTopology, config);
     }
 
     /**


### PR DESCRIPTION
Sometimes Kafka broker is unreachable/security can cause issue..making UI hang for too long.  So adding feature to allow disabling Topology Lag monitoring.