### PR TITLE
[STORM-2687] Add network proximity needs based executor sorting method

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -340,7 +340,7 @@ topology.ras.constraint.max.state.search: 10_000     # The maximum number of sta
 resource.aware.scheduler.constraint.max.state.search: 100_000 # Daemon limit on maximum number of states that will be searched looking for a solution in the constraint solver strategy
 topology.ras.one.executor.per.worker: false
 topology.ras.one.component.per.worker: false
-topology.ras.schedule.executors.by.proximity.needs: false
+topology.ras.order.executors.by.proximity.needs: false
 
 blacklist.scheduler.tolerance.time.secs: 300
 blacklist.scheduler.tolerance.count: 3

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -340,6 +340,7 @@ topology.ras.constraint.max.state.search: 10_000     # The maximum number of sta
 resource.aware.scheduler.constraint.max.state.search: 100_000 # Daemon limit on maximum number of states that will be searched looking for a solution in the constraint solver strategy
 topology.ras.one.executor.per.worker: false
 topology.ras.one.component.per.worker: false
+topology.ras.schedule.executors.by.proximity.needs: false
 
 blacklist.scheduler.tolerance.time.secs: 300
 blacklist.scheduler.tolerance.count: 3

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -340,7 +340,6 @@ topology.ras.constraint.max.state.search: 10_000     # The maximum number of sta
 resource.aware.scheduler.constraint.max.state.search: 100_000 # Daemon limit on maximum number of states that will be searched looking for a solution in the constraint solver strategy
 topology.ras.one.executor.per.worker: false
 topology.ras.one.component.per.worker: false
-topology.ras.order.executors.by.proximity.needs: false
 
 blacklist.scheduler.tolerance.time.secs: 300
 blacklist.scheduler.tolerance.count: 3

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -317,7 +317,7 @@ public class Config extends HashMap<String, Object> {
      * it will arrange unassigned executors based a particular order.
      * If this config is set to true, the arrangement will be made by network proximity needs.
      */
-    public static final String TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS = "topology.ras.order.executors.by.proximity.needs";
+    public static final String TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS = "topology.ras.schedule.executors.by.proximity.needs";
 
     /**
      * Declare scheduling constraints for a topology used by the constraint solver strategy. The format can be either

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -314,10 +314,10 @@ public class Config extends HashMap<String, Object> {
 
     /**
      * When DefaultResourceAwareStrategy or GenericResourceAwareStrategy is used,
-     * it will arrange unassigned executors based a particular order.
-     * If this config is set to true, the arrangement will be made by network proximity needs.
+     * scheduler will sort unassigned executors based on a particular order.
+     * If this config is set to true, unassigned executors will be sorted by topological order with network proximity needs.
      */
-    public static final String TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS = "topology.ras.schedule.executors.by.proximity.needs";
+    public static final String TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS = "topology.ras.order.executors.by.proximity.needs";
 
     /**
      * Declare scheduling constraints for a topology used by the constraint solver strategy. The format can be either

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -313,6 +313,13 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_SCHEDULER_STRATEGY = "topology.scheduler.strategy";
 
     /**
+     * When DefaultResourceAwareStrategy or GenericResourceAwareStrategy is used,
+     * it will arrange unassigned executors based a particular order.
+     * If this config is set to true, the arrangement will be made by network proximity needs.
+     */
+    public static final String TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS = "topology.ras.order.executors.by.proximity.needs";
+
+    /**
      * Declare scheduling constraints for a topology used by the constraint solver strategy. The format can be either
      * old style (validated by ListOfListOfStringValidator.class or the newer style, which is a list of specific type of
      * Maps (validated by RasConstraintsTypeValidator.class). The value must be in one or the other format.

--- a/storm-server/src/main/java/org/apache/storm/scheduler/Component.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Component.java
@@ -18,10 +18,14 @@
 
 package org.apache.storm.scheduler;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.storm.generated.ComponentType;
+import org.apache.storm.generated.GlobalStreamId;
+import org.apache.storm.generated.Grouping;
 
 public class Component {
     private final String id;
@@ -29,6 +33,7 @@ public class Component {
     private final ComponentType type;
     private final Set<String> parents = new HashSet<>();
     private final Set<String> children = new HashSet<>();
+    private final Map<GlobalStreamId, Grouping> inputs = new HashMap<>();
 
     /**
      * Create a new component.
@@ -37,10 +42,11 @@ public class Component {
      * @param compId the id of the component
      * @param execs  the executors for this component.
      */
-    public Component(ComponentType type, String compId, List<ExecutorDetails> execs) {
+    public Component(ComponentType type, String compId, List<ExecutorDetails> execs, Map<GlobalStreamId, Grouping> inputs) {
         this.type = type;
         this.id = compId;
         this.execs = execs;
+        this.inputs.putAll(inputs);
     }
 
     /**
@@ -73,16 +79,19 @@ public class Component {
         return children;
     }
 
+    public Map<GlobalStreamId, Grouping> getInputs() {
+        return inputs;
+    }
+
     @Override
     public String toString() {
-        return "{id: "
-               + getId()
-               + " Parents: "
-               + getParents()
-               + " Children: "
-               + getChildren()
-               + " Execs: "
-               + getExecs()
-               + "}";
+        return "Component{"
+            + "id='" + id + '\''
+            + ", execs=" + execs
+            + ", type=" + type
+            + ", parents=" + parents
+            + ", children=" + children
+            + ", inputs=" + inputs
+            + '}';
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/TopologyDetails.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/TopologyDetails.java
@@ -207,8 +207,9 @@ public class TopologyDetails {
         if (spouts != null) {
             for (Map.Entry<String, SpoutSpec> entry : spouts.entrySet()) {
                 String compId = entry.getKey();
+                SpoutSpec spout = entry.getValue();
                 if (!Utils.isSystemId(compId)) {
-                    Component comp = new Component(ComponentType.SPOUT, compId, componentToExecs(compId));
+                    Component comp = new Component(ComponentType.SPOUT, compId, componentToExecs(compId), spout.get_common().get_inputs());
                     ret.put(compId, comp);
                 }
             }
@@ -216,8 +217,9 @@ public class TopologyDetails {
         if (bolts != null) {
             for (Map.Entry<String, Bolt> entry : bolts.entrySet()) {
                 String compId = entry.getKey();
+                Bolt bolt = entry.getValue();
                 if (!Utils.isSystemId(compId)) {
-                    Component comp = new Component(ComponentType.BOLT, compId, componentToExecs(compId));
+                    Component comp = new Component(ComponentType.BOLT, compId, componentToExecs(compId), bolt.get_common().get_inputs());
                     ret.put(compId, comp);
                 }
             }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
@@ -517,11 +517,11 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
     protected List<ExecutorDetails> orderExecutors(
         TopologyDetails td, Collection<ExecutorDetails> unassignedExecutors) {
         Boolean orderByProximity = (Boolean) td.getConf()
-            .getOrDefault(Config.TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS, false);
+            .getOrDefault(Config.TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS, false);
         if (!orderByProximity) {
             return orderExecutorsDefault(td, unassignedExecutors);
         } else {
-            LOG.info("{} is set to true", Config.TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS);
+            LOG.info("{} is set to true", Config.TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS);
             return orderExecutorsByProximityNeeds(td, unassignedExecutors);
         }
     }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
@@ -54,6 +54,7 @@ import org.apache.storm.scheduler.resource.normalization.NormalizedResourceOffer
 import org.apache.storm.scheduler.resource.normalization.NormalizedResourceRequest;
 import org.apache.storm.shade.com.google.common.annotations.VisibleForTesting;
 import org.apache.storm.shade.com.google.common.collect.Sets;
+import org.apache.storm.utils.ObjectReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -516,12 +517,12 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
 
     protected List<ExecutorDetails> orderExecutors(
         TopologyDetails td, Collection<ExecutorDetails> unassignedExecutors) {
-        Boolean orderByProximity = (Boolean) td.getConf()
-            .getOrDefault(Config.TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS, false);
+        Boolean orderByProximity = ObjectReader.getBoolean(
+            td.getConf().get(Config.TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS), false);
         if (!orderByProximity) {
             return orderExecutorsDefault(td, unassignedExecutors);
         } else {
-            LOG.info("{} is set to true", Config.TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS);
+            LOG.info("{} is set to true", Config.TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS);
             return orderExecutorsByProximityNeeds(td, unassignedExecutors);
         }
     }

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -500,7 +500,7 @@ public class TestDefaultResourceAwareStrategy {
         conf.put(Config.TOPOLOGY_NAME, "testTopology");
         conf.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, Double.MAX_VALUE);
         conf.put(Config.TOPOLOGY_SUBMITTER_USER, "user");
-        conf.put(Config.TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS, true);
+        conf.put(Config.TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS, true);
 
         TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
             genExecsAndComps(stormToplogy), CURRENT_TIME, "user");

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -500,7 +500,7 @@ public class TestDefaultResourceAwareStrategy {
         conf.put(Config.TOPOLOGY_NAME, "testTopology");
         conf.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, Double.MAX_VALUE);
         conf.put(Config.TOPOLOGY_SUBMITTER_USER, "user");
-        conf.put(Config.TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS, true);
+        conf.put(Config.TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS, true);
 
         TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
             genExecsAndComps(stormToplogy), CURRENT_TIME, "user");

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
@@ -332,7 +332,7 @@ public class TestGenericResourceAwareStrategy {
         conf.put(Config.TOPOLOGY_NAME, "testTopology");
         conf.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, Double.MAX_VALUE);
         conf.put(Config.TOPOLOGY_SUBMITTER_USER, "user");
-        conf.put(Config.TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS, true);
+        conf.put(Config.TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS, true);
 
         TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
             genExecsAndComps(stormToplogy), currentTime, "user");

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
@@ -332,7 +332,7 @@ public class TestGenericResourceAwareStrategy {
         conf.put(Config.TOPOLOGY_NAME, "testTopology");
         conf.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, Double.MAX_VALUE);
         conf.put(Config.TOPOLOGY_SUBMITTER_USER, "user");
-        conf.put(Config.TOPOLOGY_RAS_SCHEDULE_EXECUTORS_BY_PROXIMITY_NEEDS, true);
+        conf.put(Config.TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS, true);
 
         TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
             genExecsAndComps(stormToplogy), currentTime, "user");


### PR DESCRIPTION
## What is the purpose of the change

This change provides an option to schedule executors based on network-proximity based topological order.

This is a re-work from @Ethanlm's previous PR #2623

This PR only provides this new sorting algorithm as a configurable option. Per Ethan's previous plan, we will remove this config and integrate this sorting method to our current default method as a follow-up once we decide to completely replace current executors sorting method with this new algorithm.

## How was the change tested

A simple wordcount test:

![Screen Shot 2020-05-07 at 11 51 47 PM](https://user-images.githubusercontent.com/15622046/81372329-b0f1a080-90bf-11ea-83bb-92e45a883f51.png)
