### PR TITLE
[STORM-3607] Add warnings about exceptions from hadoop TGT renewal thread

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java
@@ -205,8 +205,18 @@ public class AutoTGT implements IAutoCredentials, ICredentialsRenewer, IMetricsR
                          + "in your jar");
                 return;
             }
+
+            LOG.info("Invoking Hadoop UserGroupInformation.loginUserFromSubject.");
             Method login = ugi.getMethod("loginUserFromSubject", Subject.class);
             login.invoke(null, subject);
+
+            //Refer to STORM-3606 for details
+            LOG.warn("UserGroupInformation.loginUserFromSubject will spawn a TGT renewal thread (\"TGT Renewer for <username>\") "
+                + "to execute \"kinit -R\" command some time before the current TGT expires. "
+                + "It will fail because TGT is not in the local TGT cache and the thread will eventually abort. "
+                + "Exceptions from this TGT renewal thread can be ignored. Note: TGT for the Worker is kept in memory. "
+                + "Please refer to STORM-3606 for detailed explanations");
+
         } catch (Exception e) {
             LOG.warn("Something went wrong while trying to initialize Hadoop through reflection. This version of hadoop "
                      + "may not be compatible.", e);


### PR DESCRIPTION
An example run:

```
2020-03-25 18:36:59.391 o.a.s.s.a.k.AutoTGT main [INFO] Populating TGT from credentials
2020-03-25 18:36:59.763 o.a.h.u.NativeCodeLoader main [WARN] Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
2020-03-25 18:36:59.763 o.a.h.s.JniBasedUnixGroupsNetgroupMappingWithFallback main [INFO] Falling back to shell based
2020-03-25 18:36:59.798 o.a.s.s.a.k.AutoTGT main [INFO] Invoking Hadoop UserGroupInformation.loginUserFromSubject.
2020-03-25 18:36:59.808 o.a.s.s.a.k.AutoTGT main [WARN] UserGroupInformation.loginUserFromSubject will spawn a TGT renewal thread ("TGT Renewer for <username>") to ex
ecute "kinit -R" command some time before the current TGT expires. It will fail because TGT is not in the local TGT cache and the thread will eventually abort. Except
ions from this TGT renewal thread can be ignored. Note: TGT for the Worker is kept in memory. Please refer to STORM-3606 for detailed explanations
```