### PR TITLE
MINOR: Maven upgrade to 3.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ before_install:
   - sudo add-apt-repository ppa:deadsnakes/ppa -y
   - sudo apt-get update
   - sudo apt-get install python3.6
-  - export MVN_HOME=$HOME/apache-maven-3.6.1
-  - if [ ! -d $MVN_HOME/bin ]; then wget https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz -P $HOME; tar xzvf $HOME/apache-maven-3.6.1-bin.tar.gz -C $HOME; fi
+  - export MVN_HOME=$HOME/apache-maven-3.6.3
+  - if [ ! -d $MVN_HOME/bin ]; then wget https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -P $HOME; tar xzvf $HOME/apache-maven-3.6.3-bin.tar.gz -C $HOME; fi
   - export PATH=$MVN_HOME/bin:$PATH
 install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
 script:
@@ -54,4 +54,4 @@ cache:
     - "$HOME/.m2/repository"
     - "$HOME/.rvm"
     - "$NVM_DIR"
-    - "$HOME/apache-maven-3.6.1"
+    - "$HOME/apache-maven-3.6.3"


### PR DESCRIPTION
3.6.3 is faster than 3.6.1.