### PR TITLE
[STORM-3613] storm.py should include lib-worker instead of lib directory in the classpath while submitting a topology

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -283,7 +283,8 @@ def run_client_jar(klass, args, daemon=False, client=True, extrajvmopts=[]):
         jvmtype="-client",
         extrajars=extra_jars,
         main_class_args=args.main_args,
-        daemon=False,
+        daemon=daemon,
+        client=client,
         jvmopts=JAR_JVM_OPTS + extrajvmopts + ["-Dstorm.jar=" + jarfile] +
                 ["-Dstorm.dependency.jars=" + ",".join(local_jars)] +
                 ["-Dstorm.dependency.artifacts=" + json.dumps(artifact_to_file_jars)],

--- a/storm-client/test/py/test_storm_cli.py
+++ b/storm-client/test/py/test_storm_cli.py
@@ -62,7 +62,7 @@ class TestStormCli(TestCase):
                 self.java_cmd, '-client', '-Ddaemon.name=', '-Dstorm.options=+topology.blobstore.map%3D%27%7B%22key1%22%3A%7B%22localname%22%3A%22blob_file%22%2C+%22uncompress%22%3Afalse%7D%2C%22key2%22%3A%7B%7D%7D%27',
                 '-Dstorm.home=' + self.storm_dir, '-Dstorm.log.dir=' + self.storm_dir + "/logs",
                 '-Djava.library.path=', '-Dstorm.conf.file=', '-cp',
-                self.storm_dir + '/*:' + self.storm_dir + '/lib:' + self.storm_dir
+                self.storm_dir + '/*:' + self.storm_dir + '/lib-worker:' + self.storm_dir
                 + '/extlib:example/storm-starter/storm-starter-topologies-*.jar:' + self.storm_dir + '/conf:'
                 + self.storm_dir + '/bin:./external/storm-redis/storm-redis-1.1.0.jar:./external/storm-kafka-client/storm-kafka-client-1.1.0.jar"', '-Dstorm.jar=example/storm-starter/storm-starter-topologies-*.jar', '-Dstorm.dependency.jars=./external/storm-redis/storm-redis-1.1.0.jar,./external/storm-kafka-client/storm-kafka-client-1.1.0.jar"', '-Dstorm.dependency.artifacts={}',
                 'org.apache.storm.starter.RollingTopWords', 'blobstore-remote2', 'remote'
@@ -80,7 +80,7 @@ class TestStormCli(TestCase):
                 self.java_cmd, '-client', '-Ddaemon.name=', '-Dstorm.options=',
                 '-Dstorm.home=' + self.storm_dir, '-Dstorm.log.dir=' + self.storm_dir + "/logs",
                 '-Djava.library.path=', '-Dstorm.conf.file=', '-cp',
-                self.storm_dir + '/*:' + self.storm_dir + '/lib:' + self.storm_dir
+                self.storm_dir + '/*:' + self.storm_dir + '/lib-worker:' + self.storm_dir
                 + '/extlib:/path/to/jar.jar:' + self.storm_dir + '/conf:' + self.storm_dir + '/bin:',
                 '-Dstorm.jar=/path/to/jar.jar', '-Dstorm.dependency.jars=', '-Dstorm.dependency.artifacts={}',
                 'some.Topology.Class', '-name', 'run-topology', 'randomArgument', '-randomFlag', 'randomFlagValue',


### PR DESCRIPTION
Explained in https://issues.apache.org/jira/browse/STORM-3613
