### PR TITLE
STORM-3371: Metrics v2 in Trident operations

### DIFF
--- a/examples/storm-perf/src/main/java/org/apache/storm/perf/JCQueuePerfTest.java
+++ b/examples/storm-perf/src/main/java/org/apache/storm/perf/JCQueuePerfTest.java
@@ -19,6 +19,7 @@
 package org.apache.storm.perf;
 
 import java.util.concurrent.locks.LockSupport;
+import org.apache.storm.metrics2.StormMetricRegistry;
 import org.apache.storm.policy.WaitStrategyPark;
 import org.apache.storm.utils.JCQueue;
 import org.apache.storm.utils.MutableLong;
@@ -45,8 +46,9 @@ public class JCQueuePerfTest {
 
     private static void ackingProducerSimulation() {
         WaitStrategyPark ws = new WaitStrategyPark(100);
-        JCQueue spoutQ = new JCQueue("spoutQ", 1024, 0, 100, ws, "test", "test", 1000, 1000);
-        JCQueue ackQ = new JCQueue("ackQ", 1024, 0, 100, ws, "test", "test", 1000, 1000);
+        StormMetricRegistry registry = new StormMetricRegistry();
+        JCQueue spoutQ = new JCQueue("spoutQ", 1024, 0, 100, ws, "test", "test", 1000, 1000, registry);
+        JCQueue ackQ = new JCQueue("ackQ", 1024, 0, 100, ws, "test", "test", 1000, 1000, registry);
 
         final AckingProducer ackingProducer = new AckingProducer(spoutQ, ackQ);
         final Acker acker = new Acker(ackQ, spoutQ);
@@ -56,8 +58,9 @@ public class JCQueuePerfTest {
 
     private static void producerFwdConsumer(int prodBatchSz) {
         WaitStrategyPark ws = new WaitStrategyPark(100);
-        JCQueue q1 = new JCQueue("q1", 1024, 0, prodBatchSz, ws, "test", "test", 1000, 1000);
-        JCQueue q2 = new JCQueue("q2", 1024, 0, prodBatchSz, ws, "test", "test", 1000, 1000);
+        StormMetricRegistry registry = new StormMetricRegistry();
+        JCQueue q1 = new JCQueue("q1", 1024, 0, prodBatchSz, ws, "test", "test", 1000, 1000, registry);
+        JCQueue q2 = new JCQueue("q2", 1024, 0, prodBatchSz, ws, "test", "test", 1000, 1000, registry);
 
         final Producer prod = new Producer(q1);
         final Forwarder fwd = new Forwarder(q1, q2);
@@ -68,7 +71,8 @@ public class JCQueuePerfTest {
 
 
     private static void oneProducer1Consumer(int prodBatchSz) {
-        JCQueue q1 = new JCQueue("q1", 50_000, 0, prodBatchSz, new WaitStrategyPark(100), "test", "test", 1000, 1000);
+        JCQueue q1 = new JCQueue("q1", 50_000, 0, prodBatchSz, new WaitStrategyPark(100), "test", "test", 1000, 1000,
+            new StormMetricRegistry());
 
         final Producer prod1 = new Producer(q1);
         final Consumer cons1 = new Consumer(q1);
@@ -77,7 +81,8 @@ public class JCQueuePerfTest {
     }
 
     private static void twoProducer1Consumer(int prodBatchSz) {
-        JCQueue q1 = new JCQueue("q1", 50_000, 0, prodBatchSz, new WaitStrategyPark(100), "test", "test", 1000, 1000);
+        JCQueue q1 = new JCQueue("q1", 50_000, 0, prodBatchSz, new WaitStrategyPark(100), "test", "test", 1000, 1000,
+            new StormMetricRegistry());
 
         final Producer prod1 = new Producer(q1);
         final Producer prod2 = new Producer(q1);
@@ -87,7 +92,8 @@ public class JCQueuePerfTest {
     }
 
     private static void threeProducer1Consumer(int prodBatchSz) {
-        JCQueue q1 = new JCQueue("q1", 50_000, 0, prodBatchSz, new WaitStrategyPark(100), "test", "test", 1000, 1000);
+        JCQueue q1 = new JCQueue("q1", 50_000, 0, prodBatchSz, new WaitStrategyPark(100), "test", "test", 1000, 1000,
+            new StormMetricRegistry());
 
         final Producer prod1 = new Producer(q1);
         final Producer prod2 = new Producer(q1);
@@ -100,8 +106,9 @@ public class JCQueuePerfTest {
 
     private static void oneProducer2Consumers(int prodBatchSz) {
         WaitStrategyPark ws = new WaitStrategyPark(100);
-        JCQueue q1 = new JCQueue("q1", 1024, 0, prodBatchSz, ws, "test", "test", 1000, 1000);
-        JCQueue q2 = new JCQueue("q2", 1024, 0, prodBatchSz, ws, "test", "test", 1000, 1000);
+        StormMetricRegistry registry = new StormMetricRegistry();
+        JCQueue q1 = new JCQueue("q1", 1024, 0, prodBatchSz, ws, "test", "test", 1000, 1000, registry);
+        JCQueue q2 = new JCQueue("q2", 1024, 0, prodBatchSz, ws, "test", "test", 1000, 1000, registry);
 
         final Producer2 prod1 = new Producer2(q1, q2);
         final Consumer cons1 = new Consumer(q1);

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/format/TestSimpleFileNameFormat.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/bolt/format/TestSimpleFileNameFormat.java
@@ -72,6 +72,6 @@ public class TestSimpleFileNameFormat {
         Map<Integer, String> taskToComponent = new HashMap<Integer, String>();
         taskToComponent.put(7, "Xcom");
         return new TopologyContext(null, topoConf, taskToComponent, null, null, null, null, null, null, 7, 6703, null, null, null, null,
-                                   null, null);
+                                   null, null, null);
     }
 }

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -772,12 +772,7 @@ public class TestHdfsSpout {
         private final int componentId;
 
         public MockTopologyContext(int componentId, Map<String, Object> topoConf) {
-            // StormTopology topology, Map<String, Object> topoConf, Map<Integer, String> taskToComponent, Map<String, List<Integer>>
-            // componentToSortedTasks, Map<String, Map<String, Fields>> componentToStreamToFields, String stormId, String codeDir, String
-            // pidDir, Integer taskId, Integer workerPort, List<Integer> workerTasks, Map<String, Object> defaultResources, Map<String,
-            // Object> userResources, Map<String, Object> executorData, Map<Integer, Map<Integer, Map<String, IMetric>>>
-            // registeredMetrics, Atom openOrPrepareWasCalled
-            super(null, topoConf, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+            super(null, topoConf, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
             this.componentId = componentId;
         }
 

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerTransfer.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerTransfer.java
@@ -41,13 +41,13 @@ class WorkerTransfer implements JCQueue.Consumer {
     static final Logger LOG = LoggerFactory.getLogger(WorkerTransfer.class);
 
     private final TransferDrainer drainer;
-    private WorkerState workerState;
+    private final WorkerState workerState;
 
-    private IWaitStrategy backPressureWaitStrategy;
+    private final IWaitStrategy backPressureWaitStrategy;
 
     private JCQueue transferQueue; // [remoteTaskId] -> JCQueue. Some entries maybe null (if no emits to those tasksIds from this worker)
 
-    private AtomicBoolean[] remoteBackPressureStatus; // [[remoteTaskId] -> true/false : indicates if remote task is under BP.
+    private final AtomicBoolean[] remoteBackPressureStatus; // [[remoteTaskId] -> true/false : indicates if remote task is under BP.
 
     public WorkerTransfer(WorkerState workerState, Map<String, Object> topologyConf, int maxTaskIdInTopo) {
         this.workerState = workerState;
@@ -66,7 +66,8 @@ class WorkerTransfer implements JCQueue.Consumer {
         }
 
         this.transferQueue = new JCQueue("worker-transfer-queue", xferQueueSz, 0, xferBatchSz, backPressureWaitStrategy,
-                                         workerState.getTopologyId(), Constants.SYSTEM_COMPONENT_ID, -1, workerState.getPort());
+            workerState.getTopologyId(), Constants.SYSTEM_COMPONENT_ID, -1, workerState.getPort(),
+            workerState.getMetricRegistry());
     }
 
     public JCQueue getTransferQueue() {

--- a/storm-client/src/jvm/org/apache/storm/metrics2/StormMetricRegistry.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/StormMetricRegistry.java
@@ -32,46 +32,44 @@ import org.slf4j.LoggerFactory;
 public class StormMetricRegistry {
 
     private static final Logger LOG = LoggerFactory.getLogger(StormMetricRegistry.class);
+    
+    private final MetricRegistry registry = new MetricRegistry();
+    private final List<StormReporter> reporters = new ArrayList<>();
+    private String hostName = null;
 
-    private static final MetricRegistry REGISTRY = new MetricRegistry();
-
-    private static final List<StormReporter> REPORTERS = new ArrayList<>();
-
-    private static String hostName = null;
-
-    public static <T> SimpleGauge<T> gauge(
+    public <T> SimpleGauge<T> gauge(
         T initialValue, String name, String topologyId, String componentId, Integer taskId, Integer port) {
         String metricName = metricName(name, topologyId, componentId, taskId, port);
-        if (REGISTRY.getGauges().containsKey(metricName)) {
-            return (SimpleGauge) REGISTRY.getGauges().get(metricName);
-        } else {
-            return REGISTRY.register(metricName, new SimpleGauge<>(initialValue));
-        }
+        return (SimpleGauge<T>)registry.gauge(metricName, () -> new SimpleGauge<>(initialValue));
     }
 
-    public static JcMetrics jcMetrics(String name, String topologyId, String componentId, Integer taskId, Integer port) {
+    public JcMetrics jcMetrics(String name, String topologyId, String componentId, Integer taskId, Integer port) {
         return new JcMetrics(
-            StormMetricRegistry.gauge(0L, name + "-capacity", topologyId, componentId, taskId, port),
-            StormMetricRegistry.gauge(0L, name + "-population", topologyId, componentId, taskId, port)
+            gauge(0L, name + "-capacity", topologyId, componentId, taskId, port),
+            gauge(0L, name + "-population", topologyId, componentId, taskId, port)
         );
     }
 
-    public static Meter meter(String name, WorkerTopologyContext context, String componentId, Integer taskId, String streamId) {
+    public Meter meter(String name, WorkerTopologyContext context, String componentId, Integer taskId, String streamId) {
         String metricName = metricName(name, context.getStormId(), componentId, streamId, taskId, context.getThisWorkerPort());
-        return REGISTRY.meter(metricName);
+        return registry.meter(metricName);
     }
 
-    public static Counter counter(String name, WorkerTopologyContext context, String componentId, Integer taskId, String streamId) {
+    public Counter counter(String name, WorkerTopologyContext context, String componentId, Integer taskId, String streamId) {
         String metricName = metricName(name, context.getStormId(), componentId, streamId, taskId, context.getThisWorkerPort());
-        return REGISTRY.counter(metricName);
+        return registry.counter(metricName);
     }
 
-    public static Counter counter(String name, String topologyId, String componentId, Integer taskId, Integer workerPort, String streamId) {
+    public Counter counter(String name, String topologyId, String componentId, Integer taskId, Integer workerPort, String streamId) {
         String metricName = metricName(name, topologyId, componentId, streamId, taskId, workerPort);
-        return REGISTRY.counter(metricName);
+        return registry.counter(metricName);
+    }
+    
+    public MetricRegistry registry() {
+        return registry;
     }
 
-    public static void start(Map<String, Object> stormConfig, DaemonType type) {
+    public void start(Map<String, Object> stormConfig, DaemonType type) {
         try {
             hostName = dotToUnderScore(Utils.localHostname());
         } catch (UnknownHostException e) {
@@ -94,29 +92,25 @@ public class StormMetricRegistry {
         }
     }
 
-    public static MetricRegistry registry() {
-        return REGISTRY;
-    }
-
-    private static void startReporter(Map<String, Object> stormConfig, Map<String, Object> reporterConfig) {
+    private void startReporter(Map<String, Object> stormConfig, Map<String, Object> reporterConfig) {
         String clazz = (String) reporterConfig.get("class");
         LOG.info("Attempting to instantiate reporter class: {}", clazz);
         StormReporter reporter = ReflectionUtils.newInstance(clazz);
         if (reporter != null) {
-            reporter.prepare(REGISTRY, stormConfig, reporterConfig);
+            reporter.prepare(registry, stormConfig, reporterConfig);
             reporter.start();
-            REPORTERS.add(reporter);
+            reporters.add(reporter);
         }
 
     }
 
-    public static void stop() {
-        for (StormReporter sr : REPORTERS) {
+    public void stop() {
+        for (StormReporter sr : reporters) {
             sr.stop();
         }
     }
 
-    public static String metricName(String name, String stormId, String componentId, String streamId, Integer taskId, Integer workerPort) {
+    private String metricName(String name, String stormId, String componentId, String streamId, Integer taskId, Integer workerPort) {
         StringBuilder sb = new StringBuilder("storm.worker.");
         sb.append(stormId);
         sb.append(".");
@@ -134,7 +128,7 @@ public class StormMetricRegistry {
         return sb.toString();
     }
 
-    public static String metricName(String name, String stormId, String componentId, Integer taskId, Integer workerPort) {
+    private String metricName(String name, String stormId, String componentId, Integer taskId, Integer workerPort) {
         StringBuilder sb = new StringBuilder("storm.worker.");
         sb.append(stormId);
         sb.append(".");
@@ -150,9 +144,7 @@ public class StormMetricRegistry {
         return sb.toString();
     }
 
-    public static String metricName(String name, TopologyContext context) {
-
-
+    public String metricName(String name, TopologyContext context) {
         StringBuilder sb = new StringBuilder("storm.topology.");
         sb.append(context.getStormId());
         sb.append(".");
@@ -168,7 +160,7 @@ public class StormMetricRegistry {
         return sb.toString();
     }
 
-    private static String dotToUnderScore(String str) {
+    private String dotToUnderScore(String str) {
         return str.replace('.', '_');
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/TaskMetrics.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/TaskMetrics.java
@@ -23,17 +23,19 @@ public class TaskMetrics {
     private static final String METRIC_NAME_EMITTED = "emitted";
     private static final String METRIC_NAME_TRANSFERRED = "transferred";
 
-    private ConcurrentMap<String, Counter> ackedByStream = new ConcurrentHashMap<>();
-    private ConcurrentMap<String, Counter> failedByStream = new ConcurrentHashMap<>();
-    private ConcurrentMap<String, Counter> emittedByStream = new ConcurrentHashMap<>();
-    private ConcurrentMap<String, Counter> transferredByStream = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Counter> ackedByStream = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Counter> failedByStream = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Counter> emittedByStream = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Counter> transferredByStream = new ConcurrentHashMap<>();
 
-    private String topologyId;
-    private String componentId;
-    private Integer taskId;
-    private Integer workerPort;
+    private final String topologyId;
+    private final String componentId;
+    private final Integer taskId;
+    private final Integer workerPort;
+    private final StormMetricRegistry metricRegistry;
 
-    public TaskMetrics(WorkerTopologyContext context, String componentId, Integer taskid) {
+    public TaskMetrics(WorkerTopologyContext context, String componentId, Integer taskid, StormMetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
         this.topologyId = context.getStormId();
         this.componentId = componentId;
         this.taskId = taskid;
@@ -43,7 +45,7 @@ public class TaskMetrics {
     public Counter getAcked(String streamId) {
         Counter c = this.ackedByStream.get(streamId);
         if (c == null) {
-            c = StormMetricRegistry.counter(METRIC_NAME_ACKED, this.topologyId, this.componentId, this.taskId, this.workerPort, streamId);
+            c = metricRegistry.counter(METRIC_NAME_ACKED, this.topologyId, this.componentId, this.taskId, this.workerPort, streamId);
             this.ackedByStream.put(streamId, c);
         }
         return c;
@@ -52,7 +54,7 @@ public class TaskMetrics {
     public Counter getFailed(String streamId) {
         Counter c = this.failedByStream.get(streamId);
         if (c == null) {
-            c = StormMetricRegistry.counter(METRIC_NAME_FAILED, this.topologyId, this.componentId, this.taskId, this.workerPort, streamId);
+            c = metricRegistry.counter(METRIC_NAME_FAILED, this.topologyId, this.componentId, this.taskId, this.workerPort, streamId);
             this.failedByStream.put(streamId, c);
         }
         return c;
@@ -61,7 +63,7 @@ public class TaskMetrics {
     public Counter getEmitted(String streamId) {
         Counter c = this.emittedByStream.get(streamId);
         if (c == null) {
-            c = StormMetricRegistry.counter(METRIC_NAME_EMITTED, this.topologyId, this.componentId, this.taskId, this.workerPort, streamId);
+            c = metricRegistry.counter(METRIC_NAME_EMITTED, this.topologyId, this.componentId, this.taskId, this.workerPort, streamId);
             this.emittedByStream.put(streamId, c);
         }
         return c;
@@ -70,7 +72,7 @@ public class TaskMetrics {
     public Counter getTransferred(String streamId) {
         Counter c = this.transferredByStream.get(streamId);
         if (c == null) {
-            c = StormMetricRegistry.counter(
+            c = metricRegistry.counter(
                 METRIC_NAME_TRANSFERRED, this.topologyId, this.componentId, this.taskId, this.workerPort, streamId);
             this.transferredByStream.put(streamId, c);
         }

--- a/storm-client/src/jvm/org/apache/storm/task/IMetricsContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/IMetricsContext.java
@@ -12,6 +12,11 @@
 
 package org.apache.storm.task;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
 import org.apache.storm.metric.api.CombinedMetric;
 import org.apache.storm.metric.api.ICombiner;
 import org.apache.storm.metric.api.IMetric;
@@ -20,9 +25,31 @@ import org.apache.storm.metric.api.ReducedMetric;
 
 
 public interface IMetricsContext {
+    /**
+     * @deprecated in favor of metrics v2 (the non-deprecated methods on this class)
+     */
+    @Deprecated
     <T extends IMetric> T registerMetric(String name, T metric, int timeBucketSizeInSecs);
 
+    /**
+     * @deprecated in favor of metrics v2 (the non-deprecated methods on this class)
+     */
+    @Deprecated
     ReducedMetric registerMetric(String name, IReducer reducer, int timeBucketSizeInSecs);
 
+    /**
+     * @deprecated in favor of metrics v2 (the non-deprecated methods on this class)
+     */
+    @Deprecated
     CombinedMetric registerMetric(String name, ICombiner combiner, int timeBucketSizeInSecs);
+    
+    public Timer registerTimer(String name);
+
+    public Histogram registerHistogram(String name);
+
+    public Meter registerMeter(String name);
+
+    public Counter registerCounter(String name);
+
+    public <T> Gauge<T> registerGauge(String name, Gauge<T> gauge);
 }

--- a/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
@@ -48,14 +48,15 @@ import org.apache.storm.utils.Utils;
  * to.
  */
 public class TopologyContext extends WorkerTopologyContext implements IMetricsContext {
-    private Integer _taskId;
-    private Map<String, Object> _taskData = new HashMap<>();
-    private List<ITaskHook> _hooks = new ArrayList<>();
-    private Map<String, Object> _executorData;
-    private Map<Integer, Map<Integer, Map<String, IMetric>>> _registeredMetrics;
-    private AtomicBoolean _openOrPrepareWasCalled;
+    private final Integer _taskId;
+    private final Map<String, Object> _taskData = new HashMap<>();
+    private final List<ITaskHook> _hooks = new ArrayList<>();
+    private final Map<String, Object> _executorData;
+    private final Map<Integer, Map<Integer, Map<String, IMetric>>> _registeredMetrics;
+    private final AtomicBoolean _openOrPrepareWasCalled;
+    private final StormMetricRegistry metricRegistry;
     // This is updated by the Worker and the topology has shared access to it
-    private Map<String, Long> blobToLastKnownVersion;
+    private final Map<String, Long> blobToLastKnownVersion;
 
     public TopologyContext(StormTopology topology,
                            Map<String, Object> topoConf,
@@ -73,10 +74,12 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
                            Map<String, Object> userResources,
                            Map<String, Object> executorData,
                            Map<Integer, Map<Integer, Map<String, IMetric>>> registeredMetrics,
-                           AtomicBoolean openOrPrepareWasCalled) {
+                           AtomicBoolean openOrPrepareWasCalled,
+                           StormMetricRegistry metricRegistry) {
         super(topology, topoConf, taskToComponent, componentToSortedTasks,
               componentToStreamToFields, stormId, codeDir, pidDir,
               workerPort, workerTasks, defaultResources, userResources);
+        this.metricRegistry = metricRegistry;
         _taskId = taskId;
         _executorData = executorData;
         _registeredMetrics = registeredMetrics;
@@ -392,26 +395,26 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
     }
 
     public Timer registerTimer(String name) {
-        return StormMetricRegistry.registry().timer(metricName(name));
+        return metricRegistry.registry().timer(metricName(name));
     }
 
     public Histogram registerHistogram(String name) {
-        return StormMetricRegistry.registry().histogram(metricName(name));
+        return metricRegistry.registry().histogram(metricName(name));
     }
 
     public Meter registerMeter(String name) {
-        return StormMetricRegistry.registry().meter(metricName(name));
+        return metricRegistry.registry().meter(metricName(name));
     }
 
     public Counter registerCounter(String name) {
-        return StormMetricRegistry.registry().counter(metricName(name));
+        return metricRegistry.registry().counter(metricName(name));
     }
 
     public Gauge registerGauge(String name, Gauge gauge) {
-        return StormMetricRegistry.registry().register(metricName(name), gauge);
+        return metricRegistry.registry().register(metricName(name), gauge);
     }
 
     private String metricName(String name) {
-        return StormMetricRegistry.metricName(name, this);
+        return metricRegistry.metricName(name, this);
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
@@ -394,23 +394,28 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
         return registerMetric(name, new CombinedMetric(combiner), timeBucketSizeInSecs);
     }
 
+    @Override
     public Timer registerTimer(String name) {
         return metricRegistry.registry().timer(metricName(name));
     }
 
+    @Override
     public Histogram registerHistogram(String name) {
         return metricRegistry.registry().histogram(metricName(name));
     }
 
+    @Override
     public Meter registerMeter(String name) {
         return metricRegistry.registry().meter(metricName(name));
     }
 
+    @Override
     public Counter registerCounter(String name) {
         return metricRegistry.registry().counter(metricName(name));
     }
 
-    public Gauge registerGauge(String name, Gauge gauge) {
+    @Override
+    public <T> Gauge<T> registerGauge(String name, Gauge<T> gauge) {
         return metricRegistry.registry().register(metricName(name), gauge);
     }
 

--- a/storm-client/src/jvm/org/apache/storm/trident/operation/TridentOperationContext.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/operation/TridentOperationContext.java
@@ -12,6 +12,11 @@
 
 package org.apache.storm.trident.operation;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
 import org.apache.storm.metric.api.CombinedMetric;
 import org.apache.storm.metric.api.ICombiner;
 import org.apache.storm.metric.api.IMetric;
@@ -58,5 +63,30 @@ public class TridentOperationContext implements IMetricsContext {
 
     public CombinedMetric registerMetric(String name, ICombiner combiner, int timeBucketSizeInSecs) {
         return _topoContext.registerMetric(name, new CombinedMetric(combiner), timeBucketSizeInSecs);
+    }
+    
+    @Override
+    public Timer registerTimer(String name) {
+        return _topoContext.registerTimer(name);
+    }
+
+    @Override
+    public Histogram registerHistogram(String name) {
+        return _topoContext.registerHistogram(name);
+    }
+
+    @Override
+    public Meter registerMeter(String name) {
+        return _topoContext.registerMeter(name);
+    }
+
+    @Override
+    public Counter registerCounter(String name) {
+        return _topoContext.registerCounter(name);
+    }
+
+    @Override
+    public <T> Gauge<T> registerGauge(String name, Gauge<T> gauge) {
+        return _topoContext.registerGauge(name, gauge);
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/utils/JCQueue.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/JCQueue.java
@@ -60,14 +60,14 @@ public class JCQueue implements IStatefulObject, Closeable {
     private final String queueName;
 
     public JCQueue(String queueName, int size, int overflowLimit, int producerBatchSz, IWaitStrategy backPressureWaitStrategy,
-                   String topologyId, String componentId, Integer taskId, int port) {
+                   String topologyId, String componentId, Integer taskId, int port, StormMetricRegistry metricRegistry) {
         this.queueName = queueName;
         this.overflowLimit = overflowLimit;
         this.recvQueue = new MpscArrayQueue<>(size);
         this.overflowQ = new MpscUnboundedArrayQueue<>(size);
 
         this.metrics = new JCQueue.QueueMetrics();
-        this.jcMetrics = StormMetricRegistry.jcMetrics(queueName, topologyId, componentId, taskId, port);
+        this.jcMetrics = metricRegistry.jcMetrics(queueName, topologyId, componentId, taskId, port);
 
         //The batch size can be no larger than half the full recvQueue size, to avoid contention issues.
         this.producerBatchSz = Math.max(1, Math.min(producerBatchSz, size / 2));

--- a/storm-client/test/jvm/org/apache/storm/utils/JCQueueBackpressureTest.java
+++ b/storm-client/test/jvm/org/apache/storm/utils/JCQueueBackpressureTest.java
@@ -12,6 +12,7 @@
 
 package org.apache.storm.utils;
 
+import org.apache.storm.metrics2.StormMetricRegistry;
 import org.apache.storm.policy.WaitStrategyPark;
 import org.apache.storm.utils.JCQueue.Consumer;
 import org.junit.Assert;
@@ -21,7 +22,7 @@ import org.junit.Test;
 public class JCQueueBackpressureTest {
     
     private static JCQueue createQueue(String name, int queueSize) {
-        return new JCQueue(name, queueSize, 0, 1, new WaitStrategyPark(0), "test", "test", 1000, 1000);
+        return new JCQueue(name, queueSize, 0, 1, new WaitStrategyPark(0), "test", "test", 1000, 1000, new StormMetricRegistry());
     }
 
     @Test

--- a/storm-client/test/jvm/org/apache/storm/utils/JCQueueTest.java
+++ b/storm-client/test/jvm/org/apache/storm/utils/JCQueueTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertFalse;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.storm.metrics2.StormMetricRegistry;
 import org.apache.storm.policy.IWaitStrategy;
 import org.apache.storm.policy.WaitStrategyPark;
 import org.junit.Assert;
@@ -156,7 +157,7 @@ public class JCQueueTest {
     }
 
     private JCQueue createQueue(String name, int batchSize, int queueSize) {
-        return new JCQueue(name, queueSize, 0, batchSize, waitStrategy, "test", "test", 1000, 1000);
+        return new JCQueue(name, queueSize, 0, batchSize, waitStrategy, "test", "test", 1000, 1000, new StormMetricRegistry());
     }
 
     private static class IncProducer implements Runnable {

--- a/storm-server/src/main/java/org/apache/storm/Testing.java
+++ b/storm-server/src/main/java/org/apache/storm/Testing.java
@@ -668,22 +668,23 @@ public class Testing {
         compToStreamToFields.put(component, streamToFields);
 
         TopologyContext context = new TopologyContext(null,
-                                                      ConfigUtils.readStormConfig(),
-                                                      taskToComp,
-                                                      null,
-                                                      compToStreamToFields,
-                                                      null,
-                                                      "test-storm-id",
-                                                      null,
-                                                      null,
-                                                      1,
-                                                      null,
-                                                      null,
-                                                      new HashMap<>(),
-                                                      new HashMap<>(),
-                                                      new HashMap<>(),
-                                                      new HashMap<>(),
-                                                      new AtomicBoolean(false));
+            ConfigUtils.readStormConfig(),
+            taskToComp,
+            null,
+            compToStreamToFields,
+            null,
+            "test-storm-id",
+            null,
+            null,
+            1,
+            null,
+            null,
+            new HashMap<>(),
+            new HashMap<>(),
+            new HashMap<>(),
+            new HashMap<>(),
+            new AtomicBoolean(false),
+            null);
         return new TupleImpl(context, values, component, 1, stream);
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3371

Adds on to STORM-3370.

Metrics v2 is currently inaccessible from Trident operations. This should fix that.