### PR TITLE
STORM-3390: Lock python test dependency versions

### DIFF
--- a/dev-tools/travis/requirements.txt
+++ b/dev-tools/travis/requirements.txt
@@ -10,4 +10,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-mock
+mock == 2.0.0


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3390