### PR TITLE
[STORM-3380] Use Objects.equals to avoid possible NullPointerException

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/stats/StatsUtil.java
+++ b/storm-server/src/main/java/org/apache/storm/stats/StatsUtil.java
@@ -2004,7 +2004,7 @@ public class StatsUtil {
         win2stats.put(FAILED, ClientStatsUtil.getMapByKey(data, WIN_TO_FAILED));
 
         String compType = (String) data.get(TYPE);
-        if (compType.equals(ClientStatsUtil.SPOUT)) {
+        if (Objects.equals(compType,ClientStatsUtil.SPOUT)) {
             ret.set_component_type(ComponentType.SPOUT);
             win2stats.put(COMP_LATENCY, ClientStatsUtil.getMapByKey(data, WIN_TO_COMP_LAT));
         } else {

--- a/storm-server/src/main/java/org/apache/storm/stats/StatsUtil.java
+++ b/storm-server/src/main/java/org/apache/storm/stats/StatsUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.storm.stats;
 
+import java.util.Objects;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
Hello,
I found that if the Map "data" does not have the key "TYPE", the String "compType" may cause potential risk of NullPointerException since it is immediately used after initialization and there is no null checker. One recommended API is Objects.equals(String,String) which can avoid this exception.