### PR TITLE
[STORM-3507] add greylist for superviosrs which are forced out of blacklist due to low resources

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.storm.Config;
 import org.apache.storm.Constants;
@@ -84,6 +83,7 @@ public class Cluster implements ISchedulingState {
     private final ResourceMetrics resourceMetrics;
     private SchedulerAssignmentImpl assignment;
     private Set<String> blackListedHosts = new HashSet<>();
+    private List<String> greyListedSupervisors = new ArrayList<>();
     private INimbus inimbus;
     private double minWorkerCpu = 0.0;
 
@@ -102,7 +102,7 @@ public class Cluster implements ISchedulingState {
         Map<String, ? extends SchedulerAssignment> map,
         Topologies topologies,
         Map<String, Object> conf) {
-        this(nimbus, resourceMetrics, supervisors, map, topologies, conf, null, null, null);
+        this(nimbus, resourceMetrics, supervisors, map, topologies, conf, null, null, null, null);
     }
 
     /**
@@ -118,6 +118,7 @@ public class Cluster implements ISchedulingState {
             new HashMap<>(src.conf),
             src.status,
             src.blackListedHosts,
+            src.greyListedSupervisors,
             src.networkTopography);
     }
 
@@ -138,6 +139,7 @@ public class Cluster implements ISchedulingState {
             new HashMap<>(src.conf),
             src.status,
             src.blackListedHosts,
+            src.greyListedSupervisors,
             src.networkTopography);
     }
 
@@ -150,6 +152,7 @@ public class Cluster implements ISchedulingState {
         Map<String, Object> conf,
         Map<String, String> status,
         Set<String> blackListedHosts,
+        List<String> greyListedSupervisors,
         Map<String, List<String>> networkTopography) {
         this.inimbus = nimbus;
         this.resourceMetrics = resourceMetrics;
@@ -200,6 +203,10 @@ public class Cluster implements ISchedulingState {
 
         if (blackListedHosts != null) {
             this.blackListedHosts.addAll(blackListedHosts);
+        }
+
+        if (greyListedSupervisors != null) {
+            this.greyListedSupervisors.addAll(greyListedSupervisors);
         }
         setAssignments(assignments, true);
     }
@@ -1084,5 +1091,14 @@ public class Cluster implements ISchedulingState {
 
     public double getMinWorkerCpu() {
         return minWorkerCpu;
+    }
+
+    public List<String> getGreyListedSupervisors() {
+        return greyListedSupervisors;
+    }
+
+    public void setGreyListedSupervisors(Set<String> greyListedSupervisors) {
+        this.greyListedSupervisors.clear();
+        this.greyListedSupervisors.addAll(greyListedSupervisors);
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/BlacklistScheduler.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/BlacklistScheduler.java
@@ -115,6 +115,7 @@ public class BlacklistScheduler implements IScheduler {
         Map<String, SupervisorDetails> supervisors = cluster.getSupervisors();
         blacklistStrategy.resumeFromBlacklist();
         badSupervisors(supervisors);
+        // this step also frees up some bad supervisors to greylist due to resource shortage
         blacklistedSupervisorIds = refreshBlacklistedSupervisorIds(cluster, topologies);
         Set<String> blacklistHosts = getBlacklistHosts(cluster, blacklistedSupervisorIds);
         cluster.setBlacklistedHosts(blacklistHosts);

--- a/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/strategies/DefaultBlacklistStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/blacklist/strategies/DefaultBlacklistStrategy.java
@@ -85,9 +85,12 @@ public class DefaultBlacklistStrategy implements IBlacklistStrategy {
             }
         }
         Set<String> toRelease = releaseBlacklistWhenNeeded(cluster, new ArrayList<>(blacklist.keySet()));
+        // After having computed the final blacklist,
+        // the nodes which are released due to resource shortage will be put to the "greylist".
         if (toRelease != null) {
             LOG.debug("Releasing {} nodes because of low resources", toRelease.size());
-            for (String key: toRelease) {
+            cluster.setGreyListedSupervisors(toRelease);
+            for (String key : toRelease) {
                 blacklist.remove(key);
             }
         }


### PR DESCRIPTION
* Add greylist to cluster state
* When releasing supervisors due to low resources, put these released supervisors to greylist
* When scheduling, these greylisted supervisors will be scheduled only after having gone through other supervisors