### PR TITLE
STORM-3366 allow configuring workers to have a minimum cpu percentage

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -389,6 +389,8 @@ storm.supervisor.low.memory.threshold.mb: 1024
 storm.supervisor.medium.memory.threshold.mb: 1536
 storm.supervisor.medium.memory.grace.period.ms: 30000
 
+storm.worker.min.cpu.pcore.percent: 0.0
+
 storm.topology.classpath.beginning.enabled: false
 worker.metrics:
     "CGroupMemory": "org.apache.storm.metric.cgroup.CGroupMemoryUsage"

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -1126,6 +1126,17 @@ public class DaemonConfig implements Validated {
     public static String STORM_SUPERVISOR_MEDIUM_MEMORY_GRACE_PERIOD_MS =
         "storm.supervisor.medium.memory.grace.period.ms";
 
+    /**
+     * The config indicates the minimum percentage of cpu for a core that a worker will use. Assuming the a core value to be
+     * 100, a value of 10 indicates 10% of the core. The P in PCORE represents the term "physical".  A default value will be set for this
+     * config if user does not override.
+     * <P></P>
+     * Workers in containers or cgroups may require a minimum amount of CPU in order to launch within the supervisor timeout.
+     * This setting allows configuring this to occur.
+     */
+    @isPositiveNumber(includeZero = true)
+    public static String STORM_WORKER_MIN_CPU_PCORE_PERCENT = "storm.worker.min.cpu.pcore.percent";
+
     // VALIDATION ONLY CONFIGS
     // Some configs inside Config.java may reference classes we don't want to expose in storm-client, but we still want to validate
     // That they reference a valid class.  To allow this to happen we do part of the validation on the client side with annotations on

--- a/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.storm.Config;
 import org.apache.storm.Constants;
+import org.apache.storm.DaemonConfig;
 import org.apache.storm.daemon.nimbus.TopologyResources;
 import org.apache.storm.generated.SharedMemory;
 import org.apache.storm.generated.WorkerResources;
@@ -85,6 +86,7 @@ public class Cluster implements ISchedulingState {
     private SchedulerAssignmentImpl assignment;
     private Set<String> blackListedHosts = new HashSet<>();
     private INimbus inimbus;
+    private double minWorkerCpu = 0.0;
 
     public Cluster(
         INimbus nimbus,
@@ -157,6 +159,7 @@ public class Cluster implements ISchedulingState {
         }
         this.conf = conf;
         this.topologies = topologies;
+        this.minWorkerCpu = ObjectReader.getDouble(conf.get(DaemonConfig.STORM_WORKER_MIN_CPU_PCORE_PERCENT), 0.0);
 
         ArrayList<String> supervisorHostNames = new ArrayList<>();
         for (SupervisorDetails s : supervisors.values()) {
@@ -473,7 +476,7 @@ public class Cluster implements ISchedulingState {
         for (SchedulerAssignment assignment: assignments.values()) {
             for (Entry<WorkerSlot, WorkerResources> entry: assignment.getScheduledResources().entrySet()) {
                 if (sd.getId().equals(entry.getKey().getNodeId())) {
-                   ret.remove(entry.getValue(), getResourceMetrics());
+                    ret.remove(entry.getValue(), getResourceMetrics());
                 }
             }
         }
@@ -513,11 +516,19 @@ public class Cluster implements ISchedulingState {
             );
         }
         sharedTotalResources = NormalizedResources.RESOURCE_NAME_NORMALIZER.normalizedResourceMap(sharedTotalResources);
-        WorkerResources ret = new WorkerResources();
-        ret.set_resources(totalResources.toNormalizedMap());
-        ret.set_shared_resources(sharedTotalResources);
 
-        ret.set_cpu(totalResources.getTotalCpu());
+        Map<String, Double> totalResourcesMap = totalResources.toNormalizedMap();
+        Double cpu = totalResources.getTotalCpu();
+        if (cpu < minWorkerCpu) {
+            cpu = minWorkerCpu;
+            totalResourcesMap.put(Constants.COMMON_CPU_RESOURCE_NAME, cpu);
+        }
+
+        WorkerResources ret = new WorkerResources();
+        ret.set_resources(totalResourcesMap);
+        ret.set_shared_resources(sharedTotalResources);
+        ret.set_cpu(cpu);
+
         ret.set_mem_off_heap(totalResources.getOffHeapMemoryMb());
         ret.set_mem_on_heap(totalResources.getOnHeapMemoryMb());
         ret.set_shared_mem_off_heap(
@@ -548,6 +559,9 @@ public class Cluster implements ISchedulingState {
         double afterTotal = 0.0;
         double afterOnHeap = 0.0;
 
+        double currentCpuTotal = 0.0;
+        double afterCpuTotal = 0.0;
+
         Set<ExecutorDetails> wouldBeAssigned = new HashSet<>();
         wouldBeAssigned.add(exec);
         SchedulerAssignmentImpl assignment = assignments.get(td.getId());
@@ -558,6 +572,7 @@ public class Cluster implements ISchedulingState {
                 wouldBeAssigned.addAll(currentlyAssigned);
                 WorkerResources wrCurrent = calculateWorkerResources(td, currentlyAssigned);
                 currentTotal = wrCurrent.get_mem_off_heap() + wrCurrent.get_mem_on_heap();
+                currentCpuTotal = wrCurrent.get_cpu();
             }
             WorkerResources wrAfter = calculateWorkerResources(td, wouldBeAssigned);
             afterTotal = wrAfter.get_mem_off_heap() + wrAfter.get_mem_on_heap();
@@ -565,6 +580,25 @@ public class Cluster implements ISchedulingState {
 
             currentTotal += calculateSharedOffHeapMemory(ws.getNodeId(), assignment);
             afterTotal += calculateSharedOffHeapMemory(ws.getNodeId(), assignment, exec);
+            afterCpuTotal = wrAfter.get_cpu();
+        } else {
+            WorkerResources wrAfter = calculateWorkerResources(td, wouldBeAssigned);
+            afterCpuTotal = wrAfter.get_cpu();
+        }
+
+        double cpuAdded = afterCpuTotal - currentCpuTotal;
+        double cpuAvailable = resourcesAvailable.getTotalCpu();
+
+        if (cpuAdded > cpuAvailable) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Could not schedule {}:{} on {} not enough CPU {} > {}",
+                        td.getName(),
+                        exec,
+                        ws,
+                        cpuAdded,
+                        cpuAvailable);
+            }
+            return false;
         }
 
         double memoryAdded = afterTotal - currentTotal;
@@ -967,7 +1001,7 @@ public class Cluster implements ISchedulingState {
     }
 
     /**
-     * This medhod updates ScheduledResources and UsedSlots cache for given workerSlot.
+     * This method updates ScheduledResources and UsedSlots cache for given workerSlot.
      */
     private void updateCachesForWorkerSlot(WorkerSlot workerSlot, WorkerResources workerResources, Double sharedoffHeapMemory) {
         String nodeId = workerSlot.getNodeId();


### PR DESCRIPTION
While testing supporting a fixed maximum CPU limit, we found that workers with small amounts of CPU failed to start within the configured timeout period.  This PR allows configuring a minimum threshold of CPU for a worker to allow them to come up within a reasonable amount of time.