### PR TITLE
[STORM-3629] Logviewer should always allow admins to access logs

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandler.java
@@ -266,7 +266,7 @@ public class LogviewerLogPageHandler {
                 return LogviewerResponseBuilder.buildResponsePageNotFound();
             }
         } else {
-            if (resourceAuthorizer.getLogUserGroupWhitelist(fileName) != null) {
+            if (resourceAuthorizer.getLogUserGroupWhitelist(fileName) == null) {
                 return LogviewerResponseBuilder.buildResponsePageNotFound();
             } else {
                 return LogviewerResponseBuilder.buildResponseUnauthorizedUser(user);

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/ResourceAuthorizer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/ResourceAuthorizer.java
@@ -84,25 +84,27 @@ public class ResourceAuthorizer {
             return false;
         }
         LogUserGroupWhitelist whitelist = getLogUserGroupWhitelist(fileName);
-        if (whitelist == null) {
-            return false;
-        } else {
-            List<String> logsUsers = new ArrayList<>();
-            logsUsers.addAll(ObjectReader.getStrings(stormConf.get(DaemonConfig.LOGS_USERS)));
-            logsUsers.addAll(ObjectReader.getStrings(stormConf.get(Config.NIMBUS_ADMINS)));
+
+        List<String> logsUsers = new ArrayList<>();
+        logsUsers.addAll(ObjectReader.getStrings(stormConf.get(DaemonConfig.LOGS_USERS)));
+        logsUsers.addAll(ObjectReader.getStrings(stormConf.get(Config.NIMBUS_ADMINS)));
+        if (whitelist != null) {
             logsUsers.addAll(whitelist.getUserWhitelist());
-
-            List<String> logsGroups = new ArrayList<>();
-            logsGroups.addAll(ObjectReader.getStrings(stormConf.get(DaemonConfig.LOGS_GROUPS)));
-            logsGroups.addAll(ObjectReader.getStrings(stormConf.get(Config.NIMBUS_ADMINS_GROUPS)));
-            logsGroups.addAll(whitelist.getGroupWhitelist());
-
-            String userName = principalToLocal.toLocal(user);
-            Set<String> groups = getUserGroups(userName);
-
-            return logsUsers.stream().anyMatch(u -> u.equals(userName))
-                    || Sets.intersection(groups, new HashSet<>(logsGroups)).size() > 0;
         }
+
+        List<String> logsGroups = new ArrayList<>();
+        logsGroups.addAll(ObjectReader.getStrings(stormConf.get(DaemonConfig.LOGS_GROUPS)));
+        logsGroups.addAll(ObjectReader.getStrings(stormConf.get(Config.NIMBUS_ADMINS_GROUPS)));
+        if (whitelist != null) {
+            logsGroups.addAll(whitelist.getGroupWhitelist());
+        }
+
+        String userName = principalToLocal.toLocal(user);
+        Set<String> groups = getUserGroups(userName);
+
+        return logsUsers.stream().anyMatch(u -> u.equals(userName))
+            || Sets.intersection(groups, new HashSet<>(logsGroups)).size() > 0;
+
     }
 
     /**


### PR DESCRIPTION
Explained in https://issues.apache.org/jira/browse/STORM-3629

Also fixed a translation error from clojure: 
https://github.com/apache/storm/blob/1.x-branch/storm-core/src/clj/org/apache/storm/daemon/logviewer.clj#L454-L457