### PR TITLE
MINOR: remove scm tag in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,6 @@
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/storm.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/storm.git</developerConnection>
-        <tag>v2.0.0</tag>
         <url>https://gitbox.apache.org/repos/asf/storm</url>
     </scm>
 


### PR DESCRIPTION
I think this is not needed. And it can be confusing when it's not updated correctly