### PR TITLE
STORM-3549 allow use of custom jaas conf files for Kafka

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/Login.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/Login.java
@@ -19,6 +19,9 @@ package org.apache.storm.messaging.netty;
  * does not die.
  */
 
+import java.io.File;
+import java.net.URI;
+import java.security.URIParameter;
 import java.util.Date;
 import java.util.Random;
 import java.util.Set;
@@ -31,6 +34,7 @@ import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import org.apache.log4j.Logger;
+import org.apache.storm.security.auth.ClientAuthUtils;
 import org.apache.storm.shade.org.apache.zookeeper.Shell;
 import org.apache.storm.shade.org.apache.zookeeper.client.ZooKeeperSaslClient;
 
@@ -57,12 +61,9 @@ public class Login {
     private Thread thread = null;
     private boolean isKrbTicket = false;
     private boolean isUsingTicketCache = false;
-    private boolean isUsingKeytab = false;
     private LoginContext login = null;
     private String loginContextName = null;
-    private String keytabFile = null;
     private String principal = null;
-
     private long lastLogin = 0;
 
     /**
@@ -77,14 +78,14 @@ public class Login {
      * @throws javax.security.auth.login.LoginException
      *               Thrown if authentication fails.
      */
-    public Login(final String loginContextName, CallbackHandler callbackHandler)
+    public Login(final String loginContextName, CallbackHandler callbackHandler, String jaasConfFile)
         throws LoginException {
         this.callbackHandler = callbackHandler;
-        login = login(loginContextName);
+        login = login(loginContextName, jaasConfFile);
         this.loginContextName = loginContextName;
         subject = login.getSubject();
         isKrbTicket = !subject.getPrivateCredentials(KerberosTicket.class).isEmpty();
-        AppConfigurationEntry[] entries = Configuration.getConfiguration().getAppConfigurationEntry(loginContextName);
+        AppConfigurationEntry[] entries = this.getConfiguration(jaasConfFile).getAppConfigurationEntry(loginContextName);
         for (AppConfigurationEntry entry : entries) {
             // there will only be a single entry, so this for() loop will only be iterated through once.
             if (entry.getOptions().get("useTicketCache") != null) {
@@ -92,10 +93,6 @@ public class Login {
                 if (val.equals("true")) {
                     isUsingTicketCache = true;
                 }
-            }
-            if (entry.getOptions().get("keyTab") != null) {
-                keytabFile = (String) entry.getOptions().get("keyTab");
-                isUsingKeytab = true;
             }
             if (entry.getOptions().get("principal") != null) {
                 principal = (String) entry.getOptions().get("principal");
@@ -251,6 +248,19 @@ public class Login {
         thread.setDaemon(true);
     }
 
+    private Configuration getConfiguration(String jaasConfFile) {
+        File configFile = new File(jaasConfFile);
+        if (!configFile.canRead()) {
+            throw new RuntimeException("File " + jaasConfFile + " cannot be read.");
+        }
+        try {
+            URI configUri = configFile.toURI();
+            return Configuration.getInstance("JavaLoginConfig", new URIParameter(configUri));
+        } catch (Exception ex) {
+            throw new RuntimeException("Failed to get configuration for " + jaasConfFile, ex);
+        }
+    }
+
     public void startThreadIfNeeded() {
         // thread object 'thread' will be null if a refresh thread is not needed.
         if (thread != null) {
@@ -277,7 +287,7 @@ public class Login {
         return loginContextName;
     }
 
-    private synchronized LoginContext login(final String loginContextName) throws LoginException {
+    private synchronized LoginContext login(final String loginContextName, String jaasConfFile) throws LoginException {
         if (loginContextName == null) {
             throw new LoginException("loginContext name (JAAS file section header) was null. "
                     + "Please check your java.security.login.auth.config (="
@@ -285,9 +295,10 @@ public class Login {
                     + ") and your " + ZooKeeperSaslClient.LOGIN_CONTEXT_NAME_KEY + "(="
                     + System.getProperty(ZooKeeperSaslClient.LOGIN_CONTEXT_NAME_KEY, "Client") + ")");
         }
-        LoginContext loginContext = new LoginContext(loginContextName, callbackHandler);
+        Configuration configuration = this.getConfiguration(jaasConfFile);
+        LoginContext loginContext = new LoginContext(loginContextName, null, callbackHandler, configuration);
         loginContext.login();
-        LOG.info("successfully logged in.");
+        LOG.info("Successfully logged in to context " + loginContextName + " using " + jaasConfFile);
         return loginContext;
     }
 

--- a/storm-client/src/jvm/org/apache/storm/pacemaker/PacemakerClient.java
+++ b/storm-client/src/jvm/org/apache/storm/pacemaker/PacemakerClient.java
@@ -73,9 +73,8 @@ public class PacemakerClient implements ISaslClient {
         switch (auth) {
 
             case "DIGEST":
-                Configuration loginConf = ClientAuthUtils.getConfiguration(config);
                 authMethod = ThriftNettyClientCodec.AuthMethod.DIGEST;
-                secret = ClientAuthUtils.makeDigestPayload(loginConf, ClientAuthUtils.LOGIN_CONTEXT_PACEMAKER_DIGEST);
+                secret = ClientAuthUtils.makeDigestPayload(config, ClientAuthUtils.LOGIN_CONTEXT_PACEMAKER_DIGEST);
                 if (secret == null) {
                     LOG.error("Can't start pacemaker server without digest secret.");
                     throw new RuntimeException("Can't start pacemaker server without digest secret.");

--- a/storm-client/src/jvm/org/apache/storm/security/auth/ClientAuthUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/ClientAuthUtils.java
@@ -60,6 +60,10 @@ public class ClientAuthUtils {
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
 
+    public static String getJaasConf(Map<String, Object> topoConf) {
+        return (String) topoConf.get("java.security.auth.login.config");
+    }
+
     /**
      * Construct a JAAS configuration object per storm configuration file.
      *
@@ -70,7 +74,7 @@ public class ClientAuthUtils {
         Configuration loginConf = null;
 
         //find login file configuration from Storm configuration
-        String loginConfigurationFile = (String) topoConf.get("java.security.auth.login.config");
+        String loginConfigurationFile = getJaasConf(topoConf);
         if ((loginConfigurationFile != null) && (loginConfigurationFile.length() > 0)) {
             File configFile = new File(loginConfigurationFile);
             if (!configFile.canRead()) {
@@ -111,12 +115,13 @@ public class ClientAuthUtils {
     /**
      * Pull a set of keys out of a Configuration.
      *
-     * @param configuration The config to pull the key/value pairs out of.
+     * @param topoConf  The config containing the jaas conf file.
      * @param section       The app configuration entry name to get stuff from.
      * @return Return a map of the configs in conf.
      */
-    public static SortedMap<String, ?> pullConfig(Configuration configuration,
+    public static SortedMap<String, ?> pullConfig(Map<String, Object> topoConf,
                                                   String section) throws IOException {
+        Configuration configuration = ClientAuthUtils.getConfiguration(topoConf);
         AppConfigurationEntry[] configurationEntries = ClientAuthUtils.getEntries(configuration, section);
 
         if (configurationEntries == null) {
@@ -138,12 +143,17 @@ public class ClientAuthUtils {
     /**
      * Pull a the value given section and key from Configuration.
      *
-     * @param configuration The config to pull the key/value pairs out of.
+     * @param topoConf   The config containing the jaas conf file.
      * @param section       The app configuration entry name to get stuff from.
      * @param key           The key to look up inside of the section
      * @return Return a the String value of the configuration value
      */
-    public static String get(Configuration configuration, String section, String key) throws IOException {
+    public static String get(Map<String, Object> topoConf, String section, String key) throws IOException {
+        Configuration configuration = ClientAuthUtils.getConfiguration(topoConf);
+        return get(configuration, section, key);
+    }
+
+    static String get(Configuration configuration, String section, String key) throws IOException {
         AppConfigurationEntry[] configurationEntries = ClientAuthUtils.getEntries(configuration, section);
 
         if (configurationEntries == null) {
@@ -456,22 +466,22 @@ public class ClientAuthUtils {
     /**
      * Construct a transport plugin per storm configuration.
      */
-    public static ITransportPlugin getTransportPlugin(ThriftConnectionType type, Map<String, Object> topoConf, Configuration loginConf) {
+    public static ITransportPlugin getTransportPlugin(ThriftConnectionType type, Map<String, Object> topoConf) {
         try {
             String transportPluginClassName = type.getTransportPlugin(topoConf);
             ITransportPlugin transportPlugin = ReflectionUtils.newInstance(transportPluginClassName);
-            transportPlugin.prepare(type, topoConf, loginConf);
+            transportPlugin.prepare(type, topoConf);
             return transportPlugin;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static String makeDigestPayload(Configuration loginConfig, String configSection) {
+    public static String makeDigestPayload(Map<String, Object> topoConf, String configSection) {
         String username = null;
         String password = null;
         try {
-            Map<String, ?> results = ClientAuthUtils.pullConfig(loginConfig, configSection);
+            Map<String, ?> results = ClientAuthUtils.pullConfig(topoConf, configSection);
             username = (String) results.get(USERNAME);
             password = (String) results.get(PASSWORD);
         } catch (Exception e) {
@@ -491,6 +501,8 @@ public class ClientAuthUtils {
             throw new RuntimeException(e);
         }
     }
+
+
 
     public static byte[] serializeKerberosTicket(KerberosTicket tgt) throws Exception {
         ByteArrayOutputStream bao = new ByteArrayOutputStream();

--- a/storm-client/src/jvm/org/apache/storm/security/auth/ITransportPlugin.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/ITransportPlugin.java
@@ -29,9 +29,8 @@ public interface ITransportPlugin {
      *
      * @param type      the type of connection this will process.
      * @param topoConf  Storm configuration
-     * @param loginConf login configuration
      */
-    void prepare(ThriftConnectionType type, Map<String, Object> topoConf, Configuration loginConf);
+    void prepare(ThriftConnectionType type, Map<String, Object> topoConf);
 
     /**
      * Create a server associated with a given port, service handler, and purpose.

--- a/storm-client/src/jvm/org/apache/storm/security/auth/SimpleTransportPlugin.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/SimpleTransportPlugin.java
@@ -48,14 +48,12 @@ public class SimpleTransportPlugin implements ITransportPlugin {
     private static final Logger LOG = LoggerFactory.getLogger(SimpleTransportPlugin.class);
     protected ThriftConnectionType type;
     protected Map<String, Object> topoConf;
-    protected Configuration loginConf;
     private int port;
 
     @Override
-    public void prepare(ThriftConnectionType type, Map<String, Object> topoConf, Configuration loginConf) {
+    public void prepare(ThriftConnectionType type, Map<String, Object> topoConf) {
         this.type = type;
         this.topoConf = topoConf;
-        this.loginConf = loginConf;
     }
 
     @Override

--- a/storm-client/src/jvm/org/apache/storm/security/auth/ThriftClient.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/ThriftClient.java
@@ -83,11 +83,8 @@ public class ThriftClient implements AutoCloseable {
                 socket.setTimeout(timeout);
             }
 
-            //locate login configuration 
-            Configuration loginConf = ClientAuthUtils.getConfiguration(conf);
-
             //construct a transport plugin
-            ITransportPlugin transportPlugin = ClientAuthUtils.getTransportPlugin(type, conf, loginConf);
+            ITransportPlugin transportPlugin = ClientAuthUtils.getTransportPlugin(type, conf);
 
             //TODO get this from type instead of hardcoding to Nimbus.
             //establish client-server transport via plugin

--- a/storm-client/src/jvm/org/apache/storm/security/auth/ThriftServer.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/ThriftServer.java
@@ -12,10 +12,8 @@
 
 package org.apache.storm.security.auth;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
-import javax.security.auth.login.Configuration;
 import org.apache.storm.security.auth.sasl.SaslTransportPlugin;
 import org.apache.storm.thrift.TProcessor;
 import org.apache.storm.thrift.server.TServer;
@@ -29,7 +27,6 @@ public class ThriftServer {
     private final Map<String, Object> conf; //storm configuration
     private final ThriftConnectionType type;
     private TServer server;
-    private Configuration loginConf;
     private int port;
     private boolean areWorkerTokensSupported;
     private ITransportPlugin transportPlugin;
@@ -40,14 +37,8 @@ public class ThriftServer {
         this.type = type;
 
         try {
-            //retrieve authentication configuration 
-            loginConf = ClientAuthUtils.getConfiguration(this.conf);
-        } catch (Exception x) {
-            LOG.error(x.getMessage(), x);
-        }
-        try {
             //locate our thrift transport plugin
-            transportPlugin = ClientAuthUtils.getTransportPlugin(this.type, this.conf, loginConf);
+            transportPlugin = ClientAuthUtils.getTransportPlugin(this.type, this.conf);
             //server
             server = transportPlugin.getServer(this.processor);
             port = transportPlugin.getPort();

--- a/storm-client/src/jvm/org/apache/storm/security/auth/digest/JassPasswordProvider.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/digest/JassPasswordProvider.java
@@ -36,10 +36,12 @@ public class JassPasswordProvider implements PasswordProvider {
     /**
      * Constructor.
      *
-     * @param configuration the jaas configuration to get the credentials out of.
+     * @param topoConf the configuration containing the jaas conf to use.
      * @throws IOException if we could not read the Server section in the jaas conf.
      */
-    public JassPasswordProvider(Configuration configuration) throws IOException {
+    public JassPasswordProvider(Map<String, Object> topoConf) throws IOException {
+
+        Configuration configuration = ClientAuthUtils.getConfiguration(topoConf);
         if (configuration == null) {
             return;
         }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java
@@ -121,11 +121,10 @@ public class AutoTGT implements IAutoCredentials, ICredentialsRenewer, IMetricsR
         //Log the user in and get the TGT
         try {
             Configuration loginConf = ClientAuthUtils.getConfiguration(conf);
-            ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler(loginConf);
+            ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler(conf);
 
             //login our user
-            Configuration.setConfiguration(loginConf);
-            LoginContext lc = new LoginContext(ClientAuthUtils.LOGIN_CONTEXT_CLIENT, clientCallbackHandler);
+            LoginContext lc = new LoginContext(ClientAuthUtils.LOGIN_CONTEXT_CLIENT, null, clientCallbackHandler, loginConf);
             try {
                 lc.login();
                 final Subject subject = lc.getSubject();

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ClientCallbackHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ClientCallbackHandler.java
@@ -13,6 +13,7 @@
 package org.apache.storm.security.auth.kerberos;
 
 import java.io.IOException;
+import java.util.Map;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
@@ -36,7 +37,8 @@ public class ClientCallbackHandler implements CallbackHandler {
      *
      * <p>For digest, you should have a pair of user name and password defined in this figgure.
      */
-    public ClientCallbackHandler(Configuration configuration) throws IOException {
+    public ClientCallbackHandler(Map<String, Object> topoConf) throws IOException {
+        Configuration configuration = ClientAuthUtils.getConfiguration(topoConf);
         if (configuration == null) {
             return;
         }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ServerCallbackHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/ServerCallbackHandler.java
@@ -13,6 +13,7 @@
 package org.apache.storm.security.auth.kerberos;
 
 import java.io.IOException;
+import java.util.Map;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
@@ -35,8 +36,10 @@ public class ServerCallbackHandler implements CallbackHandler {
     private static final Logger LOG = LoggerFactory.getLogger(ServerCallbackHandler.class);
     private final boolean impersonationAllowed;
 
-    public ServerCallbackHandler(Configuration configuration, boolean impersonationAllowed) throws IOException {
+    public ServerCallbackHandler(Map<String, Object> topoConf, boolean impersonationAllowed) throws IOException {
         this.impersonationAllowed = impersonationAllowed;
+
+        Configuration configuration = ClientAuthUtils.getConfiguration(topoConf);
         if (configuration == null) {
             return;
         }

--- a/storm-client/src/jvm/org/apache/storm/security/auth/sasl/SaslTransportPlugin.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/sasl/SaslTransportPlugin.java
@@ -49,14 +49,12 @@ import org.apache.storm.utils.ExtendedThreadPoolExecutor;
 public abstract class SaslTransportPlugin implements ITransportPlugin, Closeable {
     protected ThriftConnectionType type;
     protected Map<String, Object> conf;
-    protected Configuration loginConf;
     private int port;
 
     @Override
-    public void prepare(ThriftConnectionType type, Map<String, Object> conf, Configuration loginConf) {
+    public void prepare(ThriftConnectionType type, Map<String, Object> conf) {
         this.type = type;
         this.conf = conf;
-        this.loginConf = loginConf;
     }
 
     @Override

--- a/storm-client/test/jvm/org/apache/storm/security/auth/ClientAuthUtilsTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/ClientAuthUtilsTest.java
@@ -95,8 +95,9 @@ public class ClientAuthUtilsTest {
 
     @Test
     public void objGettersReturnNullWithNullConfigTest() throws IOException {
-        Assert.assertNull(ClientAuthUtils.pullConfig(null, "foo"));
-        Assert.assertNull(ClientAuthUtils.get(null, "foo", "bar"));
+        Map<String, Object> topoConf = new HashMap<>();
+        Assert.assertNull(ClientAuthUtils.pullConfig(topoConf, "foo"));
+        Assert.assertNull(ClientAuthUtils.get(topoConf, "foo", "bar"));
 
         Assert.assertNull(ClientAuthUtils.getConfiguration(Collections.emptyMap()));
     }
@@ -139,39 +140,6 @@ public class ClientAuthUtilsTest {
         Collection<IAutoCredentials> autos = Arrays.asList(new IAutoCredentials[]{ autoCred });
         ClientAuthUtils.populateSubject(subject, autos, cred);
         Mockito.verify(autoCred, Mockito.times(1)).populateSubject(subject, cred);
-    }
-
-    @Test
-    public void makeDigestPayloadTest() throws NoSuchAlgorithmException {
-        String section = "user-pass-section";
-        Map<String, String> optionMap = new HashMap<String, String>();
-        String user = "user";
-        String pass = "pass";
-        optionMap.put("username", user);
-        optionMap.put("password", pass);
-        AppConfigurationEntry entry = Mockito.mock(AppConfigurationEntry.class);
-
-        Mockito.<Map<String, ?>>when(entry.getOptions()).thenReturn(optionMap);
-        Configuration mockConfig = Mockito.mock(Configuration.class);
-        Mockito.when(mockConfig.getAppConfigurationEntry(section))
-               .thenReturn(new AppConfigurationEntry[]{ entry });
-
-        MessageDigest digest = MessageDigest.getInstance("SHA-512");
-        byte[] output = digest.digest((user + ":" + pass).getBytes());
-        String sha = Hex.encodeHexString(output);
-
-        // previous code used this method to generate the string, ensure the two match
-        StringBuilder builder = new StringBuilder();
-        for (byte b : output) {
-            builder.append(String.format("%02x", b));
-        }
-        String stringFormatMethod = builder.toString();
-
-        Assert.assertEquals(
-            ClientAuthUtils.makeDigestPayload(mockConfig, "user-pass-section"),
-            sha);
-
-        Assert.assertEquals(sha, stringFormatMethod);
     }
 
     @Test(expected = RuntimeException.class)

--- a/storm-server/src/main/java/org/apache/storm/pacemaker/PacemakerServer.java
+++ b/storm-server/src/main/java/org/apache/storm/pacemaker/PacemakerServer.java
@@ -63,9 +63,8 @@ class PacemakerServer implements ISaslServer {
         switch (auth) {
 
             case "DIGEST":
-                Configuration loginConf = ClientAuthUtils.getConfiguration(config);
                 authMethod = ThriftNettyServerCodec.AuthMethod.DIGEST;
-                this.secret = ClientAuthUtils.makeDigestPayload(loginConf, ClientAuthUtils.LOGIN_CONTEXT_PACEMAKER_DIGEST);
+                this.secret = ClientAuthUtils.makeDigestPayload(config, ClientAuthUtils.LOGIN_CONTEXT_PACEMAKER_DIGEST);
                 if (this.secret == null) {
                     LOG.error("Can't start pacemaker server without digest secret.");
                     throw new RuntimeException("Can't start pacemaker server without digest secret.");

--- a/storm-server/src/test/java/org/apache/storm/security/auth/AuthTest.java
+++ b/storm-server/src/test/java/org/apache/storm/security/auth/AuthTest.java
@@ -576,7 +576,7 @@ public class AuthTest {
     public void getTransportPluginThrowsRunimeTest() {
         Map<String, Object> conf = ConfigUtils.readStormConfig();
         conf.put(Config.STORM_THRIFT_TRANSPORT_PLUGIN, "null.invalid");
-        ClientAuthUtils.getTransportPlugin(ThriftConnectionType.NIMBUS, conf, null);
+        ClientAuthUtils.getTransportPlugin(ThriftConnectionType.NIMBUS, conf);
     }
 
     @Test


### PR DESCRIPTION
Previous to this change, client code would fetch a Configuration from a jaas conf file provided in the topo conf, set the Configuration globally, and then call Login. The Login code would fetch the singleton Configuration and use that to determine the jaas conf entries.

The problem with this is that for external services such as Kafka, if they see a Configuration is set, they could default to using the set Configuration, which may not match the custom jaas conf specified by the user. Rather than setting the Configuration, when we call Login, we should just specify which jaas conf file to use for logging in and read that jaas file Configuration without setting it.

Since the Configuration is now just being read when needed and not set, we do not need to pass it around. The file to use is already specified in the topoConf which is already passed around. A lot of clean up was done to remove the unnecessary parameter.