### PR TITLE
[STORM-3587] Allow Scheduler futureTask to gracefully exit before TimeoutException.

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceAwareScheduler.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceAwareScheduler.java
@@ -166,7 +166,7 @@ public class ResourceAwareScheduler implements IScheduler {
                     Future<SchedulingResult> schedulingFuture = backgroundScheduling.submit(
                         () -> finalRasStrategy.schedule(toSchedule, td));
                     try {
-                        result = schedulingFuture.get(schedulingTimeoutSeconds, TimeUnit.SECONDS);
+                        result = schedulingFuture.get(schedulingTimeoutSeconds + 1, TimeUnit.SECONDS);
                     } catch (TimeoutException te) {
                         markFailedTopology(topologySubmitter, cluster, td, "Scheduling took too long for "
                                 + td.getId() + " using strategy " + rasStrategy.getClass().getName() + " timeout after "
@@ -226,7 +226,17 @@ public class ResourceAwareScheduler implements IScheduler {
                         //Only place we fall though to do the loop over again...
                     } else { //Any other failure result
                         //The assumption is that the strategy set the status...
-                        topologySubmitter.markTopoUnsuccess(td, cluster);
+                        String msg = "";
+                        if (result.getStatus() != null) {
+                            msg += result.getStatus().name() + ":";
+                        }
+                        if (result.getErrorMessage() != null && !result.getErrorMessage().isEmpty()) {
+                            msg += result.getErrorMessage();
+                        }
+                        if (result.getMessage() != null && !result.getMessage().isEmpty()) {
+                            msg += " " + result.getMessage();
+                        }
+                        topologySubmitter.markTopoUnsuccess(td, cluster, msg);
                         return;
                     }
                 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceAwareScheduler.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceAwareScheduler.java
@@ -166,7 +166,7 @@ public class ResourceAwareScheduler implements IScheduler {
                     Future<SchedulingResult> schedulingFuture = backgroundScheduling.submit(
                         () -> finalRasStrategy.schedule(toSchedule, td));
                     try {
-                        result = schedulingFuture.get(schedulingTimeoutSeconds + 1, TimeUnit.SECONDS);
+                        result = schedulingFuture.get(schedulingTimeoutSeconds, TimeUnit.SECONDS);
                     } catch (TimeoutException te) {
                         markFailedTopology(topologySubmitter, cluster, td, "Scheduling took too long for "
                                 + td.getId() + " using strategy " + rasStrategy.getClass().getName() + " timeout after "

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceAwareScheduler.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/ResourceAwareScheduler.java
@@ -225,18 +225,7 @@ public class ResourceAwareScheduler implements IScheduler {
                         }
                         //Only place we fall though to do the loop over again...
                     } else { //Any other failure result
-                        //The assumption is that the strategy set the status...
-                        String msg = "";
-                        if (result.getStatus() != null) {
-                            msg += result.getStatus().name() + ":";
-                        }
-                        if (result.getErrorMessage() != null && !result.getErrorMessage().isEmpty()) {
-                            msg += result.getErrorMessage();
-                        }
-                        if (result.getMessage() != null && !result.getMessage().isEmpty()) {
-                            msg += " " + result.getMessage();
-                        }
-                        topologySubmitter.markTopoUnsuccess(td, cluster, msg);
+                        topologySubmitter.markTopoUnsuccess(td, cluster, result.toString());
                         return;
                     }
                 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/User.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/User.java
@@ -79,15 +79,18 @@ public class User {
         return ret;
     }
 
-    public void markTopoUnsuccess(TopologyDetails topo, Cluster cluster) {
+    public void markTopoUnsuccess(TopologyDetails topo, Cluster cluster, String msg) {
         unsuccess.add(topo);
         if (cluster != null) {
-            cluster.setStatus(topo.getId(), "Scheduling Attempted but topology is invalid");
+            if (msg == null) {
+                msg = "Scheduling Attempted but topology is invalid";
+            }
+            cluster.setStatus(topo.getId(), msg);
         }
     }
 
     public void markTopoUnsuccess(TopologyDetails topo) {
-        this.markTopoUnsuccess(topo, null);
+        this.markTopoUnsuccess(topo, null, null);
     }
 
     public double getResourcePoolAverageUtilization(ISchedulingState cluster) {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -252,7 +252,10 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         int daemonMaxStateSearch = ObjectReader.getInt(cluster.getConf().get(DaemonConfig.RESOURCE_AWARE_SCHEDULER_MAX_STATE_SEARCH));
         final int maxStateSearch = Math.min(daemonMaxStateSearch, confMaxStateSearch);
 
-        final long maxTimeMs = ObjectReader.getInt(td.getConf().get(Config.TOPOLOGY_RAS_CONSTRAINT_MAX_TIME_SECS), -1) * 1000L;
+        // expect to be killed by DaemonConfig.SCHEDULING_TIMEOUT_SECONDS_PER_TOPOLOGY seconds, terminate slightly before
+        int daemonMaxTimeSec = ObjectReader.getInt(td.getConf().get(DaemonConfig.SCHEDULING_TIMEOUT_SECONDS_PER_TOPOLOGY), 60);
+        int confMaxTimeSec = ObjectReader.getInt(td.getConf().get(Config.TOPOLOGY_RAS_CONSTRAINT_MAX_TIME_SECS), daemonMaxTimeSec);
+        final long maxTimeMs = (confMaxTimeSec >= daemonMaxTimeSec) ? daemonMaxTimeSec * 1000L - 200L :  confMaxTimeSec * 1000L;
 
         favoredNodeIds = makeHostToNodeIds((List<String>) td.getConf().get(Config.TOPOLOGY_SCHEDULER_FAVORED_NODES));
         unFavoredNodeIds = makeHostToNodeIds((List<String>) td.getConf().get(Config.TOPOLOGY_SCHEDULER_UNFAVORED_NODES));


### PR DESCRIPTION
ResourceAwareScheduler creates a FutureTask with timeout specified in DaemonConfig.

ConstraintSolverStrategy uses the the another configuration variable to determine when to terminate its effort. Limit this value so that it terminates at most slightly before TimeoutException. This graceful exit allows result (and its error) to be available in ResourceAwareScheduler.