### PR TITLE
MINOR: Fix typo in storm/docs/storm-eventhubs.md

### DIFF
--- a/docs/storm-eventhubs.md
+++ b/docs/storm-eventhubs.md
@@ -1,5 +1,5 @@
 ---
-title: Azue Event Hubs Integration
+title: Azure Event Hubs Integration
 layout: documentation
 documentation: true
 ---


### PR DESCRIPTION
This PR fixes a typo "Azue" -> "Azure" in the title of the `storm/docs/storm-eventhubs.md` page.
cc @krichter722 as author.