### PR TITLE
[STORM-3423] improve logviewer directory cleaner logging

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/DirectoryCleaner.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/DirectoryCleaner.java
@@ -170,6 +170,9 @@ public class DirectoryCleaner {
             } else {
                 LOG.warn("No more files able to delete this round, but {} is over quota by {} MB",
                     forPerDir ? "this directory" : "root directory", toDeleteSize * 1e-6);
+                LOG.warn("No more files eligible to be deleted this round, but {} is over {} quota by {} MB",
+                        forPerDir ? "worker directory: " + dirs.get(0).toAbsolutePath().normalize() : "log root directory",
+                        forPerDir ? "per-worker" : "global", toDeleteSize * 1e-6);
             }
         }
         return new DeletionMeta(deletedSize, deletedFiles);

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/WorkerLogs.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/WorkerLogs.java
@@ -125,7 +125,7 @@ public class WorkerLogs {
     }
 
     /**
-     * Return a set of all worker directories in root log directory.
+     * Return a set of all worker directories in all topology directories in root log directory.
      */
     public Set<Path> getAllWorkerDirs() {
         try (Stream<Path> topoDirs = Files.list(logRootDir)) {


### PR DESCRIPTION
Used to be:
2019-06-20T20:38:11.626Z gsbl839n04.blue.ygrid.yahoo.com [logviewer][99056] No more files able to delete this round, but this directory is over quota by 5269.828259999999 MB
2019-06-20T20:38:11.626Z gsbl839n04.blue.ygrid.yahoo.com [logviewer][99056] No more files able to delete this round, but this directory is over quota by 5269.828259999999 MB
2019-06-20T20:38:11.626Z gsbl839n04.blue.ygrid.yahoo.com [logviewer][99056] No more files able to delete this round, but this directory is over quota by 5269.828259999999 MB


Now:
2019-06-25 20:00:02.135 o.a.s.d.l.u.DirectoryCleaner logviewer-cleanup [WARN] No more files eligible to be deleted this round, but worker directory: /home/y/var/storm/workers-artifacts/wc-1-1560810826/6700 is over per-worker quota by 77.559234 MB
2019-06-25 20:00:02.135 o.a.s.d.l.u.DirectoryCleaner logviewer-cleanup [WARN] No more files eligible to be deleted this round, but worker directory: /home/y/var/storm/workers-artifacts/wc-1-1560810826/6700 is over per-worker quota by 77.559234 MB
