### PR TITLE
[STORM-3494] use HdfsLoginUtil singleton to login to hdfs

### DIFF
--- a/dev-tools/travis/travis-script.sh
+++ b/dev-tools/travis/travis-script.sh
@@ -43,7 +43,7 @@ elif [ "$2" == "External" ]
 then
   if [ "$TRAVIS_JDK_VERSION" == "openjdk11" ]
   then 
-    TEST_MODULES='!storm-client,!storm-server,!storm-core,!storm-webapp,!storm-shaded-deps,!external/storm-cassandra,!external/storm-hive,!external/storm-hdfs,!external/storm-hbase,!sql/storm-sql-external/storm-sql-hdfs,!external/storm-hdfs-blobstore'
+    TEST_MODULES='!storm-client,!storm-server,!storm-core,!storm-webapp,!storm-shaded-deps,!external/storm-cassandra,!external/storm-hive,!external/storm-hdfs,!external/storm-hbase,!sql/storm-sql-external/storm-sql-hdfs,!external/storm-hdfs-blobstore,!external/storm-hdfs-login'
   else
     TEST_MODULES='!storm-client,!storm-server,!storm-core,!storm-webapp,!storm-shaded-deps'
   fi

--- a/docs/distcache-blobstore.md
+++ b/docs/distcache-blobstore.md
@@ -315,6 +315,26 @@ The default is 60 seconds, a value of -1 indicates to wait for ever.
 * nimbus.code.sync.freq.secs: Frequency at which the background thread on nimbus which syncs code for locally missing blobs. Default is 2 minutes.
 ```
 
+### Access to Secure HDFS Blobstore
+
+Specifically, if you want to access to secure HDFS blobstore, you need to use `org.apache.storm.hdfs.login.HdfsSingleLogin` as `storm.hdfs.login.plugin` and have the 
+following configs set properly:
+
+```
+storm.hdfs.login.keytab or blobstore.hdfs.keytab (deprecated)
+storm.hdfs.login.principal or blobstore.hdfs.principal (deprecated)
+```
+
+For example,
+```
+storm.hdfs.login.plugin: org.apache.storm.hdfs.login.HdfsSingleLogin
+storm.hdfs.login.keytab: /etc/keytab
+storm.hdfs.login.principal: primary/instance@REALM
+```
+
+As a pre-requisite, you need to build the `external/storm-hdfs-login` module and copy the jar file (`target/storm-hdfs-login.jar`) to the `extlib-daemon` directory. 
+
+
 ## Using the Distributed Cache API, Command Line Interface (CLI)
 
 ### Creating blobs 

--- a/external/storm-blobstore-migration/src/main/java/org/apache/storm/blobstore/ListHDFS.java
+++ b/external/storm-blobstore-migration/src/main/java/org/apache/storm/blobstore/ListHDFS.java
@@ -49,11 +49,11 @@ public class ListHDFS {
         hdfsConf.put(Config.STORM_PRINCIPAL_TO_LOCAL_PLUGIN, "org.apache.storm.security.auth.DefaultPrincipalToLocal");
         if (args.length >= 2) {
             System.out.println("SETTING HDFS PRINCIPAL!");
-            hdfsConf.put(Config.BLOBSTORE_HDFS_PRINCIPAL, args[1]);
+            hdfsConf.put(Config.STORM_HDFS_LOGIN_PRINCIPAL, args[1]);
         }
         if (args.length >= 3) {
             System.out.println("SETTING HDFS KEYTAB!");
-            hdfsConf.put(Config.BLOBSTORE_HDFS_KEYTAB, args[2]);
+            hdfsConf.put(Config.STORM_HDFS_LOGIN_KEYTAB, args[2]);
         }
         
         /* CREATE THE BLOBSTORES */

--- a/external/storm-blobstore-migration/src/main/java/org/apache/storm/blobstore/MigrateBlobs.java
+++ b/external/storm-blobstore-migration/src/main/java/org/apache/storm/blobstore/MigrateBlobs.java
@@ -84,11 +84,11 @@ public class MigrateBlobs {
         hdfsConf.put(Config.STORM_PRINCIPAL_TO_LOCAL_PLUGIN, "org.apache.storm.security.auth.DefaultPrincipalToLocal");
         if (args.length >= 3) {
             System.out.println("SETTING HDFS PRINCIPAL!");
-            hdfsConf.put(Config.BLOBSTORE_HDFS_PRINCIPAL, args[2]);
+            hdfsConf.put(Config.STORM_HDFS_LOGIN_PRINCIPAL, args[2]);
         }
         if (args.length >= 4) {
             System.out.println("SETTING HDFS KEYTAB!");
-            hdfsConf.put(Config.BLOBSTORE_HDFS_KEYTAB, args[3]);
+            hdfsConf.put(Config.STORM_HDFS_LOGIN_KEYTAB, args[3]);
         }
         hdfsConf.put(Config.STORM_BLOBSTORE_REPLICATION_FACTOR, 7);
         

--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
@@ -48,6 +48,7 @@ import org.apache.storm.generated.ReadableBlobMeta;
 import org.apache.storm.generated.SettableBlobMeta;
 import org.apache.storm.nimbus.ILeaderElector;
 import org.apache.storm.nimbus.NimbusInfo;
+import org.apache.storm.utils.HdfsLoginUtil;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.utils.WrappedKeyAlreadyExistsException;
 import org.apache.storm.utils.WrappedKeyNotFoundException;
@@ -74,36 +75,14 @@ import org.slf4j.LoggerFactory;
  * subject. The blobstore gets the hadoop user and validates permissions for the supervisor.
  */
 public class HdfsBlobStore extends BlobStore {
-    public static final Logger LOG = LoggerFactory.getLogger(HdfsBlobStore.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HdfsBlobStore.class);
     private static final String DATA_PREFIX = "data_";
     private static final String META_PREFIX = "meta_";
-    private static final HashMap<String, Subject> alreadyLoggedInUsers = new HashMap<>();
 
     private BlobStoreAclHandler aclHandler;
     private HdfsBlobStoreImpl hbs;
     private Subject localSubject;
     private Map<String, Object> conf;
-
-    /**
-     * Get the subject from Hadoop so we can use it to validate the acls. There is no direct
-     * interface from UserGroupInformation to get the subject, so do a doAs and get the context.
-     * We could probably run everything in the doAs but for now just grab the subject.
-     */
-    private Subject getHadoopUser() {
-        Subject subj;
-        try {
-            subj = UserGroupInformation.getCurrentUser().doAs(
-                    new PrivilegedAction<Subject>() {
-                        @Override
-                        public Subject run() {
-                            return Subject.getSubject(AccessController.getContext());
-                        }
-                    });
-        } catch (IOException e) {
-            throw new RuntimeException("Error creating subject and logging user in!", e);
-        }
-        return subj;
-    }
 
     /**
      * If who is null then we want to use the user hadoop says we are.
@@ -136,36 +115,10 @@ public class HdfsBlobStore extends BlobStore {
             throw new RuntimeException("You must specify a blobstore directory for HDFS to use!");
         }
         LOG.debug("directory is: {}", overrideBase);
-        try {
-            // if a HDFS keytab/principal have been supplied login, otherwise assume they are
-            // logged in already or running insecure HDFS.
-            String principal = Config.getBlobstoreHDFSPrincipal(conf);
-            String keyTab = (String) conf.get(Config.BLOBSTORE_HDFS_KEYTAB);
 
-            if (principal != null && keyTab != null) {
-                String combinedKey = principal + " from " + keyTab;
-                synchronized (alreadyLoggedInUsers) {
-                    localSubject = alreadyLoggedInUsers.get(combinedKey);
-                    if (localSubject == null) {
-                        UserGroupInformation.loginUserFromKeytab(principal, keyTab);
-                        localSubject = getHadoopUser();
-                        alreadyLoggedInUsers.put(combinedKey, localSubject);
-                    }
-                }
-            } else {
-                if (principal == null && keyTab != null) {
-                    throw new RuntimeException("You must specify an HDFS principal to go with the keytab!");
+        //Login to hdfs
+        localSubject = HdfsLoginUtil.getInstance().logintoHdfs(conf);
 
-                } else {
-                    if (principal != null && keyTab == null) {
-                        throw new RuntimeException("You must specify HDFS keytab go with the principal!");
-                    }
-                }
-                localSubject = getHadoopUser();
-            }
-        } catch (IOException e) {
-            throw new RuntimeException("Error logging in from keytab: " + e.getMessage(), e);
-        }
         aclHandler = new BlobStoreAclHandler(conf);
         Path baseDir = new Path(overrideBase, BASE_BLOBS_DIR_NAME);
         try {

--- a/external/storm-hdfs-login/pom.xml
+++ b/external/storm-hdfs-login/pom.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>storm</artifactId>
+        <groupId>org.apache.storm</groupId>
+        <version>2.2.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>storm-hdfs-login</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.storm</groupId>
+            <artifactId>storm-client</artifactId>
+            <version>${project.version}</version>
+            <scope>${provided.scope}</scope>
+            <exclusions>
+                <!--log4j-over-slf4j must be excluded for hadoop-minicluster
+                    see: http://stackoverflow.com/q/20469026/3542091 -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet.jsp</groupId>
+                    <artifactId>jsp-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- This is leaking from hadoop-annotations. -->
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>false</reuseForks>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>cleanup</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>./build/</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <!--Note - the version would be inherited-->
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/external/storm-hdfs-login/src/main/java/org/apache/storm/hdfs/login/HdfsSingleLogin.java
+++ b/external/storm-hdfs-login/src/main/java/org/apache/storm/hdfs/login/HdfsSingleLogin.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.hdfs.login;
+
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Map;
+import javax.security.auth.Subject;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.storm.Config;
+import org.apache.storm.utils.IHdfsLoginPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Hadoop {@link UserGroupInformation} has some limitations/bugs (at least in hadoop-2.x).
+ * We should only use {@link UserGroupInformation#loginUserFromKeytab(String, String)} to login to HDFS
+ * at most once in a JVM process because this method changes the static fields of {@link UserGroupInformation},
+ * which could introduce nasty bugs if it's called multiple times.
+ * {@link UserGroupInformation#loginUserFromKeytabAndReturnUGI(String, String)} also has bugs so
+ * it shouldn't be used.
+ * <br>
+ * Don't use this class directly. Use {@link org.apache.storm.utils.HdfsLoginUtil} instead.
+ * The combination of this class and {@link org.apache.storm.utils.HdfsLoginUtil}
+ * guarantees single login in a JVM process.
+ */
+public class HdfsSingleLogin implements IHdfsLoginPlugin {
+    private Subject loggedInSubject;
+    private static final Logger LOG = LoggerFactory.getLogger(HdfsSingleLogin.class);
+
+    /**
+     * Login to hdfs using principal and keytab at most once.
+     * @param conf the storm configuration.
+     * @return the subject.
+     */
+    @Override
+    public Subject login(Map<String, Object> conf) {
+        if (loggedInSubject != null) {
+            LOG.debug("Already logged in to hdfs as {}. Will not re-login or login as another user.",
+                loggedInSubject.getPrincipals());
+            return loggedInSubject;
+        }
+
+        try {
+            String principal = Config.getHdfsPrincipal(conf);
+            String keyTab = Config.getHdfsKeytab(conf);
+
+            if (principal != null && keyTab != null) {
+                synchronized (this) {
+                    if (loggedInSubject == null) {
+                        UserGroupInformation.loginUserFromKeytab(principal, keyTab);
+                        loggedInSubject = getHdfsUser();
+                        LOG.info("Successfully logged in to hdfs as {}", loggedInSubject.getPrincipals());
+                    } else {
+                        LOG.debug("Already logged in to hdfs as {}. Will not re-login or login as another user.",
+                            loggedInSubject.getPrincipals());
+                    }
+                }
+            } else {
+                throw new IllegalArgumentException("You must specify both HDFS principal and keytab!");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error logging in from keytab: " + e.getMessage(), e);
+        }
+        return loggedInSubject;
+    }
+
+    /**
+     * Get the subject from Hadoop. There is no direct interface from UserGroupInformation
+     * to get the subject, so do a doAs and get the context.
+     */
+    private Subject getHdfsUser() {
+        Subject subj;
+        try {
+            subj = UserGroupInformation.getCurrentUser().doAs(
+                new PrivilegedAction<Subject>() {
+                    @Override
+                    public Subject run() {
+                        return Subject.getSubject(AccessController.getContext());
+                    }
+                });
+        } catch (IOException e) {
+            throw new RuntimeException("Error creating subject and logging user in!", e);
+        }
+        return subj;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -633,6 +633,7 @@
                 <module>external/storm-autocreds</module>
                 <module>external/storm-hdfs</module>
                 <module>external/storm-hdfs-blobstore</module>
+                <module>external/storm-hdfs-login</module>
                 <module>external/storm-hbase</module>
                 <module>external/storm-hive</module>
                 <module>external/storm-jdbc</module>

--- a/storm-client/src/jvm/org/apache/storm/utils/HdfsLoginUtil.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/HdfsLoginUtil.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.utils;
+
+import java.net.UnknownHostException;
+import java.util.Map;
+import javax.security.auth.Subject;
+import org.apache.storm.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Use this class only to login to HDFS from storm servers.
+ */
+public class HdfsLoginUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HdfsLoginUtil.class);
+
+    private static HdfsLoginUtil singleton;
+
+    private IHdfsLoginPlugin hdfsLoginPlugin;
+
+    private HdfsLoginUtil() {
+        // private constructor
+    }
+
+    /**
+     * Get the singleton instance.
+     * @return the singleton instance
+     */
+    public static HdfsLoginUtil getInstance() {
+        if (singleton == null) {
+            synchronized (HdfsLoginUtil.class) {
+                if (singleton == null) {
+                    singleton = new HdfsLoginUtil();
+                }
+            }
+        }
+        return singleton;
+    }
+
+    /**
+     * Login to hdfs.
+     * We use the single HdfsLoginPlugin instance because it may use some local state/cache.
+     * @param conf the storm configuration
+     * @return the logged in subject
+     */
+    public Subject logintoHdfs(Map<String, Object> conf) {
+        validateConf(conf);
+
+        if (hdfsLoginPlugin == null) {
+            synchronized (HdfsLoginUtil.class) {
+                if (hdfsLoginPlugin == null) {
+                    String className = (String) conf.get(Config.STORM_HDFS_LOGIN_PLUGIN);
+                    if (className != null) {
+                        LOG.info("{} is set to {}", Config.STORM_HDFS_LOGIN_PLUGIN, className);
+                        hdfsLoginPlugin = ReflectionUtils.newInstance(className);
+                    } else {
+                        LOG.info("{} is null or not set. {} is used.", Config.STORM_HDFS_LOGIN_PLUGIN,
+                            NoOpHdfsLoginPlugin.class.getCanonicalName());
+                        hdfsLoginPlugin = new NoOpHdfsLoginPlugin();
+                    }
+                }
+            }
+        }
+
+        return hdfsLoginPlugin.login(conf);
+    }
+
+    /* STORM-3494 breaks backwards compatibility by adding a new config {@link Config.STORM_HDFS_LOGIN_PLUGIN}.
+     * Storm used to be able to access secure HDFS cluster if HDFS keytab and principal were set properly.
+     * With the compatibility-breaking change in STORM-3494, this config {@link Config.STORM_HDFS_LOGIN_PLUGIN} has to be set
+     * correctly for it to work.
+     * This method is a ugly work-around to tell users to set the new config properly by throwing exceptions when
+     * the principal and keytab are present.
+     */
+    private void validateConf(Map<String, Object> conf) {
+        String className = (String) conf.get(Config.STORM_HDFS_LOGIN_PLUGIN);
+        String principal = null;
+        try {
+            principal = Config.getHdfsPrincipal(conf);
+        } catch (UnknownHostException e) {
+            //ignore
+        }
+        String keyTab = Config.getHdfsKeytab(conf);
+        if (className == null && (principal != null || keyTab != null)) {
+            throw new IllegalArgumentException("Please set " + Config.STORM_HDFS_LOGIN_PLUGIN
+                + " correctly to be able to use hdfs principal and keytab");
+        }
+    }
+
+    static class NoOpHdfsLoginPlugin implements IHdfsLoginPlugin {
+        @Override
+        public Subject login(Map<String, Object> conf) {
+            return null;
+        }
+    }
+}

--- a/storm-client/src/jvm/org/apache/storm/utils/IHdfsLoginPlugin.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/IHdfsLoginPlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.utils;
+
+import java.util.Map;
+import javax.security.auth.Subject;
+
+/**
+ * A utility interface for use to login to hdfs.
+ * Don't use it directly. Use {@link HdfsLoginUtil} instead.
+ */
+public interface IHdfsLoginPlugin {
+
+    Subject login(Map<String, Object> conf);
+
+}

--- a/storm-client/test/jvm/org/apache/storm/utils/ConfigUtilsTest.java
+++ b/storm-client/test/jvm/org/apache/storm/utils/ConfigUtilsTest.java
@@ -92,6 +92,7 @@ public class ConfigUtilsTest {
     }
 
     @Test
+    @Deprecated
     public void getBlobstoreHDFSPrincipal() throws UnknownHostException {
         Map<String, Object> conf = mockMap(Config.BLOBSTORE_HDFS_PRINCIPAL, "primary/_HOST@EXAMPLE.COM");
         Assert.assertEquals(Config.getBlobstoreHDFSPrincipal(conf), "primary/" +  Utils.localHostname() + "@EXAMPLE.COM");
@@ -119,5 +120,35 @@ public class ConfigUtilsTest {
         principal = "primary/instance@EXAMPLE.COM";
         conf.put(Config.BLOBSTORE_HDFS_PRINCIPAL, principal);
         Assert.assertEquals(Config.getBlobstoreHDFSPrincipal(conf), principal);
+    }
+
+    @Test
+    public void getHfdsPrincipal() throws UnknownHostException {
+        Map<String, Object> conf = mockMap(Config.STORM_HDFS_LOGIN_PRINCIPAL, "primary/_HOST@EXAMPLE.COM");
+        Assert.assertEquals(Config.getHdfsPrincipal(conf), "primary/" +  Utils.localHostname() + "@EXAMPLE.COM");
+
+        String principal = "primary/_HOST_HOST@EXAMPLE.COM";
+        conf.put(Config.STORM_HDFS_LOGIN_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getHdfsPrincipal(conf), principal);
+
+        principal = "primary/_HOST2@EXAMPLE.COM";
+        conf.put(Config.STORM_HDFS_LOGIN_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getHdfsPrincipal(conf), principal);
+
+        principal = "_HOST/instance@EXAMPLE.COM";
+        conf.put(Config.STORM_HDFS_LOGIN_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getHdfsPrincipal(conf), principal);
+
+        principal = "primary/instance@_HOST.COM";
+        conf.put(Config.STORM_HDFS_LOGIN_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getHdfsPrincipal(conf), principal);
+
+        principal = "_HOST@EXAMPLE.COM";
+        conf.put(Config.STORM_HDFS_LOGIN_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getHdfsPrincipal(conf), principal);
+
+        principal = "primary/instance@EXAMPLE.COM";
+        conf.put(Config.STORM_HDFS_LOGIN_PRINCIPAL, principal);
+        Assert.assertEquals(Config.getHdfsPrincipal(conf), principal);
     }
 }


### PR DESCRIPTION
Please refer to https://issues.apache.org/jira/browse/STORM-3494

Use HdfsLoginUtil singleton to login to hdfs exactly once for a process.

This will break backwards-compatibility. I didn't find a better way to resolve this. Suggestions are very welcome.