### PR TITLE
[STORM-3384] set-log-level command throws wrong exception if the topology is not running

### DIFF
--- a/storm-core/src/clj/org/apache/storm/command/set_log_level.clj
+++ b/storm-core/src/clj/org/apache/storm/command/set_log_level.clj
@@ -28,7 +28,7 @@
         topology (first (filter (fn [topo] (= name (.get_name topo))) topologies))]
     (if topology 
       (.get_id topology)
-      (throw (.IllegalArgumentException (str name " is not a running topology"))))))
+      (throw (IllegalArgumentException. (str name " is not a running topology"))))))
 
 (defn- parse-named-log-levels [action]
   "Parses [logger name]=[level string]:[optional timeout],[logger name2]...


### PR DESCRIPTION
cherry-pick from https://github.com/apache/storm/pull/3001