### PR TITLE
STORM-3476 don't query remote files on cleanup if target size is acce…

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResourceRetentionSet.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResourceRetentionSet.java
@@ -81,6 +81,10 @@ public class LocalizedResourceRetentionSet {
     public void cleanup(ClientBlobStore store) {
         LOG.debug("cleanup target size: {} current size is: {}", targetSize, currentSize);
         long bytesOver = currentSize - targetSize;
+        if (bytesOver <= 0) { // no need to query remote files
+            return;
+        }
+
         //First delete everything that no longer exists...
         for (Iterator<Map.Entry<LocallyCachedBlob, Map<String, ? extends LocallyCachedBlob>>> i = noReferences.entrySet().iterator();
              i.hasNext(); ) {


### PR DESCRIPTION
…ptable

I'm seeing supervisors querying files over and over on the namenode from this method and never deleting them, adding namenode load.  If we're below the cleanup target size, it seems we should just not bother doing these checks.

