### PR TITLE
STORM-3211: Fix NPE in WindowedBoltExecutor on getComponentConfiguration

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/WindowedBoltExecutor.java
@@ -16,6 +16,7 @@ import static org.apache.storm.topology.base.BaseWindowedBolt.Count;
 import static org.apache.storm.topology.base.BaseWindowedBolt.Duration;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -345,7 +346,7 @@ public class WindowedBoltExecutor implements IRichBolt {
 
     @Override
     public Map<String, Object> getComponentConfiguration() {
-        return bolt.getComponentConfiguration();
+        return bolt.getComponentConfiguration() != null ? bolt.getComponentConfiguration() : Collections.emptyMap();
     }
 
     protected WindowLifecycleListener<Tuple> newWindowLifecycleListener() {

--- a/storm-client/test/jvm/org/apache/storm/topology/WindowedBoltExecutorTest.java
+++ b/storm-client/test/jvm/org/apache/storm/topology/WindowedBoltExecutorTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -212,6 +213,14 @@ public class WindowedBoltExecutorTest {
         System.out.println(testWindowedBolt.tupleWindows);
         Tuple tuple = tuples.get(tuples.size() - 1);
         Mockito.verify(outputCollector).emit("$late", Arrays.asList(tuple), new Values(tuple));
+    }
+
+    @Test
+    public void testEmptyConfigOnWrappedBolt() {
+        IWindowedBolt wrappedBolt = Mockito.mock(IWindowedBolt.class);
+        Mockito.when(wrappedBolt.getComponentConfiguration()).thenReturn(null);
+        executor = new WindowedBoltExecutor(wrappedBolt);
+        assertTrue("Configuration is not empty", executor.getComponentConfiguration().isEmpty());
     }
 
     private static class TestWindowedBolt extends BaseWindowedBolt {


### PR DESCRIPTION
Avoid NPE in WindowedBoltExecutor when the wrapped bolt returns a null configuration.