### PR TITLE
[STORM-3580] Processs -c option to storm.py for Rebalance

### DIFF
--- a/storm-core/src/jvm/org/apache/storm/command/Rebalance.java
+++ b/storm-core/src/jvm/org/apache/storm/command/Rebalance.java
@@ -20,6 +20,7 @@ import org.apache.storm.generated.Nimbus;
 import org.apache.storm.generated.RebalanceOptions;
 import org.apache.storm.utils.NimbusClient;
 import org.apache.storm.utils.Utils;
+import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,15 @@ public class Rebalance {
         }
 
         Map<String, Object> confOverrides = (Map<String, Object>) cl.get("t");
+        Map<String, Object> jvmOpts = Utils.readCommandLineOpts(); // values in -Dstorm.options (originally -c in storm.py)
+        if (jvmOpts != null && !jvmOpts.isEmpty()) {
+            if (confOverrides == null) {
+                confOverrides = jvmOpts;
+            } else {
+                confOverrides.putAll(jvmOpts); // override with values obtained from -Dstorm.options
+            }
+            LOG.info("Rebalancing topology with overrides {}", JSONObject.toJSONString(confOverrides));
+        }
 
         if (null != confOverrides) {
             rebalanceOptions.set_topology_conf_overrides(JSONValue.toJSONString(confOverrides));

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3356,12 +3356,6 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             if (subject != null) {
                 options.set_principal(subject.getPrincipals().iterator().next().getName());
             }
-            String topoId = toTopoId(topoName);
-            StormTopology stormTopology = tryReadTopology(topoId, topoCache);
-            StormBase base = new StormBase();
-            base.set_name(topoName);
-            idToExecutors.getAndUpdate(new Assoc<>(topoId,
-                    new HashSet<>(computeExecutors(topoId, base, topoConf, stormTopology))));
 
             transitionName(topoName, TopologyActions.REBALANCE, options, true);
             notifyTopologyActionListener(topoName, operation);

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3356,6 +3356,12 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             if (subject != null) {
                 options.set_principal(subject.getPrincipals().iterator().next().getName());
             }
+            String topoId = toTopoId(topoName);
+            StormTopology stormTopology = tryReadTopology(topoId, topoCache);
+            StormBase base = new StormBase();
+            base.set_name(topoName);
+            idToExecutors.getAndUpdate(new Assoc<>(topoId,
+                    new HashSet<>(computeExecutors(topoId, base, topoConf, stormTopology))));
 
             transitionName(topoName, TopologyActions.REBALANCE, options, true);
             notifyTopologyActionListener(topoName, operation);


### PR DESCRIPTION
storm.py passes utf encoded "-c" parameters as csv jvm property "storm.options". This system property is not being used in rebalance client command when passing information to Nimbus. Change Rebalance to use this system property.