### PR TITLE
STORM-3634 validate numa ports contained in supervisor.slots.ports

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/ReadClusterState.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import org.apache.storm.DaemonConfig;
 import org.apache.storm.cluster.IStormClusterState;
 import org.apache.storm.daemon.supervisor.Slot.MachineState;
 import org.apache.storm.daemon.supervisor.Slot.TopoProfileAction;
@@ -98,9 +97,9 @@ public class ReadClusterState implements Runnable, AutoCloseable {
         }
 
         @SuppressWarnings("unchecked")
-        List<Number> ports = (List<Number>) superConf.get(DaemonConfig.SUPERVISOR_SLOTS_PORTS);
-        for (Number port : ports) {
-            slots.put(port.intValue(), mkSlot(port.intValue()));
+        List<Integer> ports = SupervisorUtils.getSlotsPorts(superConf);
+        for (Integer port : ports) {
+            slots.put(port, mkSlot(port));
         }
 
         try {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
@@ -67,6 +67,7 @@ import org.apache.storm.daemon.logviewer.utils.ExceptionMeterNames;
 import org.apache.storm.daemon.logviewer.utils.LogviewerResponseBuilder;
 import org.apache.storm.daemon.logviewer.utils.ResourceAuthorizer;
 import org.apache.storm.daemon.logviewer.utils.WorkerLogs;
+import org.apache.storm.daemon.supervisor.SupervisorUtils;
 import org.apache.storm.daemon.ui.InvalidRequestException;
 import org.apache.storm.daemon.utils.StreamUtil;
 import org.apache.storm.daemon.utils.UrlBuilder;
@@ -259,8 +260,7 @@ public class LogviewerLogSearchHandler {
                 int port = Integer.parseInt(portStr);
                 // check just the one port
                 @SuppressWarnings("unchecked")
-                List<Integer> slotsPorts = (List<Integer>) stormConf.getOrDefault(DaemonConfig.SUPERVISOR_SLOTS_PORTS,
-                    new ArrayList<>());
+                List<Integer> slotsPorts = SupervisorUtils.getSlotsPorts(stormConf);
                 boolean containsPort = slotsPorts.stream()
                     .anyMatch(slotPort -> slotPort != null && (slotPort == port));
                 if (!containsPort) {


### PR DESCRIPTION
## What is the purpose of the change

It's currently possible to have a numa port configured that is not in supervisor.slots.ports.  When a supervisor restarts, any worker running on numa ports not in supervisor.slots.ports will be killed.  We should consider this an invalid configuration.

## How was the change tested

Tested starting up a supervisor with no numa ports and numa ports matching supervisor.slots.ports successfully.  Verified supervisor with numa ports not in supervisor.slots.ports fails to start.