### PR TITLE
 STORM-3493: Allow overriding python interpreter by environment variable

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -34,7 +34,9 @@ while [ -h "${PRG}" ]; do
 done
 
 # check for version
-PYTHON="/usr/bin/env python"
+if [ -z $PYTHON ]; then
+  PYTHON="/usr/bin/env python"
+fi
 majversion=`$PYTHON -V 2>&1 | awk '{print $2}' | cut -d'.' -f1`
 minversion=`$PYTHON -V 2>&1 | awk '{print $2}' | cut -d'.' -f2`
 numversion=$(( 10 * $majversion + $minversion))


### PR DESCRIPTION
This is specially needed on FreeBSD because there is no "python" = there is python2.7