### PR TITLE
STORM-3396:fix uploading dependency jars too slow when storm client and server located in different IDC

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -144,6 +144,7 @@ nimbus.blobstore.class: "org.apache.storm.blobstore.LocalFsBlobStore"
 nimbus.blobstore.expiration.secs: 600
 
 storm.blobstore.inputstream.buffer.size.bytes: 65536
+storm.blobstore.dependency.jar.upload.chuck.size.bytes: 1048576
 client.blobstore.class: "org.apache.storm.blobstore.NimbusBlobStore"
 storm.blobstore.replication.factor: 3
 # For secure mode we would want to change this config to true

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -1411,6 +1411,12 @@ public class Config extends HashMap<String, Object> {
     @isInteger
     public static final String STORM_BLOBSTORE_INPUTSTREAM_BUFFER_SIZE_BYTES = "storm.blobstore.inputstream.buffer.size.bytes";
     /**
+     * What chuck size to use for storm client to upload dependency jars.
+     */
+    @isPositiveNumber
+    @isInteger
+    public static final String STORM_BLOBSTORE_DEPENDENCY_JAR_UPLOAD_CHUCK_SIZE_BYTES = "storm.blobstore.dependency.jar.upload.chuck.size.bytes";
+    /**
      * FQCN of a class that implements {@code ISubmitterHook} @see ISubmitterHook for details.
      */
     @isString


### PR DESCRIPTION
when storm client and server is locating in different IDC(one is in Beijing, while another in Shanghai), uploading dependency jars may take a very long long time(in my case, 31minutes!)...

    when I digged into this, I found that in DependencyUploader,  method "uploadDependencyToBlobStore" using JDK NIO's Files.copy to upload local jars to remote Blob server. In Files.copy(Path, OutputStream), the buffer size is 8k by default, given that latency between Beijing and Shanghai is about 20ms, a dependency fat jar of 360M finally cost me 'a lunch time' to finish uploading!!!