### PR TITLE
STORM-3543 Change task hook info objects to use basic for loops to reduce garbag…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/hooks/info/BoltAckInfo.java
+++ b/storm-client/src/jvm/org/apache/storm/hooks/info/BoltAckInfo.java
@@ -12,6 +12,8 @@
 
 package org.apache.storm.hooks.info;
 
+import java.util.List;
+
 import org.apache.storm.hooks.ITaskHook;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
@@ -28,8 +30,9 @@ public class BoltAckInfo {
     }
 
     public void applyOn(TopologyContext topologyContext) {
-        for (ITaskHook hook : topologyContext.getHooks()) {
-            hook.boltAck(this);
+        List<ITaskHook> hooks = topologyContext.getHooks();
+        for (int i = 0; i < hooks.size(); i++) {
+            hooks.get(i).boltAck(this);
         }
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/hooks/info/BoltExecuteInfo.java
+++ b/storm-client/src/jvm/org/apache/storm/hooks/info/BoltExecuteInfo.java
@@ -12,6 +12,8 @@
 
 package org.apache.storm.hooks.info;
 
+import java.util.List;
+
 import org.apache.storm.hooks.ITaskHook;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
@@ -28,9 +30,9 @@ public class BoltExecuteInfo {
     }
 
     public void applyOn(TopologyContext topologyContext) {
-        for (int i = 0; i < topologyContext.getHooks().size(); i++) { // perf critical loop. dont use iterators
-            ITaskHook hook = topologyContext.getHooks().get(i);
-            hook.boltExecute(this);
+        List<ITaskHook> hooks = topologyContext.getHooks();
+        for (int i = 0; i < hooks.size(); i++) {
+            hooks.get(i).boltExecute(this);
         }
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/hooks/info/BoltFailInfo.java
+++ b/storm-client/src/jvm/org/apache/storm/hooks/info/BoltFailInfo.java
@@ -12,6 +12,8 @@
 
 package org.apache.storm.hooks.info;
 
+import java.util.List;
+
 import org.apache.storm.hooks.ITaskHook;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.tuple.Tuple;
@@ -28,8 +30,9 @@ public class BoltFailInfo {
     }
 
     public void applyOn(TopologyContext topologyContext) {
-        for (ITaskHook hook : topologyContext.getHooks()) {
-            hook.boltFail(this);
+        List<ITaskHook> hooks = topologyContext.getHooks();
+        for (int i = 0; i < hooks.size(); i++) {
+            hooks.get(i).boltFail(this);
         }
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/hooks/info/EmitInfo.java
+++ b/storm-client/src/jvm/org/apache/storm/hooks/info/EmitInfo.java
@@ -31,8 +31,9 @@ public class EmitInfo {
     }
 
     public void applyOn(TopologyContext topologyContext) {
-        for (ITaskHook hook : topologyContext.getHooks()) {
-            hook.emit(this);
+        List<ITaskHook> hooks = topologyContext.getHooks();
+        for (int i = 0; i < hooks.size(); i++) {
+            hooks.get(i).emit(this);
         }
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/hooks/info/SpoutAckInfo.java
+++ b/storm-client/src/jvm/org/apache/storm/hooks/info/SpoutAckInfo.java
@@ -12,6 +12,8 @@
 
 package org.apache.storm.hooks.info;
 
+import java.util.List;
+
 import org.apache.storm.hooks.ITaskHook;
 import org.apache.storm.task.TopologyContext;
 
@@ -27,8 +29,9 @@ public class SpoutAckInfo {
     }
 
     public void applyOn(TopologyContext topologyContext) {
-        for (ITaskHook hook : topologyContext.getHooks()) {
-            hook.spoutAck(this);
+        List<ITaskHook> hooks = topologyContext.getHooks();
+        for (int i = 0; i < hooks.size(); i++) {
+            hooks.get(i).spoutAck(this);
         }
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/hooks/info/SpoutFailInfo.java
+++ b/storm-client/src/jvm/org/apache/storm/hooks/info/SpoutFailInfo.java
@@ -12,6 +12,8 @@
 
 package org.apache.storm.hooks.info;
 
+import java.util.List;
+
 import org.apache.storm.hooks.ITaskHook;
 import org.apache.storm.task.TopologyContext;
 
@@ -27,8 +29,9 @@ public class SpoutFailInfo {
     }
 
     public void applyOn(TopologyContext topologyContext) {
-        for (ITaskHook hook : topologyContext.getHooks()) {
-            hook.spoutFail(this);
+        List<ITaskHook> hooks = topologyContext.getHooks();
+        for (int i = 0; i < hooks.size(); i++) {
+            hooks.get(i).spoutFail(this);
         }
     }
 }


### PR DESCRIPTION
A big drive was made in 2.0 to avoid iterators on the critical path to reduce garbage collection.

When task hooks are used, an iterator is used for each info object to pass it to all hooks.

As this is on the critical path when task hooks are used, the same reasoning should apply and the iterators be replaced with for loops.
