### PR TITLE
Remove caching of $HOME/.m2/repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,5 @@ script:
   - /bin/bash ./dev-tools/travis/travis-script.sh `pwd` $MODULES
 cache:
   directories:
-    - "$HOME/.m2/repository"
     - "$HOME/.rvm"
     - "$NVM_DIR"


### PR DESCRIPTION
Remove caching of $HOME/.m2/repository because it causes missing build dependencies to be unspotted