### PR TITLE
MINOR: Bump required python version in documentation

### DIFF
--- a/docs/Setting-up-a-Storm-cluster.md
+++ b/docs/Setting-up-a-Storm-cluster.md
@@ -30,7 +30,7 @@ A few notes about Zookeeper deployment:
 Next you need to install Storm's dependencies on Nimbus and the worker machines. These are:
 
 1. Java 8+ (Apache Storm 2.x is tested through travis ci against a java 8 JDK)
-2. Python 2.6.6 (Python 3.x should work too, but is not tested as part of our CI enviornment)
+2. Python 2.7.x or Python 3.x
 
 These are the versions of the dependencies that have been tested with Storm. Storm may or may not work with different versions of Java and/or Python.
 

--- a/docs/flux.md
+++ b/docs/flux.md
@@ -47,7 +47,7 @@ The easiest way to use Flux, is to add it as a Maven dependency in you project a
 If you would like to build Flux from source and run the unit/integration tests, you will need the following installed
 on your system:
 
-* Python 2.6.x or later
+* Python 2.7.x or later
 * Node.js 0.10.x or later
 
 #### Building with unit tests enabled:


### PR DESCRIPTION
Due to argparse in the storm.py script, we actually need at least 2.7