### PR TITLE
MINOR: Clarify error message when TGT has problems

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java
@@ -133,15 +133,15 @@ public class AutoTGT implements IAutoCredentials, ICredentialsRenewer, IMetricsR
                 }
 
                 if (!tgt.isForwardable()) {
-                    throw new RuntimeException("The TGT found is not forwardable. Please use -f option.");
+                    throw new RuntimeException("The TGT found is not forwardable. Please use -f option with 'kinit'.");
                 }
 
                 if (!tgt.isRenewable()) {
-                    throw new RuntimeException("The TGT found is not renewable. Please use -r option.");
+                    throw new RuntimeException("The TGT found is not renewable. Please use -r option with 'kinit'.");
                 }
 
                 if (tgt.getClientAddresses() != null) {
-                    throw new RuntimeException("The TGT found is not address-less. Please use -A option.");
+                    throw new RuntimeException("The TGT found is not address-less. Please use -A option with 'kinit'.");
                 }
 
                 LOG.info("Pushing TGT for " + tgt.getClient() + " to topology.");


### PR DESCRIPTION
If you're not very familiar with Kerberos, having more explicit instructions in these error messages can be helpful.