### PR TITLE
[STORM-2483] misnamed parameters

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -934,11 +934,11 @@ public class Utils {
         return rtn;
     }
 
-    public static GlobalStreamId getGlobalStreamId(String streamId, String componentId) {
-        if (componentId == null) {
-            return new GlobalStreamId(streamId, DEFAULT_STREAM_ID);
+    public static GlobalStreamId getGlobalStreamId(String componentId, String streamId) {
+        if (streamId == null) {
+            return new GlobalStreamId(componentId, DEFAULT_STREAM_ID);
         }
-        return new GlobalStreamId(streamId, componentId);
+        return new GlobalStreamId(componentId, streamId);
     }
 
     public static Object getSetComponentObject(ComponentObject obj) {


### PR DESCRIPTION
all 15 usages of method were already sending in componentId as first argument, streamId as second argument - so only naming inside of method needed to be changed

![image](https://user-images.githubusercontent.com/16319551/76791382-afd77d80-67b8-11ea-871e-9999a69d6153.png)
