### PR TITLE
[MINOR] makes the exception message more clear in StormSubmitter

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -252,8 +252,8 @@ public class StormSubmitter {
         try {
             String serConf = JSONValue.toJSONString(topoConf);
             try (NimbusClient client = NimbusClient.getConfiguredClientAs(conf, asUser)) {
-                if (isTopologyNameAllowed(name, client)) {
-                    throw new RuntimeException("Topology with name `" + name + "` is either not allowed or it already exists on cluster");
+                if (!isTopologyNameAllowed(name, client)) {
+                    throw new RuntimeException("Topology name " + name + " is either not allowed or it already exists on the cluster");
                 }
 
                 // Dependency uploading only makes sense for distributed mode
@@ -438,7 +438,7 @@ public class StormSubmitter {
 
     private static boolean isTopologyNameAllowed(String name, NimbusClient client) {
         try {
-            return !client.getClient().isTopologyNameAllowed(name);
+            return client.getClient().isTopologyNameAllowed(name);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This is not a bug. But changing it to make the code more clear.
Orignal message "topology with name xx is not allowed" can be interpreted as some permission issue. But it only means the name is not valid/accepted. 