### PR TITLE
[STORM-3626] storm-kafka-migration should ull in storm-client as provided instead of compile dependency

### DIFF
--- a/external/storm-kafka-migration/pom.xml
+++ b/external/storm-kafka-migration/pom.xml
@@ -36,6 +36,7 @@
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-client</artifactId>
             <version>${project.version}</version>
+            <scope>${provided.scope}</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION

https://issues.apache.org/jira/browse/STORM-3626