### PR TITLE
[STORM-3574] Rebalance accepts config change affecting system component.

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3346,6 +3346,12 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             if (subject != null) {
                 options.set_principal(subject.getPrincipals().iterator().next().getName());
             }
+            String topoId = toTopoId(topoName);
+            StormTopology stormTopology = tryReadTopology(topoId, topoCache);
+            StormBase base = new StormBase();
+            base.set_name(topoName);
+            idToExecutors.getAndUpdate(new Assoc<>(topoId,
+                    new HashSet<>(computeExecutors(topoId, base, topoConf, stormTopology))));
 
             transitionName(topoName, TopologyActions.REBALANCE, options, true);
             notifyTopologyActionListener(topoName, operation);


### PR DESCRIPTION
 Example when topology.metrics.consumer.register is specified to add metrics consumer.
 Change rebalance() to start new tasks by calling computeExecutors and consequently
 StormCommon.stormTaskInfo and StormCommon.systemTopology.