### PR TITLE
[STORM-3385] Avoid two threads reading from the same input stream of a process

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/supervisor/ClientSupervisorUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/supervisor/ClientSupervisorUtils.java
@@ -64,7 +64,7 @@ public class ClientSupervisorUtils {
                                              final Map<String, String> environment, final String logPreFix)
         throws IOException {
         int ret = 0;
-        Process process = processLauncher(conf, user, null, args, environment, logPreFix, null, null);
+        Process process = processLauncher(conf, user, null, args, environment, null, null, null);
         if (StringUtils.isNotBlank(logPreFix)) {
             Utils.readAndLogStream(logPreFix, process.getInputStream());
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3385

This is not causing any problem so far. But having two threads are reading from the same input stream doesn't seem right.  