### PR TITLE
Add thrift.supervisor.port to documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,7 @@ IPsec to encrypt all traffic being sent between the hosts in the cluster.
 |--------------|--------------|------------------------|--------|
 | 2181 | `storm.zookeeper.port` | Nimbus, Supervisors, and Worker processes | ZooKeeper |
 | 6627 | `nimbus.thrift.port` | Storm clients, Supervisors, and UI | Nimbus |
+| 6628 | `supervisor.thrift.port` | Nimbus | Supervisors |
 | 8080 | `ui.port` | Client Web Browsers | UI |
 | 8000 | `logviewer.port` | Client Web Browsers | Logviewer |
 | 3772 | `drpc.port` | External DRPC Clients | DRPC |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -36,6 +36,7 @@ IPsec to encrypt all traffic being sent between the hosts in the cluster.
 |--------------|--------------|------------------------|--------|
 | 2181 | `storm.zookeeper.port` | Nimbus, Supervisors, and Worker processes | Zookeeper |
 | 6627 | `nimbus.thrift.port` | Storm clients, Supervisors, and UI | Nimbus |
+| 6628 | `supervisor.thrift.port` | Nimbus | Supervisors |
 | 8080 | `ui.port` | Client Web Browsers | UI |
 | 8000 | `logviewer.port` | Client Web Browsers | Logviewer |
 | 3772 | `drpc.port` | External DRPC Clients | DRPC |


### PR DESCRIPTION
I spent a whole lot of time trying to figure out why my workers wouldn't start, and it ended up being that i had to open port 6628 (thrift.supervisor.port) on the workers.

This caused me a lot of headache as it is omitted from the documentation.

Can someone confirm that i have the client for this port correct?  I put Nimbus but it might be Zookeeper or other workers, i'm not sure exactly how it works