### PR TITLE
[STORM-3636] Enable SSL credentials auto reload

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -483,6 +483,12 @@ public class DaemonConfig implements Validated {
     public static final String LOGVIEWER_HTTPS_NEED_CLIENT_AUTH = "logviewer.https.need.client.auth";
 
     /**
+     * If set to true, keystore and truststore for Logviewer will be automatically reloaded when modified.
+     */
+    @IsBoolean
+    public static final String LOGVIEWER_HTTPS_ENABLE_SSL_RELOAD = "logviewer.https.enable.ssl.reload";
+
+    /**
      * A list of users allowed to view logs via the Log Viewer.
      */
     @IsStringOrStringList
@@ -603,6 +609,12 @@ public class DaemonConfig implements Validated {
     public static final String UI_HTTPS_NEED_CLIENT_AUTH = "ui.https.need.client.auth";
 
     /**
+     * If set to true, keystore and truststore for UI will be automatically reloaded when modified.
+     */
+    @IsBoolean
+    public static final String UI_HTTPS_ENABLE_SSL_RELOAD = "ui.https.enable.ssl.reload";
+
+    /**
      * The maximum number of threads that should be used by the Pacemaker. When Pacemaker gets loaded it will spawn new threads, up to this
      * many total, to handle the load.
      */
@@ -686,6 +698,12 @@ public class DaemonConfig implements Validated {
 
     @IsBoolean
     public static final String DRPC_HTTPS_NEED_CLIENT_AUTH = "drpc.https.need.client.auth";
+
+    /**
+     * If set to true, keystore and truststore for DRPC Server will be automatically reloaded when modified.
+     */
+    @IsBoolean
+    public static final String DRPC_HTTPS_ENABLE_SSL_RELOAD = "drpc.https.enable.ssl.reload";
 
     /**
      * Class name for authorization plugin for DRPC client.

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/FileWatcher.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/FileWatcher.java
@@ -54,7 +54,7 @@ public class FileWatcher implements Runnable {
     }
 
     public void start() {
-        Thread t = new Thread(this);
+        Thread t = new Thread(this, "FileWatcher-" + watchedFile.getFileName());
         t.setDaemon(true);
         LOG.info("Starting FileWatcher on {}", watchedFile);
         t.start();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/FileWatcher.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/FileWatcher.java
@@ -1,3 +1,15 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package org.apache.storm.daemon.common;
 
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/FileWatcher.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/FileWatcher.java
@@ -1,13 +1,19 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
- * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
  */
 
 package org.apache.storm.daemon.common;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/FileWatcher.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/FileWatcher.java
@@ -1,0 +1,78 @@
+package org.apache.storm.daemon.common;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.Collections;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileWatcher implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileWatcher.class);
+
+    private final WatchService watcher;
+    private volatile boolean stopped = false;
+    private final Path watchedFile;
+    private final Callback callback;
+    List<WatchEvent.Kind<Path>> kinds;
+
+    public FileWatcher(final Path watchedFile, Callback callback) throws IOException {
+        this(watchedFile, callback, Collections.singletonList(ENTRY_MODIFY));
+    }
+
+    public FileWatcher(final Path watchedFile, Callback callback, List<WatchEvent.Kind<Path>> kinds) throws IOException {
+        this.watchedFile = watchedFile;
+        this.callback = callback;
+        Path parent = watchedFile.getParent();
+        this.watcher = parent.getFileSystem().newWatchService();
+        this.kinds = kinds;
+        parent.register(watcher, this.kinds.toArray(new WatchEvent.Kind[0]));
+    }
+
+    public void start() {
+        Thread t = new Thread(this);
+        t.setDaemon(true);
+        LOG.info("Starting FileWatcher on {}", watchedFile);
+        t.start();
+    }
+
+    public void stop() {
+        LOG.info("Stopping FileWatcher on {}", watchedFile);
+        this.stopped = true;
+    }
+
+    @Override
+    public void run() {
+        while (!stopped) {
+            WatchKey watchKey;
+            try {
+                watchKey = watcher.take();
+            } catch (InterruptedException ex) {
+                LOG.warn("FileWatch for {} is interrupted", watchedFile, ex);
+                Thread.currentThread().interrupt();
+                return;
+            }
+            for (WatchEvent<?> event : watchKey.pollEvents()) {
+                if (this.kinds.contains(event.kind()) && event.context().equals(watchedFile.getFileName())) {
+                    try {
+                        LOG.info("Event {} on {}; invoking callback", event.kind(), watchedFile);
+                        callback.run();
+                    } catch (Exception ex) {
+                        LOG.error("Error invoking FileWatcher callback for {}", watchedFile, ex);
+                    }
+                }
+            }
+            watchKey.reset();
+        }
+    }
+
+    public interface Callback {
+        void run() throws Exception;
+    }
+}

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/ReloadableSslContextFactory.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/ReloadableSslContextFactory.java
@@ -1,6 +1,17 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 package org.apache.storm.daemon.common;
 
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/ReloadableSslContextFactory.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/ReloadableSslContextFactory.java
@@ -1,0 +1,67 @@
+package org.apache.storm.daemon.common;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReloadableSslContextFactory extends SslContextFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReloadableSslContextFactory.class);
+
+    private boolean enableSslReload;
+    private FileWatcher keyStoreWatcher;
+    private FileWatcher trustStoreWatcher;
+
+    public ReloadableSslContextFactory() {
+        this(false);
+    }
+
+    public ReloadableSslContextFactory(boolean enableSslReload) {
+        this.enableSslReload = enableSslReload;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        if (enableSslReload) {
+            LOG.info("Enabling reloading of SSL credentials without server restart");
+
+            String keyStorePathStr = getKeyStorePath();
+            if (keyStorePathStr != null) {
+                Path keyStorePath = Paths.get(URI.create(keyStorePathStr).getPath());
+                FileWatcher.Callback keyStoreWatcherCallback = () ->
+                    ReloadableSslContextFactory.this.reload((scf) -> LOG.info("Reloading SslContextFactory due to keystore change"));
+                keyStoreWatcher = new FileWatcher(keyStorePath, keyStoreWatcherCallback);
+                keyStoreWatcher.start();
+            } else {
+                LOG.warn("KeyStore is null; it won't be watched/reloaded");
+            }
+
+            String trustStorePathStr = getTrustStorePath();
+            if (trustStorePathStr != null) {
+                Path trustStorePath = Paths.get(URI.create(trustStorePathStr).getPath());
+                FileWatcher.Callback trustStoreWatcherCallback = () ->
+                    ReloadableSslContextFactory.this.reload((scf) -> LOG.info("Reloading SslContextFactory due to truststore change"));
+                trustStoreWatcher = new FileWatcher(trustStorePath, trustStoreWatcherCallback);
+                trustStoreWatcher.start();
+            } else {
+                LOG.warn("TrustStore is null; it won't be watched/reloaded");
+            }
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        if (keyStoreWatcher != null) {
+            keyStoreWatcher.stop();
+        }
+        if (trustStoreWatcher != null) {
+            trustStoreWatcher.stop();
+        }
+        super.doStop();
+    }
+}

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/ReloadableSslContextFactory.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/ReloadableSslContextFactory.java
@@ -1,13 +1,19 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
- * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
  */
 
 package org.apache.storm.daemon.common;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
@@ -104,13 +104,14 @@ public class DRPCServer implements AutoCloseable {
             final Boolean httpsWantClientAuth = (Boolean) (conf.get(DaemonConfig.DRPC_HTTPS_WANT_CLIENT_AUTH));
             final Boolean httpsNeedClientAuth = (Boolean) (conf.get(DaemonConfig.DRPC_HTTPS_NEED_CLIENT_AUTH));
             final Boolean disableHttpBinding = (Boolean) (conf.get(DaemonConfig.DRPC_DISABLE_HTTP_BINDING));
+            final boolean enableSslReload = ObjectReader.getBoolean(conf.get(DaemonConfig.DRPC_HTTPS_ENABLE_SSL_RELOAD), false);
 
             //TODO a better way to do this would be great.
             DRPCApplication.setup(drpc, metricsRegistry);
             ret = UIHelpers.jettyCreateServer(drpcHttpPort, null, httpsPort, disableHttpBinding);
             
             UIHelpers.configSsl(ret, httpsPort, httpsKsPath, httpsKsPassword, httpsKsType, httpsKeyPassword,
-                    httpsTsPath, httpsTsPassword, httpsTsType, httpsNeedClientAuth, httpsWantClientAuth);
+                    httpsTsPath, httpsTsPassword, httpsTsType, httpsNeedClientAuth, httpsWantClientAuth, enableSslReload);
             
             ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
             context.setContextPath("/");

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
@@ -85,12 +85,14 @@ public class LogviewerServer implements AutoCloseable {
             final Boolean httpsWantClientAuth = (Boolean) (conf.get(DaemonConfig.LOGVIEWER_HTTPS_WANT_CLIENT_AUTH));
             final Boolean httpsNeedClientAuth = (Boolean) (conf.get(DaemonConfig.LOGVIEWER_HTTPS_NEED_CLIENT_AUTH));
             final Boolean disableHttpBinding = (Boolean) (conf.get(DaemonConfig.LOGVIEWER_DISABLE_HTTP_BINDING));
+            final boolean enableSslReload = ObjectReader.getBoolean(conf.get(DaemonConfig.LOGVIEWER_HTTPS_ENABLE_SSL_RELOAD), false);
+
 
             LogviewerApplication.setup(conf, metricsRegistry);
             ret = UIHelpers.jettyCreateServer(logviewerHttpPort, null, httpsPort, disableHttpBinding);
 
             UIHelpers.configSsl(ret, httpsPort, httpsKsPath, httpsKsPassword, httpsKsType, httpsKeyPassword,
-                    httpsTsPath, httpsTsPassword, httpsTsType, httpsNeedClientAuth, httpsWantClientAuth);
+                    httpsTsPath, httpsTsPassword, httpsTsType, httpsNeedClientAuth, httpsWantClientAuth, enableSslReload);
 
             ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
             try {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -47,6 +47,7 @@ import javax.ws.rs.core.SecurityContext;
 import org.apache.storm.Config;
 import org.apache.storm.Constants;
 import org.apache.storm.DaemonConfig;
+import org.apache.storm.daemon.common.ReloadableSslContextFactory;
 import org.apache.storm.generated.Bolt;
 import org.apache.storm.generated.BoltAggregateStats;
 import org.apache.storm.generated.ClusterSummary;
@@ -230,8 +231,8 @@ public class UIHelpers {
                                                   String keyPassword, String tsPath,
                                                   String tsPassword, String tsType,
                                                   Boolean needClientAuth, Boolean wantClientAuth,
-                                                  Integer headerBufferSize) {
-        SslContextFactory factory = new SslContextFactory();
+                                                  Integer headerBufferSize, boolean enableSslReload) {
+        SslContextFactory factory = new ReloadableSslContextFactory(enableSslReload);
         factory.setExcludeCipherSuites("SSL_RSA_WITH_RC4_128_MD5", "SSL_RSA_WITH_RC4_128_SHA");
         factory.setExcludeProtocols("SSLv3");
         factory.setRenegotiationAllowed(false);
@@ -270,9 +271,9 @@ public class UIHelpers {
                                  String ksPassword, String ksType,
                                  String keyPassword, String tsPath,
                                  String tsPassword, String tsType,
-                                 Boolean needClientAuth, Boolean wantClientAuth) {
+                                 Boolean needClientAuth, Boolean wantClientAuth, boolean enableSslReload) {
         configSsl(server, port, ksPath, ksPassword, ksType, keyPassword,
-                  tsPath, tsPassword, tsType, needClientAuth, wantClientAuth, null);
+                  tsPath, tsPassword, tsType, needClientAuth, wantClientAuth, null, enableSslReload);
     }
 
     /**
@@ -289,19 +290,21 @@ public class UIHelpers {
      * @param needClientAuth needClientAuth
      * @param wantClientAuth wantClientAuth
      * @param headerBufferSize headerBufferSize
+     * @param enableSslReload enable ssl reload
      */
     public static void configSsl(Server server, Integer port, String ksPath,
                                  String ksPassword, String ksType,
                                  String keyPassword, String tsPath,
                                  String tsPassword, String tsType,
                                  Boolean needClientAuth,
-                                 Boolean wantClientAuth, Integer headerBufferSize) {
+                                 Boolean wantClientAuth, Integer headerBufferSize,
+                                 boolean enableSslReload) {
         if (port > 0) {
             server.addConnector(
                     mkSslConnector(
                             server, port, ksPath, ksPassword, ksType, keyPassword,
                             tsPath, tsPassword, tsType,
-                            needClientAuth, wantClientAuth, headerBufferSize
+                            needClientAuth, wantClientAuth, headerBufferSize, enableSslReload
                     )
             );
         }

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIServer.java
@@ -96,13 +96,14 @@ public class UIServer {
         final Boolean httpsWantClientAuth = (Boolean) (conf.get(DaemonConfig.UI_HTTPS_WANT_CLIENT_AUTH));
         final Boolean httpsNeedClientAuth = (Boolean) (conf.get(DaemonConfig.UI_HTTPS_NEED_CLIENT_AUTH));
         final Boolean disableHttpBinding = (Boolean) (conf.get(DaemonConfig.UI_DISABLE_HTTP_BINDING));
+        final boolean enableSslReload = ObjectReader.getBoolean(conf.get(DaemonConfig.UI_HTTPS_ENABLE_SSL_RELOAD), false);
 
         Server jettyServer =
                 UIHelpers.jettyCreateServer(
                         (int) conf.get(DaemonConfig.UI_PORT), null, httpsPort, headerBufferSize, disableHttpBinding);
 
         UIHelpers.configSsl(jettyServer, httpsPort, httpsKsPath, httpsKsPassword, httpsKsType, httpsKeyPassword,
-                httpsTsPath, httpsTsPassword, httpsTsType, httpsNeedClientAuth, httpsWantClientAuth);
+                httpsTsPath, httpsTsPassword, httpsTsType, httpsNeedClientAuth, httpsWantClientAuth, enableSslReload);
 
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
         context.setContextPath("/");


### PR DESCRIPTION
## What is the purpose of the change

This enables ssl auto reload without restarting servers.

## How was the change tested

Tested with replacing keystore with empty file and replace back. 
Example:
1. At start up:
```
2020-05-13 14:55:11.896 o.a.s.d.c.ReloadableSslContextFactory main [INFO] Enabling reloading of SSL credentials without server restart
2020-05-13 14:55:11.921 o.a.s.d.c.FileWatcher main [INFO] Starting FileWatcher on <keystore-path>
2020-05-13 14:55:11.923 o.a.s.d.c.ReloadableSslContextFactory main [WARN] TrustStore is null; it won't be watched/reloaded
2020-05-13 14:55:11.928 o.e.j.s.AbstractConnector main [INFO] Started ServerConnector@2b2954e1{SSL,[ssl, http/1.1]}{0.0.0.0:4443}
2020-05-13 14:55:11.928 o.e.j.s.Server main [INFO] Started @4645ms
```

2. Replace the keystore with a empty file 
```
2020-05-13 14:55:39.962 o.a.s.d.c.FileWatcher Thread-17 [INFO] Event ENTRY_MODIFY on <keystore-path>; invoking callback
2020-05-13 14:55:39.964 o.a.s.d.c.ReloadableSslContextFactory Thread-17 [INFO] Reloading SslContextFactory due to keystore change
2020-05-13 14:55:39.964 o.a.s.d.c.FileWatcher Thread-17 [ERROR] Error invoking FileWatcher callback for <keystore-path>
java.io.IOException: Short read of DER length
        at sun.security.util.DerInputStream.getLength(DerInputStream.java:582) ~[?:1.8.0_242]
        at sun.security.util.DerValue.init(DerValue.java:391) ~[?:1.8.0_242]
        at sun.security.util.DerValue.<init>(DerValue.java:332) ~[?:1.8.0_242]
        at sun.security.util.DerValue.<init>(DerValue.java:345) ~[?:1.8.0_242]
        at sun.security.pkcs12.PKCS12KeyStore.engineLoad(PKCS12KeyStore.java:1938) ~[?:1.8.0_242]
        at java.security.KeyStore.load(KeyStore.java:1445) ~[?:1.8.0_242]
        at org.eclipse.jetty.util.security.CertificateUtils.getKeyStore(CertificateUtils.java:54) ~[jetty-util-9.4.14.v20181114.jar:9.4.14.v20181114]
```
3. Replace it back:
```
2020-05-13 14:56:00.860 o.a.s.d.c.FileWatcher Thread-17 [INFO] Event ENTRY_MODIFY on <keystore-path>; invoking callback
2020-05-13 14:56:00.860 o.a.s.d.c.ReloadableSslContextFactory Thread-17 [INFO] Reloading SslContextFactory due to keystore change
2020-05-13 14:56:01.097 o.e.j.u.s.SslContextFactory Thread-17 [INFO] x509=X509@e1871c7(<cert>,h=[],w=[<domain>]) for ReloadableSslContextFactory@1192b58e[provider=null,keyStore=file://<keystore-path>,trustStore=null]
```

The same test was done with TrustStore too.




