### PR TITLE
[STORM-3568] prevent user from changing log level with empty logger name from topo UI

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
@@ -142,6 +142,10 @@ function sendLoggerLevel(id){
             return;
         }
     }
+    if (!loggerName) {
+        alert ("Logger name must be provided. Use \"ROOT\" if you want to change current default log behavior.");
+        return;
+    }
     var data = {};
     var loggerSetting;
 


### PR DESCRIPTION
A minor fix to topo UI. This change alert user when they try to change log level on topology page without providing a logger name.
Currently user can do this and get a 500 Server Error at the bottom which could be confusing.

![Screen Shot 2020-01-17 at 3 26 22 PM](https://user-images.githubusercontent.com/15622046/72647849-1e29cc00-393f-11ea-9a1b-f55d1fdea4c3.png)
