### PR TITLE
MINOR PATCH: Avoid fragmented resources on supervisor creation in nimbus

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2920,7 +2920,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                                                       (int) info.get_uptime_secs(), numPorts, numUsedPorts, supervisorId);
         ret.set_total_resources(info.get_resources_map());
         SupervisorResources resources = nodeIdToResources.get().get(supervisorId);
-        if (resources != null) {
+        if (resources != null && underlyingScheduler instanceof ResourceAwareScheduler) {
             ret.set_used_mem(resources.getUsedMem());
             ret.set_used_cpu(resources.getUsedCpu());
             ret.set_used_generic_resources(resources.getUsedGenericResources());
@@ -3019,7 +3019,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 summary.set_sched_status(status);
             }
             TopologyResources resources = getResourcesForTopology(topoId, base);
-            if (resources != null) {
+            if (resources != null  && underlyingScheduler instanceof ResourceAwareScheduler) {
                 summary.set_requested_memonheap(resources.getRequestedMemOnHeap());
                 summary.set_requested_memoffheap(resources.getRequestedMemOffHeap());
                 summary.set_requested_cpu(resources.getRequestedCpu());
@@ -4110,7 +4110,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 topoInfo.set_sched_status(schedStatus);
             }
             TopologyResources resources = getResourcesForTopology(topoId, common.base);
-            if (resources != null) {
+            if (resources != null && underlyingScheduler instanceof ResourceAwareScheduler) {
                 topoInfo.set_requested_memonheap(resources.getRequestedMemOnHeap());
                 topoInfo.set_requested_memoffheap(resources.getRequestedMemOffHeap());
                 topoInfo.set_requested_cpu(resources.getRequestedCpu());
@@ -4210,7 +4210,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 topoPageInfo.set_sched_status(schedStatus);
             }
             TopologyResources resources = getResourcesForTopology(topoId, base);
-            if (resources != null) {
+            if (resources != null && underlyingScheduler instanceof ResourceAwareScheduler) {
                 topoPageInfo.set_requested_memonheap(resources.getRequestedMemOnHeap());
                 topoPageInfo.set_requested_memoffheap(resources.getRequestedMemOffHeap());
                 topoPageInfo.set_requested_cpu(resources.getRequestedCpu());


### PR DESCRIPTION
## What is the purpose of the change
If the underlying scheduler is not _ResourceAwareScheduler_ and scheduler has no resources to register, then it does not have to calculate or report  any resources.

*(Explain why we should have this change)*

## How was the change tested
local unit tests.

*(Explain what tests did you do to verify the code change)*