### PR TITLE
STORM-3540 fix Pacemaker connection issues

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/pacemaker/PacemakerClientHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/pacemaker/PacemakerClientHandler.java
@@ -36,6 +36,7 @@ public class PacemakerClientHandler extends ChannelInboundHandlerAdapter {
         Channel channel = ctx.channel();
         LOG.info("Connection established from {} to {}",
                  channel.localAddress(), channel.remoteAddress());
+        client.channelReady(channel);
     }
 
     @Override
@@ -57,7 +58,7 @@ public class PacemakerClientHandler extends ChannelInboundHandlerAdapter {
         if (cause instanceof ConnectException) {
             LOG.warn("Connection to pacemaker failed. Trying to reconnect {}", cause.getMessage());
         } else {
-            LOG.error("Exception occurred in Pacemaker.", cause);
+            LOG.error("Exception occurred in Pacemaker: " + cause);
         }
         client.reconnect();
     }

--- a/storm-client/src/jvm/org/apache/storm/pacemaker/codec/ThriftNettyClientCodec.java
+++ b/storm-client/src/jvm/org/apache/storm/pacemaker/codec/ThriftNettyClientCodec.java
@@ -72,7 +72,7 @@ public class ThriftNettyClientCodec extends ChannelInitializer<Channel> {
                 throw new RuntimeException(e);
             }
         } else {
-            client.channelReady(ch);
+            // no work for AuthMethod.NONE
         }
 
         pipeline.addLast("PacemakerClientHandler", new PacemakerClientHandler(client));


### PR DESCRIPTION
"Exception occurred in Pacemaker" message was not logging cause properly until I changed the message for some reason.

Problem:

1) ThriftNettyClientCodec.initChannel() is called, which we map to PacemakerClient.channelReady().
2) We get a pacemaker message to write
3) We see the channel as ready and write/flush the message
4) The flush causes a NotYetConnected exception
5) This triggers a reconnect
6) The reconnect causes us to go to step 1) and we get stuck in a loop failing to talk to Pacemaker

The solution I think is more appropriate:

PacemakerClientHandler.channelActive() should be the one calling PacemakerClient.channelReady().

