### PR TITLE
[STORM-3404]KafkaOffsetLagUtil cant pull the offset correctly

### DIFF
--- a/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtil.java
+++ b/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtil.java
@@ -214,8 +214,12 @@ public class KafkaOffsetLagUtil {
             props.put("session.timeout.ms", "30000");
             props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
             props.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+
             if (newKafkaSpoutOffsetQuery.getSecurityProtocol() != null) {
                 props.put("security.protocol", newKafkaSpoutOffsetQuery.getSecurityProtocol());
+                if (newKafkaSpoutOffsetQuery.getSecurityProtocol().contains("PLAIN")){
+                    props.put("sasl.mechanism", "PLAIN");
+                }
             }
             List<TopicPartition> topicPartitionList = new ArrayList<>();
             consumer = new KafkaConsumer<>(props);


### PR DESCRIPTION
when use SASL_PLAIN kafka JAAS auth, missing sasl.mechanism will lead to KafkaOffsetLagUtil cant pull the offset correctly
kafka version 2.2.0

Apache JIRA url: https://issues.apache.org/jira/browse/STORM-3404