### PR TITLE
Revert "STORM-3476 don't query remote files on cleanup if target size…

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResourceRetentionSet.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResourceRetentionSet.java
@@ -81,10 +81,6 @@ public class LocalizedResourceRetentionSet {
     public void cleanup(ClientBlobStore store) {
         LOG.debug("cleanup target size: {} current size is: {}", targetSize, currentSize);
         long bytesOver = currentSize - targetSize;
-        if (bytesOver <= 0) { // no need to query remote files
-            return;
-        }
-
         //First delete everything that no longer exists...
         for (Iterator<Map.Entry<LocallyCachedBlob, Map<String, ? extends LocallyCachedBlob>>> i = noReferences.entrySet().iterator();
              i.hasNext(); ) {


### PR DESCRIPTION
… is acceptable"

I've reopened https://issues.apache.org/jira/browse/STORM-3476 as it is causing an issue when topologies are killed. I verified that this issue is causing the problem in the supervisor by running a topology with the current code and this code commented out.

This needs to be applied here and in 2.1.x.