### PR TITLE
 STORM-3375 change Date.getTime() to System.currentTimeMillis()

### DIFF
--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/DelimitedRecordHiveMapper.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/DelimitedRecordHiveMapper.java
@@ -132,8 +132,7 @@ public class DelimitedRecordHiveMapper implements HiveMapper {
     }
 
     private String getPartitionsByTimeFormat() {
-        Date d = new Date();
-        return parseDate.format(d.getTime());
+        return parseDate.format(System.currentTimeMillis());
     }
 
     @VisibleForTesting

--- a/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/JsonRecordHiveMapper.java
+++ b/external/storm-hive/src/main/java/org/apache/storm/hive/bolt/mapper/JsonRecordHiveMapper.java
@@ -119,7 +119,6 @@ public class JsonRecordHiveMapper implements HiveMapper {
     }
 
     private String getPartitionsByTimeFormat() {
-        Date d = new Date();
-        return parseDate.format(d.getTime());
+        return parseDate.format(System.currentTimeMillis());
     }
 }


### PR DESCRIPTION
new Date() is just a thin wrapper around System.currentTimeMillis(). Using System.currentTimeMillis() can help avoid to create a new Date object and the system can speed up.