### PR TITLE
[STORM-3491] BoltReaderRunnable shouldn't throw IllegalArgumentException for sync command

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/task/ShellBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/task/ShellBolt.java
@@ -363,8 +363,7 @@ public class ShellBolt implements IBolt {
                             handleMetrics(shellMsg);
                             break;
                         default:
-                            throw new IllegalArgumentException(String.format("command %s is not supported",
-                                    command));
+                            break;
                     }
                 } catch (InterruptedException e) {
                     // It's likely that Bolt is shutting down so no need to die.


### PR DESCRIPTION
Refer to https://issues.apache.org/jira/browse/STORM-3491
