### PR TITLE
[STORM-3604] HealthChecker should print out error message when it fails

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/healthcheck/HealthChecker.java
+++ b/storm-server/src/main/java/org/apache/storm/healthcheck/HealthChecker.java
@@ -149,10 +149,11 @@ public class HealthChecker {
 
     private static String readFromStream(InputStream is) throws IOException {
         StringBuilder stringBuilder = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(is));
-        String str;
-        while ((str = reader.readLine()) != null) {
-            stringBuilder.append(str).append("\n");
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
+            String str;
+            while ((str = reader.readLine()) != null) {
+                stringBuilder.append(str).append("\n");
+            }
         }
         return stringBuilder.toString().trim();
     }

--- a/storm-server/src/main/java/org/apache/storm/healthcheck/HealthChecker.java
+++ b/storm-server/src/main/java/org/apache/storm/healthcheck/HealthChecker.java
@@ -119,14 +119,17 @@ public class HealthChecker {
             curThread.interrupted();
 
             if (process.exitValue() != 0) {
-                String str;
+                StringBuilder stringBuilder = new StringBuilder();
                 InputStream stdin = process.getInputStream();
                 BufferedReader reader = new BufferedReader(new InputStreamReader(stdin));
+                String str;
                 while ((str = reader.readLine()) != null) {
-                    if (str.startsWith("ERROR")) {
-                        LOG.warn("The healthcheck process {} exited with code {}", script, process.exitValue());
-                        return FAILED;
-                    }
+                    stringBuilder.append(str).append("\n");
+                }
+                String message = stringBuilder.toString().trim();
+                LOG.warn("The healthcheck process {} exited with code {} and message {}", script, process.exitValue(), message);
+                if (message.startsWith("ERROR")) {
+                    return FAILED;
                 }
                 return FAILED_WITH_EXIT_CODE;
             }


### PR DESCRIPTION
explained at https://issues.apache.org/jira/browse/STORM-3604

Example after fix:
```
19:33:15.633 [main] WARN  o.a.s.h.HealthChecker - The healthcheck process check_1 exited with code 2 and message ERROR: /dir/xxx is owned by incorrect user:group : xxx:yyy
19:33:15.633 [main] INFO  o.a.s.h.HealthChecker - The healthcheck script [ check_1 ] exited with status: failed
```