### PR TITLE
[STORM-3000] Add missing @Override annotations

### DIFF
--- a/examples/storm-hbase-examples/src/main/java/org/apache/storm/hbase/topology/TotalWordCounter.java
+++ b/examples/storm-hbase-examples/src/main/java/org/apache/storm/hbase/topology/TotalWordCounter.java
@@ -32,6 +32,7 @@ public class TotalWordCounter implements IBasicBolt {
     private static final Random RANDOM = new Random();
     private BigInteger total = BigInteger.ZERO;
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context) {
     }
 
@@ -39,6 +40,7 @@ public class TotalWordCounter implements IBasicBolt {
      * Just output the word value with a count of 1.
      * The HBaseBolt will handle incrementing the counter.
      */
+    @Override
     public void execute(Tuple input, BasicOutputCollector collector) {
         total = total.add(new BigInteger(input.getValues().get(1).toString()));
         collector.emit(tuple(total.toString()));
@@ -48,10 +50,12 @@ public class TotalWordCounter implements IBasicBolt {
         }
     }
 
+    @Override
     public void cleanup() {
         LOG.info("Final total = " + total);
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("total"));
     }

--- a/examples/storm-hbase-examples/src/main/java/org/apache/storm/hbase/topology/WordCounter.java
+++ b/examples/storm-hbase-examples/src/main/java/org/apache/storm/hbase/topology/WordCounter.java
@@ -25,6 +25,7 @@ import static org.apache.storm.utils.Utils.tuple;
 public class WordCounter implements IBasicBolt {
 
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context) {
     }
 
@@ -32,14 +33,17 @@ public class WordCounter implements IBasicBolt {
      * Just output the word value with a count of 1.
      * The HBaseBolt will handle incrementing the counter.
      */
+    @Override
     public void execute(Tuple input, BasicOutputCollector collector) {
         collector.emit(tuple(input.getValues().get(0), 1));
     }
 
+    @Override
     public void cleanup() {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("word", "count"));
     }

--- a/examples/storm-hbase-examples/src/main/java/org/apache/storm/hbase/topology/WordSpout.java
+++ b/examples/storm-hbase-examples/src/main/java/org/apache/storm/hbase/topology/WordSpout.java
@@ -39,14 +39,17 @@ public class WordSpout implements IRichSpout {
         return this.isDistributed;
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         this.collector = collector;
     }
 
+    @Override
     public void close() {
 
     }
 
+    @Override
     public void nextTuple() {
         final Random rand = new Random();
         final String word = words[rand.nextInt(words.length)];
@@ -54,14 +57,17 @@ public class WordSpout implements IRichSpout {
         Thread.yield();
     }
 
+    @Override
     public void ack(Object msgId) {
 
     }
 
+    @Override
     public void fail(Object msgId) {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("word"));
     }

--- a/examples/storm-hdfs-examples/src/main/java/org/apache/storm/hdfs/bolt/HdfsFileTopology.java
+++ b/examples/storm-hdfs-examples/src/main/java/org/apache/storm/hdfs/bolt/HdfsFileTopology.java
@@ -118,16 +118,19 @@ public class HdfsFileTopology {
         private int count = 0;
         private long total = 0L;
 
+        @Override
         public void declareOutputFields(OutputFieldsDeclarer declarer) {
             declarer.declare(new Fields("sentence", "timestamp"));
         }
 
+        @Override
         public void open(Map<String, Object> config, TopologyContext context,
                          SpoutOutputCollector collector) {
             this.collector = collector;
             this.pending = new ConcurrentHashMap<UUID, Values>();
         }
 
+        @Override
         public void nextTuple() {
             Values values = new Values(sentences[index], System.currentTimeMillis());
             UUID msgId = UUID.randomUUID();
@@ -146,10 +149,12 @@ public class HdfsFileTopology {
             Thread.yield();
         }
 
+        @Override
         public void ack(Object msgId) {
             this.pending.remove(msgId);
         }
 
+        @Override
         public void fail(Object msgId) {
             System.out.println("**** RESENDING FAILED TUPLE");
             this.collector.emit(this.pending.get(msgId), msgId);
@@ -161,15 +166,18 @@ public class HdfsFileTopology {
         private HashMap<String, Long> counts = null;
         private OutputCollector collector;
 
+        @Override
         public void prepare(Map<String, Object> config, TopologyContext context, OutputCollector collector) {
             this.counts = new HashMap<String, Long>();
             this.collector = collector;
         }
 
+        @Override
         public void execute(Tuple tuple) {
             collector.ack(tuple);
         }
 
+        @Override
         public void declareOutputFields(OutputFieldsDeclarer declarer) {
             // this bolt does not emit anything
         }

--- a/examples/storm-hdfs-examples/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileTopology.java
+++ b/examples/storm-hdfs-examples/src/main/java/org/apache/storm/hdfs/bolt/SequenceFileTopology.java
@@ -124,16 +124,19 @@ public class SequenceFileTopology {
         private int count = 0;
         private long total = 0L;
 
+        @Override
         public void declareOutputFields(OutputFieldsDeclarer declarer) {
             declarer.declare(new Fields("sentence", "timestamp"));
         }
 
+        @Override
         public void open(Map<String, Object> config, TopologyContext context,
                          SpoutOutputCollector collector) {
             this.collector = collector;
             this.pending = new ConcurrentHashMap<UUID, Values>();
         }
 
+        @Override
         public void nextTuple() {
             Values values = new Values(sentences[index], System.currentTimeMillis());
             UUID msgId = UUID.randomUUID();
@@ -152,11 +155,13 @@ public class SequenceFileTopology {
             Thread.yield();
         }
 
+        @Override
         public void ack(Object msgId) {
             //            System.out.println("ACK");
             this.pending.remove(msgId);
         }
 
+        @Override
         public void fail(Object msgId) {
             System.out.println("**** RESENDING FAILED TUPLE");
             this.collector.emit(this.pending.get(msgId), msgId);
@@ -169,16 +174,19 @@ public class SequenceFileTopology {
         private HashMap<String, Long> counts = null;
         private OutputCollector collector;
 
+        @Override
         public void prepare(Map<String, Object> config, TopologyContext context, OutputCollector collector) {
             this.counts = new HashMap<String, Long>();
             this.collector = collector;
         }
 
+        @Override
         public void execute(Tuple tuple) {
             collector.ack(tuple);
         }
 
 
+        @Override
         public void declareOutputFields(OutputFieldsDeclarer declarer) {
             // this bolt does not emit anything
         }

--- a/examples/storm-hive-examples/src/main/java/org/apache/storm/hive/bolt/BucketTestHiveTopology.java
+++ b/examples/storm-hive-examples/src/main/java/org/apache/storm/hive/bolt/BucketTestHiveTopology.java
@@ -119,10 +119,12 @@ public class BucketTestHiveTopology {
             return this;
         }
 
+        @Override
         public void declareOutputFields(OutputFieldsDeclarer declarer) {
             declarer.declare(new Fields(this.outputFields));
         }
 
+        @Override
         public void open(Map<String, Object> config, TopologyContext context,
                          SpoutOutputCollector collector) {
             this.collector = collector;
@@ -135,6 +137,7 @@ public class BucketTestHiveTopology {
             }
         }
 
+        @Override
         public void nextTuple() {
             String line;
             try {
@@ -161,10 +164,12 @@ public class BucketTestHiveTopology {
             }
         }
 
+        @Override
         public void ack(Object msgId) {
             this.pending.remove(msgId);
         }
 
+        @Override
         public void fail(Object msgId) {
             System.out.println("**** RESENDING FAILED TUPLE");
             this.collector.emit(this.pending.get(msgId), msgId);

--- a/examples/storm-hive-examples/src/main/java/org/apache/storm/hive/bolt/HiveTopology.java
+++ b/examples/storm-hive-examples/src/main/java/org/apache/storm/hive/bolt/HiveTopology.java
@@ -100,16 +100,19 @@ public class HiveTopology {
         private int count = 0;
         private long total = 0L;
 
+        @Override
         public void declareOutputFields(OutputFieldsDeclarer declarer) {
             declarer.declare(new Fields("id","name","phone","street","city","state"));
         }
 
+        @Override
         public void open(Map<String, Object> config, TopologyContext context,
                          SpoutOutputCollector collector) {
             this.collector = collector;
             this.pending = new ConcurrentHashMap<UUID, Values>();
         }
 
+        @Override
         public void nextTuple() {
             String[] user = sentences[index].split(",");
             Values values = new Values(Integer.parseInt(user[0]),user[1],user[2],user[3],user[4],user[5]);
@@ -129,10 +132,12 @@ public class HiveTopology {
             Thread.yield();
         }
 
+        @Override
         public void ack(Object msgId) {
             this.pending.remove(msgId);
         }
 
+        @Override
         public void fail(Object msgId) {
             System.out.println("**** RESENDING FAILED TUPLE");
             this.collector.emit(this.pending.get(msgId), msgId);

--- a/examples/storm-hive-examples/src/main/java/org/apache/storm/hive/bolt/HiveTopologyPartitioned.java
+++ b/examples/storm-hive-examples/src/main/java/org/apache/storm/hive/bolt/HiveTopologyPartitioned.java
@@ -101,16 +101,19 @@ public class HiveTopologyPartitioned {
         private int count = 0;
         private long total = 0L;
 
+        @Override
         public void declareOutputFields(OutputFieldsDeclarer declarer) {
             declarer.declare(new Fields("id","name","phone","street","city","state"));
         }
 
+        @Override
         public void open(Map<String, Object> config, TopologyContext context,
                          SpoutOutputCollector collector) {
             this.collector = collector;
             this.pending = new ConcurrentHashMap<UUID, Values>();
         }
 
+        @Override
         public void nextTuple() {
             String[] user = sentences[index].split(",");
             Values values = new Values(Integer.parseInt(user[0]),user[1],user[2],user[3],user[4],user[5]);
@@ -130,10 +133,12 @@ public class HiveTopologyPartitioned {
             }
         }
 
+        @Override
         public void ack(Object msgId) {
             this.pending.remove(msgId);
         }
 
+        @Override
         public void fail(Object msgId) {
             System.out.println("**** RESENDING FAILED TUPLE");
             this.collector.emit(this.pending.get(msgId), msgId);

--- a/examples/storm-jdbc-examples/src/main/java/org/apache/storm/jdbc/spout/UserSpout.java
+++ b/examples/storm-jdbc-examples/src/main/java/org/apache/storm/jdbc/spout/UserSpout.java
@@ -47,14 +47,17 @@ public class UserSpout implements IRichSpout {
         return this.isDistributed;
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         this.collector = collector;
     }
 
+    @Override
     public void close() {
 
     }
 
+    @Override
     public void nextTuple() {
         final Random rand = new Random();
         final Values row = rows.get(rand.nextInt(rows.size() - 1));
@@ -62,14 +65,17 @@ public class UserSpout implements IRichSpout {
         Thread.yield();
     }
 
+    @Override
     public void ack(Object msgId) {
 
     }
 
+    @Override
     public void fail(Object msgId) {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("user_id","user_name","create_date"));
     }

--- a/examples/storm-jms-examples/src/main/java/org/apache/storm/jms/example/GenericBolt.java
+++ b/examples/storm-jms-examples/src/main/java/org/apache/storm/jms/example/GenericBolt.java
@@ -67,12 +67,14 @@ public class GenericBolt extends BaseRichBolt {
         this(name, autoAck, autoAnchor, null);
     }
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context,
                         OutputCollector collector) {
         this.collector = collector;
 
     }
 
+    @Override
     public void execute(Tuple input) {
         LOG.debug("[" + this.name + "] Received message: " + input);
 
@@ -94,10 +96,12 @@ public class GenericBolt extends BaseRichBolt {
 
     }
 
+    @Override
     public void cleanup() {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         if (this.declaredFields != null) {
             declarer.declare(this.declaredFields);

--- a/examples/storm-jms-examples/src/main/java/org/apache/storm/jms/example/JsonTupleProducer.java
+++ b/examples/storm-jms-examples/src/main/java/org/apache/storm/jms/example/JsonTupleProducer.java
@@ -42,6 +42,7 @@ import org.apache.storm.tuple.Values;
 @SuppressWarnings("serial")
 public class JsonTupleProducer implements JmsTupleProducer {
 
+    @Override
 	public Values toTuple(Message msg) throws JMSException {
 		if(msg instanceof TextMessage){
 			String json = ((TextMessage) msg).getText();
@@ -51,6 +52,7 @@ public class JsonTupleProducer implements JmsTupleProducer {
 		}
 	}
 
+    @Override
 	public void declareOutputFields(OutputFieldsDeclarer declarer) {
 		declarer.declare(new Fields("json"));
 	}

--- a/examples/storm-jms-examples/src/main/java/org/apache/storm/jms/example/SpringJmsProvider.java
+++ b/examples/storm-jms-examples/src/main/java/org/apache/storm/jms/example/SpringJmsProvider.java
@@ -63,10 +63,12 @@ public class SpringJmsProvider implements JmsProvider {
 		this.destination = (Destination)context.getBean(destinationBean);
 	}
 
+	@Override
 	public ConnectionFactory connectionFactory() throws Exception {
 		return this.connectionFactory;
 	}
 
+	@Override
 	public Destination destination() throws Exception {
 		return this.destination;
 	}

--- a/examples/storm-kafka-client-examples/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutTopologyMainWildcardTopicsLocal.java
+++ b/examples/storm-kafka-client-examples/src/test/java/org/apache/storm/kafka/spout/KafkaSpoutTopologyMainWildcardTopicsLocal.java
@@ -22,6 +22,7 @@ public class KafkaSpoutTopologyMainWildcardTopicsLocal extends KafkaSpoutTopolog
         new KafkaSpoutTopologyMainWildcardTopicsLocal().runExample();
     } 
     
+    @Override
     protected KafkaSpoutTopologyMainNamedTopics getTopology() {
         return new KafkaSpoutTopologyMainWildcardTopics();
     }

--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/HttpForwardingMetricsServer.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/HttpForwardingMetricsServer.java
@@ -54,6 +54,7 @@ public abstract class HttpForwardingMetricsServer {
     };
 
     private class MetricsCollectionServlet extends HttpServlet {
+        @Override
         protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
             Input in = new Input(request.getInputStream());
             List<Object> metrics = des.get().deserializeFrom(in);

--- a/examples/storm-mongodb-examples/src/main/java/org/apache/storm/mongodb/topology/TotalWordCounter.java
+++ b/examples/storm-mongodb-examples/src/main/java/org/apache/storm/mongodb/topology/TotalWordCounter.java
@@ -37,12 +37,14 @@ public class TotalWordCounter implements IBasicBolt {
     private BigInteger total = BigInteger.ZERO;
     private static final Logger LOG = LoggerFactory.getLogger(TotalWordCounter.class);
     private static final Random RANDOM = new Random();
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context) {
     }
 
     /*
      * Just output the word value with a count of 1.
      */
+    @Override
     public void execute(Tuple input, BasicOutputCollector collector) {
         total = total.add(new BigInteger(input.getValues().get(1).toString()));
         collector.emit(tuple(total.toString()));
@@ -52,10 +54,12 @@ public class TotalWordCounter implements IBasicBolt {
         }
     }
 
+    @Override
     public void cleanup() {
         LOG.info("Final total = " + total);
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("total"));
     }

--- a/examples/storm-mongodb-examples/src/main/java/org/apache/storm/mongodb/topology/WordCounter.java
+++ b/examples/storm-mongodb-examples/src/main/java/org/apache/storm/mongodb/topology/WordCounter.java
@@ -31,10 +31,12 @@ import java.util.Map;
 public class WordCounter implements IBasicBolt {
     private Map<String, Integer> wordCounter = Maps.newHashMap();
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context) {
         
     }
 
+    @Override
     public void execute(Tuple input, BasicOutputCollector collector) {
         String word = input.getStringByField("word");
         int count;
@@ -49,10 +51,12 @@ public class WordCounter implements IBasicBolt {
         collector.emit(new Values(word, String.valueOf(count)));
     }
 
+    @Override
     public void cleanup() {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("word", "count"));
     }

--- a/examples/storm-mongodb-examples/src/main/java/org/apache/storm/mongodb/topology/WordSpout.java
+++ b/examples/storm-mongodb-examples/src/main/java/org/apache/storm/mongodb/topology/WordSpout.java
@@ -45,14 +45,17 @@ public class WordSpout implements IRichSpout {
         return this.isDistributed;
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         this.collector = collector;
     }
 
+    @Override
     public void close() {
 
     }
 
+    @Override
     public void nextTuple() {
         final Random rand = new Random();
         final String word = words[rand.nextInt(words.length)];
@@ -60,14 +63,17 @@ public class WordSpout implements IRichSpout {
         Thread.yield();
     }
 
+    @Override
     public void ack(Object msgId) {
 
     }
 
+    @Override
     public void fail(Object msgId) {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("word"));
     }

--- a/examples/storm-perf/src/main/java/org/apache/storm/perf/StrGenSpoutHdfsBoltTopo.java
+++ b/examples/storm-perf/src/main/java/org/apache/storm/perf/StrGenSpoutHdfsBoltTopo.java
@@ -153,6 +153,7 @@ public class StrGenSpoutHdfsBoltTopo {
             return this;
         }
 
+        @Override
         public byte[] format(Tuple tuple) {
             return (tuple.getValueByField(fieldName).toString() + this.lineDelimiter).getBytes();
         }

--- a/examples/storm-perf/src/main/java/org/apache/storm/perf/utils/Helper.java
+++ b/examples/storm-perf/src/main/java/org/apache/storm/perf/utils/Helper.java
@@ -74,6 +74,7 @@ public class Helper {
         Map<String, Object> clusterConf = Utils.readStormConfig();
         final Nimbus.Iface client = NimbusClient.getConfiguredClient(clusterConf).getClient();
         Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
             public void run() {
                 try {
                     System.out.println("Killing...");

--- a/examples/storm-redis-examples/src/main/java/org/apache/storm/redis/topology/WordCounter.java
+++ b/examples/storm-redis-examples/src/main/java/org/apache/storm/redis/topology/WordCounter.java
@@ -31,9 +31,11 @@ import java.util.Map;
 public class WordCounter implements IBasicBolt {
     private Map<String, Integer> wordCounter = Maps.newHashMap();
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context) {
     }
 
+    @Override
     public void execute(Tuple input, BasicOutputCollector collector) {
         String word = input.getStringByField("word");
         int count;
@@ -48,10 +50,12 @@ public class WordCounter implements IBasicBolt {
         collector.emit(new Values(word, String.valueOf(count)));
     }
 
+    @Override
     public void cleanup() {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("word", "count"));
     }

--- a/examples/storm-redis-examples/src/main/java/org/apache/storm/redis/topology/WordSpout.java
+++ b/examples/storm-redis-examples/src/main/java/org/apache/storm/redis/topology/WordSpout.java
@@ -45,14 +45,17 @@ public class WordSpout implements IRichSpout {
         return this.isDistributed;
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         this.collector = collector;
     }
 
+    @Override
     public void close() {
 
     }
 
+    @Override
     public void nextTuple() {
         final Random rand = new Random();
         final String word = words[rand.nextInt(words.length)];
@@ -60,14 +63,17 @@ public class WordSpout implements IRichSpout {
         Thread.yield();
     }
 
+    @Override
     public void ack(Object msgId) {
 
     }
 
+    @Override
     public void fail(Object msgId) {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("word"));
     }

--- a/examples/storm-solr-examples/src/main/java/org/apache/storm/solr/topology/SolrFieldsTopology.java
+++ b/examples/storm-solr-examples/src/main/java/org/apache/storm/solr/topology/SolrFieldsTopology.java
@@ -43,10 +43,12 @@ public class SolrFieldsTopology extends SolrTopology {
                     .setMultiValueFieldToken("%").build();
     }
 
+    @Override
     protected SolrCommitStrategy getSolrCommitStgy() {
         return new CountBasedCommit(2);         // To Commit to Solr and Ack according to the commit strategy
     }
 
+    @Override
     protected StormTopology getTopology() throws IOException {
         TopologyBuilder builder = new TopologyBuilder();
         builder.setSpout("SolrFieldsSpout", new SolrFieldsSpout());

--- a/examples/storm-solr-examples/src/main/java/org/apache/storm/solr/topology/SolrJsonTopology.java
+++ b/examples/storm-solr-examples/src/main/java/org/apache/storm/solr/topology/SolrJsonTopology.java
@@ -38,6 +38,7 @@ public class SolrJsonTopology extends SolrTopology {
         return new SolrJsonMapper.Builder(COLLECTION, jsonTupleField).build();
     }
 
+    @Override
     protected StormTopology getTopology() throws IOException {
         TopologyBuilder builder = new TopologyBuilder();
         builder.setSpout("SolrJsonSpout", new SolrJsonSpout());

--- a/examples/storm-solr-examples/src/main/java/org/apache/storm/solr/trident/SolrFieldsTridentTopology.java
+++ b/examples/storm-solr-examples/src/main/java/org/apache/storm/solr/trident/SolrFieldsTridentTopology.java
@@ -35,6 +35,7 @@ public class SolrFieldsTridentTopology extends SolrFieldsTopology {
         solrFieldsTridentTopology.run(args);
     }
 
+    @Override
     protected StormTopology getTopology() throws IOException {
         final TridentTopology tridentTopology = new TridentTopology();
         final SolrFieldsSpout spout = new SolrFieldsSpout();

--- a/examples/storm-solr-examples/src/main/java/org/apache/storm/solr/trident/SolrJsonTridentTopology.java
+++ b/examples/storm-solr-examples/src/main/java/org/apache/storm/solr/trident/SolrJsonTridentTopology.java
@@ -34,6 +34,7 @@ public class SolrJsonTridentTopology extends SolrJsonTopology {
         solrJsonTridentTopology.run(args);
     }
 
+    @Override
     protected StormTopology getTopology() throws IOException {
         final TridentTopology topology = new TridentTopology();
         final SolrJsonSpout spout = new SolrJsonSpout();

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/RollingTopWords.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/RollingTopWords.java
@@ -61,6 +61,7 @@ public class RollingTopWords extends ConfigurableTopology {
      *          locally ("-local") or remotely, i.e. on a real cluster.
      * @throws Exception
      */
+    @Override
     protected int run(String[] args) {
         String topologyName = "slidingWindowCounts";
         if (args.length >= 1) {

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/SkewedRollingTopWords.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/SkewedRollingTopWords.java
@@ -64,6 +64,7 @@ public class SkewedRollingTopWords extends ConfigurableTopology {
      *          locally ("-local") or remotely, i.e. on a real cluster.
      * @throws Exception
      */
+    @Override
     protected int run(String[] args) {
         String topologyName = "slidingWindowCounts";
         if (args.length >= 1) {

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/WordCountTopology.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/WordCountTopology.java
@@ -35,6 +35,7 @@ public class WordCountTopology extends ConfigurableTopology {
         ConfigurableTopology.start(new WordCountTopology(), args);
     }
 
+    @Override
     protected int run(String[] args) throws Exception {
 
         TopologyBuilder builder = new TopologyBuilder();

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/spout/RandomSentenceSpout.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/spout/RandomSentenceSpout.java
@@ -82,6 +82,7 @@ public class RandomSentenceSpout extends BaseRichSpout {
             this.prefix = prefix;
         }
 
+        @Override
         protected String sentence(String input) {
             return prefix + currentDate() + " " + input;
         }

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/tools/RankableObjectWithFields.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/tools/RankableObjectWithFields.java
@@ -63,10 +63,12 @@ public class RankableObjectWithFields implements Rankable, Serializable {
         return new RankableObjectWithFields(obj, count, otherFields.toArray());
     }
 
+    @Override
     public Object getObject() {
         return obj;
     }
 
+    @Override
     public long getCount() {
         return count;
     }
@@ -111,6 +113,7 @@ public class RankableObjectWithFields implements Rankable, Serializable {
         return result;
     }
 
+    @Override
     public String toString() {
         StringBuffer buf = new StringBuffer();
         buf.append("[");

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/tools/Rankings.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/tools/Rankings.java
@@ -135,6 +135,7 @@ public class Rankings implements Serializable {
         }
     }
 
+    @Override
     public String toString() {
         return rankedItems.toString();
     }

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/DebugMemoryMapState.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/trident/DebugMemoryMapState.java
@@ -40,6 +40,7 @@ public class DebugMemoryMapState<T> extends MemoryMapState<T> {
         super(id);
     }
 
+    @Override
     public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
         print(keys, updaters);
         if ((updateCount++ % 5) == 0) {

--- a/examples/storm-starter/test/jvm/org/apache/storm/starter/tools/RankingsTest.java
+++ b/examples/storm-starter/test/jvm/org/apache/storm/starter/tools/RankingsTest.java
@@ -341,6 +341,7 @@ public class RankingsTest {
 
         // when
         blitzer.blitz(new Runnable() {
+            @Override
             public void run() {
                 for (Rankable r : entries) {
                     try {

--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/executor/impl/BatchAsyncResultHandler.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/executor/impl/BatchAsyncResultHandler.java
@@ -41,6 +41,7 @@ public class BatchAsyncResultHandler implements AsyncResultHandler<List<Tuple>> 
      *
      * The default method does no-operation.
      */
+    @Override
     public void failure(Throwable t, List<Tuple> input) {
         completed.offer(new ExecutionResultCollector.FailedCollector(input, t));
     }
@@ -50,6 +51,7 @@ public class BatchAsyncResultHandler implements AsyncResultHandler<List<Tuple>> 
      *
      * The default method does no-operation.
      */
+    @Override
     public void success(List<Tuple> input) {
         completed.offer(new ExecutionResultCollector.SucceedCollector(input));
     }

--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/executor/impl/SingleAsyncResultHandler.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/executor/impl/SingleAsyncResultHandler.java
@@ -40,6 +40,7 @@ public class SingleAsyncResultHandler implements AsyncResultHandler<Tuple> {
      *
      * The default method does no-operation.
      */
+    @Override
     public void failure(Throwable t, Tuple input) {
         completed.offer(new ExecutionResultCollector.FailedCollector(input, t));
     }
@@ -49,6 +50,7 @@ public class SingleAsyncResultHandler implements AsyncResultHandler<Tuple> {
      *
      * The default method does no-operation.
      */
+    @Override
     public void success(Tuple input) {
         completed.offer(new ExecutionResultCollector.SucceedCollector(input));
     }

--- a/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/query/builder/ObjectMapperCqlStatementMapperBuilder.java
+++ b/external/storm-cassandra/src/main/java/org/apache/storm/cassandra/query/builder/ObjectMapperCqlStatementMapperBuilder.java
@@ -47,6 +47,7 @@ public class ObjectMapperCqlStatementMapperBuilder implements CQLStatementBuilde
     /**
      * Builds an ObjectMapperCqlStatementMapper.
      */
+    @Override
     public ObjectMapperCqlStatementMapper build() {
         List<TypeCodec<?>> codecs = codecProducers.stream().map(codecProducer -> {
             try {

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/state/HBaseMapState.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/state/HBaseMapState.java
@@ -234,6 +234,7 @@ public class HBaseMapState<T> implements IBackingMap<T> {
         }
 
         @SuppressWarnings({ "rawtypes", "unchecked" })
+        @Override
         public State makeState(Map<String, Object> conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
             LOG.info("Preparing HBase State for partition {} of {}.", partitionIndex + 1, numPartitions);
             IBackingMap state = new HBaseMapState(options, conf, partitionIndex);

--- a/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/windowing/HBaseWindowsStoreFactory.java
+++ b/external/storm-hbase/src/main/java/org/apache/storm/hbase/trident/windowing/HBaseWindowsStoreFactory.java
@@ -34,6 +34,7 @@ public class HBaseWindowsStoreFactory implements WindowsStoreFactory {
         this.qualifier = qualifier;
     }
 
+    @Override
     public WindowsStore create(Map<String, Object> topoConf) {
         Configuration configuration = HBaseConfiguration.create();
         for (Map.Entry<String, Object> entry : config.entrySet()) {

--- a/external/storm-hdfs-blobstore/src/test/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImplTest.java
+++ b/external/storm-hdfs-blobstore/src/test/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImplTest.java
@@ -64,6 +64,7 @@ public class HdfsBlobStoreImplTest {
             super(path, conf, hconf);
         }
 
+        @Override
         protected Path getKeyDir(String key) {
             return new Path(new Path(blobDir, KEYDIR), key);
         }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/AbstractHdfsBolt.java
@@ -91,6 +91,7 @@ public abstract class AbstractHdfsBolt extends BaseRichBolt {
      * @param topologyContext
      * @param collector
      */
+    @Override
     public final void prepare(Map<String, Object> conf, TopologyContext topologyContext, OutputCollector collector) {
         this.writeLock = new Object();
         if (this.syncPolicy == null) throw new IllegalStateException("SyncPolicy must be specified.");

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/format/DefaultFileNameFormat.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/bolt/format/DefaultFileNameFormat.java
@@ -74,6 +74,7 @@ public class DefaultFileNameFormat implements FileNameFormat {
         return this.prefix + this.componentId + "-" + this.taskId + "-" + rotation + "-" + timeStamp + this.extension;
     }
 
+    @Override
     public String getPath() {
         return this.path;
     }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/AbstractHDFSWriter.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/common/AbstractHDFSWriter.java
@@ -31,6 +31,7 @@ abstract public class AbstractHDFSWriter implements Writer {
         this.filePath = path;
     }
 
+    @Override
     final public long write(Tuple tuple) throws IOException {
         doWrite(tuple);
         this.needsRotation = rotationPolicy.mark(tuple, offset);
@@ -38,18 +39,22 @@ abstract public class AbstractHDFSWriter implements Writer {
         return this.offset;
     }
 
+    @Override
     final public void sync() throws IOException {
         doSync();
     }
 
+    @Override
     final public void close() throws IOException {
         doClose();
     }
 
+    @Override
     public boolean needsRotation() {
         return needsRotation;
     }
 
+    @Override
     public Path getFilePath() {
         return this.filePath;
     }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileLock.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/FileLock.java
@@ -302,6 +302,7 @@ public class FileLock {
             return new LogEntry(Long.parseLong(fields[0]), fields[1], fields[2]);
         }
 
+        @Override
         public String toString() {
             return eventTime + "," + componentID + "," + fileOffset;
         }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/HdfsSpout.java
@@ -230,6 +230,7 @@ public class HdfsSpout extends BaseRichSpout {
         return collector;
     }
 
+    @Override
     public void nextTuple() {
         LOG.trace("Next Tuple {}", spoutId);
         // 1) First re-emit any previously failed tuples (from retryList)
@@ -387,6 +388,7 @@ public class HdfsSpout extends BaseRichSpout {
     }
 
     @SuppressWarnings("deprecation")
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         LOG.info("Opening HDFS Spout");
         this.conf = conf;

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
@@ -69,6 +69,7 @@ public class SequenceFileReader<Key extends Writable, Value extends Writable>
         }
     }
 
+    @Override
     public List<Object> next() throws IOException, ParseException {
         if (reader.next(key, value)) {
             ArrayList<Object> result = new ArrayList<Object>(2);
@@ -88,6 +89,7 @@ public class SequenceFileReader<Key extends Writable, Value extends Writable>
         }
     }
 
+    @Override
     public Offset getFileOffset() {
         return offset;
     }

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/TextFileReader.java
@@ -59,10 +59,12 @@ public class TextFileReader extends AbstractFileReader {
 
     }
 
+    @Override
     public Offset getFileOffset() {
         return offset.clone();
     }
 
+    @Override
     public List<Object> next() throws IOException, ParseException {
         String line = readLineAndTrackOffset(reader);
         if (line != null) {

--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/trident/format/DefaultFileNameFormat.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/trident/format/DefaultFileNameFormat.java
@@ -72,6 +72,7 @@ public class DefaultFileNameFormat implements FileNameFormat {
         return this.prefix + "-" + this.partitionIndex + "-" + rotation + "-" + timeStamp + this.extension;
     }
 
+    @Override
     public String getPath() {
         return this.path;
     }

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/spout/TestHdfsSpout.java
@@ -776,6 +776,7 @@ public class TestHdfsSpout {
             this.componentId = componentId;
         }
 
+        @Override
         public String getThisComponentId() {
             return Integer.toString(componentId);
         }

--- a/external/storm-jms/src/main/java/org/apache/storm/jms/spout/JmsSpout.java
+++ b/external/storm-jms/src/main/java/org/apache/storm/jms/spout/JmsSpout.java
@@ -255,6 +255,7 @@ public class JmsSpout extends BaseRichSpout {
      * <p>When overridden, should always call {@code super}
      * to finalize the active connections.
      */
+    @Override
     public void close() {
         try {
             LOG.debug("Closing JMS connection.");
@@ -272,6 +273,7 @@ public class JmsSpout extends BaseRichSpout {
      * <p>This method polls the queue that's being filled asynchronously by the
      * jms connection, every {@link #POLL_INTERVAL_MS} seconds.
      */
+    @Override
     public void nextTuple() {
         try {
             Message msg = consumer.receive(POLL_INTERVAL_MS);

--- a/external/storm-jms/src/test/java/org/apache/storm/jms/spout/MockJmsProvider.java
+++ b/external/storm-jms/src/test/java/org/apache/storm/jms/spout/MockJmsProvider.java
@@ -46,6 +46,7 @@ public class MockJmsProvider implements JmsProvider {
      *
      * @throws Exception
      */
+    @Override
     public ConnectionFactory connectionFactory() throws Exception {
         return this.connectionFactory;
     }
@@ -58,6 +59,7 @@ public class MockJmsProvider implements JmsProvider {
      *
      * @throws Exception
      */
+    @Override
     public Destination destination() throws Exception {
         return this.destination;
     }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/KafkaSpoutConfig.java
@@ -293,6 +293,7 @@ public class KafkaSpoutConfig<K, V> extends CommonKafkaSpoutConfig<K, V> {
             return this;
         }
 
+        @Override
         public KafkaSpoutConfig<K, V> build() {
             return new KafkaSpoutConfig<>(this);
         }

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/RecordTranslator.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/RecordTranslator.java
@@ -39,6 +39,7 @@ public interface RecordTranslator<K, V> extends Serializable, Func<ConsumerRecor
      *     Return {@code null} to discard an invalid {@link ConsumerRecord}
      *     if {@link Builder#setEmitNullTuples(boolean)} is set to {@code false}.
      */
+    @Override
     List<Object> apply(ConsumerRecord<K,V> record);
     
     /**

--- a/external/storm-mongodb/src/main/java/org/apache/storm/mongodb/common/mapper/SimpleMongoUpdateMapper.java
+++ b/external/storm-mongodb/src/main/java/org/apache/storm/mongodb/common/mapper/SimpleMongoUpdateMapper.java
@@ -39,6 +39,7 @@ public class SimpleMongoUpdateMapper extends SimpleMongoMapper implements MongoU
         return new Document("$set", document);
     }
 
+    @Override
     public SimpleMongoUpdateMapper withFields(String... fields) {
         this.fields = fields;
         return this;

--- a/external/storm-mongodb/src/main/java/org/apache/storm/mongodb/trident/state/MongoMapState.java
+++ b/external/storm-mongodb/src/main/java/org/apache/storm/mongodb/trident/state/MongoMapState.java
@@ -147,6 +147,7 @@ public class MongoMapState<T> implements IBackingMap<T> {
         }
 
         @SuppressWarnings({"rawtypes", "unchecked"})
+        @Override
         public State makeState(Map<String, Object> conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
             IBackingMap state = new MongoMapState(conf, options);
 

--- a/external/storm-mqtt/src/main/java/org/apache/storm/mqtt/mappers/ByteArrayMessageMapper.java
+++ b/external/storm-mqtt/src/main/java/org/apache/storm/mqtt/mappers/ByteArrayMessageMapper.java
@@ -19,10 +19,12 @@ import org.apache.storm.tuple.Values;
 
 
 public class ByteArrayMessageMapper implements MqttMessageMapper {
+    @Override
     public Values toValues(MqttMessage message) {
         return new Values(message.getTopic(), message.getMessage());
     }
 
+    @Override
     public Fields outputFields() {
         return new Fields("topic", "message");
     }

--- a/external/storm-mqtt/src/main/java/org/apache/storm/mqtt/mappers/StringMessageMapper.java
+++ b/external/storm-mqtt/src/main/java/org/apache/storm/mqtt/mappers/StringMessageMapper.java
@@ -22,10 +22,12 @@ import org.apache.storm.tuple.Values;
  * "topic" and "message", both of which are Strings.
  */
 public class StringMessageMapper implements MqttMessageMapper {
+    @Override
     public Values toValues(MqttMessage message) {
         return new Values(message.getTopic(), new String(message.getMessage()));
     }
 
+    @Override
     public Fields outputFields() {
         return new Fields("topic", "message");
     }

--- a/external/storm-mqtt/src/main/java/org/apache/storm/mqtt/spout/MqttSpout.java
+++ b/external/storm-mqtt/src/main/java/org/apache/storm/mqtt/spout/MqttSpout.java
@@ -76,14 +76,17 @@ public class MqttSpout implements IRichSpout, Listener {
         return this.sequence;
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(this.type.outputFields());
     }
 
+    @Override
     public Map<String, Object> getComponentConfiguration() {
         return null;
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         this.topologyName = (String) conf.get(Config.TOPOLOGY_NAME);
 
@@ -129,13 +132,16 @@ public class MqttSpout implements IRichSpout, Listener {
     }
 
 
+    @Override
     public void close() {
         this.connection.disconnect(new DisconnectCallback());
     }
 
+    @Override
     public void activate() {
     }
 
+    @Override
     public void deactivate() {
     }
 
@@ -147,6 +153,7 @@ public class MqttSpout implements IRichSpout, Listener {
      * to have nextTuple sleep for a short amount of time (like a single millisecond)
      * so as not to waste too much CPU.
      */
+    @Override
     public void nextTuple() {
         AckableMessage tm = this.incoming.poll();
         if (tm != null) {
@@ -166,6 +173,7 @@ public class MqttSpout implements IRichSpout, Listener {
      *
      * @param msgId
      */
+    @Override
     public void ack(Object msgId) {
         AckableMessage msg = this.pending.remove(msgId);
         this.connection.getDispatchQueue().execute(msg.ack());
@@ -178,6 +186,7 @@ public class MqttSpout implements IRichSpout, Listener {
      *
      * @param msgId
      */
+    @Override
     public void fail(Object msgId) {
         try {
             this.incoming.put(this.pending.remove(msgId));
@@ -188,14 +197,17 @@ public class MqttSpout implements IRichSpout, Listener {
 
 
     // ################# Listener Implementation ######################
+    @Override
     public void onConnected() {
         // this gets called repeatedly for no apparent reason, don't do anything
     }
 
+    @Override
     public void onDisconnected() {
         // this gets called repeatedly for no apparent reason, don't do anything
     }
 
+    @Override
     public void onPublish(UTF8Buffer topic, Buffer payload, Runnable ack) {
         LOG.debug("Received message: topic={}, payload={}", topic.toString(), new String(payload.toByteArray()));
         try {
@@ -205,6 +217,7 @@ public class MqttSpout implements IRichSpout, Listener {
         }
     }
 
+    @Override
     public void onFailure(Throwable throwable) {
         LOG.error("MQTT Connection Failure.", throwable);
         MqttSpout.this.connection.disconnect(new DisconnectCallback());
@@ -213,11 +226,13 @@ public class MqttSpout implements IRichSpout, Listener {
 
     // ################# Connect Callback Implementation ######################
     private class ConnectCallback implements Callback<Void> {
+        @Override
         public void onSuccess(Void v) {
             LOG.info("MQTT Connected. Subscribing to topic...");
             MqttSpout.this.mqttConnected = true;
         }
 
+        @Override
         public void onFailure(Throwable throwable) {
             LOG.info("MQTT Connection failed.");
             MqttSpout.this.mqttConnectFailed = true;
@@ -226,10 +241,12 @@ public class MqttSpout implements IRichSpout, Listener {
 
     // ################# Subscribe Callback Implementation ######################
     private class SubscribeCallback implements Callback<byte[]> {
+        @Override
         public void onSuccess(byte[] qos) {
             LOG.info("Subscripton sucessful.");
         }
 
+        @Override
         public void onFailure(Throwable throwable) {
             LOG.error("MQTT Subscripton failed.", throwable);
             throw new RuntimeException("MQTT Subscribe failed.", throwable);
@@ -238,10 +255,12 @@ public class MqttSpout implements IRichSpout, Listener {
 
     // ################# Subscribe Callback Implementation ######################
     private class DisconnectCallback implements Callback<Void> {
+        @Override
         public void onSuccess(Void aVoid) {
             LOG.info("MQTT Disconnect successful.");
         }
 
+        @Override
         public void onFailure(Throwable throwable) {
             // Disconnects don't fail.
         }

--- a/external/storm-opentsdb/src/main/java/org/apache/storm/opentsdb/bolt/TupleOpenTsdbDatapointMapper.java
+++ b/external/storm-opentsdb/src/main/java/org/apache/storm/opentsdb/bolt/TupleOpenTsdbDatapointMapper.java
@@ -86,6 +86,7 @@ public final class TupleOpenTsdbDatapointMapper implements ITupleOpenTsdbDatapoi
         return tagsField;
     }
 
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof TupleOpenTsdbDatapointMapper)) return false;

--- a/flux/flux-examples/src/main/java/org/apache/storm/flux/examples/WordCounter.java
+++ b/flux/flux-examples/src/main/java/org/apache/storm/flux/examples/WordCounter.java
@@ -43,6 +43,7 @@ public class WordCounter extends BaseBasicBolt {
 
 
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context) {
     }
 
@@ -50,14 +51,17 @@ public class WordCounter extends BaseBasicBolt {
      * Just output the word value with a count of 1.
      * The HBaseBolt will handle incrementing the counter.
      */
+    @Override
     public void execute(Tuple input, BasicOutputCollector collector) {
         collector.emit(tuple(input.getValues().get(0), 1));
     }
 
+    @Override
     public void cleanup() {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("word", "count"));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1254,6 +1254,32 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>3.12.0</version>
+                    <configuration>
+                        <rulesets>
+                            <ruleset>storm/pmd-ruleset.xml</ruleset>
+                        </rulesets>
+                        <includeTests>true</includeTests>
+                        <printFailingErrors>true</printFailingErrors>
+                        <excludes>
+                            <exclude>org/apache/storm/generated/**</exclude>
+                            <exclude>org/apache/storm/sql/parser/impl/**</exclude>
+                        </excludes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>pmd-check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.storm</groupId>
+                            <artifactId>storm-checkstyle</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>

--- a/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/RexNodeToJavaCodeCompiler.java
+++ b/sql/storm-sql-core/src/jvm/org/apache/storm/sql/compiler/RexNodeToJavaCodeCompiler.java
@@ -158,6 +158,7 @@ public class RexNodeToJavaCodeCompiler {
                                         JavaRowFormat.ARRAY, false))));
         final Function1<String, RexToLixTranslator.InputGetter> correlates =
             new Function1<String, RexToLixTranslator.InputGetter>() {
+                @Override
                 public RexToLixTranslator.InputGetter apply(String a0) {
                     throw new UnsupportedOperationException();
                 }

--- a/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/spout/SocketSpout.java
+++ b/sql/storm-sql-runtime/src/jvm/org/apache/storm/sql/runtime/datasource/socket/spout/SocketSpout.java
@@ -157,6 +157,7 @@ public class SocketSpout implements IRichSpout {
     }
 
     private class SocketReaderRunnable implements Runnable {
+        @Override
         public void run() {
             while (running) {
                 try {

--- a/storm-checkstyle/src/main/resources/storm/pmd-ruleset.xml
+++ b/storm-checkstyle/src/main/resources/storm/pmd-ruleset.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<ruleset name="Custom ruleset"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>
+        The default ruleset for Apache Storm
+    </description>
+    <rule ref="category/java/bestpractices.xml/MissingOverride"/>
+</ruleset>

--- a/storm-client/src/jvm/org/apache/storm/ILocalDRPC.java
+++ b/storm-client/src/jvm/org/apache/storm/ILocalDRPC.java
@@ -27,5 +27,6 @@ public interface ILocalDRPC extends DistributedRPC.Iface, DistributedRPCInvocati
      * @deprecated use {@link #close()} instead
      */
     @Deprecated
+    @Override
     public void shutdown();
 }

--- a/storm-client/src/jvm/org/apache/storm/LogWriter.java
+++ b/storm-client/src/jvm/org/apache/storm/LogWriter.java
@@ -56,6 +56,7 @@ public class LogWriter extends Thread {
         System.exit(ret);
     }
 
+    @Override
     public void run() {
         Logger logger = this.logger;
         BufferedReader in = this.in;

--- a/storm-client/src/jvm/org/apache/storm/assignments/ILocalAssignmentsBackend.java
+++ b/storm-client/src/jvm/org/apache/storm/assignments/ILocalAssignmentsBackend.java
@@ -116,5 +116,6 @@ public interface ILocalAssignmentsBackend extends AutoCloseable {
     /**
      * Function to release resource.
      */
+    @Override
     void close();
 }

--- a/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
@@ -171,6 +171,7 @@ public abstract class ClientBlobStore implements Shutdownable, AutoCloseable {
      */
     public abstract void createStateInZookeeper(String key);
 
+    @Override
     public abstract void close();
 
     /**

--- a/storm-client/src/jvm/org/apache/storm/coordination/CoordinatedBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/coordination/CoordinatedBolt.java
@@ -74,6 +74,7 @@ public class CoordinatedBolt implements IRichBolt {
         return ret;
     }
 
+    @Override
     public void prepare(Map<String, Object> config, TopologyContext context, OutputCollector collector) {
         TimeCacheMap.ExpiredCallback<Object, TrackingInfo> callback = null;
         if (_delegate instanceof TimeoutCallback) {
@@ -167,6 +168,7 @@ public class CoordinatedBolt implements IRichBolt {
         return failed;
     }
 
+    @Override
     public void execute(Tuple tuple) {
         Object id = tuple.getValue(0);
         TrackingInfo track;
@@ -201,11 +203,13 @@ public class CoordinatedBolt implements IRichBolt {
         }
     }
 
+    @Override
     public void cleanup() {
         _delegate.cleanup();
         _tracked.cleanup();
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         _delegate.declareOutputFields(declarer);
         declarer.declareStream(Constants.COORDINATED_STREAM_ID, true, new Fields("id", "count"));
@@ -306,17 +310,20 @@ public class CoordinatedBolt implements IRichBolt {
             _delegate = delegate;
         }
 
+        @Override
         public List<Integer> emit(String stream, Collection<Tuple> anchors, List<Object> tuple) {
             List<Integer> tasks = _delegate.emit(stream, anchors, tuple);
             updateTaskCounts(tuple.get(0), tasks);
             return tasks;
         }
 
+        @Override
         public void emitDirect(int task, String stream, Collection<Tuple> anchors, List<Object> tuple) {
             updateTaskCounts(tuple.get(0), Arrays.asList(task));
             _delegate.emitDirect(task, stream, anchors, tuple);
         }
 
+        @Override
         public void ack(Tuple tuple) {
             Object id = tuple.getValue(0);
             synchronized (_tracked) {
@@ -333,6 +340,7 @@ public class CoordinatedBolt implements IRichBolt {
             }
         }
 
+        @Override
         public void fail(Tuple tuple) {
             Object id = tuple.getValue(0);
             synchronized (_tracked) {
@@ -345,14 +353,17 @@ public class CoordinatedBolt implements IRichBolt {
             _delegate.fail(tuple);
         }
 
+        @Override
         public void flush() {
             _delegate.flush();
         }
 
+        @Override
         public void resetTimeout(Tuple tuple) {
             _delegate.resetTimeout(tuple);
         }
 
+        @Override
         public void reportError(Throwable error) {
             _delegate.reportError(error);
         }

--- a/storm-client/src/jvm/org/apache/storm/daemon/supervisor/AdvancedFSOps.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/supervisor/AdvancedFSOps.java
@@ -73,6 +73,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param dir the directory to change permissions on
      * @throws IOException on any error
      */
+    @Override
     public void restrictDirectoryPermissions(File dir) throws IOException {
         Set<PosixFilePermission> perms = new HashSet<>(
             Arrays.asList(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE,
@@ -88,6 +89,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param toDir   where to move it from
      * @throws IOException on any error
      */
+    @Override
     public void moveDirectoryPreferAtomic(File fromDir, File toDir) throws IOException {
         FileUtils.forceMkdir(toDir);
         Files.move(fromDir.toPath(), toDir.toPath(), StandardCopyOption.ATOMIC_MOVE);
@@ -96,6 +98,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
     /**
      * @return true if an atomic directory move works, else false.
      */
+    @Override
     public boolean supportsAtomicDirectoryMove() {
         return true;
     }
@@ -107,6 +110,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param toDir   to where
      * @throws IOException on any error
      */
+    @Override
     public void copyDirectory(File fromDir, File toDir) throws IOException {
         FileUtils.copyDirectory(fromDir, toDir);
     }
@@ -118,6 +122,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param user the user to change the permissions for
      * @throws IOException on any error
      */
+    @Override
     public void setupBlobPermissions(File path, String user) throws IOException {
         //Normally this is a NOOP
     }
@@ -130,6 +135,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param logPrefix if an external process needs to be launched to delete the object what prefix to include in the logs
      * @throws IOException on any error.
      */
+    @Override
     public void deleteIfExists(File path, String user, String logPrefix) throws IOException {
         //by default no need to do this as a different user
         deleteIfExists(path);
@@ -141,6 +147,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param path what to delete
      * @throws IOException on any error.
      */
+    @Override
     public void deleteIfExists(File path) throws IOException {
         LOG.info("Deleting path {}", path);
         Path p = path.toPath();
@@ -159,6 +166,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param path the directory to set the permissions on
      * @throws IOException on any error
      */
+    @Override
     public void setupStormCodeDir(String user, File path) throws IOException {
         //By default this is a NOOP
     }
@@ -170,6 +178,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param path the directory to set the permissions on
      * @throws IOException on any error
      */
+    @Override
     public void setupWorkerArtifactsDir(String user, File path) throws IOException {
         //By default this is a NOOP
     }
@@ -183,6 +192,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      *
      * @throws IOException on any error
      */
+    @Override
     public boolean doRequiredTopoFilesExist(Map<String, Object> conf, String topologyId) throws IOException {
         return ClientSupervisorUtils.doRequiredTopoFilesExist(conf, topologyId);
     }
@@ -193,6 +203,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param path the directory to create
      * @throws IOException on any error
      */
+    @Override
     public void forceMkdir(File path) throws IOException {
         FileUtils.forceMkdir(path);
     }
@@ -203,14 +214,17 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param path the directory to create
      * @throws IOException on any error
      */
+    @Override
     public void forceMkdir(Path path) throws IOException {
         Files.createDirectories(path);
     }
 
+    @Override
     public DirectoryStream<Path> newDirectoryStream(Path dir, DirectoryStream.Filter<? super Path> filter) throws IOException {
         return Files.newDirectoryStream(dir, filter);
     }
 
+    @Override
     public DirectoryStream<Path> newDirectoryStream(Path dir) throws IOException {
         return Files.newDirectoryStream(dir);
     }
@@ -223,6 +237,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      *
      * @throws IOException on any error.
      */
+    @Override
     public boolean fileExists(File path) throws IOException {
         return path.exists();
     }
@@ -235,6 +250,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      *
      * @throws IOException on any error.
      */
+    @Override
     public boolean fileExists(Path path) throws IOException {
         return Files.exists(path);
     }
@@ -247,6 +263,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      *
      * @throws IOException on any error
      */
+    @Override
     public Writer getWriter(File file) throws IOException {
         return new FileWriter(file);
     }
@@ -259,6 +276,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      *
      * @throws IOException on any error
      */
+    @Override
     public OutputStream getOutputStream(File file) throws IOException {
         return new FileOutputStream(file);
     }
@@ -270,6 +288,7 @@ public class AdvancedFSOps implements IAdvancedFSOps {
      * @param data     the data to write
      * @throws IOException on any error
      */
+    @Override
     public void dump(File location, String data) throws IOException {
         File parent = location.getParentFile();
         if (!parent.exists()) {

--- a/storm-client/src/jvm/org/apache/storm/daemon/supervisor/ClientSupervisorUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/supervisor/ClientSupervisorUtils.java
@@ -139,6 +139,7 @@ public class ClientSupervisorUtils {
         }
         if (logPrefix != null || exitCodeCallback != null) {
             Utils.asyncLoop(new Callable<Long>() {
+                @Override
                 public Long call() {
                     if (logPrefix != null) {
                         Utils.readAndLogStream(logPrefix,

--- a/storm-client/src/jvm/org/apache/storm/drpc/DRPCInvocationsClient.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/DRPCInvocationsClient.java
@@ -57,6 +57,7 @@ public class DRPCInvocationsClient extends ThriftClient implements DistributedRP
         return client.get() != null;
     }
 
+    @Override
     public void result(String id, String result) throws TException, AuthorizationException {
         DistributedRPCInvocations.Client c = client.get();
         try {
@@ -72,6 +73,7 @@ public class DRPCInvocationsClient extends ThriftClient implements DistributedRP
         }
     }
 
+    @Override
     public DRPCRequest fetchRequest(String func) throws TException, AuthorizationException {
         DistributedRPCInvocations.Client c = client.get();
         try {
@@ -87,6 +89,7 @@ public class DRPCInvocationsClient extends ThriftClient implements DistributedRP
         }
     }
 
+    @Override
     public void failRequest(String id) throws TException, AuthorizationException {
         DistributedRPCInvocations.Client c = client.get();
         try {

--- a/storm-client/src/jvm/org/apache/storm/drpc/JoinResult.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/JoinResult.java
@@ -39,10 +39,12 @@ public class JoinResult extends BaseRichBolt {
         this.returnComponent = returnComponent;
     }
 
+    @Override
     public void prepare(Map<String, Object> map, TopologyContext context, OutputCollector collector) {
         _collector = collector;
     }
 
+    @Override
     public void execute(Tuple tuple) {
         Object requestId = tuple.getValue(0);
         if (tuple.getSourceComponent().equals(returnComponent)) {
@@ -64,6 +66,7 @@ public class JoinResult extends BaseRichBolt {
         }
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("result", "return-info"));
     }

--- a/storm-client/src/jvm/org/apache/storm/drpc/KeyedFairBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/KeyedFairBolt.java
@@ -39,7 +39,7 @@ public class KeyedFairBolt implements IRichBolt, FinishedCallback {
         this(new BasicBoltExecutor(delegate));
     }
 
-
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
         if (_delegate instanceof FinishedCallback) {
             _callback = (FinishedCallback) _delegate;
@@ -47,6 +47,7 @@ public class KeyedFairBolt implements IRichBolt, FinishedCallback {
         _delegate.prepare(topoConf, context, collector);
         _rrQueue = new KeyedRoundRobinQueue<Tuple>();
         _executor = new Thread(new Runnable() {
+            @Override
             public void run() {
                 try {
                     while (true) {
@@ -61,20 +62,24 @@ public class KeyedFairBolt implements IRichBolt, FinishedCallback {
         _executor.start();
     }
 
+    @Override
     public void execute(Tuple input) {
         Object key = input.getValue(0);
         _rrQueue.add(key, input);
     }
 
+    @Override
     public void cleanup() {
         _executor.interrupt();
         _delegate.cleanup();
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         _delegate.declareOutputFields(declarer);
     }
 
+    @Override
     public void finishedId(Object id) {
         if (_callback != null) {
             _callback.finishedId(id);

--- a/storm-client/src/jvm/org/apache/storm/drpc/PrepareRequest.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/PrepareRequest.java
@@ -46,6 +46,7 @@ public class PrepareRequest extends BaseBasicBolt {
         collector.emit(ID_STREAM, new Values(requestId));
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declareStream(ARGS_STREAM, new Fields("request", "args"));
         declarer.declareStream(RETURN_STREAM, new Fields("request", "return"));

--- a/storm-client/src/jvm/org/apache/storm/drpc/ReturnResults.java
+++ b/storm-client/src/jvm/org/apache/storm/drpc/ReturnResults.java
@@ -126,6 +126,7 @@ public class ReturnResults extends BaseRichBolt {
         }
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/executor/ExecutorShutdown.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/ExecutorShutdown.java
@@ -72,6 +72,7 @@ public class ExecutorShutdown implements Shutdownable, IRunningExecutor {
         }
     }
 
+    @Override
     public void loadChanged(LoadMapping loadMapping) {
         executor.reflectNewLoadMapping(loadMapping);
     }

--- a/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltOutputCollectorImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltOutputCollectorImpl.java
@@ -59,6 +59,7 @@ public class BoltOutputCollectorImpl implements IOutputCollector {
         this.xsfer = executor.getExecutorTransfer();
     }
 
+    @Override
     public List<Integer> emit(String streamId, Collection<Tuple> anchors, List<Object> tuple) {
         try {
             return boltEmit(streamId, anchors, tuple, null);

--- a/storm-client/src/jvm/org/apache/storm/generated/NumErrorsChoice.java
+++ b/storm-client/src/jvm/org/apache/storm/generated/NumErrorsChoice.java
@@ -39,6 +39,7 @@ public enum NumErrorsChoice implements org.apache.storm.thrift.TEnum {
   /**
    * Get the integer value of this enum value, as defined in the Thrift IDL.
    */
+  @Override
   public int getValue() {
     return value;
   }

--- a/storm-client/src/jvm/org/apache/storm/generated/TopologyInitialStatus.java
+++ b/storm-client/src/jvm/org/apache/storm/generated/TopologyInitialStatus.java
@@ -38,6 +38,7 @@ public enum TopologyInitialStatus implements org.apache.storm.thrift.TEnum {
   /**
    * Get the integer value of this enum value, as defined in the Thrift IDL.
    */
+  @Override
   public int getValue() {
     return value;
   }

--- a/storm-client/src/jvm/org/apache/storm/grouping/Load.java
+++ b/storm-client/src/jvm/org/apache/storm/grouping/Load.java
@@ -64,6 +64,7 @@ public class Load {
         return connectionLoad > boltLoad ? connectionLoad : boltLoad;
     }
 
+    @Override
     public String toString() {
         return "[:load " + boltLoad + " " + connectionLoad + "]";
     }

--- a/storm-client/src/jvm/org/apache/storm/grouping/PartialKeyGrouping.java
+++ b/storm-client/src/jvm/org/apache/storm/grouping/PartialKeyGrouping.java
@@ -156,6 +156,7 @@ public class PartialKeyGrouping implements CustomStreamGrouping, Serializable {
         /**
          * Creates a two task assignment by selecting random tasks.
          */
+        @Override
         public int[] createAssignment(List<Integer> tasks, byte[] key) {
             // It is necessary that this produce a deterministic assignment based on the key, so seed the Random from the key
             final long seedForRandom = Arrays.hashCode(key);
@@ -178,6 +179,7 @@ public class PartialKeyGrouping implements CustomStreamGrouping, Serializable {
         /**
          * Chooses one of the incoming tasks and selects the one that has been selected the fewest times so far.
          */
+        @Override
         public Integer chooseTask(int[] assignedTasks) {
             Integer taskIdWithMinLoad = null;
             Long minTaskLoad = Long.MAX_VALUE;

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/Client.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/Client.java
@@ -177,6 +177,7 @@ public class Client extends ConnectionWithStatus implements IStatefulObject, ISa
         // netty TimerTask is already defined and hence a fully
         // qualified name
         TIMER.schedule(new java.util.TimerTask() {
+            @Override
             public void run() {
                 try {
                     LOG.debug("running timer task, address {}", dstAddress);

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/KerberosSaslNettyClient.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/KerberosSaslNettyClient.java
@@ -107,6 +107,7 @@ public class KerberosSaslNettyClient {
             final CallbackHandler fch = ch;
             LOG.debug("Kerberos Client with principal: {}, host: {}", fPrincipalName, fHost);
             saslClient = Subject.doAs(subject, new PrivilegedExceptionAction<SaslClient>() {
+                @Override
                 public SaslClient run() {
                     try {
                         Map<String, String> props = new TreeMap<String, String>();
@@ -146,6 +147,7 @@ public class KerberosSaslNettyClient {
         try {
             final SaslMessageToken fSaslTokenMessage = saslTokenMessage;
             byte[] retval = Subject.doAs(subject, new PrivilegedExceptionAction<byte[]>() {
+                @Override
                 public byte[] run() {
                     try {
                         byte[] retval = saslClient.evaluateChallenge(fSaslTokenMessage
@@ -176,6 +178,7 @@ public class KerberosSaslNettyClient {
          * @param callbacks objects that indicate what credential information the server's SaslServer requires from the client.
          * @throws UnsupportedCallbackException
          */
+        @Override
         public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
             for (Callback callback : callbacks) {
                 LOG.info("Kerberos Client Callback Handler got callback: {}", callback.getClass());

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/KerberosSaslNettyServer.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/KerberosSaslNettyServer.java
@@ -97,6 +97,7 @@ class KerberosSaslNettyServer {
             LOG.debug("Server with host: {}", fHost);
             saslServer =
                 Subject.doAs(subject, new PrivilegedExceptionAction<SaslServer>() {
+                    @Override
                     public SaslServer run() {
                         try {
                             Map<String, String> props = new TreeMap<String, String>();
@@ -136,6 +137,7 @@ class KerberosSaslNettyServer {
     public byte[] response(final byte[] token) {
         try {
             byte[] retval = Subject.doAs(subject, new PrivilegedExceptionAction<byte[]>() {
+                @Override
                 public byte[] run() {
                     try {
                         LOG.debug("response: Responding to input token of length: {}",

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/Login.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/Login.java
@@ -111,6 +111,7 @@ public class Login {
         // you can decrease the interval of expiration of tickets (for example, to 3 minutes) by running :
         //  "modprinc -maxlife 3mins <principal>" in kadmin.
         t = new Thread(new Runnable() {
+            @Override
             public void run() {
                 LOG.info("TGT refresh thread started.");
                 while (true) {  // renewal thread's main loop. if it exits from here, thread will exit.

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/SaslNettyClient.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/SaslNettyClient.java
@@ -108,6 +108,7 @@ public class SaslNettyClient {
          * @param callbacks objects that indicate what credential information the server's SaslServer requires from the client.
          * @throws UnsupportedCallbackException
          */
+        @Override
         public void handle(Callback[] callbacks)
             throws UnsupportedCallbackException {
             NameCallback nc = null;

--- a/storm-client/src/jvm/org/apache/storm/metric/api/AssignableMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/AssignableMetric.java
@@ -23,6 +23,7 @@ public class AssignableMetric implements IMetric {
         _value = value;
     }
 
+    @Override
     public Object getValueAndReset() {
         return _value;
     }

--- a/storm-client/src/jvm/org/apache/storm/metric/api/CombinedMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/CombinedMetric.java
@@ -25,6 +25,7 @@ public class CombinedMetric implements IMetric {
         _value = _combiner.combine(_value, value);
     }
 
+    @Override
     public Object getValueAndReset() {
         Object ret = _value;
         _value = _combiner.identity();

--- a/storm-client/src/jvm/org/apache/storm/metric/api/CountMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/CountMetric.java
@@ -26,6 +26,7 @@ public class CountMetric implements IMetric {
         _value += incrementBy;
     }
 
+    @Override
     public Object getValueAndReset() {
         long ret = _value;
         _value = 0;

--- a/storm-client/src/jvm/org/apache/storm/metric/api/MeanReducer.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/MeanReducer.java
@@ -24,10 +24,12 @@ class MeanReducerState {
 }
 
 public class MeanReducer implements IReducer<MeanReducerState> {
+    @Override
     public MeanReducerState init() {
         return new MeanReducerState();
     }
 
+    @Override
     public MeanReducerState reduce(MeanReducerState acc, Object input) {
         acc.count++;
         if (input instanceof Double) {
@@ -44,6 +46,7 @@ public class MeanReducer implements IReducer<MeanReducerState> {
         return acc;
     }
 
+    @Override
     public Object extractResult(MeanReducerState acc) {
         if (acc.count > 0) {
             return acc.sum / (double) acc.count;

--- a/storm-client/src/jvm/org/apache/storm/metric/api/MultiCountMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/MultiCountMetric.java
@@ -29,6 +29,7 @@ public class MultiCountMetric implements IMetric {
         return val;
     }
 
+    @Override
     public Map<String, Object> getValueAndReset() {
         Map<String, Object> ret = new HashMap<>();
         for (Map.Entry<String, CountMetric> e : _value.entrySet()) {

--- a/storm-client/src/jvm/org/apache/storm/metric/api/MultiReducedMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/MultiReducedMetric.java
@@ -31,6 +31,7 @@ public class MultiReducedMetric implements IMetric {
         return val;
     }
 
+    @Override
     public Map<String, Object> getValueAndReset() {
         Map<String, Object> ret = new HashMap<>();
         for (Map.Entry<String, ReducedMetric> e : _value.entrySet()) {

--- a/storm-client/src/jvm/org/apache/storm/metric/api/ReducedMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/ReducedMetric.java
@@ -25,6 +25,7 @@ public class ReducedMetric implements IMetric {
         _accumulator = _reducer.reduce(_accumulator, value);
     }
 
+    @Override
     public Object getValueAndReset() {
         Object ret = _reducer.extractResult(_accumulator);
         _accumulator = _reducer.init();

--- a/storm-client/src/jvm/org/apache/storm/metric/api/rpc/AssignableShellMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/rpc/AssignableShellMetric.java
@@ -19,6 +19,7 @@ public class AssignableShellMetric extends AssignableMetric implements IShellMet
         super(value);
     }
 
+    @Override
     public void updateMetricFromRPC(Object value) {
         setValue(value);
     }

--- a/storm-client/src/jvm/org/apache/storm/metric/api/rpc/CombinedShellMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/rpc/CombinedShellMetric.java
@@ -20,6 +20,7 @@ public class CombinedShellMetric extends CombinedMetric implements IShellMetric 
         super(combiner);
     }
 
+    @Override
     public void updateMetricFromRPC(Object value) {
         update(value);
     }

--- a/storm-client/src/jvm/org/apache/storm/metric/api/rpc/CountShellMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/rpc/CountShellMetric.java
@@ -20,6 +20,7 @@ public class CountShellMetric extends CountMetric implements IShellMetric {
      *  if value is null, it will call incr()
      *  if value is long, it will call incrBy((long)params)
      * */
+    @Override
     public void updateMetricFromRPC(Object value) {
         if (value == null) {
             incr();

--- a/storm-client/src/jvm/org/apache/storm/metric/api/rpc/ReducedShellMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/api/rpc/ReducedShellMetric.java
@@ -21,6 +21,7 @@ public class ReducedShellMetric extends ReducedMetric implements IShellMetric {
         super(reducer);
     }
 
+    @Override
     public void updateMetricFromRPC(Object value) {
         update(value);
     }

--- a/storm-client/src/jvm/org/apache/storm/metric/internal/CountStatAndMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/internal/CountStatAndMetric.java
@@ -187,6 +187,7 @@ public class CountStatAndMetric implements IMetric {
     }
 
     private class Fresher extends TimerTask {
+        @Override
         public void run() {
             rotateSched(System.currentTimeMillis());
         }

--- a/storm-client/src/jvm/org/apache/storm/metric/internal/LatencyStatAndMetric.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/internal/LatencyStatAndMetric.java
@@ -245,6 +245,7 @@ public class LatencyStatAndMetric implements IMetric {
     }
 
     private class Fresher extends TimerTask {
+        @Override
         public void run() {
             rotateSched(System.currentTimeMillis());
         }

--- a/storm-client/src/jvm/org/apache/storm/metric/internal/RateTracker.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/internal/RateTracker.java
@@ -130,6 +130,7 @@ public class RateTracker implements Closeable {
     }
 
     private class Fresher extends TimerTask {
+        @Override
         public void run() {
             rotateBuckets(System.currentTimeMillis());
         }

--- a/storm-client/src/jvm/org/apache/storm/multilang/JsonSerializer.java
+++ b/storm-client/src/jvm/org/apache/storm/multilang/JsonSerializer.java
@@ -39,6 +39,7 @@ public class JsonSerializer implements ISerializer {
     private transient BufferedWriter processIn;
     private transient BufferedReader processOut;
 
+    @Override
     public void initialize(OutputStream processIn, InputStream processOut) {
         try {
             this.processIn = new BufferedWriter(new OutputStreamWriter(processIn, DEFAULT_CHARSET));
@@ -48,6 +49,7 @@ public class JsonSerializer implements ISerializer {
         }
     }
 
+    @Override
     public Number connect(Map<String, Object> conf, TopologyContext context)
         throws IOException, NoOutputException {
         JSONObject setupInfo = new JSONObject();
@@ -60,6 +62,7 @@ public class JsonSerializer implements ISerializer {
         return pid;
     }
 
+    @Override
     public void writeBoltMsg(BoltMsg boltMsg) throws IOException {
         JSONObject obj = new JSONObject();
         obj.put("id", boltMsg.getId());
@@ -70,6 +73,7 @@ public class JsonSerializer implements ISerializer {
         writeMessage(obj);
     }
 
+    @Override
     public void writeSpoutMsg(SpoutMsg msg) throws IOException {
         JSONObject obj = new JSONObject();
         obj.put("command", msg.getCommand());
@@ -77,6 +81,7 @@ public class JsonSerializer implements ISerializer {
         writeMessage(obj);
     }
 
+    @Override
     public void writeTaskIds(List<Integer> taskIds) throws IOException {
         writeMessage(taskIds);
     }
@@ -91,6 +96,7 @@ public class JsonSerializer implements ISerializer {
         processIn.flush();
     }
 
+    @Override
     public ShellMsg readShellMsg() throws IOException, NoOutputException {
         JSONObject msg = (JSONObject) readMessage();
         ShellMsg shellMsg = new ShellMsg();

--- a/storm-client/src/jvm/org/apache/storm/pacemaker/PacemakerClient.java
+++ b/storm-client/src/jvm/org/apache/storm/pacemaker/PacemakerClient.java
@@ -145,10 +145,12 @@ public class PacemakerClient implements ISaslClient {
         this.notifyAll();
     }
 
+    @Override
     public String name() {
         return client_name;
     }
 
+    @Override
     public String secretKey() {
         return secret;
     }
@@ -231,6 +233,7 @@ public class PacemakerClient implements ISaslClient {
     public void reconnect() {
         final PacemakerClient client = this;
         timer.schedule(new TimerTask() {
+            @Override
             public void run() {
                 client.doReconnect();
             }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/AutoSSL.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/AutoSSL.java
@@ -83,6 +83,7 @@ public class AutoSSL implements IAutoCredentials {
         }
     }
 
+    @Override
     public void prepare(Map<String, Object> conf) {
         this.conf = conf;
         writeDir = getSSLWriteDirFromConf(this.conf);

--- a/storm-client/src/jvm/org/apache/storm/security/auth/DefaultPrincipalToLocal.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/DefaultPrincipalToLocal.java
@@ -21,6 +21,7 @@ public class DefaultPrincipalToLocal implements IPrincipalToLocal {
     /**
      * Invoked once immediately after construction
      */
+    @Override
     public void prepare(Map<String, Object> topoConf) {
     }
 

--- a/storm-client/src/jvm/org/apache/storm/security/auth/KerberosPrincipalToLocal.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/KerberosPrincipalToLocal.java
@@ -24,6 +24,7 @@ public class KerberosPrincipalToLocal implements IPrincipalToLocal {
      *
      * @param topoConf Storm configuration
      */
+    @Override
     public void prepare(Map<String, Object> topoConf) {
     }
 

--- a/storm-client/src/jvm/org/apache/storm/security/auth/SimpleTransportPlugin.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/SimpleTransportPlugin.java
@@ -127,6 +127,7 @@ public class SimpleTransportPlugin implements ITransportPlugin {
             this.wrapped = wrapped;
         }
 
+        @Override
         public boolean process(final TProtocol inProt, final TProtocol outProt) throws TException {
             //populating request context 
             ReqContext req_context = ReqContext.context();
@@ -152,10 +153,12 @@ public class SimpleTransportPlugin implements ITransportPlugin {
                 if (user != null) {
                     HashSet<Principal> principals = new HashSet<>();
                     principals.add(new Principal() {
+                        @Override
                         public String getName() {
                             return user;
                         }
 
+                        @Override
                         public String toString() {
                             return user;
                         }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/DenyAuthorizer.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/DenyAuthorizer.java
@@ -26,6 +26,7 @@ public class DenyAuthorizer implements IAuthorizer {
      *
      * @param conf Storm configuration
      */
+    @Override
     public void prepare(Map<String, Object> conf) {
     }
 
@@ -37,6 +38,7 @@ public class DenyAuthorizer implements IAuthorizer {
      * @param topoConf  configuration of targeted topology
      * @return true if the request is authorized, false if reject
      */
+    @Override
     public boolean permit(ReqContext context, String operation, Map<String, Object> topoConf) {
         return false;
     }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/NoopAuthorizer.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/NoopAuthorizer.java
@@ -26,6 +26,7 @@ public class NoopAuthorizer implements IAuthorizer {
      *
      * @param conf Storm configuration
      */
+    @Override
     public void prepare(Map<String, Object> conf) {
     }
 
@@ -37,6 +38,7 @@ public class NoopAuthorizer implements IAuthorizer {
      * @param topoConf  configuration of targeted topology
      * @return true if the request is authorized, false if reject
      */
+    @Override
     public boolean permit(ReqContext context, String operation, Map<String, Object> topoConf) {
         return true;
     }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/digest/DigestSaslTransportPlugin.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/digest/DigestSaslTransportPlugin.java
@@ -36,6 +36,7 @@ public class DigestSaslTransportPlugin extends SaslTransportPlugin {
     private static final Logger LOG = LoggerFactory.getLogger(DigestSaslTransportPlugin.class);
     private WorkerTokenAuthorizer workerTokenAuthorizer;
 
+    @Override
     protected TTransportFactory getServerTransportFactory(boolean impersonationAllowed) throws IOException {
         if (workerTokenAuthorizer == null) {
             workerTokenAuthorizer = new WorkerTokenAuthorizer(conf, type);

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGTKrb5LoginModule.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGTKrb5LoginModule.java
@@ -33,6 +33,7 @@ public class AutoTGTKrb5LoginModule implements LoginModule {
     // initial state
     private Subject subject;
 
+    @Override
     public void initialize(Subject subject,
                            CallbackHandler callbackHandler,
                            Map<String, ?> sharedState,
@@ -41,6 +42,7 @@ public class AutoTGTKrb5LoginModule implements LoginModule {
         this.subject = subject;
     }
 
+    @Override
     public boolean login() throws LoginException {
         LOG.debug("Acquire TGT from Cache");
         getKerbTicketFromCache();
@@ -62,6 +64,7 @@ public class AutoTGTKrb5LoginModule implements LoginModule {
         return null;
     }
 
+    @Override
     public boolean commit() throws LoginException {
         if (isSucceeded() == false) {
             return false;
@@ -80,6 +83,7 @@ public class AutoTGTKrb5LoginModule implements LoginModule {
         return true;
     }
 
+    @Override
     public boolean abort() throws LoginException {
         if (isSucceeded() == false) {
             return false;
@@ -88,6 +92,7 @@ public class AutoTGTKrb5LoginModule implements LoginModule {
         }
     }
 
+    @Override
     public boolean logout() throws LoginException {
         if (subject != null && !subject.isReadOnly() && kerbTicket != null) {
             subject.getPrincipals().remove(kerbTicket.getClient());

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ClientCallbackHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ClientCallbackHandler.java
@@ -57,6 +57,7 @@ public class ClientCallbackHandler implements CallbackHandler {
      *
      * @param callbacks a collection of challenge callbacks
      */
+    @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
         for (Callback c : callbacks) {
             if (c instanceof NameCallback) {

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/KerberosSaslTransportPlugin.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/KerberosSaslTransportPlugin.java
@@ -205,6 +205,7 @@ public class KerberosSaslTransportPlugin extends SaslTransportPlugin {
         try {
             Subject.doAs(subject,
                          new PrivilegedExceptionAction<Void>() {
+                             @Override
                              public Void run() {
                                  try {
                                      LOG.debug("do as:" + principal);

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ServerCallbackHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ServerCallbackHandler.java
@@ -50,6 +50,7 @@ public class ServerCallbackHandler implements CallbackHandler {
         }
     }
 
+    @Override
     public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
         NameCallback nc = null;
         PasswordCallback pc = null;

--- a/storm-client/src/jvm/org/apache/storm/security/auth/sasl/SaslTransportPlugin.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/sasl/SaslTransportPlugin.java
@@ -124,6 +124,7 @@ public abstract class SaslTransportPlugin implements ITransportPlugin, Closeable
             this.wrapped = wrapped;
         }
 
+        @Override
         public boolean process(final TProtocol inProt, final TProtocol outProt) throws TException {
             //populating request context
             ReqContext reqContext = ReqContext.context();
@@ -163,6 +164,7 @@ public abstract class SaslTransportPlugin implements ITransportPlugin, Closeable
         /**
          * Get the full name of the user.
          */
+        @Override
         public String getName() {
             return name;
         }

--- a/storm-client/src/jvm/org/apache/storm/serialization/DefaultKryoFactory.java
+++ b/storm-client/src/jvm/org/apache/storm/serialization/DefaultKryoFactory.java
@@ -32,6 +32,7 @@ public class DefaultKryoFactory implements IKryoFactory {
     public void preRegister(Kryo k, Map<String, Object> conf) {
     }
 
+    @Override
     public void postRegister(Kryo k, Map<String, Object> conf) {
         ((KryoSerializableDefault) k).overrideDefault(true);
     }

--- a/storm-client/src/jvm/org/apache/storm/serialization/KryoTupleSerializer.java
+++ b/storm-client/src/jvm/org/apache/storm/serialization/KryoTupleSerializer.java
@@ -29,6 +29,7 @@ public class KryoTupleSerializer implements ITupleSerializer {
         _ids = new SerializationFactory.IdDictionary(context.getRawTopology());
     }
 
+    @Override
     public byte[] serialize(Tuple tuple) {
         try {
 

--- a/storm-client/src/jvm/org/apache/storm/spout/RawScheme.java
+++ b/storm-client/src/jvm/org/apache/storm/spout/RawScheme.java
@@ -24,12 +24,14 @@ import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
 
 public class RawScheme implements Scheme {
+    @Override
     public List<Object> deserialize(ByteBuffer ser) {
         // Maintain backward compatibility for 0.10
         byte[] b = Utils.toByteArray(ser);
         return Utils.tuple(new Object[]{ b });
     }
 
+    @Override
     public Fields getOutputFields() {
         return new Fields("bytes");
     }

--- a/storm-client/src/jvm/org/apache/storm/spout/ShellSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/spout/ShellSpout.java
@@ -87,6 +87,7 @@ public class ShellSpout implements ISpout {
         this.changeDirectory = changeDirectory;
     }
 
+    @Override
     public void open(Map<String, Object> topoConf, TopologyContext context,
                      SpoutOutputCollector collector) {
         _collector = collector;
@@ -112,20 +113,24 @@ public class ShellSpout implements ISpout {
         heartBeatExecutorService = MoreExecutors.getExitingScheduledExecutorService(new ScheduledThreadPoolExecutor(1));
     }
 
+    @Override
     public void close() {
         heartBeatExecutorService.shutdownNow();
         _process.destroy();
         _running = false;
     }
 
+    @Override
     public void nextTuple() {
         this.sendSyncCommand("next", "");
     }
 
+    @Override
     public void ack(Object msgId) {
         this.sendSyncCommand("ack", msgId);
     }
 
+    @Override
     public void fail(Object msgId) {
         this.sendSyncCommand("fail", msgId);
     }

--- a/storm-client/src/jvm/org/apache/storm/spout/SpoutOutputCollector.java
+++ b/storm-client/src/jvm/org/apache/storm/spout/SpoutOutputCollector.java
@@ -38,6 +38,7 @@ public class SpoutOutputCollector implements ISpoutOutputCollector {
      *
      * @return the list of task ids that this tuple was sent to
      */
+    @Override
     public List<Integer> emit(String streamId, List<Object> tuple, Object messageId) {
         return _delegate.emit(streamId, tuple, messageId);
     }
@@ -77,6 +78,7 @@ public class SpoutOutputCollector implements ISpoutOutputCollector {
      * functionality will only work if the messageId is serializable via Kryo or the Serializable interface. The emitted values must be
      * immutable.
      */
+    @Override
     public void emitDirect(int taskId, String streamId, List<Object> tuple, Object messageId) {
         _delegate.emitDirect(taskId, streamId, tuple, messageId);
     }

--- a/storm-client/src/jvm/org/apache/storm/state/BaseBinaryStateIterator.java
+++ b/storm-client/src/jvm/org/apache/storm/state/BaseBinaryStateIterator.java
@@ -40,6 +40,7 @@ public abstract class BaseBinaryStateIterator<K, V> extends BaseStateIterator<K,
      *
      * @return Iterator of loaded state KVs
      */
+    @Override
     protected abstract Iterator<Map.Entry<byte[], byte[]>> loadChunkFromStateStorage();
 
     /**
@@ -47,6 +48,7 @@ public abstract class BaseBinaryStateIterator<K, V> extends BaseStateIterator<K,
      *
      * @return whether end of data is reached from storage state KVs
      */
+    @Override
     protected abstract boolean isEndOfDataFromStorage();
 
     /**
@@ -55,6 +57,7 @@ public abstract class BaseBinaryStateIterator<K, V> extends BaseStateIterator<K,
      * @param key byte array encoded key
      * @return Decoded value of key
      */
+    @Override
     protected abstract K decodeKey(byte[] key);
 
     /**
@@ -63,6 +66,7 @@ public abstract class BaseBinaryStateIterator<K, V> extends BaseStateIterator<K,
      * @param value byte array encoded value
      * @return Decoded value of value
      */
+    @Override
     protected abstract V decodeValue(byte[] value);
 
     /**
@@ -71,6 +75,7 @@ public abstract class BaseBinaryStateIterator<K, V> extends BaseStateIterator<K,
      * @param value the value to check
      * @return true if the value is tombstone, false otherwise
      */
+    @Override
     protected abstract boolean isTombstoneValue(byte[] value);
 
 }

--- a/storm-client/src/jvm/org/apache/storm/state/DefaultStateEncoder.java
+++ b/storm-client/src/jvm/org/apache/storm/state/DefaultStateEncoder.java
@@ -41,19 +41,23 @@ public class DefaultStateEncoder<K, V> implements StateEncoder<K, V, byte[], byt
         return valueSerializer;
     }
 
+    @Override
     public byte[] encodeKey(K key) {
         return keySerializer.serialize(key);
     }
 
+    @Override
     public byte[] encodeValue(V value) {
         return internalValueSerializer.serialize(
             Optional.of(valueSerializer.serialize(value)));
     }
 
+    @Override
     public K decodeKey(byte[] encodedKey) {
         return keySerializer.deserialize(encodedKey);
     }
 
+    @Override
     public V decodeValue(byte[] encodedValue) {
         Optional<byte[]> internalValue = internalValueSerializer.deserialize(encodedValue);
         if (internalValue.isPresent()) {

--- a/storm-client/src/jvm/org/apache/storm/streams/operations/Reducer.java
+++ b/storm-client/src/jvm/org/apache/storm/streams/operations/Reducer.java
@@ -25,5 +25,6 @@ public interface Reducer<T> extends BiFunction<T, T, T> {
      * @param arg2 the second argument
      * @return the result
      */
+    @Override
     T apply(T arg1, T arg2);
 }

--- a/storm-client/src/jvm/org/apache/storm/task/ShellBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/task/ShellBolt.java
@@ -122,6 +122,7 @@ public class ShellBolt implements IBolt {
         this.changeDirectory = changeDirectory;
     }
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context,
                         final OutputCollector collector) {
         if (ConfigUtils.isLocalMode(topoConf)) {
@@ -169,6 +170,7 @@ public class ShellBolt implements IBolt {
         heartBeatExecutorService.scheduleAtFixedRate(new BoltHeartbeatTimerTask(this), 1, 1, TimeUnit.SECONDS);
     }
 
+    @Override
     public void execute(Tuple input) {
         if (_exception != null) {
             throw new RuntimeException(_exception);
@@ -197,6 +199,7 @@ public class ShellBolt implements IBolt {
         return boltMsg;
     }
 
+    @Override
     public void cleanup() {
         _running = false;
         heartBeatExecutorService.shutdownNow();
@@ -323,6 +326,7 @@ public class ShellBolt implements IBolt {
     }
 
     private class BoltReaderRunnable implements Runnable {
+        @Override
         public void run() {
             while (_running) {
                 try {
@@ -367,6 +371,7 @@ public class ShellBolt implements IBolt {
     }
 
     private class BoltWriterRunnable implements Runnable {
+        @Override
         public void run() {
             while (_running) {
                 try {

--- a/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/TopologyContext.java
@@ -316,6 +316,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
      * @return The IMetric argument unchanged.
      */
     @Deprecated
+    @Override
     public <T extends IMetric> T registerMetric(String name, T metric, int timeBucketSizeInSecs) {
         if (_openOrPrepareWasCalled.get()) {
             throw new RuntimeException("TopologyContext.registerMetric can only be called from within overridden " +
@@ -382,6 +383,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
      * Convenience method for registering ReducedMetric.
      */
     @Deprecated
+    @Override
     public ReducedMetric registerMetric(String name, IReducer reducer, int timeBucketSizeInSecs) {
         return registerMetric(name, new ReducedMetric(reducer), timeBucketSizeInSecs);
     }
@@ -390,6 +392,7 @@ public class TopologyContext extends WorkerTopologyContext implements IMetricsCo
      * Convenience method for registering CombinedMetric.
      */
     @Deprecated
+    @Override
     public CombinedMetric registerMetric(String name, ICombiner combiner, int timeBucketSizeInSecs) {
         return registerMetric(name, new CombinedMetric(combiner), timeBucketSizeInSecs);
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/BoltTracker.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/BoltTracker.java
@@ -26,6 +26,7 @@ public class BoltTracker extends NonRichBoltTracker implements IRichBolt {
         _richDelegate = delegate;
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         _richDelegate.declareOutputFields(declarer);
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/FeederSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/FeederSpout.java
@@ -60,14 +60,17 @@ public class FeederSpout extends BaseRichSpout {
         InprocMessaging.waitForReader(_id);
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         _collector = collector;
     }
 
+    @Override
     public void close() {
 
     }
 
+    @Override
     public void nextTuple() {
         List<Object> toEmit = (List<Object>) InprocMessaging.pollMessage(_id);
         if (toEmit != null) {
@@ -78,18 +81,21 @@ public class FeederSpout extends BaseRichSpout {
         }
     }
 
+    @Override
     public void ack(Object msgId) {
         if (_ackFailDelegate != null) {
             _ackFailDelegate.ack(msgId);
         }
     }
 
+    @Override
     public void fail(Object msgId) {
         if (_ackFailDelegate != null) {
             _ackFailDelegate.fail(msgId);
         }
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(_outFields);
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/FixedTupleSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/FixedTupleSpout.java
@@ -104,6 +104,7 @@ public class FixedTupleSpout implements IRichSpout, CompletableSpout {
         }
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         _context = context;
         List<Integer> tasks = context.getComponentTasks(context.getThisComponentId());
@@ -121,9 +122,11 @@ public class FixedTupleSpout implements IRichSpout, CompletableSpout {
         }
     }
 
+    @Override
     public void close() {
     }
 
+    @Override
     public void nextTuple() {
         if (_serveTuples.size() > 0) {
             FixedTuple ft = _serveTuples.remove(0);
@@ -133,6 +136,7 @@ public class FixedTupleSpout implements IRichSpout, CompletableSpout {
         }
     }
 
+    @Override
     public void ack(Object msgId) {
         synchronized (acked) {
             int curr = get(acked, _id, 0);
@@ -140,6 +144,7 @@ public class FixedTupleSpout implements IRichSpout, CompletableSpout {
         }
     }
 
+    @Override
     public void fail(Object msgId) {
         synchronized (failed) {
             int curr = get(failed, _id, 0);

--- a/storm-client/src/jvm/org/apache/storm/testing/NonRichBoltTracker.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/NonRichBoltTracker.java
@@ -30,16 +30,19 @@ public class NonRichBoltTracker implements IBolt {
         _trackId = id;
     }
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
         _delegate.prepare(topoConf, context, collector);
     }
 
+    @Override
     public void execute(Tuple input) {
         _delegate.execute(input);
         Map<String, Object> stats = (Map<String, Object>) RegisteredGlobalState.getState(_trackId);
         ((AtomicInteger) stats.get("processed")).incrementAndGet();
     }
 
+    @Override
     public void cleanup() {
         _delegate.cleanup();
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/PythonShellMetricsBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/PythonShellMetricsBolt.java
@@ -37,6 +37,7 @@ public class PythonShellMetricsBolt extends ShellBolt implements IRichBolt {
         super(command, file);
     }
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
         super.prepare(topoConf, context, collector);
 
@@ -44,9 +45,11 @@ public class PythonShellMetricsBolt extends ShellBolt implements IRichBolt {
         context.registerMetric("my-custom-shell-metric", cMetric, 5);
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
     }
 
+    @Override
     public Map<String, Object> getComponentConfiguration() {
         return null;
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/PythonShellMetricsSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/PythonShellMetricsSpout.java
@@ -46,10 +46,12 @@ public class PythonShellMetricsSpout extends ShellSpout implements IRichSpout {
         context.registerMetric("my-custom-shellspout-metric", cMetric, 5);
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("field1"));
     }
 
+    @Override
     public Map<String, Object> getComponentConfiguration() {
         return null;
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/SingleUserSimpleTransport.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/SingleUserSimpleTransport.java
@@ -23,10 +23,12 @@ public class SingleUserSimpleTransport extends SimpleTransportPlugin {
     protected Subject getDefaultSubject() {
         HashSet<Principal> principals = new HashSet<Principal>();
         principals.add(new Principal() {
+            @Override
             public String getName() {
                 return "user";
             }
 
+            @Override
             public String toString() {
                 return "user";
             }

--- a/storm-client/src/jvm/org/apache/storm/testing/SpoutTracker.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/SpoutTracker.java
@@ -35,31 +35,37 @@ public class SpoutTracker extends BaseRichSpout {
         _trackId = trackId;
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         _tracker = new SpoutTrackOutputCollector(collector);
         _delegate.open(conf, context, new SpoutOutputCollector(_tracker));
     }
 
+    @Override
     public void close() {
         _delegate.close();
     }
 
+    @Override
     public void nextTuple() {
         _delegate.nextTuple();
     }
 
+    @Override
     public void ack(Object msgId) {
         _delegate.ack(msgId);
         Map<String, Object> stats = (Map<String, Object>) RegisteredGlobalState.getState(_trackId);
         ((AtomicInteger) stats.get("processed")).incrementAndGet();
     }
 
+    @Override
     public void fail(Object msgId) {
         _delegate.fail(msgId);
         Map<String, Object> stats = (Map<String, Object>) RegisteredGlobalState.getState(_trackId);
         ((AtomicInteger) stats.get("processed")).incrementAndGet();
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         _delegate.declareOutputFields(declarer);
     }
@@ -79,12 +85,14 @@ public class SpoutTracker extends BaseRichSpout {
 
         }
 
+        @Override
         public List<Integer> emit(String streamId, List<Object> tuple, Object messageId) {
             List<Integer> ret = _collector.emit(streamId, tuple, messageId);
             recordSpoutEmit();
             return ret;
         }
 
+        @Override
         public void emitDirect(int taskId, String streamId, List<Object> tuple, Object messageId) {
             _collector.emitDirect(taskId, streamId, tuple, messageId);
             recordSpoutEmit();

--- a/storm-client/src/jvm/org/apache/storm/testing/TestAggregatesCounter.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TestAggregatesCounter.java
@@ -32,11 +32,13 @@ public class TestAggregatesCounter extends BaseRichBolt {
     Map<String, Integer> _counts;
     OutputCollector _collector;
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
         _collector = collector;
         _counts = new HashMap<String, Integer>();
     }
 
+    @Override
     public void execute(Tuple input) {
         String word = (String) input.getValues().get(0);
         int count = (Integer) input.getValues().get(1);
@@ -49,10 +51,12 @@ public class TestAggregatesCounter extends BaseRichBolt {
         _collector.ack(input);
     }
 
+    @Override
     public void cleanup() {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("agg-global"));
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/TestEventLogSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TestEventLogSpout.java
@@ -62,6 +62,7 @@ public class TestEventLogSpout extends BaseRichSpout implements CompletableSpout
         }
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         _collector = collector;
         this.source = context.getThisTaskId();
@@ -69,6 +70,7 @@ public class TestEventLogSpout extends BaseRichSpout implements CompletableSpout
         myCount = totalCount / taskCount;
     }
 
+    @Override
     public void close() {
 
     }
@@ -101,6 +103,7 @@ public class TestEventLogSpout extends BaseRichSpout implements CompletableSpout
         return false;
     }
 
+    @Override
     public void nextTuple() {
         if (eventId < myCount) {
             eventId++;
@@ -108,6 +111,7 @@ public class TestEventLogSpout extends BaseRichSpout implements CompletableSpout
         }
     }
 
+    @Override
     public void ack(Object msgId) {
         synchronized (acked) {
             int curr = get(acked, uid, 0);
@@ -115,6 +119,7 @@ public class TestEventLogSpout extends BaseRichSpout implements CompletableSpout
         }
     }
 
+    @Override
     public void fail(Object msgId) {
         synchronized (failed) {
             int curr = get(failed, uid, 0);
@@ -122,6 +127,7 @@ public class TestEventLogSpout extends BaseRichSpout implements CompletableSpout
         }
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("source", "eventId"));
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/TestEventOrderCheckBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TestEventOrderCheckBolt.java
@@ -30,11 +30,13 @@ public class TestEventOrderCheckBolt extends BaseRichBolt {
     Map<Integer, Long> recentEventId = new HashMap<Integer, Long>();
     private int _count;
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
         _collector = collector;
         _count = 0;
     }
 
+    @Override
     public void execute(Tuple input) {
         Integer sourceId = input.getInteger(0);
         Long eventId = input.getLong(1);
@@ -51,6 +53,7 @@ public class TestEventOrderCheckBolt extends BaseRichBolt {
         _collector.ack(input);
     }
 
+    @Override
     public void cleanup() {
 
     }
@@ -59,6 +62,7 @@ public class TestEventOrderCheckBolt extends BaseRichBolt {
         return new Fields("error");
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("error"));
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/TestGlobalCount.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TestGlobalCount.java
@@ -29,17 +29,20 @@ public class TestGlobalCount extends BaseRichBolt {
     OutputCollector _collector;
     private int _count;
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
         _collector = collector;
         _count = 0;
     }
 
+    @Override
     public void execute(Tuple input) {
         _count++;
         _collector.emit(input, new Values(_count));
         _collector.ack(input);
     }
 
+    @Override
     public void cleanup() {
 
     }
@@ -48,6 +51,7 @@ public class TestGlobalCount extends BaseRichBolt {
         return new Fields("global-count");
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("global-count"));
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/TestKryoDecorator.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TestKryoDecorator.java
@@ -17,6 +17,7 @@ import org.apache.storm.serialization.IKryoDecorator;
 
 public class TestKryoDecorator implements IKryoDecorator {
 
+    @Override
     public void decorate(Kryo k) {
         k.register(TestSerObject.class);
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/TestPlannerBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TestPlannerBolt.java
@@ -22,10 +22,12 @@ import org.apache.storm.tuple.Tuple;
 
 
 public class TestPlannerBolt extends BaseRichBolt {
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
 
     }
 
+    @Override
     public void execute(Tuple input) {
 
     }
@@ -34,6 +36,7 @@ public class TestPlannerBolt extends BaseRichBolt {
         return new Fields("field1", "field2");
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(getOutputFields());
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/TestPlannerSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TestPlannerSpout.java
@@ -45,26 +45,32 @@ public class TestPlannerSpout extends BaseRichSpout {
     }
 
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
 
     }
 
+    @Override
     public void close() {
 
     }
 
+    @Override
     public void nextTuple() {
         Utils.sleep(100);
     }
 
+    @Override
     public void ack(Object msgId) {
 
     }
 
+    @Override
     public void fail(Object msgId) {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(getOutputFields());
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/TestWordCounter.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TestWordCounter.java
@@ -31,6 +31,7 @@ public class TestWordCounter extends BaseBasicBolt {
 
     Map<String, Integer> _counts;
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context) {
         _counts = new HashMap<String, Integer>();
     }
@@ -39,6 +40,7 @@ public class TestWordCounter extends BaseBasicBolt {
         return (String) t.getValues().get(idx);
     }
 
+    @Override
     public void execute(Tuple input, BasicOutputCollector collector) {
         String word = getTupleValue(input, 0);
         int count = 0;
@@ -50,10 +52,12 @@ public class TestWordCounter extends BaseBasicBolt {
         collector.emit(tuple(word, count));
     }
 
+    @Override
     public void cleanup() {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("word", "count"));
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/TestWordSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TestWordSpout.java
@@ -40,14 +40,17 @@ public class TestWordSpout extends BaseRichSpout {
         _isDistributed = isDistributed;
     }
 
+    @Override
     public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
         _collector = collector;
     }
 
+    @Override
     public void close() {
 
     }
 
+    @Override
     public void nextTuple() {
         Utils.sleep(100);
         final String[] words = new String[]{ "nathan", "mike", "jackson", "golda", "bertels" };
@@ -56,14 +59,17 @@ public class TestWordSpout extends BaseRichSpout {
         _collector.emit(new Values(word));
     }
 
+    @Override
     public void ack(Object msgId) {
 
     }
 
+    @Override
     public void fail(Object msgId) {
 
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("word"));
     }

--- a/storm-client/src/jvm/org/apache/storm/testing/TupleCaptureBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/testing/TupleCaptureBolt.java
@@ -35,10 +35,12 @@ public class TupleCaptureBolt implements IRichBolt {
         emitted_tuples.put(_name, new HashMap<String, List<FixedTuple>>());
     }
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
         _collector = collector;
     }
 
+    @Override
     public void execute(Tuple input) {
         String component = input.getSourceComponent();
         Map<String, List<FixedTuple>> captured = emitted_tuples.get(_name);
@@ -53,6 +55,7 @@ public class TupleCaptureBolt implements IRichBolt {
         return emitted_tuples.get(_name);
     }
 
+    @Override
     public void cleanup() {
     }
 

--- a/storm-client/src/jvm/org/apache/storm/topology/BasicBoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/BasicBoltExecutor.java
@@ -29,16 +29,19 @@ public class BasicBoltExecutor implements IRichBolt {
         _bolt = bolt;
     }
 
+    @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         _bolt.declareOutputFields(declarer);
     }
 
 
+    @Override
     public void prepare(Map<String, Object> topoConf, TopologyContext context, OutputCollector collector) {
         _bolt.prepare(topoConf, context);
         _collector = new BasicOutputCollector(collector);
     }
 
+    @Override
     public void execute(Tuple input) {
         _collector.setContext(input);
         try {
@@ -52,10 +55,12 @@ public class BasicBoltExecutor implements IRichBolt {
         }
     }
 
+    @Override
     public void cleanup() {
         _bolt.cleanup();
     }
 
+    @Override
     public Map<String, Object> getComponentConfiguration() {
         return _bolt.getComponentConfiguration();
     }

--- a/storm-client/src/jvm/org/apache/storm/topology/BasicOutputCollector.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/BasicOutputCollector.java
@@ -27,6 +27,7 @@ public class BasicOutputCollector implements IBasicOutputCollector {
         this.out = out;
     }
 
+    @Override
     public List<Integer> emit(String streamId, List<Object> tuple) {
         return out.emit(streamId, inputTuple, tuple);
     }
@@ -39,6 +40,7 @@ public class BasicOutputCollector implements IBasicOutputCollector {
         this.inputTuple = inputTuple;
     }
 
+    @Override
     public void emitDirect(int taskId, String streamId, List<Object> tuple) {
         out.emitDirect(taskId, streamId, inputTuple, tuple);
     }
@@ -53,6 +55,7 @@ public class BasicOutputCollector implements IBasicOutputCollector {
      *
      * @param tuple the tuple to reset timeout for
      */
+    @Override
     public void resetTimeout(Tuple tuple) {
         out.resetTimeout(tuple);
     }
@@ -61,6 +64,7 @@ public class BasicOutputCollector implements IBasicOutputCollector {
         return out;
     }
 
+    @Override
     public void reportError(Throwable t) {
         out.reportError(t);
     }

--- a/storm-client/src/jvm/org/apache/storm/topology/CheckpointTupleForwarder.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/CheckpointTupleForwarder.java
@@ -67,6 +67,7 @@ public class CheckpointTupleForwarder extends BaseStatefulBoltExecutor {
      * @param action          the action (prepare, commit, rollback or initstate)
      * @param txid            the transaction id.
      */
+    @Override
     protected void handleCheckpoint(Tuple checkpointTuple, Action action, long txid) {
         collector.emit(CHECKPOINT_STREAM_ID, checkpointTuple, new Values(txid, action));
         collector.ack(checkpointTuple);
@@ -82,6 +83,7 @@ public class CheckpointTupleForwarder extends BaseStatefulBoltExecutor {
      *
      * @param input the input tuple
      */
+    @Override
     protected void handleTuple(Tuple input) {
         bolt.execute(input);
     }

--- a/storm-client/src/jvm/org/apache/storm/topology/OutputFieldsGetter.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/OutputFieldsGetter.java
@@ -21,18 +21,22 @@ import org.apache.storm.utils.Utils;
 public class OutputFieldsGetter implements OutputFieldsDeclarer {
     private Map<String, StreamInfo> _fields = new HashMap<>();
 
+    @Override
     public void declare(Fields fields) {
         declare(false, fields);
     }
 
+    @Override
     public void declare(boolean direct, Fields fields) {
         declareStream(Utils.DEFAULT_STREAM_ID, direct, fields);
     }
 
+    @Override
     public void declareStream(String streamId, Fields fields) {
         declareStream(streamId, false, fields);
     }
 
+    @Override
     public void declareStream(String streamId, boolean direct, Fields fields) {
         if (null == streamId) {
             throw new IllegalArgumentException("streamId can't be null");

--- a/storm-client/src/jvm/org/apache/storm/trident/fluent/ChainedAggregatorDeclarer.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/fluent/ChainedAggregatorDeclarer.java
@@ -41,6 +41,7 @@ public class ChainedAggregatorDeclarer implements ChainedFullAggregatorDeclarer,
         _globalScheme = globalScheme;
     }
 
+    @Override
     public Stream chainEnd() {
         Fields[] inputFields = new Fields[_aggs.size()];
         Aggregator[] aggs = new Aggregator[_aggs.size()];
@@ -89,37 +90,45 @@ public class ChainedAggregatorDeclarer implements ChainedFullAggregatorDeclarer,
         return _stream.toStream();
     }
 
+    @Override
     public ChainedPartitionAggregatorDeclarer partitionAggregate(Aggregator agg, Fields functionFields) {
         return partitionAggregate(null, agg, functionFields);
     }
 
+    @Override
     public ChainedPartitionAggregatorDeclarer partitionAggregate(Fields inputFields, Aggregator agg, Fields functionFields) {
         _type = AggType.PARTITION;
         _aggs.add(new AggSpec(inputFields, agg, functionFields));
         return this;
     }
 
+    @Override
     public ChainedPartitionAggregatorDeclarer partitionAggregate(CombinerAggregator agg, Fields functionFields) {
         return partitionAggregate(null, agg, functionFields);
     }
 
+    @Override
     public ChainedPartitionAggregatorDeclarer partitionAggregate(Fields inputFields, CombinerAggregator agg, Fields functionFields) {
         initCombiner(inputFields, agg, functionFields);
         return partitionAggregate(functionFields, new CombinerAggregatorCombineImpl(agg), functionFields);
     }
 
+    @Override
     public ChainedPartitionAggregatorDeclarer partitionAggregate(ReducerAggregator agg, Fields functionFields) {
         return partitionAggregate(null, agg, functionFields);
     }
 
+    @Override
     public ChainedPartitionAggregatorDeclarer partitionAggregate(Fields inputFields, ReducerAggregator agg, Fields functionFields) {
         return partitionAggregate(inputFields, new ReducerAggregatorImpl(agg), functionFields);
     }
 
+    @Override
     public ChainedFullAggregatorDeclarer aggregate(Aggregator agg, Fields functionFields) {
         return aggregate(null, agg, functionFields);
     }
 
+    @Override
     public ChainedFullAggregatorDeclarer aggregate(Fields inputFields, Aggregator agg, Fields functionFields) {
         return aggregate(inputFields, agg, functionFields, false);
     }
@@ -136,19 +145,23 @@ public class ChainedAggregatorDeclarer implements ChainedFullAggregatorDeclarer,
         return this;
     }
 
+    @Override
     public ChainedFullAggregatorDeclarer aggregate(CombinerAggregator agg, Fields functionFields) {
         return aggregate(null, agg, functionFields);
     }
 
+    @Override
     public ChainedFullAggregatorDeclarer aggregate(Fields inputFields, CombinerAggregator agg, Fields functionFields) {
         initCombiner(inputFields, agg, functionFields);
         return aggregate(functionFields, new CombinerAggregatorCombineImpl(agg), functionFields, true);
     }
 
+    @Override
     public ChainedFullAggregatorDeclarer aggregate(ReducerAggregator agg, Fields functionFields) {
         return aggregate(null, agg, functionFields);
     }
 
+    @Override
     public ChainedFullAggregatorDeclarer aggregate(Fields inputFields, ReducerAggregator agg, Fields functionFields) {
         return aggregate(inputFields, new ReducerAggregatorImpl(agg), functionFields);
     }

--- a/storm-client/src/jvm/org/apache/storm/trident/operation/TridentOperationContext.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/operation/TridentOperationContext.java
@@ -53,14 +53,17 @@ public class TridentOperationContext implements IMetricsContext {
         return _topoContext.getThisTaskIndex();
     }
 
+    @Override
     public <T extends IMetric> T registerMetric(String name, T metric, int timeBucketSizeInSecs) {
         return _topoContext.registerMetric(name, metric, timeBucketSizeInSecs);
     }
 
+    @Override
     public ReducedMetric registerMetric(String name, IReducer reducer, int timeBucketSizeInSecs) {
         return _topoContext.registerMetric(name, new ReducedMetric(reducer), timeBucketSizeInSecs);
     }
 
+    @Override
     public CombinedMetric registerMetric(String name, ICombiner combiner, int timeBucketSizeInSecs) {
         return _topoContext.registerMetric(name, new CombinedMetric(combiner), timeBucketSizeInSecs);
     }

--- a/storm-client/src/jvm/org/apache/storm/trident/operation/impl/ChainedAggregatorImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/operation/impl/ChainedAggregatorImpl.java
@@ -39,6 +39,7 @@ public class ChainedAggregatorImpl implements Aggregator<ChainedResult> {
         }
     }
 
+    @Override
     public void prepare(Map<String, Object> conf, TridentOperationContext context) {
         _inputFactories = new ProjectionFactory[_inputFields.length];
         for (int i = 0; i < _inputFields.length; i++) {
@@ -47,6 +48,7 @@ public class ChainedAggregatorImpl implements Aggregator<ChainedResult> {
         }
     }
 
+    @Override
     public ChainedResult init(Object batchId, TridentCollector collector) {
         ChainedResult initted = new ChainedResult(collector, _aggs.length);
         for (int i = 0; i < _aggs.length; i++) {
@@ -55,6 +57,7 @@ public class ChainedAggregatorImpl implements Aggregator<ChainedResult> {
         return initted;
     }
 
+    @Override
     public void aggregate(ChainedResult val, TridentTuple tuple, TridentCollector collector) {
         val.setFollowThroughCollector(collector);
         for (int i = 0; i < _aggs.length; i++) {
@@ -63,6 +66,7 @@ public class ChainedAggregatorImpl implements Aggregator<ChainedResult> {
         }
     }
 
+    @Override
     public void complete(ChainedResult val, TridentCollector collector) {
         val.setFollowThroughCollector(collector);
         for (int i = 0; i < _aggs.length; i++) {
@@ -101,6 +105,7 @@ public class ChainedAggregatorImpl implements Aggregator<ChainedResult> {
         return true;
     }
 
+    @Override
     public void cleanup() {
         for (Aggregator a : _aggs) {
             a.cleanup();

--- a/storm-client/src/jvm/org/apache/storm/trident/operation/impl/CombinerAggregatorCombineImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/operation/impl/CombinerAggregatorCombineImpl.java
@@ -27,16 +27,19 @@ public class CombinerAggregatorCombineImpl implements Aggregator<Result> {
         _agg = agg;
     }
 
+    @Override
     public void prepare(Map<String, Object> conf, TridentOperationContext context) {
 
     }
 
+    @Override
     public Result init(Object batchId, TridentCollector collector) {
         Result ret = new Result();
         ret.obj = _agg.zero();
         return ret;
     }
 
+    @Override
     public void aggregate(Result val, TridentTuple tuple, TridentCollector collector) {
         Object v = tuple.getValue(0);
         if (val.obj == null) {
@@ -46,10 +49,12 @@ public class CombinerAggregatorCombineImpl implements Aggregator<Result> {
         }
     }
 
+    @Override
     public void complete(Result val, TridentCollector collector) {
         collector.emit(new Values(val.obj));
     }
 
+    @Override
     public void cleanup() {
 
     }

--- a/storm-client/src/jvm/org/apache/storm/trident/operation/impl/ReducerAggregatorImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/operation/impl/ReducerAggregatorImpl.java
@@ -27,24 +27,29 @@ public class ReducerAggregatorImpl implements Aggregator<Result> {
         _agg = agg;
     }
 
+    @Override
     public void prepare(Map<String, Object> conf, TridentOperationContext context) {
 
     }
 
+    @Override
     public Result init(Object batchId, TridentCollector collector) {
         Result ret = new Result();
         ret.obj = _agg.init();
         return ret;
     }
 
+    @Override
     public void aggregate(Result val, TridentTuple tuple, TridentCollector collector) {
         val.obj = _agg.reduce(val.obj, tuple);
     }
 
+    @Override
     public void complete(Result val, TridentCollector collector) {
         collector.emit(new Values(val.obj));
     }
 
+    @Override
     public void cleanup() {
 
     }

--- a/storm-client/src/jvm/org/apache/storm/trident/testing/FeederBatchSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/testing/FeederBatchSpout.java
@@ -45,6 +45,7 @@ public class FeederBatchSpout implements ITridentSpout<Map<Integer, List<List<Ob
         _waitToEmit = trueIfWait;
     }
 
+    @Override
     public void feed(Object tuples) {
         Semaphore sem = new Semaphore(0);
         ((List) RegisteredGlobalState.getState(_semaphoreId)).add(sem);

--- a/storm-client/src/jvm/org/apache/storm/trident/testing/LRUMemoryMapState.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/testing/LRUMemoryMapState.java
@@ -43,38 +43,47 @@ public class LRUMemoryMapState<T> implements Snapshottable<T>, ITupleCollection,
         _delegate = new SnapshottableMap(OpaqueMap.build(_backing), new Values("$MEMORY-MAP-STATE-GLOBAL$"));
     }
 
+    @Override
     public T update(ValueUpdater updater) {
         return _delegate.update(updater);
     }
 
+    @Override
     public void set(T o) {
         _delegate.set(o);
     }
 
+    @Override
     public T get() {
         return _delegate.get();
     }
 
+    @Override
     public void beginCommit(Long txid) {
         _delegate.beginCommit(txid);
     }
 
+    @Override
     public void commit(Long txid) {
         _delegate.commit(txid);
     }
 
+    @Override
     public Iterator<List<Object>> getTuples() {
         return _backing.getTuples();
     }
 
+    @Override
     public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
         return _delegate.multiUpdate(keys, updaters);
     }
 
+    @Override
     public void multiPut(List<List<Object>> keys, List<T> vals) {
         _delegate.multiPut(keys, vals);
     }
 
+    @Override
     public List<T> multiGet(List<List<Object>> keys) {
         return _delegate.multiGet(keys);
     }
@@ -135,10 +144,12 @@ public class LRUMemoryMapState<T> implements Snapshottable<T>, ITupleCollection,
 
                 private Iterator<Map.Entry<List<Object>, T>> it = db.entrySet().iterator();
 
+                @Override
                 public boolean hasNext() {
                     return it.hasNext();
                 }
 
+                @Override
                 public List<Object> next() {
                     Map.Entry<List<Object>, T> e = it.next();
                     List<Object> ret = new ArrayList<Object>();
@@ -147,6 +158,7 @@ public class LRUMemoryMapState<T> implements Snapshottable<T>, ITupleCollection,
                     return ret;
                 }
 
+                @Override
                 public void remove() {
                     throw new UnsupportedOperationException("Not supported yet.");
                 }

--- a/storm-client/src/jvm/org/apache/storm/trident/testing/MemoryMapState.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/testing/MemoryMapState.java
@@ -46,18 +46,22 @@ public class MemoryMapState<T> implements Snapshottable<T>, ITupleCollection, Ma
         _delegate = new SnapshottableMap(OpaqueMap.build(_backing), new Values("$MEMORY-MAP-STATE-GLOBAL$"));
     }
 
+    @Override
     public T update(ValueUpdater updater) {
         return _delegate.update(updater);
     }
 
+    @Override
     public void set(T o) {
         _delegate.set(o);
     }
 
+    @Override
     public T get() {
         return _delegate.get();
     }
 
+    @Override
     public void beginCommit(Long txid) {
         _delegate.beginCommit(txid);
         if (txid == null || !txid.equals(_currTx)) {
@@ -67,22 +71,27 @@ public class MemoryMapState<T> implements Snapshottable<T>, ITupleCollection, Ma
         _currTx = txid;
     }
 
+    @Override
     public void commit(Long txid) {
         _delegate.commit(txid);
     }
 
+    @Override
     public Iterator<List<Object>> getTuples() {
         return _backing.getTuples();
     }
 
+    @Override
     public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
         return _delegate.multiUpdate(keys, updaters);
     }
 
+    @Override
     public void multiPut(List<List<Object>> keys, List<T> vals) {
         _delegate.multiPut(keys, vals);
     }
 
+    @Override
     public List<T> multiGet(List<List<Object>> keys) {
         return _delegate.multiGet(keys);
     }
@@ -159,10 +168,12 @@ public class MemoryMapState<T> implements Snapshottable<T>, ITupleCollection, Ma
 
                 private Iterator<Map.Entry<List<Object>, T>> it = db.entrySet().iterator();
 
+                @Override
                 public boolean hasNext() {
                     return it.hasNext();
                 }
 
+                @Override
                 public List<Object> next() {
                     Map.Entry<List<Object>, T> e = it.next();
                     List<Object> ret = new ArrayList<Object>();
@@ -171,6 +182,7 @@ public class MemoryMapState<T> implements Snapshottable<T>, ITupleCollection, Ma
                     return ret;
                 }
 
+                @Override
                 public void remove() {
                     throw new UnsupportedOperationException("Not supported yet.");
                 }

--- a/storm-client/src/jvm/org/apache/storm/trident/topology/TransactionAttempt.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/topology/TransactionAttempt.java
@@ -34,10 +34,12 @@ public class TransactionAttempt implements IBatchID {
         return _txid;
     }
 
+    @Override
     public Object getId() {
         return _txid;
     }
 
+    @Override
     public int getAttemptId() {
         return _attemptId;
     }

--- a/storm-client/src/jvm/org/apache/storm/trident/topology/TridentBoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/topology/TridentBoltExecutor.java
@@ -400,25 +400,30 @@ public class TridentBoltExecutor implements IRichBolt {
             _currBatch = batch;
         }
 
+        @Override
         public List<Integer> emit(String stream, Collection<Tuple> anchors, List<Object> tuple) {
             List<Integer> tasks = _delegate.emit(stream, anchors, tuple);
             updateTaskCounts(tasks);
             return tasks;
         }
 
+        @Override
         public void emitDirect(int task, String stream, Collection<Tuple> anchors, List<Object> tuple) {
             updateTaskCounts(Arrays.asList(task));
             _delegate.emitDirect(task, stream, anchors, tuple);
         }
 
+        @Override
         public void ack(Tuple tuple) {
             throw new IllegalStateException("Method should never be called");
         }
 
+        @Override
         public void fail(Tuple tuple) {
             throw new IllegalStateException("Method should never be called");
         }
 
+        @Override
         public void resetTimeout(Tuple tuple) {
             throw new IllegalStateException("Method should never be called");
         }
@@ -428,6 +433,7 @@ public class TridentBoltExecutor implements IRichBolt {
             _delegate.flush();
         }
 
+        @Override
         public void reportError(Throwable error) {
             _delegate.reportError(error);
         }

--- a/storm-client/src/jvm/org/apache/storm/trident/windowing/AbstractTridentWindowManager.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/windowing/AbstractTridentWindowManager.java
@@ -138,10 +138,12 @@ public abstract class AbstractTridentWindowManager<T> implements ITridentWindowM
      */
     protected abstract List<TridentTuple> getTridentTuples(List<T> tupleEvents);
 
+    @Override
     public Queue<TriggerResult> getPendingTriggers() {
         return pendingTriggers;
     }
 
+    @Override
     public void shutdown() {
         try {
             LOG.info("window manager [{}] is being shutdown", windowManager);

--- a/storm-client/src/jvm/org/apache/storm/trident/windowing/InMemoryTridentWindowManager.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/windowing/InMemoryTridentWindowManager.java
@@ -47,6 +47,7 @@ public class InMemoryTridentWindowManager extends AbstractTridentWindowManager<T
         LOG.debug("InMemoryTridentWindowManager.onTuplesExpired");
     }
 
+    @Override
     public void addTuplesBatch(Object batchId, List<TridentTuple> tuples) {
         LOG.debug("Adding tuples to window-manager for batch: [{}]", batchId);
         for (TridentTuple tridentTuple : tuples) {

--- a/storm-client/src/jvm/org/apache/storm/trident/windowing/StoreBasedTridentWindowManager.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/windowing/StoreBasedTridentWindowManager.java
@@ -52,6 +52,7 @@ public class StoreBasedTridentWindowManager extends AbstractTridentWindowManager
         windowTupleTaskId = TUPLE_PREFIX + windowTaskId;
     }
 
+    @Override
     protected void initialize() {
 
         // get existing tuples and pending/unsuccessful triggers for this operator-component/task and add them to WindowManager
@@ -119,6 +120,7 @@ public class StoreBasedTridentWindowManager extends AbstractTridentWindowManager
         return key.substring(secondLastSepIndex + 1, lastSepIndex);
     }
 
+    @Override
     public void addTuplesBatch(Object batchId, List<TridentTuple> tuples) {
         LOG.debug("Adding tuples to window-manager for batch: [{}]", batchId);
         List<WindowsStore.Entry> entries = new ArrayList<>();
@@ -159,6 +161,7 @@ public class StoreBasedTridentWindowManager extends AbstractTridentWindowManager
         return windowTupleTaskId + getBatchTxnId(batchId) + WindowsStore.KEY_SEPARATOR;
     }
 
+    @Override
     public List<TridentTuple> getTridentTuples(List<TridentBatchTuple> tridentBatchTuples) {
         List<TridentTuple> resultTuples = new ArrayList<>();
         List<String> keys = new ArrayList<>();
@@ -188,6 +191,7 @@ public class StoreBasedTridentWindowManager extends AbstractTridentWindowManager
         return null;
     }
 
+    @Override
     public void onTuplesExpired(List<TridentBatchTuple> expiredTuples) {
         if (maxCachedTuplesSize != null) {
             currentCachedTuplesSize.addAndGet(-expiredTuples.size());

--- a/storm-client/src/jvm/org/apache/storm/trident/windowing/config/BaseWindowConfig.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/windowing/config/BaseWindowConfig.java
@@ -34,6 +34,7 @@ public abstract class BaseWindowConfig implements WindowConfig {
         return slideLength;
     }
 
+    @Override
     public void validate() {
         if (slideLength > windowLength) {
             throw new IllegalArgumentException(

--- a/storm-client/src/jvm/org/apache/storm/tuple/Fields.java
+++ b/storm-client/src/jvm/org/apache/storm/tuple/Fields.java
@@ -81,6 +81,7 @@ public class Fields implements Iterable<String>, Serializable {
         return _fields.get(index);
     }
 
+    @Override
     public Iterator<String> iterator() {
         return _fields.iterator();
     }

--- a/storm-client/src/jvm/org/apache/storm/utils/DRPCClient.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/DRPCClient.java
@@ -119,6 +119,7 @@ public class DRPCClient extends ThriftClient implements DistributedRPC.Iface {
         return port;
     }
 
+    @Override
     public String execute(String func, String args) throws TException, DRPCExecutionException, AuthorizationException {
         if (func == null) {
             throw new IllegalArgumentException("DRPC Function cannot be null");

--- a/storm-client/src/jvm/org/apache/storm/utils/DefaultShellLogHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/DefaultShellLogHandler.java
@@ -47,6 +47,7 @@ public class DefaultShellLogHandler implements ShellLogHandler {
      * @param context  - the current {@link TopologyContext}.
      * @see {@link ShellLogHandler#setUpContext}
      */
+    @Override
     public void setUpContext(final Class<?> ownerCls, final ShellProcess process,
                              final TopologyContext context) {
         this.log = getLogger(ownerCls);
@@ -61,6 +62,7 @@ public class DefaultShellLogHandler implements ShellLogHandler {
      * @param shellMsg - the {@link ShellMsg} to log.
      * @see {@link ShellLogHandler#log}
      */
+    @Override
     public void log(final ShellMsg shellMsg) {
         if (shellMsg == null) {
             throw new IllegalArgumentException("shellMsg is required");

--- a/storm-client/src/jvm/org/apache/storm/utils/TimeCacheMap.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/TimeCacheMap.java
@@ -42,6 +42,7 @@ public class TimeCacheMap<K, V> {
         final long expirationMillis = expirationSecs * 1000L;
         final long sleepTime = expirationMillis / (numBuckets - 1);
         _cleaner = new Thread(new Runnable() {
+            @Override
             public void run() {
                 try {
                     while (true) {

--- a/storm-client/src/jvm/org/apache/storm/windowing/WatermarkCountEvictionPolicy.java
+++ b/storm-client/src/jvm/org/apache/storm/windowing/WatermarkCountEvictionPolicy.java
@@ -32,6 +32,7 @@ public class WatermarkCountEvictionPolicy<T> implements EvictionPolicy<T, Pair<L
         currentCount = new AtomicLong();
     }
 
+    @Override
     public Action evict(Event<T> event) {
         if (getContext() == null) {
             //It is possible to get asked about eviction before we have a context, due to WindowManager.compactWindow.

--- a/storm-client/test/jvm/org/apache/storm/PaceMakerStateStorageFactoryTest.java
+++ b/storm-client/test/jvm/org/apache/storm/PaceMakerStateStorageFactoryTest.java
@@ -147,10 +147,12 @@ public class PaceMakerStateStorageFactoryTest {
             return clientMock;
         }
 
+        @Override
         public HBMessage send(HBMessage m) throws PacemakerConnectionException, InterruptedException {
             return clientMock.send(m);
         }
 
+        @Override
         public List<HBMessage> sendAll(HBMessage m) throws PacemakerConnectionException, InterruptedException {
             List<HBMessage> response = new ArrayList<>();
             response.add(clientMock.send(m));

--- a/storm-client/test/jvm/org/apache/storm/bolt/TestJoinBolt.java
+++ b/storm-client/test/jvm/org/apache/storm/bolt/TestJoinBolt.java
@@ -331,10 +331,12 @@ public class TestJoinBolt {
             this.fields = new Fields(fieldNames);
         }
 
+        @Override
         public String getComponentId(int taskId) {
             return "component";
         }
 
+        @Override
         public Fields getComponentOutputFields(String componentId, String streamId) {
             return fields;
         }

--- a/storm-client/test/jvm/org/apache/storm/dependency/DependencyUploaderTest.java
+++ b/storm-client/test/jvm/org/apache/storm/dependency/DependencyUploaderTest.java
@@ -152,6 +152,7 @@ public class DependencyUploaderTest {
 
         final AtomicInteger counter = new AtomicInteger();
         final Answer incrementCounter = new Answer() {
+            @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 counter.addAndGet(1);
                 return null;
@@ -271,6 +272,7 @@ public class DependencyUploaderTest {
 
         final AtomicInteger counter = new AtomicInteger();
         final Answer incrementCounter = new Answer() {
+            @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 counter.addAndGet(1);
                 return null;

--- a/storm-clojure/src/main/java/org/apache/storm/clojure/ClojureTuple.java
+++ b/storm-clojure/src/main/java/org/apache/storm/clojure/ClojureTuple.java
@@ -152,6 +152,7 @@ public class ClojureTuple extends TupleImpl implements Seqable, Indexed, IMeta, 
     }
 
     /* Indexed */
+    @Override
     public Object nth(int i) {
         if (i < size()) {
             return getValue(i);
@@ -160,6 +161,7 @@ public class ClojureTuple extends TupleImpl implements Seqable, Indexed, IMeta, 
         }
     }
 
+    @Override
     public Object nth(int i, Object notfound) {
         Object ret = nth(i);
         if (ret==null) ret = notfound;
@@ -167,11 +169,13 @@ public class ClojureTuple extends TupleImpl implements Seqable, Indexed, IMeta, 
     }
 
     /* Counted */
+    @Override
     public int count() {
         return size();
     }
 
     /* IMeta */
+    @Override
     public IPersistentMap meta() {
         if(_meta==null) {
             _meta = new PersistentArrayMap( new Object[] {

--- a/storm-clojure/src/main/java/org/apache/storm/clojure/IndifferentAccessMap.java
+++ b/storm-clojure/src/main/java/org/apache/storm/clojure/IndifferentAccessMap.java
@@ -48,14 +48,17 @@ public class IndifferentAccessMap  implements ILookup, IPersistentMap, Map {
         return _map;
     }
 
+    @Override
     public int size() {
         return ((Map) getMap()).size();
     }
 
+    @Override
     public int count() {
         return size();
     }
 
+    @Override
     public ISeq seq() {
         return getMap().seq();
     }
@@ -77,86 +80,105 @@ public class IndifferentAccessMap  implements ILookup, IPersistentMap, Map {
 
     /* IPersistentMap */
     /* Naive implementation, but it might be good enough */
+    @Override
     public IPersistentMap assoc(Object k, Object v) {
         if(k instanceof Keyword) return assoc(((Keyword) k).getName(), v);
         
         return new IndifferentAccessMap(getMap().assoc(k, v));
     }
 
+    @Override
     public IPersistentMap assocEx(Object k, Object v) {
         if(k instanceof Keyword) return assocEx(((Keyword) k).getName(), v);
 
         return new IndifferentAccessMap(getMap().assocEx(k, v));
     }
 
+    @Override
     public IPersistentMap without(Object k) {
         if(k instanceof Keyword) return without(((Keyword) k).getName());
 
         return new IndifferentAccessMap(getMap().without(k));
     }
 
+    @Override
     public boolean containsKey(Object k) {
         if(k instanceof Keyword) return containsKey(((Keyword) k).getName());
         return getMap().containsKey(k);
     }
 
+    @Override
     public IMapEntry entryAt(Object k) {
         if(k instanceof Keyword) return entryAt(((Keyword) k).getName());
 
         return getMap().entryAt(k);
     }
 
+    @Override
     public IPersistentCollection cons(Object o) {
         return getMap().cons(o);
     }
 
+    @Override
     public IPersistentCollection empty() {
         return new IndifferentAccessMap(PersistentArrayMap.EMPTY);
     }
 
+    @Override
     public boolean equiv(Object o) {
         return getMap().equiv(o);
     }
 
+    @Override
     public Iterator iterator() {
         return getMap().iterator();
     }
 
     /* Map */
+    @Override
     public boolean containsValue(Object v) {
         return ((Map) getMap()).containsValue(v);
     }
 
+    @Override
     public Set entrySet() {
         return ((Map) getMap()).entrySet();
     }
 
+    @Override
     public Object get(Object k) {
         return valAt(k);
     }
 
+    @Override
     public boolean isEmpty() {
         return ((Map) getMap()).isEmpty();
     }
 
+    @Override
     public Set keySet() {
         return ((Map) getMap()).keySet();
     }
 
+    @Override
     public Collection values() {
         return ((Map) getMap()).values();
     }
     
     /* Not implemented */
+    @Override
     public void clear() {
         throw new UnsupportedOperationException();
     }
+    @Override
     public Object put(Object k, Object v) {
         throw new UnsupportedOperationException();
     }
+    @Override
     public void putAll(Map m) {
         throw new UnsupportedOperationException();
     }
+    @Override
     public Object remove(Object k) {
         throw new UnsupportedOperationException();
     }

--- a/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResourceRetentionSet.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResourceRetentionSet.java
@@ -135,6 +135,7 @@ public class LocalizedResourceRetentionSet {
     }
 
     static class LRUComparator implements Comparator<LocallyCachedBlob> {
+        @Override
         public int compare(LocallyCachedBlob r1, LocallyCachedBlob r2) {
             long ret = r1.getLastUsed() - r2.getLastUsed();
             if (0 == ret) {

--- a/storm-server/src/main/java/org/apache/storm/logging/filters/AccessLoggingFilter.java
+++ b/storm-server/src/main/java/org/apache/storm/logging/filters/AccessLoggingFilter.java
@@ -28,10 +28,12 @@ public class AccessLoggingFilter implements Filter {
 
     private static final Logger LOG = LoggerFactory.getLogger(AccessLoggingFilter.class);
 
+    @Override
     public void init(FilterConfig config) throws ServletException {
         //NOOP
     }
 
+    @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         handle((HttpServletRequest) request, (HttpServletResponse) response, chain);
     }
@@ -44,6 +46,7 @@ public class AccessLoggingFilter implements Filter {
         chain.doFilter(request, response);
     }
 
+    @Override
     public void destroy() {
         //NOOP
     }

--- a/storm-server/src/main/java/org/apache/storm/metricstore/Metric.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/Metric.java
@@ -83,6 +83,7 @@ public class Metric implements Comparable<Metric> {
     /**
      *  Check if a Metric matches another object.
      */
+    @Override
     public boolean equals(Object other) {
 
         if (!(other instanceof Metric)) {

--- a/storm-server/src/main/java/org/apache/storm/metricstore/MetricStore.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/MetricStore.java
@@ -45,6 +45,7 @@ public interface MetricStore extends AutoCloseable {
     /**
      * Close the metric store.
      */
+    @Override
     void close();
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/RocksDbStore.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/RocksDbStore.java
@@ -170,6 +170,7 @@ public class RocksDbStore implements MetricStore, AutoCloseable {
      * @param metric  Metric to store
      * @throws MetricException  if database write fails
      */
+    @Override
     public void insert(Metric metric) throws MetricException {
         try {
             // don't bother blocking on a full queue, just drop metrics in case we can't keep up
@@ -341,6 +342,7 @@ public class RocksDbStore implements MetricStore, AutoCloseable {
      * @param scanCallback  callback for each Metric found
      * @throws MetricException  on error
      */
+    @Override
     public void scan(FilterOptions filter, ScanCallback scanCallback) throws MetricException {
         scanInternal(filter, scanCallback, null);
     }

--- a/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/StringMetadataCache.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/StringMetadataCache.java
@@ -101,6 +101,7 @@ public class StringMetadataCache implements LruMap.CacheEvictionCallback<String,
      * @param s   The string to look for
      * @return the metadata associated with the string or null if not found
      */
+    @Override
     public StringMetadata get(String s) {
         return lruStringCache.get(s);
     }
@@ -118,6 +119,7 @@ public class StringMetadataCache implements LruMap.CacheEvictionCallback<String,
      * @param newEntry   Indicates the metadata is being used for the first time and should be written to RocksDB immediately
      * @throws MetricException   when evicted data fails to save to the database or when the database is shutdown
      */
+    @Override
     public void put(String s, StringMetadata stringMetadata, boolean newEntry) throws MetricException {
         if (dbWriter.isShutdown()) {
             // another thread could be writing out the metadata cache to the database.
@@ -142,6 +144,7 @@ public class StringMetadataCache implements LruMap.CacheEvictionCallback<String,
      * @param val  The evicted string's metadata
      * @throws RuntimeException   when evicted data fails to save to the database
      */
+    @Override
     public void evictionCallback(String key, StringMetadata val) {
         writeMetadataToDisk(key, val);
     }
@@ -168,6 +171,7 @@ public class StringMetadataCache implements LruMap.CacheEvictionCallback<String,
      * @param stringId   The string Id to check
      * @return true if the Id is in the cache, false otherwise
      */
+    @Override
     public boolean contains(Integer stringId) {
         return hashToString.containsKey(stringId);
     }
@@ -178,6 +182,7 @@ public class StringMetadataCache implements LruMap.CacheEvictionCallback<String,
      * @param stringId   The string Id to check
      * @return the associated string if the Id is in the cache, null otherwise
      */
+    @Override
     public String getMetadataString(Integer stringId) {
         return hashToString.get(stringId);
     }
@@ -187,6 +192,7 @@ public class StringMetadataCache implements LruMap.CacheEvictionCallback<String,
      *
      * @return the string metadata map entrySet
      */
+    @Override
     public Set<Map.Entry<String, StringMetadata>> entrySet() {
         return lruStringCache.entrySet();
     }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/User.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/User.java
@@ -207,6 +207,7 @@ public class User {
      */
     static class PQsortByPriorityAndSubmittionTime implements Comparator<TopologyDetails> {
 
+        @Override
         public int compare(TopologyDetails topo1, TopologyDetails topo2) {
             if (topo1.getTopologyPriority() > topo2.getTopologyPriority()) {
                 return 1;

--- a/storm-server/src/test/java/org/apache/storm/scheduler/blacklist/TestUtilsForBlacklistScheduler.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/blacklist/TestUtilsForBlacklistScheduler.java
@@ -182,13 +182,16 @@ public class TestUtilsForBlacklistScheduler {
             _isDistributed = isDistributed;
         }
 
+        @Override
         public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
             _collector = collector;
         }
 
+        @Override
         public void close() {
         }
 
+        @Override
         public void nextTuple() {
             Utils.sleep(100);
             final String[] words = new String[]{"nathan", "mike", "jackson", "golda", "bertels"};
@@ -197,12 +200,15 @@ public class TestUtilsForBlacklistScheduler {
             _collector.emit(new Values(word));
         }
 
+        @Override
         public void ack(Object msgId) {
         }
 
+        @Override
         public void fail(Object msgId) {
         }
 
+        @Override
         public void declareOutputFields(OutputFieldsDeclarer declarer) {
             declarer.declare(new Fields("word"));
         }

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestUtilsForResourceAwareScheduler.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/TestUtilsForResourceAwareScheduler.java
@@ -316,13 +316,16 @@ public class TestUtilsForResourceAwareScheduler {
             _isDistributed = isDistributed;
         }
 
+        @Override
         public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
             _collector = collector;
         }
 
+        @Override
         public void close() {
         }
 
+        @Override
         public void nextTuple() {
             Utils.sleep(100);
             final String[] words = new String[]{ "nathan", "mike", "jackson", "golda", "bertels" };
@@ -331,12 +334,15 @@ public class TestUtilsForResourceAwareScheduler {
             _collector.emit(new Values(word));
         }
 
+        @Override
         public void ack(Object msgId) {
         }
 
+        @Override
         public void fail(Object msgId) {
         }
 
+        @Override
         public void declareOutputFields(OutputFieldsDeclarer declarer) {
             declarer.declare(new Fields("word"));
         }

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/ReqContextFilter.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/ReqContextFilter.java
@@ -52,7 +52,8 @@ public class ReqContextFilter implements Filter {
             httpCredsHandler.populateContext(ReqContext.context(), request);
         }
     }
-    
+
+    @Override
     public void init(FilterConfig config) throws ServletException {
         //NOOP
         //We could add in configs through the web.xml if we wanted something stand alone here...
@@ -64,6 +65,7 @@ public class ReqContextFilter implements Filter {
      * @param response the response to populate
      * @param chain the next chain of entities to pass the object to
      */
+    @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         handle((HttpServletRequest)request, (HttpServletResponse)response, chain);
     }
@@ -81,6 +83,7 @@ public class ReqContextFilter implements Filter {
         chain.doFilter(request, response);
     }
 
+    @Override
     public void destroy() {
         //NOOP
     }

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/NotAliveExceptionMapper.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/NotAliveExceptionMapper.java
@@ -34,6 +34,7 @@ public class NotAliveExceptionMapper implements ExceptionMapper<NotAliveExceptio
     @Inject
     public javax.inject.Provider<HttpServletRequest> request;
 
+    @Override
     public Response toResponse(NotAliveException ex) {
         return getResponse(ex, request);
     }


### PR DESCRIPTION
Adding missing `@Override` annotations helps detecting inheritance issues when generics are used more intensively.

In order to avoid missing `@Override` annotations in the future PMD is configured and used to verify the code state.

Is based on changes proposed in #3019.