### PR TITLE
STORM-3386: Require Maven version 3.5.0 for Storm's build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1436,7 +1436,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.0</version>
+                                    <version>3.5</version>
                                 </requireMavenVersion>
                                 <bannedDependencies>
                                     <excludes>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3386

Checked that the build now won't run on 3.3.9, but will run on 3.5.0 and 3.6.1.