### PR TITLE
[STORM-3585] New compact Constraint config including maxNodeCoLocationCnt and incompatibleComponents

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -29,6 +29,7 @@ import org.apache.storm.metric.IEventLogger;
 import org.apache.storm.policy.IWaitStrategy;
 import org.apache.storm.serialization.IKryoDecorator;
 import org.apache.storm.serialization.IKryoFactory;
+import org.apache.storm.utils.ShellLogHandler;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.validation.ConfigValidation;
 import org.apache.storm.validation.ConfigValidation.EventLoggerRegistryValidator;
@@ -36,9 +37,11 @@ import org.apache.storm.validation.ConfigValidation.ListOfListOfStringValidator;
 import org.apache.storm.validation.ConfigValidation.MapOfStringToMapOfStringToObjectValidator;
 import org.apache.storm.validation.ConfigValidation.MetricRegistryValidator;
 import org.apache.storm.validation.ConfigValidation.MetricReportersValidator;
+import org.apache.storm.validation.ConfigValidation.RasConstraintsTypeValidator;
 import org.apache.storm.validation.ConfigValidationAnnotations;
 import org.apache.storm.validation.ConfigValidationAnnotations.CustomValidator;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsBoolean;
+import org.apache.storm.validation.ConfigValidationAnnotations.IsExactlyOneOf;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsImplementationOfClass;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsInteger;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsKryoReg;
@@ -304,11 +307,13 @@ public class Config extends HashMap<String, Object> {
     // an error will be thrown by nimbus on topology submission and not by the client prior to submitting
     // the topology.
     public static final String TOPOLOGY_SCHEDULER_STRATEGY = "topology.scheduler.strategy";
+
     /**
-     * Declare scheduling constraints for a topology used by the constraint solver strategy. A List of pairs (also a list) of components
-     * that cannot coexist in the same worker.
+     * Declare scheduling constraints for a topology used by the constraint solver strategy. The format can be either
+     * old style (validated by ListOfListOfStringValidator.class or the newer style, which is a list of specific type of
+     * Maps (validated by RasConstraintsTypeValidator.class). The value must be in one or the other format.
      */
-    @CustomValidator(validatorClass = ListOfListOfStringValidator.class)
+    @IsExactlyOneOf(valueValidatorClasses = { ListOfListOfStringValidator.class, RasConstraintsTypeValidator.class })
     public static final String TOPOLOGY_RAS_CONSTRAINTS = "topology.ras.constraints";
     /**
      * Array of components that scheduler should try to place on separate hosts when using the constraint solver strategy or the

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -312,12 +312,29 @@ public class Config extends HashMap<String, Object> {
      * Declare scheduling constraints for a topology used by the constraint solver strategy. The format can be either
      * old style (validated by ListOfListOfStringValidator.class or the newer style, which is a list of specific type of
      * Maps (validated by RasConstraintsTypeValidator.class). The value must be in one or the other format.
+     *
+     * Old style Config.TOPOLOGY_RAS_CONSTRAINTS (ListOfListOfString) specified a list of components that cannot
+     * co-exist on the same Worker.
+     *
+     * New style Config.TOPOLOGY_RAS_CONSTRAINTS is map where each component has a list of other incompatible components
+     * (which serves the same function as the old style configuration) and optional number that specifies
+     * the maximum co-location count for the component on a node.
+     *
+     * <p>comp-1 cannot exist on same worker as comp-2 or comp-3, and at most "2" comp-1 on same node</p>
+     * <p>comp-2 and comp-4 cannot be on same node (missing comp-1 is implied from comp-1 constraint)</p>
+     *
+     *  <p>
+     *      { "comp-1": { "maxNodeCoLocationCnt": 2, "incompatibleComponents": ["comp-2", "comp-3" ] },
+     *        "comp-2": { "incompatibleComponents": [ "comp-4" ] }
+     *      }
+     *  </p>
      */
     @IsExactlyOneOf(valueValidatorClasses = { ListOfListOfStringValidator.class, RasConstraintsTypeValidator.class })
     public static final String TOPOLOGY_RAS_CONSTRAINTS = "topology.ras.constraints";
     /**
      * Array of components that scheduler should try to place on separate hosts when using the constraint solver strategy or the
-     * multi-tenant scheduler.
+     * multi-tenant scheduler. Note that this configuration can be specified in TOPOLOGY_RAS_CONSTRAINTS using the
+     * "maxNodeCoLocationCnt" map entry with value of 1.
      */
     @IsStringList
     public static final String TOPOLOGY_SPREAD_COMPONENTS = "topology.spread.components";

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -325,7 +325,7 @@ public class Config extends HashMap<String, Object> {
      * </p>
      *
      * <p>comp-1 cannot exist on same worker as comp-2 or comp-3, and at most "2" comp-1 on same node</p>
-     * <p>comp-2 and comp-4 cannot be on same node (missing comp-1 is implied from comp-1 constraint)</p>
+     * <p>comp-2 and comp-4 cannot be on same worker (missing comp-1 is implied from comp-1 constraint)</p>
      *
      *  <p>
      *      { "comp-1": { "maxNodeCoLocationCnt": 2, "incompatibleComponents": ["comp-2", "comp-3" ] },

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -340,6 +340,7 @@ public class Config extends HashMap<String, Object> {
      * multi-tenant scheduler. Note that this configuration can be specified in TOPOLOGY_RAS_CONSTRAINTS using the
      * "maxNodeCoLocationCnt" map entry with value of 1.
      */
+    @Deprecated
     @IsStringList
     public static final String TOPOLOGY_SPREAD_COMPONENTS = "topology.spread.components";
     /**

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -313,12 +313,16 @@ public class Config extends HashMap<String, Object> {
      * old style (validated by ListOfListOfStringValidator.class or the newer style, which is a list of specific type of
      * Maps (validated by RasConstraintsTypeValidator.class). The value must be in one or the other format.
      *
+     * <p>
      * Old style Config.TOPOLOGY_RAS_CONSTRAINTS (ListOfListOfString) specified a list of components that cannot
      * co-exist on the same Worker.
+     * </p>
      *
+     * <p>
      * New style Config.TOPOLOGY_RAS_CONSTRAINTS is map where each component has a list of other incompatible components
      * (which serves the same function as the old style configuration) and optional number that specifies
      * the maximum co-location count for the component on a node.
+     * </p>
      *
      * <p>comp-1 cannot exist on same worker as comp-2 or comp-3, and at most "2" comp-1 on same node</p>
      * <p>comp-2 and comp-4 cannot be on same node (missing comp-1 is implied from comp-1 constraint)</p>

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -917,7 +917,7 @@ public class ConfigValidation {
                 throw new IllegalArgumentException(
                         "Field " + name + " must be an Iterable containing only Map of Maps");
             }
-            Map<String, Object> map1 = (Map<String, Object>)o;
+            Map<String, Object> map1 = (Map<String, Object>) o;
             for (Map.Entry<String, Object> entry1: map1.entrySet()) {
                 String comp1 = entry1.getKey();
                 Object o2 = entry1.getValue();
@@ -926,7 +926,7 @@ public class ConfigValidation {
                             name, comp1, CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, o);
                     throw new IllegalArgumentException(err);
                 }
-                Map<String, Object> map2 = (Map<String, Object>)o2;
+                Map<String, Object> map2 = (Map<String, Object>) o2;
                 for (Map.Entry<String, Object> entry2: map2.entrySet()) {
                     String constraintType = entry2.getKey();
                     Object o3 = entry2.getValue();

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -27,6 +27,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.storm.Config;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.validation.ConfigValidationAnnotations.ValidatorParams;
@@ -847,6 +849,128 @@ public class ConfigValidation {
                 return;
             }
             throw new IllegalArgumentException("Field " + name + " must be one of \"NONE\", \"DIGEST\", or \"KERBEROS\"");
+        }
+    }
+
+    public static class CustomIsExactlyOneOfValidators extends Validator {
+        private Class<?>[] subValidators;
+        private List<String> validatorClassNames;
+
+        public CustomIsExactlyOneOfValidators(Map<String, Object> params) {
+            this.subValidators = (Class<?>[]) params.get(ConfigValidationAnnotations.ValidatorParams.VALUE_VALIDATOR_CLASSES);
+            this.validatorClassNames = Arrays.asList(subValidators).stream().map(x -> x.getName()).collect(Collectors.toList());
+        }
+
+        @Override
+        public void validateField(String name, Object o) {
+            if (o == null) {
+                throw new IllegalArgumentException("Field " + name + " must be set.");
+            }
+
+            HashMap<String, Exception> validatorExceptions = new HashMap<>();
+            Set<String> selectedValidators = new HashSet<>();
+            for (Class<?> vv : subValidators) {
+                Object valueValidator;
+                try {
+                    valueValidator = vv.getConstructor().newInstance();
+                } catch (Exception ex) {
+                    throw new IllegalArgumentException(vv.getName() + " instantiation failure", ex);
+                }
+                if (valueValidator instanceof Validator) {
+                    try {
+                        ((Validator) valueValidator).validateField(name + " " + vv.getSimpleName() + " value", o);
+                        selectedValidators.add(vv.getName());
+                    } catch (Exception ex) {
+                        // only one will pass, so ignore all validation errors - stored for future use
+                        validatorExceptions.put(vv.getName(), ex);
+                    }
+                } else {
+                    String err = String.format("validator: %s cannot be used in CustomExactlyOneOfValidators to validate values. "
+                            + "Individual entry validators must a instance of Validator class", vv.getName());
+                    LOG.warn(err);
+                }
+            }
+            // check if one and only one validation succeeded
+            if (selectedValidators.isEmpty()) {
+                String parseErrs = String.join(";\n\t", validatorExceptions.entrySet().stream()
+                        .map(e -> String.format("%s:%s", e.getKey(), e.getValue())).collect(Collectors.toList()));
+                String err = String.format("Field %s must be one of %s; parse errors are \n\t%s", name,
+                        String.join(", ", validatorClassNames), parseErrs);
+                throw new IllegalArgumentException(err);
+            }
+            if (selectedValidators.size() > 1) {
+                throw new IllegalArgumentException("Field " + name + " must match exactly one of " + String.join(", ", selectedValidators));
+            }
+        }
+    }
+
+    public static class RasConstraintsTypeValidator extends Validator {
+        public static final String CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT = "maxNodeCoLocationCnt";
+        public static final String CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS = "incompatibleComponents";
+
+        public static class RasConstraint {
+            int maxNodeCoLocationCnt = -1;
+            Set<String> incompatibleComponents = new HashSet<>();
+        }
+
+        public Map<String, RasConstraint> rasConstraints = new HashMap<>(); // parsedConstraints
+
+        @Override
+        public void validateField(String name, Object o) {
+            if (o == null) {
+                throw new IllegalArgumentException("Field " + name + " must be set.");
+            }
+            if (!(o instanceof Map)) {
+                throw new IllegalArgumentException(
+                        "Field " + name + " must be an Iterable containing only Map of Maps");
+            }
+            Map<String, Object> map1 = (Map<String, Object>)o;
+            for (Map.Entry<String, Object> entry1: map1.entrySet()) {
+                String comp1 = entry1.getKey();
+                Object o2 = entry1.getValue();
+                RasConstraint rasConstraint = new RasConstraint();
+                rasConstraints.put(comp1, rasConstraint);
+                if (!(o2 instanceof Map)) {
+                    String err = String.format("Field %s, component %s, expecting constraints Map with keys [\"%s\", \"%s\"], in \"%s\"",
+                            name, comp1, CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, o);
+                    throw new IllegalArgumentException(err);
+                }
+                Map<String, Object> map2 = (Map<String, Object>)o2;
+                for (Map.Entry<String, Object> entry2: map2.entrySet()) {
+                    String constraintType = entry2.getKey();
+                    Object o3 = entry2.getValue();
+                    switch (constraintType) {
+                        case CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT:
+                            try {
+                                int intVal = Integer.parseInt("" + o3);
+                                rasConstraint.maxNodeCoLocationCnt = intVal;
+                            } catch (Exception ex) {
+                                String err = String.format("Field %s, component %s, constraint %s should be a number, not \"%s\"",
+                                        name, comp1, constraintType, o3);
+                                throw new IllegalArgumentException(err);
+                            }
+                            break;
+
+                        case CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS:
+                            if (o3 instanceof String) {
+                                rasConstraint.incompatibleComponents.add((String) o3);
+                            } else if (o3 instanceof List) {
+                                for (String otherComp : (List<String>) o3) {
+                                    rasConstraint.incompatibleComponents.add(otherComp);
+                                }
+                            }
+                            break;
+
+                        default:
+                            String err = String.format(
+                                    "Field %s, component %s, has unsupported constraintType \"%s\", expecting one of [\"%s\", \"%s\"], "
+                                            + "in \"%s\"",
+                                    name, comp1, constraintType, CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT,
+                                    CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, o);
+                            throw new IllegalArgumentException(err);
+                    }
+                }
+            }
         }
     }
 

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -588,8 +588,8 @@ public class ConfigValidation {
                         ((Validator) v).validateField(name + " list entry", entry);
                     } else {
                         LOG.warn(
-                            "validator: {} cannot be used in ListEntryCustomValidator.  Individual entry validators must a instance of "
-                                    + "Validator class",
+                            "validator: {} cannot be used in ListEntryCustomValidator. "
+                                    + "Individual entry validators must be an instance of Validator class",
                             validator.getName());
                     }
                 }
@@ -658,8 +658,8 @@ public class ConfigValidation {
                         ((Validator) keyValidator).validateField(name + " Map key", entry.getKey());
                     } else {
                         LOG.warn(
-                            "validator: {} cannot be used in MapEntryCustomValidator to validate keys.  Individual entry validators must "
-                                    + "a instance of Validator class",
+                            "validator: {} cannot be used in MapEntryCustomValidator to validate keys. "
+                                    + "Individual entry validators must be an instance of Validator class",
                             kv.getName());
                     }
                 }
@@ -669,8 +669,8 @@ public class ConfigValidation {
                         ((Validator) valueValidator).validateField(name + " Map value", entry.getValue());
                     } else {
                         LOG.warn(
-                            "validator: {} cannot be used in MapEntryCustomValidator to validate values.  Individual entry validators "
-                                    + "must a instance of Validator class",
+                            "validator: {} cannot be used in MapEntryCustomValidator to validate values. "
+                                    + "Individual entry validators must be an instance of Validator class",
                             vv.getName());
                     }
                 }

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -864,7 +864,7 @@ public class ConfigValidation {
         @Override
         public void validateField(String name, Object o) {
             if (o == null) {
-                throw new IllegalArgumentException("Field " + name + " must be set.");
+                return;
             }
 
             HashMap<String, Exception> validatorExceptions = new HashMap<>();
@@ -918,7 +918,7 @@ public class ConfigValidation {
         @Override
         public void validateField(String name, Object o) {
             if (o == null) {
-                throw new IllegalArgumentException("Field " + name + " must be set.");
+                return;
             }
             if (!(o instanceof Map)) {
                 throw new IllegalArgumentException(

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidationAnnotations.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidationAnnotations.java
@@ -197,6 +197,18 @@ public class ConfigValidationAnnotations {
         Class<?> validatorClass();
     }
 
+    /**
+     * Custom validator where exactly one of the validations must be successful.
+     * Used for overloaded configuration, where value must match one (and exactly one)
+     * format of supplied values.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface IsExactlyOneOf {
+        Class<?> validatorClass() default ConfigValidation.CustomIsExactlyOneOfValidators.class;
+        Class<?>[] valueValidatorClasses();
+    }
+
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.FIELD)
     public @interface Password {

--- a/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
+++ b/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
@@ -548,8 +548,7 @@ public class TestConfigValidate {
     }
 
     @Test
-    public void testExactlyOneOfCustomAnnotation() throws InvocationTargetException, NoSuchMethodException, NoSuchFieldException,
-            InstantiationException, IllegalAccessException {
+    public void testExactlyOneOfCustomAnnotation() {
         TestConfig config = new TestConfig();
         Collection<Object> passCases = new LinkedList<Object>();
         Collection<Object> failCases = new LinkedList<Object>();

--- a/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
+++ b/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
@@ -563,13 +563,13 @@ public class TestConfigValidate {
         Map<Object, Object> passCaseMapOfMap = new HashMap<>();
         passCaseMapOfMap.put("comp1",
                 Stream.of(new Object[][] {
-                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)10 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, 10 },
                         { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp2", "comp3")},
                 }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
         );
         passCaseMapOfMap.put("comp2",
                 Stream.of(new Object[][] {
-                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)2 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, 2 },
                         { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp4", "comp5")},
                 }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
         );
@@ -583,7 +583,7 @@ public class TestConfigValidate {
         );
         passCaseMapOfMap.put("comp2",
                 Stream.of(new Object[][] {
-                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)2 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, 2 },
                         { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp4", "comp5")},
                 }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
         );
@@ -597,7 +597,7 @@ public class TestConfigValidate {
         );
         passCaseMapOfMap.put("comp2",
                 Stream.of(new Object[][] {
-                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)2 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, 2 },
                         { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, "comp4"},
                 }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
         );
@@ -616,13 +616,13 @@ public class TestConfigValidate {
         Map<String, Object> failCaseMapOfMap = new HashMap<>();
         failCaseMapOfMap.put("comp1",
                 Stream.of(new Object[][] {
-                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)10 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, 10 },
                         { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList(1, 2, 3)},
                 }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
         );
         failCaseMapOfMap.put("comp2",
                 Stream.of(new Object[][] {
-                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)2 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, 2 },
                         { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp4", "comp5")},
                 }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
         );

--- a/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
+++ b/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
@@ -628,6 +628,15 @@ public class TestConfigValidate {
         failCases.add(failCaseMapOfMap);
 
         failCaseMapOfMap = new HashMap<>();
+        failCaseMapOfMap.put("comp1",
+                Stream.of(new Object[][] {
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, 10 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp1", 3)},
+                }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+        );
+        failCases.add(failCaseMapOfMap);
+
+        failCaseMapOfMap = new HashMap<>();
         failCaseMapOfMap.put("comp1", Arrays.asList("comp2", "comp3"));
         failCaseMapOfMap.put("comp2", Arrays.asList("comp4", "comp5"));
         failCases.add(failCaseMapOfMap);

--- a/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
+++ b/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
@@ -26,7 +26,10 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.security.auth.Subject;
+
 import org.apache.storm.blobstore.BlobStore;
 import org.apache.storm.blobstore.NimbusBlobStore;
 import org.apache.storm.generated.AuthorizationException;
@@ -41,13 +44,15 @@ import org.apache.storm.validation.ConfigValidation.ImpersonationAclUserEntryVal
 import org.apache.storm.validation.ConfigValidation.IntegerValidator;
 import org.apache.storm.validation.ConfigValidation.KryoRegValidator;
 import org.apache.storm.validation.ConfigValidation.ListEntryTypeValidator;
+import org.apache.storm.validation.ConfigValidation.ListOfListOfStringValidator;
 import org.apache.storm.validation.ConfigValidation.NoDuplicateInListValidator;
 import org.apache.storm.validation.ConfigValidation.NotNullValidator;
 import org.apache.storm.validation.ConfigValidation.PositiveNumberValidator;
 import org.apache.storm.validation.ConfigValidation.PowerOf2Validator;
+import org.apache.storm.validation.ConfigValidation.RasConstraintsTypeValidator;
 import org.apache.storm.validation.ConfigValidation.StringValidator;
 import org.apache.storm.validation.ConfigValidation.UserResourcePoolEntryValidator;
-import org.apache.storm.validation.ConfigValidationAnnotations.NotNull;
+import org.apache.storm.validation.ConfigValidationAnnotations.IsExactlyOneOf;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsImplementationOfClass;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsListEntryCustom;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsListEntryType;
@@ -55,6 +60,8 @@ import org.apache.storm.validation.ConfigValidationAnnotations.IsMapEntryCustom;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsMapEntryType;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsNoDuplicateInList;
 import org.apache.storm.validation.ConfigValidationAnnotations.IsString;
+import org.apache.storm.validation.ConfigValidationAnnotations.NotNull;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -177,7 +184,6 @@ public class TestConfigValidate {
         conf.put(Config.TOPOLOGY_STATS_SAMPLE_RATE, Double.MAX_VALUE);
         ConfigValidation.validateFields(conf);
     }
-
 
     @Test
     public void testWorkerChildoptsIsStringOrStringList() throws InvocationTargetException, NoSuchMethodException, NoSuchFieldException,
@@ -542,6 +548,127 @@ public class TestConfigValidate {
     }
 
     @Test
+    public void testExactlyOneOfCustomAnnotation() throws InvocationTargetException, NoSuchMethodException, NoSuchFieldException,
+            InstantiationException, IllegalAccessException {
+        TestConfig config = new TestConfig();
+        Collection<Object> passCases = new LinkedList<Object>();
+        Collection<Object> failCases = new LinkedList<Object>();
+
+        List<Object> passCaseListOfList = new ArrayList<>();
+        passCaseListOfList.add(Arrays.asList("comp1", "comp2"));
+        passCaseListOfList.add(Arrays.asList("comp1", "comp3"));
+        passCaseListOfList.add(Arrays.asList("comp2", "comp4"));
+        passCaseListOfList.add(Arrays.asList("comp2", "comp5"));
+
+        Map<Object, Object> passCaseMapOfMap = new HashMap<>();
+        passCaseMapOfMap.put("comp1",
+                Stream.of(new Object[][] {
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)10 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp2", "comp3")},
+                }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+        );
+        passCaseMapOfMap.put("comp2",
+                Stream.of(new Object[][] {
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)2 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp4", "comp5")},
+                }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+        );
+        passCases.add(passCaseMapOfMap);
+
+        passCaseMapOfMap = new HashMap<>();
+        passCaseMapOfMap.put("comp1",
+                Stream.of(new Object[][] {
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp2", "comp3")},
+                }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+        );
+        passCaseMapOfMap.put("comp2",
+                Stream.of(new Object[][] {
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)2 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp4", "comp5")},
+                }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+        );
+        passCases.add(passCaseMapOfMap);
+
+        passCaseMapOfMap = new HashMap<>();
+        passCaseMapOfMap.put("comp1",
+                Stream.of(new Object[][] {
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, "comp2"},
+                }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+        );
+        passCaseMapOfMap.put("comp2",
+                Stream.of(new Object[][] {
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)2 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, "comp4"},
+                }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+        );
+        passCases.add(passCaseMapOfMap);
+
+        for (Object value : passCases) {
+            config.put(TestConfig.TEST_MAP_CONFIG_9, value);
+            ConfigValidation.validateFields(config, Arrays.asList(TestConfig.class));
+        }
+
+        List<Object> failCaseList = new ArrayList<>();
+        failCaseList.add(Arrays.asList("comp1", Arrays.asList("comp2", "comp3")));
+        failCaseList.add(Arrays.asList("comp3", Arrays.asList("comp4", "comp5")));
+        failCases.add(failCaseList);
+
+        Map<String, Object> failCaseMapOfMap = new HashMap<>();
+        failCaseMapOfMap.put("comp1",
+                Stream.of(new Object[][] {
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)10 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList(1, 2, 3)},
+                }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+        );
+        failCaseMapOfMap.put("comp2",
+                Stream.of(new Object[][] {
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, (Integer)2 },
+                        { RasConstraintsTypeValidator.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, Arrays.asList("comp4", "comp5")},
+                }).collect(Collectors.toMap(data -> data[0], data -> data[1]))
+        );
+        failCases.add(failCaseMapOfMap);
+
+        failCaseMapOfMap = new HashMap<>();
+        failCaseMapOfMap.put("comp1", Arrays.asList("comp2", "comp3"));
+        failCaseMapOfMap.put("comp2", Arrays.asList("comp4", "comp5"));
+        failCases.add(failCaseMapOfMap);
+
+        failCaseMapOfMap = new HashMap<>();
+        failCaseMapOfMap.put("aaa", "str");
+        failCaseMapOfMap.put("bbb", 6);
+        failCaseMapOfMap.put("ccc", 7);
+        failCases.add(failCaseMapOfMap);
+
+        failCaseMapOfMap = new HashMap<>();
+        failCaseMapOfMap.put("aaa", -1);
+        failCaseMapOfMap.put("bbb", 6);
+        failCaseMapOfMap.put("ccc", 7);
+        failCases.add(failCaseMapOfMap);
+
+        failCaseMapOfMap = new HashMap<>();
+        failCaseMapOfMap.put("aaa", 1);
+        failCaseMapOfMap.put("bbb", 6);
+        failCaseMapOfMap.put("ccc", 7.4);
+        failCases.add(failCaseMapOfMap);
+
+        failCaseMapOfMap = new HashMap<>();
+        failCaseMapOfMap.put("comp1", "comp2");
+        failCaseMapOfMap.put("comp2", "comp4");
+        failCases.add(failCaseMapOfMap);
+
+        failCases.add(null);
+
+        for (Object value : failCases) {
+            try {
+                config.put(TestConfig.TEST_MAP_CONFIG_9, value);
+                ConfigValidation.validateFields(config, Arrays.asList(TestConfig.class));
+                Assert.fail("Expected Exception not Thrown for value: " + value);
+            } catch (IllegalArgumentException Ex) {
+            }
+        }
+    }
+
+    @Test
     public void testListEntryTypeAnnotation() throws InvocationTargetException, NoSuchMethodException, NoSuchFieldException,
         InstantiationException, IllegalAccessException {
         TestConfig config = new TestConfig();
@@ -796,5 +923,9 @@ public class TestConfigValidate {
         @IsImplementationOfClass(implementsClass = org.apache.storm.networktopography.DNSToSwitchMapping.class)
         @NotNull
         public static final String TEST_MAP_CONFIG_8 = "test.map.config.8";
+
+        @IsExactlyOneOf(valueValidatorClasses = {ListOfListOfStringValidator.class, RasConstraintsTypeValidator.class})
+        @NotNull
+        public static final String TEST_MAP_CONFIG_9 = "test.map.config.9";
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/RasNode.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/RasNode.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Represents a single node in the cluster.
  */
-public class RasNode {
+public class RasNode implements Comparable<RasNode> {
     private static final Logger LOG = LoggerFactory.getLogger(RasNode.class);
     private final String nodeId;
     private final Cluster cluster;
@@ -522,5 +522,10 @@ public class RasNode {
         } else {
             return 0.0;
         }
+    }
+
+    @Override
+    public int compareTo(RasNode o) {
+        return this.nodeId.compareTo(o.nodeId);
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -94,12 +94,8 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
                         LOG.warn("Comp: {} declared in constraints is not valid!", comp2);
                         continue;
                     }
-                    if (comp1.equals(comp2)) {
-                        maxCoLocationCnts.put(comp1, 1);
-                    } else {
-                        incompatibleComponents.get(comp1).add(comp2);
-                        incompatibleComponents.get(comp2).add(comp1);
-                    }
+                    incompatibleComponents.get(comp1).add(comp2);
+                    incompatibleComponents.get(comp2).add(comp1);
                 }
             } else {
                 Map<String, Map<String,?>> constraintMap = (Map<String, Map<String,?>>) rasConstraints;

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -57,7 +57,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
      */
     private static final class ConstraintConfig {
         private Map<String, Set<String>> incompatibleComponents = new HashMap<>();
-        private HashMap<String, Integer> maxCoLocationCnts = new HashMap<>(); // maximum node CoLocationCnt for restricted components
+        private Map<String, Integer> maxCoLocationCnts = new HashMap<>(); // maximum node CoLocationCnt for restricted components
 
         ConstraintConfig(TopologyDetails topo) {
             this(topo.getConf(), topo.getComponents().keySet());

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -219,11 +219,11 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
             constraintConfig = new ConstraintConfig(topo);
         }
         Map<ExecutorDetails, String> execToComp = topo.getExecutorToComponent();
-        Map<String, HashMap<String, Integer>> nodeCompMap = new HashMap<>(); // this is the critical count
+        Map<String, Map<String, Integer>> nodeCompMap = new HashMap<>(); // this is the critical count
         Map<WorkerSlot, RasNode> workerToNodes = workerToNodes(cluster);
         boolean ret = true;
 
-        HashMap<String, Integer> spreadCompCnts = constraintConfig.maxCoLocationCnts;
+        Map<String, Integer> spreadCompCnts = constraintConfig.maxCoLocationCnts;
         for (Map.Entry<ExecutorDetails, WorkerSlot> entry : cluster.getAssignmentById(topo.getId()).getExecutorToSlot().entrySet()) {
             ExecutorDetails exec = entry.getKey();
             String comp = execToComp.get(exec);
@@ -233,7 +233,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
 
             if (spreadCompCnts.containsKey(comp)) {
                 int allowedColocationMaxCnt = spreadCompCnts.get(comp);
-                HashMap<String, Integer> oneNodeCompMap = nodeCompMap.computeIfAbsent(nodeId, (k) -> new HashMap<>());
+                Map<String, Integer> oneNodeCompMap = nodeCompMap.computeIfAbsent(nodeId, (k) -> new HashMap<>());
                 oneNodeCompMap.put(comp, oneNodeCompMap.getOrDefault(comp, 0) + 1);
                 if (allowedColocationMaxCnt < oneNodeCompMap.get(comp)) {
                     LOG.error("Incorrect Scheduling: MaxCoLocationCnt for Component: {} {} on node {} not satisfied, cnt {} > allowed {}",

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -59,7 +59,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
      * and an optional number that specifies the maximum co-location count for the component on a node.
      *
      * <p>comp-1 cannot exist on same worker as comp-2 or comp-3, and at most "2" comp-1 on same node</p>
-     * <p>comp-2 and comp-4 cannot be on same node (missing comp-1 is implied from comp-1 constraint)</p>
+     * <p>comp-2 and comp-4 cannot be on same worker (missing comp-1 is implied from comp-1 constraint)</p>
      *
      *  <p>
      *      { "comp-1": { "maxNodeCoLocationCnt": 2, "incompatibleComponents": ["comp-2", "comp-3" ] },

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -27,6 +27,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import com.esotericsoftware.minlog.Log;
+import com.google.common.collect.Sets;
 import org.apache.storm.Config;
 import org.apache.storm.DaemonConfig;
 import org.apache.storm.scheduler.Cluster;
@@ -71,7 +72,8 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         private Map<String, Integer> maxCoLocationCnts = new HashMap<>(); // maximum node CoLocationCnt for restricted components
 
         ConstraintConfig(TopologyDetails topo) {
-            this(topo.getConf(), topo.getComponents().keySet());
+            // getExecutorToComponent().values() also contains system components
+            this(topo.getConf(), Sets.union(topo.getComponents().keySet(), new HashSet(topo.getExecutorToComponent().values())));
         }
 
         ConstraintConfig(Map<String, Object> conf, Set<String> comps) {
@@ -170,7 +172,8 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
                     }
                 }
             } else {
-                Log.warn("Ignoring invalid {} config={}", Config.TOPOLOGY_SPREAD_COMPONENTS, obj);
+                String msg = String.format("Ignoring invalid %s config=%s", Config.TOPOLOGY_SPREAD_COMPONENTS, "" + obj);
+                Log.warn(msg);
             }
         }
 

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -45,64 +45,142 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
     //hard coded max number of states to search
     private static final Logger LOG = LoggerFactory.getLogger(ConstraintSolverStrategy.class);
 
-    //constraints and spreads
-    private Map<String, Map<String, Integer>> constraintMatrix;
-    private HashSet<String> spreadComps = new HashSet<>();
+    /**
+     * Component constraint as derived from configuration.
+     * This is backward compatible and can parse old style Config.TOPOLOGY_RAS_CONSTRAINTS and Config.TOPOLOGY_SPREAD_COMPONENTS.
+     * New style Config.TOPOLOGY_RAS_CONSTRAINTS is map where each component has a list of other incompatible components
+     * and an optional number that specifies the maximum co-location count for the component on a node.
+     *      { "comp-1": [ 2, "comp-2", "comp-3" ], # comp-1 cannot exist on same node as comp-2 or comp-3, and at most 2 comp-1 same node
+     *        "comp-2": [ "comp-4" ]   # comp-2 and comp-4 cannot be on same node (missing comp-1 is implied from comp-1 constraint)
+     *      }
+     *
+     */
+    private static final class ConstraintConfig {
+        private Map<String, Set<String>> incompatibleComponents = new HashMap<>();
+        private HashMap<String, Integer> maxCoLocationCnts = new HashMap<>(); // maximum node CoLocationCnt for restricted components
+
+        ConstraintConfig(TopologyDetails topo) {
+            this(topo.getConf(), topo.getComponents().keySet());
+        }
+
+        ConstraintConfig(Map<String, Object> conf, Set<String> comps) {
+            // spread constraints, old style may come from Config.TOPOLOGY_RAS_CONSTRAINTS where the target
+            Object rasConstraints = conf.get(Config.TOPOLOGY_RAS_CONSTRAINTS);
+            comps.forEach(k -> incompatibleComponents.computeIfAbsent(k, x -> new HashSet<>()));
+            if (rasConstraints instanceof List) {
+                // old style
+                List<List<String>> constraints = (List<List<String>>) rasConstraints;
+                for (List<String> constraintPair : constraints) {
+                    String comp1 = constraintPair.get(0);
+                    String comp2 = constraintPair.get(1);
+                    if (!comps.contains(comp1)) {
+                        LOG.warn("Comp: {} declared in constraints is not valid!", comp1);
+                        continue;
+                    }
+                    if (!comps.contains(comp2)) {
+                        LOG.warn("Comp: {} declared in constraints is not valid!", comp2);
+                        continue;
+                    }
+                    if (comp1.equals(comp2)) {
+                        maxCoLocationCnts.put(comp1, 1);
+                    } else {
+                        incompatibleComponents.get(comp1).add(comp2);
+                        incompatibleComponents.get(comp2).add(comp1);
+                    }
+                }
+            } else {
+                Map<String, List<?>> constraintMap = (Map<String, List<?>>) rasConstraints;
+                constraintMap.forEach((comp1, v) -> {
+                    if (comps.contains(comp1)) {
+                        // v is a list of other components and an optional number which is a maxCoLocationCnt
+                        v.forEach(item -> {
+                            String comp2 = "" + item;
+                            try {
+                                int numValue = Integer.parseInt(comp2);
+                                if (numValue < 1) {
+                                    LOG.warn("MaxCoLocationCnt {} declared for Comp {} is not valid, expected >= 1", numValue, comp1);
+                                } else {
+                                    maxCoLocationCnts.put(comp1, numValue);
+                                }
+                            } catch (Exception ex) {
+                                if (comps.contains(comp2)) {
+                                    if (comp1.equals(comp2)) {
+                                        if (!maxCoLocationCnts.containsKey(comp1)) {
+                                            maxCoLocationCnts.put(comp1, 1);
+                                        }
+                                    } else {
+                                        incompatibleComponents.get(comp1).add(comp2);
+                                        incompatibleComponents.get(comp2).add(comp1);
+                                    }
+                                }
+                            }
+                        });
+                    }
+                    ;
+                });
+            }
+
+            // process Config.TOPOLOGY_SPREAD_COMPONENTS - old style
+            Object obj = conf.get(Config.TOPOLOGY_SPREAD_COMPONENTS);
+            if (obj instanceof List) {
+                List<String> spread = (List<String>) obj;
+                if (spread != null) {
+                    for (String comp : spread) {
+                        if (comps.contains(comp)) {
+                            maxCoLocationCnts.put(comp, 1);
+                        } else {
+                            LOG.warn("Comp {} declared for spread not valid", comp);
+                        }
+                    }
+                }
+            } else if (obj instanceof Map) {
+                Map<String, Integer> spread = (Map<String, Integer>) obj;
+                if (spread != null) {
+                    for (String comp : spread.keySet()) {
+                        if (comps.contains(comp)) {
+                            maxCoLocationCnts.put(comp, spread.get(comp));
+                        } else {
+                            LOG.warn("Comp {} declared for spread not valid", comp);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     private Map<String, RasNode> nodes;
     private Map<ExecutorDetails, String> execToComp;
     private Map<String, Set<ExecutorDetails>> compToExecs;
     private List<String> favoredNodeIds;
     private List<String> unFavoredNodeIds;
-
-    static Map<String, Map<String, Integer>> getConstraintMap(TopologyDetails topo, Set<String> comps) {
-        Map<String, Map<String, Integer>> matrix = new HashMap<>();
-        for (String comp : comps) {
-            matrix.put(comp, new HashMap<>());
-            for (String comp2 : comps) {
-                matrix.get(comp).put(comp2, 0);
-            }
-        }
-        List<List<String>> constraints = (List<List<String>>) topo.getConf().get(Config.TOPOLOGY_RAS_CONSTRAINTS);
-        if (constraints != null) {
-            for (List<String> constraintPair : constraints) {
-                String comp1 = constraintPair.get(0);
-                String comp2 = constraintPair.get(1);
-                if (!matrix.containsKey(comp1)) {
-                    LOG.warn("Comp: {} declared in constraints is not valid!", comp1);
-                    continue;
-                }
-                if (!matrix.containsKey(comp2)) {
-                    LOG.warn("Comp: {} declared in constraints is not valid!", comp2);
-                    continue;
-                }
-                matrix.get(comp1).put(comp2, 1);
-                matrix.get(comp2).put(comp1, 1);
-            }
-        }
-        return matrix;
-    }
+    private ConstraintConfig constraintConfig;
 
     /**
      * Determines if a scheduling is valid and all constraints are satisfied.
      */
     @VisibleForTesting
-    public static boolean validateSolution(Cluster cluster, TopologyDetails td) {
-        return checkSpreadSchedulingValid(cluster, td)
-               && checkConstraintsSatisfied(cluster, td)
-               && checkResourcesCorrect(cluster, td);
+    public static boolean validateSolution(Cluster cluster, TopologyDetails td, ConstraintConfig constraintConfig) {
+        if (constraintConfig == null) {
+            constraintConfig = new ConstraintConfig(td);
+        }
+        return checkSpreadSchedulingValid(cluster, td, constraintConfig)
+               && checkConstraintsSatisfied(cluster, td, constraintConfig)
+               && checkResourcesCorrect(cluster, td, constraintConfig);
     }
 
     /**
      * Check if constraints are satisfied.
      */
-    private static boolean checkConstraintsSatisfied(Cluster cluster, TopologyDetails topo) {
+    private static boolean checkConstraintsSatisfied(Cluster cluster, TopologyDetails topo, ConstraintConfig constraintConfig) {
         LOG.info("Checking constraints...");
         assert (cluster.getAssignmentById(topo.getId()) != null);
+        if (constraintConfig == null) {
+            constraintConfig = new ConstraintConfig(topo);
+        }
         Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
         Map<ExecutorDetails, String> execToComp = topo.getExecutorToComponent();
         //get topology constraints
-        Map<String, Map<String, Integer>> constraintMatrix = getConstraintMap(topo, new HashSet<>(topo.getExecutorToComponent().values()));
+        Map<String, Set<String>> constraintMatrix = constraintConfig.incompatibleComponents;
 
         Map<WorkerSlot, Set<String>> workerCompMap = new HashMap<>();
         result.forEach((exec, worker) -> {
@@ -113,7 +191,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
             Set<String> comps = entry.getValue();
             for (String comp1 : comps) {
                 for (String comp2 : comps) {
-                    if (!comp1.equals(comp2) && constraintMatrix.get(comp1).get(comp2) != 0) {
+                    if (!comp1.equals(comp2) && constraintMatrix.get(comp1).contains(comp2)) {
                         LOG.error("Incorrect Scheduling: worker exclusion for Component {} and {} not satisfied on WorkerSlot: {}",
                                   comp1, comp2, entry.getKey());
                         return false;
@@ -134,38 +212,38 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         return workerToNodes;
     }
 
-    private static boolean checkSpreadSchedulingValid(Cluster cluster, TopologyDetails topo) {
+    private static boolean checkSpreadSchedulingValid(Cluster cluster, TopologyDetails topo, ConstraintConfig constraintConfig) {
         LOG.info("Checking for a valid scheduling...");
         assert (cluster.getAssignmentById(topo.getId()) != null);
-        Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
+        if (constraintConfig == null) {
+            constraintConfig = new ConstraintConfig(topo);
+        }
         Map<ExecutorDetails, String> execToComp = topo.getExecutorToComponent();
-        Map<WorkerSlot, HashSet<ExecutorDetails>> workerExecMap = new HashMap<>();
-        Map<WorkerSlot, HashSet<String>> workerCompMap = new HashMap<>();
-        Map<RasNode, HashSet<String>> nodeCompMap = new HashMap<>();
+        Map<String, HashMap<String, Integer>> nodeCompMap = new HashMap<>(); // this is the critical count
         Map<WorkerSlot, RasNode> workerToNodes = workerToNodes(cluster);
         boolean ret = true;
 
-        HashSet<String> spreadComps = getSpreadComps(topo);
-        for (Map.Entry<ExecutorDetails, WorkerSlot> entry : result.entrySet()) {
+        HashMap<String, Integer> spreadCompCnts = constraintConfig.maxCoLocationCnts;
+        for (Map.Entry<ExecutorDetails, WorkerSlot> entry : cluster.getAssignmentById(topo.getId()).getExecutorToSlot().entrySet()) {
             ExecutorDetails exec = entry.getKey();
+            String comp = execToComp.get(exec);
             WorkerSlot worker = entry.getValue();
             RasNode node = workerToNodes.get(worker);
+            String nodeId = node.getId();
 
-            if (workerExecMap.computeIfAbsent(worker, (k) -> new HashSet<>()).contains(exec)) {
-                LOG.error("Incorrect Scheduling: Found duplicate in scheduling");
-                return false;
-            }
-            workerExecMap.get(worker).add(exec);
-            String comp = execToComp.get(exec);
-            workerCompMap.computeIfAbsent(worker, (k) -> new HashSet<>()).add(comp);
-            if (spreadComps.contains(comp)) {
-                if (nodeCompMap.computeIfAbsent(node, (k) -> new HashSet<>()).contains(comp)) {
-                    LOG.error("Incorrect Scheduling: Spread for Component: {} {} on node {} not satisfied {}",
-                              comp, exec, node.getId(), nodeCompMap.get(node));
+            if (spreadCompCnts.containsKey(comp)) {
+                int allowedColocationMaxCnt = spreadCompCnts.get(comp);
+                HashMap<String, Integer> oneNodeCompMap = nodeCompMap.computeIfAbsent(nodeId, (k) -> new HashMap<>());
+                oneNodeCompMap.put(comp, oneNodeCompMap.getOrDefault(comp, 0) + 1);
+                if (allowedColocationMaxCnt < oneNodeCompMap.get(comp)) {
+                    LOG.error("Incorrect Scheduling: MaxCoLocationCnt for Component: {} {} on node {} not satisfied, cnt {} > allowed {}",
+                            comp, exec, nodeId, oneNodeCompMap.get(comp), allowedColocationMaxCnt);
                     ret = false;
                 }
             }
-            nodeCompMap.computeIfAbsent(node, (k) -> new HashSet<>()).add(comp);
+        }
+        if (!ret) {
+            LOG.error("Incorrect MaxCoLocationCnts: Node-Component-Cnt {}", nodeCompMap);
         }
         return ret;
     }
@@ -173,9 +251,12 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
     /**
      * Check if resource constraints satisfied.
      */
-    private static boolean checkResourcesCorrect(Cluster cluster, TopologyDetails topo) {
+    private static boolean checkResourcesCorrect(Cluster cluster, TopologyDetails topo, ConstraintConfig constraintConfig) {
         LOG.info("Checking Resources...");
         assert (cluster.getAssignmentById(topo.getId()) != null);
+        if (constraintConfig == null) {
+            constraintConfig = new ConstraintConfig(topo);
+        }
         Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
         Map<RasNode, Collection<ExecutorDetails>> nodeToExecs = new HashMap<>();
         Map<ExecutorDetails, WorkerSlot> mergedExecToWorker = new HashMap<>();
@@ -224,29 +305,13 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         return true;
     }
 
-    private static HashSet<String> getSpreadComps(TopologyDetails topo) {
-        HashSet<String> retSet = new HashSet<>();
-        List<String> spread = (List<String>) topo.getConf().get(Config.TOPOLOGY_SPREAD_COMPONENTS);
-        if (spread != null) {
-            Set<String> comps = topo.getComponents().keySet();
-            for (String comp : spread) {
-                if (comps.contains(comp)) {
-                    retSet.add(comp);
-                } else {
-                    LOG.warn("Comp {} declared for spread not valid", comp);
-                }
-            }
-        }
-        return retSet;
-    }
-
     @Override
     public SchedulingResult schedule(Cluster cluster, TopologyDetails td) {
         prepare(cluster);
         LOG.debug("Scheduling {}", td.getId());
         nodes = RasNodes.getAllNodesFrom(cluster);
-        Map<WorkerSlot, Set<String>> workerCompAssignment = new HashMap<>();
-        Map<RasNode, Set<String>> nodeCompAssignment = new HashMap<>();
+        Map<WorkerSlot, Map<String, Integer>> workerCompAssignment = new HashMap<>();
+        Map<RasNode, Map<String,Integer>> nodeCompAssignment = new HashMap<>();
 
         int confMaxStateSearch = ObjectReader.getInt(td.getConf().get(Config.TOPOLOGY_RAS_CONSTRAINT_MAX_STATE_SEARCH));
         int daemonMaxStateSearch = ObjectReader.getInt(cluster.getConf().get(DaemonConfig.RESOURCE_AWARE_SCHEDULER_MAX_STATE_SEARCH));
@@ -262,17 +327,15 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         //get mapping of components to executors
         compToExecs = getCompToExecs(execToComp);
 
-        //get topology constraints
-        constraintMatrix = getConstraintMap(td, compToExecs.keySet());
-
-        //get spread components
-        spreadComps = getSpreadComps(td);
+        // get constraint configuration
+        constraintConfig = new ConstraintConfig(td);
 
         //get a sorted list of unassigned executors based on number of constraints
         Set<ExecutorDetails> unassignedExecutors = new HashSet<>(cluster.getUnassignedExecutors(td));
-        List<ExecutorDetails> sortedExecs = getSortedExecs(spreadComps, constraintMatrix, compToExecs).stream()
-                                                                                                      .filter(unassignedExecutors::contains)
-                                                                                                      .collect(Collectors.toList());
+        List<ExecutorDetails> sortedExecs;
+        sortedExecs = getSortedExecs(constraintConfig.maxCoLocationCnts, constraintConfig.incompatibleComponents, compToExecs).stream()
+                .filter(unassignedExecutors::contains)
+                .collect(Collectors.toList());
 
         //populate with existing assignments
         SchedulerAssignment existingAssignment = cluster.getAssignmentById(td.getId());
@@ -280,10 +343,11 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
             existingAssignment.getExecutorToSlot().forEach((exec, ws) -> {
                 String compId = execToComp.get(exec);
                 RasNode node = nodes.get(ws.getNodeId());
-                //populate node to component Assignments
-                nodeCompAssignment.computeIfAbsent(node, (k) -> new HashSet<>()).add(compId);
+                Map<String, Integer> oneMap = nodeCompAssignment.computeIfAbsent(node, (k) -> new HashMap<>());
+                oneMap.put(compId, oneMap.getOrDefault(compId, 0) + 1); // increment
                 //populate worker to comp assignments
-                workerCompAssignment.computeIfAbsent(ws, (k) -> new HashSet<>()).add(compId);
+                oneMap = workerCompAssignment.computeIfAbsent(ws, (k) -> new HashMap<>());
+                oneMap.put(compId, oneMap.getOrDefault(compId, 0) + 1); // increment
             });
         }
 
@@ -297,11 +361,13 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
     }
 
     private boolean checkSchedulingFeasibility(int maxStateSearch) {
-        for (String comp : spreadComps) {
+        for (Map.Entry<String, Integer> entry : constraintConfig.maxCoLocationCnts.entrySet()) {
+            String comp = entry.getKey();
+            int maxCoLocationCnt = entry.getValue();
             int numExecs = compToExecs.get(comp).size();
-            if (numExecs > nodes.size()) {
+            if (numExecs > nodes.size() * maxCoLocationCnt) {
                 LOG.error("Unsatisfiable constraint: Component: {} marked as spread has {} executors which is larger "
-                          + "than number of nodes: {}", comp, numExecs, nodes.size());
+                          + "than number of nodes * maxCoLocationCnt: {} * {} ", comp, numExecs, nodes.size(), maxCoLocationCnt);
                 return false;
             }
         }
@@ -345,7 +411,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         for (int loopCnt = 0 ; true ; loopCnt++) {
             LOG.debug("backtrackSearch: loopCnt = {}, state.execIndex = {}", loopCnt, state.execIndex);
             if (state.areSearchLimitsExceeded()) {
-                LOG.warn("backtrackSearch: Search limits exceeded");
+                LOG.warn("backtrackSearch: Search limits exceeded, backtracked {} times, looped {} times", state.numBacktrack, loopCnt);
                 return new SolverResult(state, false);
             }
 
@@ -356,6 +422,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
             int execIndex = state.execIndex;
 
             ExecutorDetails exec = state.currentExec();
+            String comp = execToComp.get(exec);
             Iterable<String> sortedNodesIter = sortAllNodes(state.td, exec, favoredNodeIds, unFavoredNodeIds);
 
             int progressIdx = -1;
@@ -367,8 +434,8 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
                         continue;
                     }
                     progressIdxForExec[execIndex]++;
-                    LOG.debug("backtrackSearch: loopCnt = {}, state.execIndex = {}, node/slot-ordinal = {}, nodeId = {}",
-                        loopCnt, execIndex, progressIdx, nodeId);
+                    LOG.debug("backtrackSearch: loopCnt = {}, state.execIndex = {}, comp = {}, node/slot-ordinal = {}, nodeId = {}",
+                            loopCnt, execIndex, comp, progressIdx, nodeId);
 
                     if (!isExecAssignmentToWorkerValid(workerSlot, state)) {
                         continue;
@@ -378,20 +445,21 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
                     state.tryToSchedule(execToComp, node, workerSlot);
                     if (state.areAllExecsScheduled()) {
                         //Everything is scheduled correctly, so no need to search any more.
-                        LOG.info("backtrackSearch: AllExecsScheduled at loopCnt = {} in {} milliseconds, elapsedtime in state={}",
-                            loopCnt, System.currentTimeMillis() - startTimeMilli, Time.currentTimeMillis() - state.startTimeMillis);
+                        LOG.info("backtrackSearch: AllExecsScheduled at loopCnt={} in {} ms, elapsedtime in state={}, backtrackCnt={}",
+                                loopCnt, System.currentTimeMillis() - startTimeMilli, Time.currentTimeMillis() - state.startTimeMillis,
+                                state.numBacktrack);
                         return new SolverResult(state, true);
                     }
                     state = state.nextExecutor();
                     nodeForExec[execIndex] = node;
                     workerSlotForExec[execIndex] = workerSlot;
-                    LOG.debug("backtrackSearch: Assigned execId={} to node={}, node/slot-ordinal={} at loopCnt={}",
-                        execIndex, nodeId, progressIdx, loopCnt);
+                    LOG.debug("backtrackSearch: Assigned execId={}, comp={} to node={}, node/slot-ordinal={} at loopCnt={}",
+                            execIndex, comp, nodeId, progressIdx, loopCnt);
                     continue OUTERMOST_LOOP;
                 }
             }
             // if here, then the executor was not assigned, backtrack;
-            LOG.debug("backtrackSearch: Failed to schedule execId = {} at loopCnt = {}", execIndex, loopCnt);
+            LOG.debug("backtrackSearch: Failed to schedule execId={}, comp={} at loopCnt={}", execIndex, comp, loopCnt);
             if (execIndex == 0) {
                 break;
             } else {
@@ -400,8 +468,8 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
             }
         }
         boolean success = state.areAllExecsScheduled();
-        LOG.info("backtrackSearch: Scheduled={} in {} milliseconds, elapsedtime in state={}",
-            success, System.currentTimeMillis() - startTimeMilli, Time.currentTimeMillis() - state.startTimeMillis);
+        LOG.info("backtrackSearch: Scheduled={} in {} milliseconds, elapsedtime in state={}, backtrackCnt={}",
+            success, System.currentTimeMillis() - startTimeMilli, Time.currentTimeMillis() - state.startTimeMillis, state.numBacktrack);
         return new SolverResult(state, success);
     }
 
@@ -420,11 +488,11 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
 
         //check if exec can be on worker based on user defined component exclusions
         String execComp = execToComp.get(exec);
-        Set<String> components = state.workerCompAssignment.get(worker);
-        if (components != null) {
-            Map<String, Integer> subMatrix = constraintMatrix.get(execComp);
-            for (String comp : components) {
-                if (subMatrix.get(comp) != 0) {
+        Map<String, Integer> compAssignments = state.workerCompAssignment.get(worker);
+        if (compAssignments != null && constraintConfig.incompatibleComponents.containsKey(execComp)) {
+            Set<String> subMatrix = constraintConfig.incompatibleComponents.get(execComp);
+            for (String comp : compAssignments.keySet()) {
+                if (subMatrix.contains(comp)) {
                     LOG.trace("{} found {} constraint violation {} on {}", exec, execComp, comp, worker);
                     return false;
                 }
@@ -432,9 +500,12 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         }
 
         //check if exec satisfy spread
-        if (spreadComps.contains(execComp)) {
-            if (state.nodeCompAssignment.computeIfAbsent(node, (k) -> new HashSet<>()).contains(execComp)) {
-                LOG.trace("{} Found spread violation {} on node {}", exec, execComp, node.getId());
+        if (constraintConfig.maxCoLocationCnts.containsKey(execComp)) {
+            int coLocationMaxCnt = constraintConfig.maxCoLocationCnts.get(execComp);
+            if (state.nodeCompAssignment.containsKey(node)
+                    && state.nodeCompAssignment.get(node).getOrDefault(execComp, 0) >= coLocationMaxCnt) {
+                LOG.trace("{} Found MaxCoLocationCnt violation {} on node {}, count {} >= colocation count {}",
+                        exec, execComp, node.getId(), state.nodeCompAssignment.get(node).get(execComp), coLocationMaxCnt);
                 return false;
             }
         }
@@ -447,22 +518,24 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         return retMap;
     }
 
-    private ArrayList<ExecutorDetails> getSortedExecs(HashSet<String> spreadComps, Map<String, Map<String, Integer>> constraintMatrix,
+    private ArrayList<ExecutorDetails> getSortedExecs(Map<String, Integer> spreadCompCnts,
+                                                      Map<String, Set<String>> constraintMatrix,
                                                       Map<String, Set<ExecutorDetails>> compToExecs) {
         ArrayList<ExecutorDetails> retList = new ArrayList<>();
         //find number of constraints per component
         //Key->Comp Value-># of constraints
-        Map<String, Integer> compConstraintCountMap = new HashMap<>();
+        Map<String, Double> compConstraintCountMap = new HashMap<>();
         constraintMatrix.forEach((comp, subMatrix) -> {
-            int count = subMatrix.values().stream().mapToInt(Number::intValue).sum();
-            //check component is declared for spreading
-            if (spreadComps.contains(comp)) {
-                count++;
+            double count = subMatrix.size();
+            // check if component is declared for spreading
+            if (spreadCompCnts.containsKey(comp)) {
+                // lower (1 and above only) value is most constrained should have higher count
+                count += (1_000.0 / spreadCompCnts.get(comp));
             }
-            compConstraintCountMap.put(comp, count);
+            compConstraintCountMap.put(comp, count); // higher count sorts to the front
         });
         //Sort comps by number of constraints
-        NavigableMap<String, Integer> sortedCompConstraintCountMap = sortByValues(compConstraintCountMap);
+        NavigableMap<String, Double> sortedCompConstraintCountMap = sortByValues(compConstraintCountMap);
         //sort executors based on component constraints
         for (String comp : sortedCompConstraintCountMap.keySet()) {
             retList.addAll(compToExecs.get(comp));
@@ -471,7 +544,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
     }
 
     /**
-     * Used to sort a Map by the values.
+     * Used to sort a Map by the values - higher values up front.
      */
     @VisibleForTesting
     public <K extends Comparable<K>, V extends Comparable<V>> NavigableMap<K, V> sortByValues(final Map<K, V> map) {
@@ -488,13 +561,15 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         return sortedByValues;
     }
 
-    protected static class SolverResult {
+    protected static final class SolverResult {
+        private final SearcherState state;
         private final int statesSearched;
         private final boolean success;
         private final long timeTakenMillis;
         private final int backtracked;
 
         public SolverResult(SearcherState state, boolean success) {
+            this.state = state;
             this.statesSearched = state.getStatesSearched();
             this.success = success;
             timeTakenMillis = Time.currentTimeMillis() - state.startTimeMillis;
@@ -506,20 +581,21 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
                 return SchedulingResult.success("Fully Scheduled by ConstraintSolverStrategy (" + statesSearched
                                                 + " states traversed in " + timeTakenMillis + "ms, backtracked " + backtracked + " times)");
             }
+            state.logNodeCompAssignments();
             return SchedulingResult.failure(SchedulingStatus.FAIL_NOT_ENOUGH_RESOURCES,
                                             "Cannot find scheduling that satisfies all constraints (" + statesSearched
                                             + " states traversed in " + timeTakenMillis + "ms, backtracked " + backtracked + " times)");
         }
     }
 
-    protected static class SearcherState {
+    protected static final class SearcherState {
         final long startTimeMillis;
         private final long maxEndTimeMs;
         // A map of the worker to the components in the worker to be able to enforce constraints.
-        private final Map<WorkerSlot, Set<String>> workerCompAssignment;
+        private final Map<WorkerSlot, Map<String, Integer>> workerCompAssignment;
         private final boolean[] okToRemoveFromWorker;
         // for the currently tested assignment a Map of the node to the components on it to be able to enforce constraints
-        private final Map<RasNode, Set<String>> nodeCompAssignment;
+        private final Map<RasNode, Map<String, Integer>> nodeCompAssignment;
         private final boolean[] okToRemoveFromNode;
         // Static State
         // The list of all executors (preferably sorted to make assignments simpler).
@@ -537,8 +613,9 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         // The current executor we are trying to schedule
         private int execIndex = 0;
 
-        private SearcherState(Map<WorkerSlot, Set<String>> workerCompAssignment, Map<RasNode, Set<String>> nodeCompAssignment,
-                              int maxStatesSearched, long maxTimeMs, List<ExecutorDetails> execs, TopologyDetails td) {
+        private SearcherState(Map<WorkerSlot, Map<String, Integer>> workerCompAssignment, Map<RasNode,
+                Map<String, Integer>> nodeCompAssignment, int maxStatesSearched, long maxTimeMs,
+                              List<ExecutorDetails> execs, TopologyDetails td) {
             assert !execs.isEmpty();
             assert execs != null;
 
@@ -593,13 +670,26 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
             return execs.get(execIndex);
         }
 
+        /**
+          * Assign executor to worker and node.
+          * TODO: tryToSchedule is a misnomer, since it always schedules.
+          * Assignment validity check is done before the call to tryToSchedule().
+          *
+          * @param execToComp Mapping from executor to component name.
+          * @param node RasNode on which to schedule.
+          * @param workerSlot WorkerSlot on which to schedule.
+          */
         public void tryToSchedule(Map<ExecutorDetails, String> execToComp, RasNode node, WorkerSlot workerSlot) {
             ExecutorDetails exec = currentExec();
             String comp = execToComp.get(exec);
             LOG.trace("Trying assignment of {} {} to {}", exec, comp, workerSlot);
-            //It is possible that this component is already scheduled on this node or worker.  If so when we backtrack we cannot remove it
-            okToRemoveFromWorker[execIndex] = workerCompAssignment.computeIfAbsent(workerSlot, (k) -> new HashSet<>()).add(comp);
-            okToRemoveFromNode[execIndex] = nodeCompAssignment.computeIfAbsent(node, (k) -> new HashSet<>()).add(comp);
+            // It is possible that this component is already scheduled on this node or worker.  If so when we backtrack we cannot remove it
+            Map<String, Integer> oneMap = workerCompAssignment.computeIfAbsent(workerSlot, (k) -> new HashMap<>());
+            oneMap.put(comp, oneMap.getOrDefault(comp, 0) + 1); // increment assignment count
+            okToRemoveFromWorker[execIndex] = true;
+            oneMap = nodeCompAssignment.computeIfAbsent(node, (k) -> new HashMap<>());
+            oneMap.put(comp, oneMap.getOrDefault(comp, 0) + 1); // increment assignment count
+            okToRemoveFromNode[execIndex] = true;
             node.assignSingleExecutor(workerSlot, exec, td);
         }
 
@@ -613,14 +703,51 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
             String comp = execToComp.get(exec);
             LOG.trace("Backtracking {} {} from {}", exec, comp, workerSlot);
             if (okToRemoveFromWorker[execIndex]) {
-                workerCompAssignment.get(workerSlot).remove(comp);
+                Map<String, Integer> oneMap = workerCompAssignment.get(workerSlot);
+                oneMap.put(comp, oneMap.getOrDefault(comp, 0) - 1); // decrement assignment count
                 okToRemoveFromWorker[execIndex] = false;
             }
             if (okToRemoveFromNode[execIndex]) {
-                nodeCompAssignment.get(node).remove(comp);
+                Map<String, Integer> oneMap = nodeCompAssignment.get(node);
+                oneMap.put(comp, oneMap.getOrDefault(comp, 0) - 1); // decrement assignment count
                 okToRemoveFromNode[execIndex] = false;
             }
             node.freeSingleExecutor(exec, td);
         }
+
+        /**
+         * Use this method to log the current component assignments on the Node.
+         * Useful for debugging and tests.
+         */
+        public void logNodeCompAssignments() {
+            if (nodeCompAssignment == null || nodeCompAssignment.isEmpty()) {
+                LOG.info("NodeCompAssignment is empty");
+                return;
+            }
+            StringBuffer sb = new StringBuffer();
+            int cntAllNodes = 0;
+            int cntFilledNodes = 0;
+            for (RasNode node: new TreeSet<RasNode>(nodeCompAssignment.keySet())) {
+                cntAllNodes++;
+                Map<String, Integer> oneMap = nodeCompAssignment.get(node);
+                if (oneMap.isEmpty()) {
+                    continue;
+                }
+                cntFilledNodes++;
+                String oneMapJoined = String.join(
+                        ",",
+                        oneMap.entrySet()
+                                .stream().map(e -> String.format("%s: %s", e.getKey(), e.getValue()))
+                                .collect(Collectors.toList())
+                );
+                sb.append(String.format("\n\t(%d) Node %s: %s", cntFilledNodes, node.getId(), oneMapJoined));
+            }
+            LOG.info("NodeCompAssignments available for {} of {} nodes {}", cntFilledNodes, cntAllNodes, sb);
+            LOG.info("Executors assignments attempted (cnt={}) are: \n\t{}",
+                    execs.size(), execs.stream().map(x -> x.toString()).collect(Collectors.joining(","))
+            );
+        }
     }
 }
+
+

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -200,7 +200,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         }
         return checkSpreadSchedulingValid(cluster, td, constraintConfig)
                && checkConstraintsSatisfied(cluster, td, constraintConfig)
-               && checkResourcesCorrect(cluster, td, constraintConfig);
+               && checkResourcesCorrect(cluster, td);
     }
 
     /**
@@ -286,12 +286,9 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
     /**
      * Check if resource constraints satisfied.
      */
-    private static boolean checkResourcesCorrect(Cluster cluster, TopologyDetails topo, ConstraintConfig constraintConfig) {
+    private static boolean checkResourcesCorrect(Cluster cluster, TopologyDetails topo) {
         LOG.info("Checking Resources...");
         assert (cluster.getAssignmentById(topo.getId()) != null);
-        if (constraintConfig == null) {
-            constraintConfig = new ConstraintConfig(topo);
-        }
         Map<ExecutorDetails, WorkerSlot> result = cluster.getAssignmentById(topo.getId()).getExecutorToSlot();
         Map<RasNode, Collection<ExecutorDetails>> nodeToExecs = new HashMap<>();
         Map<ExecutorDetails, WorkerSlot> mergedExecToWorker = new HashMap<>();

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -12,6 +12,8 @@
 
 package org.apache.storm.scheduler.resource.strategies.scheduling;
 
+import com.google.common.collect.Sets;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -26,8 +28,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import com.esotericsoftware.minlog.Log;
-import com.google.common.collect.Sets;
 import org.apache.storm.Config;
 import org.apache.storm.DaemonConfig;
 import org.apache.storm.scheduler.Cluster;
@@ -172,8 +172,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
                     }
                 }
             } else {
-                String msg = String.format("Ignoring invalid %s config=%s", Config.TOPOLOGY_SPREAD_COMPONENTS, "" + obj);
-                Log.warn(msg);
+                LOG.warn("Ignoring invalid {} config={}", Config.TOPOLOGY_SPREAD_COMPONENTS, obj);
             }
         }
 
@@ -762,7 +761,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
             StringBuffer sb = new StringBuffer();
             int cntAllNodes = 0;
             int cntFilledNodes = 0;
-            for (RasNode node: new TreeSet<RasNode>(nodeCompAssignmentCnts.keySet())) {
+            for (RasNode node: new TreeSet<>(nodeCompAssignmentCnts.keySet())) {
                 cntAllNodes++;
                 Map<String, Integer> oneMap = nodeCompAssignmentCnts.get(node);
                 if (oneMap.isEmpty()) {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -98,7 +98,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
                     incompatibleComponents.get(comp2).add(comp1);
                 }
             } else {
-                Map<String, Map<String,?>> constraintMap = (Map<String, Map<String,?>>) rasConstraints;
+                Map<String, Map<String, ?>> constraintMap = (Map<String, Map<String, ?>>) rasConstraints;
                 constraintMap.forEach((comp1, v) -> {
                     if (comps.contains(comp1)) {
                         // v is a list of other components and an optional number which is a maxCoLocationCnt
@@ -341,7 +341,7 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         LOG.debug("Scheduling {}", td.getId());
         nodes = RasNodes.getAllNodesFrom(cluster);
         Map<WorkerSlot, Map<String, Integer>> workerCompAssignment = new HashMap<>();
-        Map<RasNode, Map<String,Integer>> nodeCompAssignment = new HashMap<>();
+        Map<RasNode, Map<String, Integer>> nodeCompAssignment = new HashMap<>();
 
         int confMaxStateSearch = ObjectReader.getInt(td.getConf().get(Config.TOPOLOGY_RAS_CONSTRAINT_MAX_STATE_SEARCH));
         int daemonMaxStateSearch = ObjectReader.getInt(cluster.getConf().get(DaemonConfig.RESOURCE_AWARE_SCHEDULER_MAX_STATE_SEARCH));

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/ConstraintSolverStrategy.java
@@ -77,7 +77,6 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
         }
 
         ConstraintConfig(Map<String, Object> conf, Set<String> comps) {
-            // spread constraints, old style may come from Config.TOPOLOGY_RAS_CONSTRAINTS where the target
             Object rasConstraints = conf.get(Config.TOPOLOGY_RAS_CONSTRAINTS);
             comps.forEach(k -> incompatibleComponents.computeIfAbsent(k, x -> new HashSet<>()));
             if (rasConstraints instanceof List) {
@@ -101,7 +100,6 @@ public class ConstraintSolverStrategy extends BaseResourceAwareStrategy {
                 Map<String, Map<String, ?>> constraintMap = (Map<String, Map<String, ?>>) rasConstraints;
                 constraintMap.forEach((comp1, v) -> {
                     if (comps.contains(comp1)) {
-                        // v is a list of other components and an optional number which is a maxCoLocationCnt
                         v.forEach((ctype, constraint) -> {
                             switch (ctype) {
                                 case CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT:

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
@@ -77,7 +77,7 @@ public class TestConstraintSolverStrategy {
 
     public TestConstraintSolverStrategy(boolean consolidatedConfigFlag) {
         this.consolidatedConfigFlag = consolidatedConfigFlag;
-        LOG.info("Running tests with consolidatedConfigFlag={}", ""+consolidatedConfigFlag);
+        LOG.info("Running tests with consolidatedConfigFlag={}", consolidatedConfigFlag);
     }
 
     /**
@@ -136,7 +136,7 @@ public class TestConstraintSolverStrategy {
      * Set Config.TOPOLOGY_RAS_CONSTRAINTS (when consolidatedConfigFlag is true) or both
      * Config.TOPOLOGY_RAS_CONSTRAINTS/Config.TOPOLOGY_SPREAD_COMPONENTS (when consolidatedConfigFlag is false).
      *
-     * When consolidatedConfigFlag when true, use the new more consolidated format to set Config.TOPOLOGY_RAS_CONSTRAINTS.
+     * When consolidatedConfigFlag is true, use the new more consolidated format to set Config.TOPOLOGY_RAS_CONSTRAINTS.
      * When false, use the old configuration format for Config.TOPOLOGY_RAS_CONSTRAINTS/TOPOLOGY_SPREAD_COMPONENTS.
      *
      * @param constraints List of components, where the first one cannot co-exist with the others in the list
@@ -153,12 +153,12 @@ public class TestConstraintSolverStrategy {
                 }
                 String comp = constraint.get(0);
                 List<String> others = constraint.subList(1, constraint.size());
-                List<Object> incompatibleComponents = (List<Object>)modifiedConstraints.computeIfAbsent(comp, k -> new HashMap<String,Object>())
-                        .computeIfAbsent(ConstraintSolverStrategy.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, k -> new ArrayList<Object>());
+                List<Object> incompatibleComponents = (List<Object>) modifiedConstraints.computeIfAbsent(comp, k -> new HashMap<>())
+                        .computeIfAbsent(ConstraintSolverStrategy.CONSTRAINT_TYPE_INCOMPATIBLE_COMPONENTS, k -> new ArrayList<>());
                 incompatibleComponents.addAll(others);
             }
             for (String comp: spreads.keySet()) {
-                modifiedConstraints.computeIfAbsent(comp, k -> new HashMap<String,Object>()).put(ConstraintSolverStrategy.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, ""+spreads.get(comp));
+                modifiedConstraints.computeIfAbsent(comp, k -> new HashMap<>()).put(ConstraintSolverStrategy.CONSTRAINT_TYPE_MAX_NODE_CO_LOCATION_CNT, "" + spreads.get(comp));
             }
             config.put(Config.TOPOLOGY_RAS_CONSTRAINTS, modifiedConstraints);
         } else {

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
@@ -62,13 +62,6 @@ public class TestConstraintSolverStrategy {
     public static Object[] data() {
         return new Object[] { false, true };
     }
-    //public static Collection<Object[]> data(){
-    //    return Arrays.asList(new Object[][] {
-    //            // First param is consolidatedConfigFlag
-    //            {Boolean.TRUE},
-    //            {Boolean.FALSE}
-    //    });
-    //}
 
     private static final Logger LOG = LoggerFactory.getLogger(TestConstraintSolverStrategy.class);
     private static final int MAX_TRAVERSAL_DEPTH = 2000;
@@ -84,6 +77,7 @@ public class TestConstraintSolverStrategy {
         this.consolidatedConfigFlag = consolidatedConfigFlag;
         LOG.info("Running tests with consolidatedConfigFlag={}", ""+consolidatedConfigFlag);
     }
+
     /**
      * Helper function to add a constraint specifying two components that cannot co-exist.
      * Note that it is redundant to specify the converse.
@@ -458,11 +452,10 @@ public class TestConstraintSolverStrategy {
         Map<String, SchedulerAssignment> newAssignments = new HashMap<>();
         newAssignments.put(topo.getId(), new SchedulerAssignmentImpl(topo.getId(), newExecToSlot, null, null));
         cluster.setAssignments(newAssignments, false);
-        
+
         rs.prepare(config);
         try {
             rs.schedule(topologies, cluster);
-
             assertStatusSuccess(cluster, topo.getId());
             Assert.assertEquals("topo all executors scheduled?", 0, cluster.getUnassignedExecutors(topo).size());
         } finally {


### PR DESCRIPTION
Config.TOPOLOGY_RAS_CONSTRAINTS for use by ConstraintSolverStrategy can be specified in a new
compact format that will allow specification of MaxCoLocationCnt.

Config.TOPOLOGY_SPREAD_COMPONENTS is deprecated (and is equivalent to specifying 1 as the MaxNodeCoLocationCnt for the components.

New style Config.TOPOLOGY_RAS_CONSTRAINTS is map where each component has a list of other 
incompatible components and an optional number that specifies the maximum co-location count for the component on a node, example:
<pr/>

    { "comp-1":  { "maxNodeCoLocationCnt": 2, # at most 2 comp-1 on same node
                             "incompatibleComponents": ["comp-2", "comp-3" ] }, #comp-1 cannot co-exist on same worker with comp-2, comp-3
      "comp-2": 
               { "incompatibleComponents": [ "comp-4" ] }, # comp-1 is implied from comp-1 constraint above
       "comp-3": { "incompatibleComponents": "comp-5" } 
    }
