### PR TITLE
STORM-3524 create complete blobstore path in case parent directory ge…

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResource.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResource.java
@@ -144,6 +144,7 @@ public class LocalizedResource extends LocallyCachedBlob {
 
     static void completelyRemoveUnusedUser(Path localBaseDir, String user) throws IOException {
         Path userFileCacheDir = getLocalUserFileCacheDir(localBaseDir, user);
+        LOG.info("completelyRemoveUnusedUser {} for directory {}", user, userFileCacheDir);
         // baseDir/supervisor/usercache/user1/filecache/files
         Files.deleteIfExists(getCacheDirForFiles(userFileCacheDir));
         // baseDir/supervisor/usercache/user1/filecache/archives
@@ -254,9 +255,12 @@ public class LocalizedResource extends LocallyCachedBlob {
                 if (!Files.exists(parent)) {
                     //There is a race here that we can still lose
                     try {
-                        Files.createDirectory(parent);
+                        Files.createDirectories(parent);
                     } catch (FileAlreadyExistsException e) {
                         //Ignored
+                    } catch (Exception e) {
+                        LOG.error("Failed to create parent directory {}", parent, e);
+                        throw e;
                     }
                 }
                 return path;
@@ -397,7 +401,7 @@ public class LocalizedResource extends LocallyCachedBlob {
                 }
             }
         } catch (NoSuchFileException e) {
-            LOG.warn("Nothing to cleanup with badeDir {} even though we expected there to be something there", baseDir);
+            LOG.warn("Nothing to cleanup with baseDir {} even though we expected there to be something there", baseDir);
         }
     }
 

--- a/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResource.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocalizedResource.java
@@ -143,8 +143,10 @@ public class LocalizedResource extends LocallyCachedBlob {
     }
 
     static void completelyRemoveUnusedUser(Path localBaseDir, String user) throws IOException {
+        Path localUserDir = getLocalUserDir(localBaseDir, user);
+        LOG.info("completelyRemoveUnusedUser {} for directory {}", user, localUserDir);
+
         Path userFileCacheDir = getLocalUserFileCacheDir(localBaseDir, user);
-        LOG.info("completelyRemoveUnusedUser {} for directory {}", user, userFileCacheDir);
         // baseDir/supervisor/usercache/user1/filecache/files
         Files.deleteIfExists(getCacheDirForFiles(userFileCacheDir));
         // baseDir/supervisor/usercache/user1/filecache/archives
@@ -152,7 +154,7 @@ public class LocalizedResource extends LocallyCachedBlob {
         // baseDir/supervisor/usercache/user1/filecache
         Files.deleteIfExists(userFileCacheDir);
         // baseDir/supervisor/usercache/user1
-        Files.deleteIfExists(getLocalUserDir(localBaseDir, user));
+        Files.deleteIfExists(localUserDir);
     }
 
     static List<String> getLocalizedArchiveKeys(Path localBaseDir, String user) throws IOException {
@@ -258,7 +260,7 @@ public class LocalizedResource extends LocallyCachedBlob {
                         Files.createDirectories(parent);
                     } catch (FileAlreadyExistsException e) {
                         //Ignored
-                    } catch (Exception e) {
+                    } catch (IOException e) {
                         LOG.error("Failed to create parent directory {}", parent, e);
                         throw e;
                     }


### PR DESCRIPTION
…ts deleted

Based on the exception I saw on a supervisor, I think a race condition existed between a cleanup of the localizer for an older topology and a new one starting where a parent directory was deleted right before a download.

Files.createDirectory() then throws an exception because the parent directory does not exist and can never succeed.

Files.createDirectories() should guarantee the directory gets created.  Also added logging for removing the user to better debug in the future.

