### PR TITLE
STORM-3466: storm-kafka-monitor: fix not found jar

### DIFF
--- a/bin/storm-kafka-monitor
+++ b/bin/storm-kafka-monitor
@@ -49,4 +49,4 @@ if [ -z "$JAVA_HOME" ]; then
 else
   JAVA="$JAVA_HOME/bin/java"
 fi
-exec $JAVA $STORM_JAAS_CONF_PARAM $STORM_JAR_JVM_OPTS -cp $STORM_BASE_DIR/lib-tools/storm-kafka-monitor/* org.apache.storm.kafka.monitor.KafkaOffsetLagUtil "$@"
+exec $JAVA $STORM_JAAS_CONF_PARAM $STORM_JAR_JVM_OPTS -cp "$STORM_BASE_DIR/lib-tools/storm-kafka-monitor/*" org.apache.storm.kafka.monitor.KafkaOffsetLagUtil "$@"


### PR DESCRIPTION
issue link : [STORM-3466](https://issues.apache.org/jira/browse/STORM-3466)

In storm 2.0.0, there was a "not find jar error" when running storm-kafka-monitor.

I solved this by adding "" to the jar file classpath.