### PR TITLE
[STORM-3599] Bump the rocksdbjni to 5.18.4

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -531,7 +531,7 @@ List of third-party dependencies grouped by their license type.
 
     Apache License, Version 2.0, GNU General Public License, version 2
 
-        * RocksDB JNI (org.rocksdb:rocksdbjni:5.18.3 - http://rocksdb.org/)
+        * RocksDB JNI (org.rocksdb:rocksdbjni:5.18.4 - http://rocksdb.org/)
 
     Apache License, Version 2.0, GNU Lesser General Public License (LGPL), Version 2.1
 

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -924,7 +924,7 @@ The license texts of these dependencies can be found in the licenses directory.
         * JAX-RS provider for JSON content type (org.codehaus.jackson:jackson-jaxrs:1.9.13 - http://jackson.codehaus.org)
         * Xml Compatibility extensions for Jackson (org.codehaus.jackson:jackson-xc:1.9.13 - http://jackson.codehaus.org)
         * Javassist (org.javassist:javassist:3.22.0-GA - http://www.javassist.org/)
-        * RocksDB JNI (org.rocksdb:rocksdbjni:5.18.3 - http://rocksdb.org/)
+        * RocksDB JNI (org.rocksdb:rocksdbjni:5.18.4 - http://rocksdb.org/)
         * JCTools Core (org.jctools:jctools-core:2.0.1 - http://jctools.github.io/JCTools/)
         * Bean Validation API (javax.validation:validation-api:2.0.1.Final - http://beanvalidation.org)
         * jersey-container-grizzly2-http (org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.29 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-http)

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
         <jakarta-activation-version>1.2.1</jakarta-activation-version>
         <jaxb-version>2.3.0</jaxb-version>
         <activation-version>1.1.1</activation-version>
-        <rocksdb-version>5.18.3</rocksdb-version>
+        <rocksdb-version>5.18.4</rocksdb-version>
 
         <!-- see intellij profile below... This fixes an annoyance with intellij -->
         <provided.scope>provided</provided.scope>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/STORM-3599

A special rocksdbjni version for aarch64 has been released by rocksdb community. [1][2]

This patch bumps the rocksdbjni version to 5.18.4 to make the Storm can be built in aarch64.

[1] https://github.com/facebook/rocksdb/releases/tag/v5.18.4
[2] https://github.com/facebook/rocksdb/pull/6250