### PR TITLE
STORM-3500: Fix spelling error in property storm.blobstore.dependency…

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -144,7 +144,7 @@ nimbus.blobstore.class: "org.apache.storm.blobstore.LocalFsBlobStore"
 nimbus.blobstore.expiration.secs: 600
 
 storm.blobstore.inputstream.buffer.size.bytes: 65536
-storm.blobstore.dependency.jar.upload.chuck.size.bytes: 1048576
+storm.blobstore.dependency.jar.upload.chunk.size.bytes: 1048576
 client.blobstore.class: "org.apache.storm.blobstore.NimbusBlobStore"
 storm.blobstore.replication.factor: 3
 # For secure mode we would want to change this config to true

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -1418,12 +1418,12 @@ public class Config extends HashMap<String, Object> {
     @IsInteger
     public static final String STORM_BLOBSTORE_INPUTSTREAM_BUFFER_SIZE_BYTES = "storm.blobstore.inputstream.buffer.size.bytes";
     /**
-     * What chuck size to use for storm client to upload dependency jars.
+     * What chunk size to use for storm client to upload dependency jars.
      */
     @IsPositiveNumber
     @IsInteger
-    public static final String STORM_BLOBSTORE_DEPENDENCY_JAR_UPLOAD_CHUCK_SIZE_BYTES =
-            "storm.blobstore.dependency.jar.upload.chuck.size.bytes";
+    public static final String STORM_BLOBSTORE_DEPENDENCY_JAR_UPLOAD_CHUNK_SIZE_BYTES =
+            "storm.blobstore.dependency.jar.upload.chunk.size.bytes";
     /**
      * FQCN of a class that implements {@code ISubmitterHook} @see ISubmitterHook for details.
      */

--- a/storm-client/src/jvm/org/apache/storm/dependency/DependencyUploader.java
+++ b/storm-client/src/jvm/org/apache/storm/dependency/DependencyUploader.java
@@ -48,11 +48,11 @@ public class DependencyUploader {
 
     private final Map<String, Object> conf;
     private ClientBlobStore blobStore;
-    private int uploadChuckSize;
+    private final int uploadChunkSize;
 
     public DependencyUploader() {
         conf = Utils.readStormConfig();
-        this.uploadChuckSize = ObjectReader.getInt(conf.get(Config.STORM_BLOBSTORE_DEPENDENCY_JAR_UPLOAD_CHUCK_SIZE_BYTES), 1024 * 1024);
+        this.uploadChunkSize = ObjectReader.getInt(conf.get(Config.STORM_BLOBSTORE_DEPENDENCY_JAR_UPLOAD_CHUNK_SIZE_BYTES), 1024 * 1024);
     }
 
     public void init() {
@@ -164,7 +164,7 @@ public class DependencyUploader {
             try {
                 blob = getBlobStore().createBlob(key, new SettableBlobMeta(acls));
                 try (InputStream in = Files.newInputStream(dependency.toPath())) {
-                    IOUtils.copy(in, blob, this.uploadChuckSize);
+                    IOUtils.copy(in, blob, this.uploadChunkSize);
                 }
                 blob.close();
                 blob = null;


### PR DESCRIPTION
….jar.upload.chuck.size.bytes

This is minor, but we might as well fix it before the spelling is set in stone. This needs to also go in 2.1.x