### PR TITLE
[STORM-3563] Fix broken link for apache-maven download and cache maven directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ before_install:
   - sudo add-apt-repository ppa:deadsnakes/ppa -y
   - sudo apt-get update
   - sudo apt-get install python3.6
-  - wget http://mirrors.rackhosting.com/apache/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz -P $HOME
-  - tar xzvf $HOME/apache-maven-3.6.1-bin.tar.gz -C $HOME
-  - export PATH=$HOME/apache-maven-3.6.1/bin:$PATH
+  - export MVN_HOME=$HOME/apache-maven-3.6.1
+  - if [ ! -d $MVN_HOME/bin ]; then wget https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz -P $HOME; tar xzvf $HOME/apache-maven-3.6.1-bin.tar.gz -C $HOME; fi
+  - export PATH=$MVN_HOME/bin:$PATH
 install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
 script:
   - /bin/bash ./dev-tools/travis/travis-script.sh `pwd` $MODULES
@@ -54,3 +54,4 @@ cache:
     - "$HOME/.m2/repository"
     - "$HOME/.rvm"
     - "$NVM_DIR"
+    - "$HOME/apache-maven-3.6.1"


### PR DESCRIPTION
1. maven-3.6.1 got removed from the mirror which breaks the travis build. Change to point to  archive.apache.org.

2. Cache apache-maven directory to avoid frequent download.