### PR TITLE
[STORM-3630] Remove checkForBlobOrDownload from LocalFsBlobStore

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStore.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStore.java
@@ -282,9 +282,6 @@ public class LocalFsBlobStore extends BlobStore {
     @Override
     public ReadableBlobMeta getBlobMeta(String key, Subject who) throws AuthorizationException, KeyNotFoundException {
         validateKey(key);
-        if (!checkForBlobOrDownload(key)) {
-            checkForBlobUpdate(key);
-        }
         SettableBlobMeta meta = getStoredBlobMeta(key);
         aclHandler.validateUserCanReadMeta(meta.get_acl(), who, key);
         ReadableBlobMeta rbm = new ReadableBlobMeta();
@@ -385,9 +382,6 @@ public class LocalFsBlobStore extends BlobStore {
     @Override
     public InputStreamWithMeta getBlob(String key, Subject who) throws AuthorizationException, KeyNotFoundException {
         validateKey(key);
-        if (!checkForBlobOrDownload(key)) {
-            checkForBlobUpdate(key);
-        }
         SettableBlobMeta meta = getStoredBlobMeta(key);
         aclHandler.hasPermissions(meta.get_acl(), READ, who, key);
         try {

--- a/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
@@ -802,8 +802,6 @@ public class AsyncLocalizerTest {
         conf.put(Config.STORM_LOCAL_DIR, "target");
         LocalFsBlobStore bs = new LocalFsBlobStore();
         LocalFsBlobStore spy = spy(bs);
-        Mockito.doReturn(true).when(spy).checkForBlobOrDownload(key1);
-        Mockito.doNothing().when(spy).checkForBlobUpdate(key1);
         spy.prepare(conf, null, null, null);
         spy.getBlob(key1, null);
     }


### PR DESCRIPTION
The synchronized method checks are not required for _LocalFsBlobStore_.  Removing this can speed up the calls to getBlob and getBlobMeta methods.