### PR TITLE
[STORM-3627] Add flag to use metrics shortname for topology

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -277,6 +277,13 @@ public class Config extends HashMap<String, Object> {
     @IsBoolean
     public static final String TOPOLOGY_ENABLE_V2_METRICS_TICK = "topology.enable.v2.metrics.tick";
 
+
+    /**
+     * This config allows a topology report metrics data points from the V2 metrics API to use short metrics name without prefix.
+     */
+    @IsBoolean
+    public static final String TOPOLOGY_METRICS_USE_SHORTNAME = "topology.metrics.use.shortname";
+
     /**
      * The class name of the {@link org.apache.storm.state.StateProvider} implementation. If not specified defaults to {@link
      * org.apache.storm.state.InMemoryKeyValueStateProvider}. This can be overridden at the component level.

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -116,9 +116,9 @@ public class Worker implements Shutdownable, DaemonCommon {
         this.port = port;
         this.workerId = workerId;
         this.logConfigManager = new LogConfigManager();
-        this.metricRegistry = new StormMetricRegistry();
-
         this.topologyConf = ConfigUtils.overrideLoginConfigWithSystemProperty(ConfigUtils.readSupervisorStormConf(conf, topologyId));
+        this.metricRegistry =
+            new StormMetricRegistry(ObjectReader.getBoolean(this.topologyConf.get(Config.TOPOLOGY_METRICS_USE_SHORTNAME), false));
 
         if (supervisorIfaceSupplier == null) {
             this.supervisorIfaceSupplier = () -> {


### PR DESCRIPTION
Adding topology configuration _topology.metrics.use.shortname_ to allow for use of shortnames in case metrics tick is enabled using _topology.enable.v2.metrics.tick_.

This allows for use of shortname instead of complete naming convention that includes, topology-id, worker, component details in the metrics name.