### PR TITLE
[STORM-3568] prevent user from changing log level with empty logger name from topo UI

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
@@ -142,6 +142,10 @@ function sendLoggerLevel(id){
             return;
         }
     }
+    if (!loggerName) {
+        alert ("Logger name must be provided. Use \"ROOT\" if you want to change current default log behavior.");
+        return;
+    }
     var data = {};
     var loggerSetting;
 


### PR DESCRIPTION
Cheery-pick from [#3196](https://github.com/apache/storm/pull/3195)