### PR TITLE
Fix class name of CsvStormReporter

### DIFF
--- a/docs/metrics_v2.md
+++ b/docs/metrics_v2.md
@@ -76,7 +76,7 @@ public class TupleCountingBolt extends BaseRichBolt {
  
   * Console Reporter (`org.apache.storm.metrics2.reporters.ConsoleStormReporter`):
     Reports metrics to `System.out`.
-  * CSV Reporter (`org.apache.storm.metrics2.reporters.CsvReporter`):
+  * CSV Reporter (`org.apache.storm.metrics2.reporters.CsvStormReporter`):
     Reports metrics to a CSV file.
   * Graphite Reporter (`org.apache.storm.metrics2.reporters.GraphiteStormReporter`):
     Reports metrics to a [Graphite](https://graphiteapp.org) server.


### PR DESCRIPTION
In the documentation about metrics v2, the class name of the csv is `CsvReporter`, when it actually should be `CsvStormReporter`.

Is it enough to merge this into master, or should I also ask to merge this into a branch like `1.1.x`, such that it can be fixed on all relevant online docs?