### PR TITLE
[STORM-3589] Prevent inconsistent results from consecutive hasNext and next calls in LazyNodeSortingIterator

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
@@ -271,14 +272,18 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
             if (pre.hasNext()) {
                 return true;
             }
+            if (nextValueFromNode != null) {
+                return true;
+            }
             while (true) {
                 //For the node we don't know if we have another one unless we look at the contents
                 Iterator<ObjectResources> nodeIterator = getNodeIterator();
                 if (nodeIterator == null || !nodeIterator.hasNext()) {
                     break;
                 }
-                nextValueFromNode = nodeIterator.next().id;
-                if (!skip.contains(nextValueFromNode)) {
+                String tmp = nodeIterator.next().id;
+                if (!skip.contains(tmp)) {
+                    nextValueFromNode = tmp;
                     return true;
                 }
             }
@@ -290,6 +295,9 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
 
         @Override
         public String next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
             if (pre.hasNext()) {
                 return pre.next();
             }
@@ -521,7 +529,7 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
 
         Map<String, Queue<ExecutorDetails>> compToExecsToSchedule = new HashMap<>();
         for (Component component : componentMap.values()) {
-            compToExecsToSchedule.put(component.getId(), new LinkedList<ExecutorDetails>());
+            compToExecsToSchedule.put(component.getId(), new LinkedList<>());
             for (ExecutorDetails exec : component.getExecs()) {
                 if (unassignedExecutors.contains(exec)) {
                     compToExecsToSchedule.get(component.getId()).add(exec);


### PR DESCRIPTION
Prevent the problem that consecutive hasNext() calls will lose elements in nodeIterator without using it.

Prevent the problem that consecutive next() calls will skip to post iterator since _nextValueFromNode_ is null even if nodeIterator still have available elements.