### PR TITLE
[STORM-3616] add optional flag to fail upload-credentials cmd if no creds were uploaded

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -545,7 +545,8 @@ def initialize_upload_credentials_subcommand(subparsers):
     # Command exits with non-zero code if uploaded creds collection is empty.
     sub_parser.add_argument(
         "-e", "--exception-when-empty", action='store_true',
-        help="""whether to throw exception if there are no credentials uploaded, default to be false"""
+        help="""If specified, throw exception if there are no credentials uploaded. 
+                Otherwise, it is default to be false"""
     )
 
     sub_parser.add_argument(

--- a/bin/storm.py
+++ b/bin/storm.py
@@ -541,6 +541,13 @@ def initialize_upload_credentials_subcommand(subparsers):
         help="""name of the owner of the topology (security precaution)"""
     )
 
+    # If set, this flag will become true meaning that user expects non-empty creds to be uploaded.
+    # Command exits with non-zero code if uploaded creds collection is empty.
+    sub_parser.add_argument(
+        "-e", "--exception", action='store_true',
+        help="""whether to throw exception if there are no credentials uploaded, default to be false"""
+    )
+
     sub_parser.add_argument(
         "cred_list", nargs='*', help="List of credkeys and their values [credkey credvalue]*"
     )

--- a/bin/storm.py
+++ b/bin/storm.py
@@ -544,7 +544,7 @@ def initialize_upload_credentials_subcommand(subparsers):
     # If set, this flag will become true meaning that user expects non-empty creds to be uploaded.
     # Command exits with non-zero code if uploaded creds collection is empty.
     sub_parser.add_argument(
-        "-e", "--exception", action='store_true',
+        "-e", "--exception-when-empty", action='store_true',
         help="""whether to throw exception if there are no credentials uploaded, default to be false"""
     )
 

--- a/docs/Command-line-client.md
+++ b/docs/Command-line-client.md
@@ -320,7 +320,7 @@ eg: `storm shell resources/ python topology.py arg1 arg2`
 Syntax: `storm upload_credentials topology-name [credkey credvalue]*`
 
 Uploads a new set of credentials to a running topology  
-   * `-e --exception`: optioanl flag. If set, command will fail and throw exception if no credentials were uploaded.
+   * `-e --exception`: optional flag. If set, command will fail and throw exception if no credentials were uploaded.
    
 
 ### version

--- a/docs/Command-line-client.md
+++ b/docs/Command-line-client.md
@@ -320,7 +320,7 @@ eg: `storm shell resources/ python topology.py arg1 arg2`
 Syntax: `storm upload_credentials topology-name [credkey credvalue]*`
 
 Uploads a new set of credentials to a running topology  
-   * `-e --exception`: optional flag. If set, command will fail and throw exception if no credentials were uploaded.
+   * `-e --exception-when-empty`: optional flag. If set, command will fail and throw exception if no credentials were uploaded.
    
 
 ### version

--- a/docs/Command-line-client.md
+++ b/docs/Command-line-client.md
@@ -319,7 +319,9 @@ eg: `storm shell resources/ python topology.py arg1 arg2`
 
 Syntax: `storm upload_credentials topology-name [credkey credvalue]*`
 
-Uploads a new set of credentials to a running topology
+Uploads a new set of credentials to a running topology  
+   * `-e --exception`: optioanl flag. If set, command will fail and throw exception if no credentials were uploaded.
+   
 
 ### version
 

--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -106,13 +106,14 @@ public class StormSubmitter {
      * @param name        the name of the topology to push credentials to.
      * @param topoConf    the topology-specific configuration, if desired. See {@link Config}.
      * @param credentials the credentials to push.
+     * @return whether the pushed credential collection fullCreds is non-empty. Return false if empty.
      * @throws AuthorizationException   if you are not authorized ot push credentials.
      * @throws NotAliveException        if the topology is not alive
      * @throws InvalidTopologyException if any other error happens
      */
-    public static void pushCredentials(String name, Map<String, Object> topoConf, Map<String, String> credentials)
+    public static boolean pushCredentials(String name, Map<String, Object> topoConf, Map<String, String> credentials)
         throws AuthorizationException, NotAliveException, InvalidTopologyException {
-        pushCredentials(name, topoConf, credentials, null);
+        return pushCredentials(name, topoConf, credentials, null);
     }
 
     /**
@@ -123,6 +124,7 @@ public class StormSubmitter {
      * @param topoConf    the topology-specific configuration, if desired. See {@link Config}.
      * @param credentials the credentials to push.
      * @param expectedUser the user you expect the topology to be owned by.
+     * @return whether the pushed credential collection fullCreds is non-empty. Return false if empty.
      * @throws AuthorizationException   if you are not authorized ot push credentials.
      * @throws NotAliveException        if the topology is not alive
      * @throws InvalidTopologyException if any other error happens

--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -117,6 +117,7 @@ public class StormSubmitter {
 
     /**
      * Push a new set of credentials to the running topology.
+     * Return false if push Creds map is empty, true otherwise.
      *
      * @param name        the name of the topology to push credentials to.
      * @param topoConf    the topology-specific configuration, if desired. See {@link Config}.
@@ -126,7 +127,7 @@ public class StormSubmitter {
      * @throws NotAliveException        if the topology is not alive
      * @throws InvalidTopologyException if any other error happens
      */
-    public static void pushCredentials(String name, Map<String, Object> topoConf, Map<String, String> credentials, String expectedUser)
+    public static boolean pushCredentials(String name, Map<String, Object> topoConf, Map<String, String> credentials, String expectedUser)
         throws AuthorizationException, NotAliveException, InvalidTopologyException {
         topoConf = new HashMap(topoConf);
         topoConf.putAll(Utils.readCommandLineOpts());
@@ -135,7 +136,7 @@ public class StormSubmitter {
         Map<String, String> fullCreds = populateCredentials(conf, credentials);
         if (fullCreds.isEmpty()) {
             LOG.warn("No credentials were found to push to " + name);
-            return;
+            return false;
         }
         try {
             try (NimbusClient client = NimbusClient.getConfiguredClient(conf)) {
@@ -150,6 +151,7 @@ public class StormSubmitter {
         } catch (TException e) {
             throw new RuntimeException(e);
         }
+        return true;
     }
 
 

--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -106,7 +106,7 @@ public class StormSubmitter {
      * @param name        the name of the topology to push credentials to.
      * @param topoConf    the topology-specific configuration, if desired. See {@link Config}.
      * @param credentials the credentials to push.
-     * @return whether the pushed credential collection fullCreds is non-empty. Return false if empty.
+     * @return whether the pushed credential collection is non-empty. Return false if empty.
      * @throws AuthorizationException   if you are not authorized ot push credentials.
      * @throws NotAliveException        if the topology is not alive
      * @throws InvalidTopologyException if any other error happens
@@ -124,7 +124,7 @@ public class StormSubmitter {
      * @param topoConf    the topology-specific configuration, if desired. See {@link Config}.
      * @param credentials the credentials to push.
      * @param expectedUser the user you expect the topology to be owned by.
-     * @return whether the pushed credential collection fullCreds is non-empty. Return false if empty.
+     * @return whether the pushed credential collection is non-empty. Return false if empty.
      * @throws AuthorizationException   if you are not authorized ot push credentials.
      * @throws NotAliveException        if the topology is not alive
      * @throws InvalidTopologyException if any other error happens

--- a/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/kerberos/AutoTGT.java
@@ -13,6 +13,7 @@
 package org.apache.storm.security.auth.kerberos;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -101,10 +102,10 @@ public class AutoTGT implements IAutoCredentials, ICredentialsRenewer, IMetricsR
 
     public static void main(String[] args) throws Exception {
         AutoTGT at = new AutoTGT();
-        Map<String, Object> conf = new java.util.HashMap();
+        Map<String, Object> conf = new HashMap();
         conf.put("java.security.auth.login.config", args[0]);
         at.prepare(conf);
-        Map<String, String> creds = new java.util.HashMap<String, String>();
+        Map<String, String> creds = new HashMap<>();
         at.populateCredentials(creds);
         Subject s = new Subject();
         at.populateSubject(s, creds);

--- a/storm-core/src/jvm/org/apache/storm/command/UploadCredentials.java
+++ b/storm-core/src/jvm/org/apache/storm/command/UploadCredentials.java
@@ -42,6 +42,7 @@ public class UploadCredentials {
     public static void main(String[] args) throws Exception {
         Map<String, Object> cl = CLI.opt("f", "file", null)
                                     .opt("u", "user", null)
+                                    .boolOpt("e", "exception")
                                     .arg("topologyName", CLI.FIRST_WINS)
                                     .optionalArg("rawCredentials", CLI.INTO_LIST)
                                     .parse(args);
@@ -111,7 +112,13 @@ public class UploadCredentials {
         // use the local setting for the login config rather than the topology's
         topologyConf.remove("java.security.auth.login.config");
 
-        StormSubmitter.pushCredentials(topologyName, topologyConf, credentialsMap, (String) cl.get("u"));
+        boolean throwExceptionForEmptyCreds = (boolean) cl.getOrDefault("e", false);
+        boolean hasCreds = StormSubmitter.pushCredentials(topologyName, topologyConf, credentialsMap, (String) cl.get("u"));
+        if (!hasCreds && throwExceptionForEmptyCreds) {
+            String message = "No credentials were uploaded for " + topologyName;
+            LOG.error(message);
+            throw new RuntimeException(message);
+        }
         LOG.info("Uploaded new creds to topology: {}", topologyName);
     }
 }

--- a/storm-core/src/jvm/org/apache/storm/command/UploadCredentials.java
+++ b/storm-core/src/jvm/org/apache/storm/command/UploadCredentials.java
@@ -42,7 +42,7 @@ public class UploadCredentials {
     public static void main(String[] args) throws Exception {
         Map<String, Object> cl = CLI.opt("f", "file", null)
                                     .opt("u", "user", null)
-                                    .boolOpt("e", "exception")
+                                    .boolOpt("e", "exception-when-empty")
                                     .arg("topologyName", CLI.FIRST_WINS)
                                     .optionalArg("rawCredentials", CLI.INTO_LIST)
                                     .parse(args);
@@ -112,7 +112,7 @@ public class UploadCredentials {
         // use the local setting for the login config rather than the topology's
         topologyConf.remove("java.security.auth.login.config");
 
-        boolean throwExceptionForEmptyCreds = (boolean) cl.getOrDefault("e", false);
+        boolean throwExceptionForEmptyCreds = (boolean) cl.get("e");
         boolean hasCreds = StormSubmitter.pushCredentials(topologyName, topologyConf, credentialsMap, (String) cl.get("u"));
         if (!hasCreds && throwExceptionForEmptyCreds) {
             String message = "No credentials were uploaded for " + topologyName;


### PR DESCRIPTION
```
-bash-4.1$ storm upload-credentials ec2 -c "password=password"
Running: /home/y/share/yjava_jdk/java/bin/java -client -Ddaemon.name= -Dstorm.options=password%3Dpassword -Dstorm.home=/home/y/lib64/storm/2.2.0.y -Dstorm.log.dir=/home/y/lib64/storm/2.2.0.y/logs -Djava.library.path=/home/y/lib64:/usr/local/lib64:/usr/lib64:/lib64: -Dstorm.conf.file= -cp /home/y/lib64/storm/2.2.0.y/*:/home/y/lib64/storm/2.2.0.y/lib/*:/home/y/lib64/storm/2.2.0.y/extlib/*:/home/y/lib64/storm/2.2.0.y/extlib-daemon/*:/home/y/lib64/storm/current/conf:/home/y/lib64/storm/2.2.0.y/bin org.apache.storm.command.UploadCredentials ec2
03:31:54.653 [main] INFO o.a.s.m.n.Login - Successfully logged in to context StormClient using /etc/grid-keytabs/jaas.conf
03:31:54.662 [Refresh-TGT] INFO o.a.s.m.n.Login - TGT refresh thread started.
03:31:54.691 [Refresh-TGT] INFO o.a.s.m.n.Login - TGT valid starting at: Wed Apr 01 05:14:11 UTC 2020
03:31:54.691 [Refresh-TGT] INFO o.a.s.m.n.Login - TGT expires: Thu Apr 02 05:14:11 UTC 2020
03:31:54.691 [Refresh-TGT] WARN o.a.s.m.n.Login - TGT refresh thread time adjusted from : Thu Apr 02 01:30:31 UTC 2020 to : Thu Apr 02 03:32:54 UTC 2020 since the former is sooner than the minimum refresh interval (60 seconds) from now.
03:31:54.692 [Refresh-TGT] INFO o.a.s.m.n.Login - TGT refresh sleeping until: Thu Apr 02 03:32:54 UTC 2020
03:31:54.835 [main] INFO o.a.s.u.NimbusClient - Found leader nimbus : openstorm13blue-n1.blue.ygrid.yahoo.com:50560
03:31:54.897 [main] INFO o.a.s.c.UploadCredentials - Using topology conf from ec2-1-1585797718 as basis for getting new creds
03:31:54.924 [main] INFO o.a.s.s.a.ClientAuthUtils - Got AutoCreds []
03:31:54.924 [main] INFO o.a.s.StormSubmitter - Full list of creds available: {}
03:31:54.924 [main] WARN o.a.s.StormSubmitter - No credentials were found to push to ec2
03:31:54.924 [main] INFO o.a.s.c.UploadCredentials - Uploaded new creds to topology: ec2
-bash-4.1$ echo $?
0

 

-bash-4.1$ storm upload-credentials ec2 -c "password=password" -e

Running: /home/y/share/yjava_jdk/java/bin/java -client -Ddaemon.name= -Dstorm.options=password%3Dpassword -Dstorm.home=/home/y/lib64/storm/2.2.0.y -Dstorm.log.dir=/home/y/lib64/storm/2.2.0.y/logs -Djava.library.path=/home/y/lib64:/usr/local/lib64:/usr/lib64:/lib64: -Dstorm.conf.file= -cp /home/y/lib64/storm/2.2.0.y/*:/home/y/lib64/storm/2.2.0.y/lib/*:/home/y/lib64/storm/2.2.0.y/extlib/*:/home/y/lib64/storm/2.2.0.y/extlib-daemon/*:/home/y/lib64/storm/current/conf:/home/y/lib64/storm/2.2.0.y/bin org.apache.storm.command.UploadCredentials ec2 -e
03:32:30.449 [main] INFO o.a.s.m.n.Login - Successfully logged in to context StormClient using /etc/grid-keytabs/jaas.conf
03:32:30.471 [Refresh-TGT] INFO o.a.s.m.n.Login - TGT refresh thread started.
03:32:30.492 [Refresh-TGT] INFO o.a.s.m.n.Login - TGT valid starting at: Wed Apr 01 05:14:11 UTC 2020
03:32:30.493 [Refresh-TGT] INFO o.a.s.m.n.Login - TGT expires: Thu Apr 02 05:14:11 UTC 2020
03:32:30.493 [Refresh-TGT] WARN o.a.s.m.n.Login - TGT refresh thread time adjusted from : Thu Apr 02 01:25:36 UTC 2020 to : Thu Apr 02 03:33:30 UTC 2020 since the former is sooner than the minimum refresh interval (60 seconds) from now.
03:32:30.493 [Refresh-TGT] INFO o.a.s.m.n.Login - TGT refresh sleeping until: Thu Apr 02 03:33:30 UTC 2020
03:32:30.641 [main] INFO o.a.s.u.NimbusClient - Found leader nimbus : openstorm13blue-n1.blue.ygrid.yahoo.com:50560
03:32:30.702 [main] INFO o.a.s.c.UploadCredentials - Using topology conf from ec2-1-1585797718 as basis for getting new creds
03:32:30.729 [main] INFO o.a.s.s.a.ClientAuthUtils - Got AutoCreds []
03:32:30.729 [main] INFO o.a.s.StormSubmitter - Full list of creds available: {}
03:32:30.729 [main] WARN o.a.s.StormSubmitter - No credentials were found to push to ec2
03:32:30.730 [main] ERROR o.a.s.c.UploadCredentials - No credentials were uploaded for ec2

Exception in thread "main" java.lang.RuntimeException: No credentials were uploaded for ec2
     at org.apache.storm.command.UploadCredentials.main(UploadCredentials.java:120)

-bash-4.1$ echo $?
1
```