### PR TITLE
STORM-3470: fix null dereference in SimpleSaslServer authentication

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/sasl/SimpleSaslServerCallbackHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/sasl/SimpleSaslServerCallbackHandler.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -178,9 +179,9 @@ public class SimpleSaslServerCallbackHandler implements CallbackHandler {
                 ac.setAuthorizedID(zid);
             }
 
-            //When zid and zid are not equal, nid is attempting to impersonate zid, We
+            //When nid and zid are not equal, nid is attempting to impersonate zid, We
             //add the nid as the real user in reqContext's subject which will be used during authorization.
-            if (!nid.equals(zid)) {
+            if (!Objects.equals(nid, zid)) {
                 LOG.info("Impersonation attempt  authenticationID = {} authorizationID = {}",
                          nid, zid);
                 if (!allowImpersonation) {


### PR DESCRIPTION
Fixes a possible null dereference in the case that nid is null on line 183. Switch to using a more flexible method of comparison (Objects.compare()) which will correctly compare one null on one non-null or two null values.