### PR TITLE
[STORM-3650] Add topology config to attempt to schedule system component evenly throughout workers

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -254,6 +254,7 @@ topology.enable.message.timeouts: true
 topology.debug: false
 topology.workers: 1
 topology.acker.executors: null
+topology.ras.acker.executors.per.worker: 1
 topology.eventlogger.executors: 0
 topology.tasks: null
 # maximum amount of time a message has to complete before it's considered failed

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -409,14 +409,41 @@ public class Config extends HashMap<String, Object> {
     /**
      * How many executors to spawn for ackers.
      *
-     * <p>By not setting this variable or setting it as null, Storm will set the number of acker executors to be equal to
-     * the number of workers configured for this topology (or the estimated number of workers if the Resource Aware Scheduler is used).
-     * If this variable is set to 0, then Storm will immediately ack tuples as soon as they come off the spout,
-     * effectively disabling reliability.</p>
+     * <p>
+     * 1. If not setting this variable or setting it as null,
+     *   a. If RAS is not used:
+     *        Nimbus will set it to {@link Config#TOPOLOGY_WORKERS}.
+     *   b. If RAS is used:
+     *        Nimbus will set it to (the estimate number of workers *  {@link Config#TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER}).
+     *        {@link Config#TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER} is default to be 1 if not set.
+     * 2. If this variable is set to 0,
+     *    then Storm will immediately ack tuples as soon as they come off the spout,
+     *    effectively disabling reliability.
+     * 3. If this variable is set to a positive integer,
+     *    Storm will not honor {@link Config#TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER} setting.
+     *    Instead, nimbus will set it as (this variable / estimate num of workers).
+     * </p>
      */
     @IsInteger
     @IsPositiveNumber(includeZero = true)
     public static final String TOPOLOGY_ACKER_EXECUTORS = "topology.acker.executors";
+
+    /**
+     * How many ackers to put in when launching a new worker until we run out of ackers.
+     *
+     * <p>
+     * This setting is RAS specific.
+     * If {@link Config#TOPOLOGY_ACKER_EXECUTORS} is not configured,
+     * this setting will be used to calculate {@link Config#TOPOLOGY_ACKER_EXECUTORS}.
+     *
+     * If {@link Config#TOPOLOGY_ACKER_EXECUTORS} is configured,
+     * nimbus will ignore this and set it as ({@link Config#TOPOLOGY_ACKER_EXECUTORS} / estimate num of workers).
+     * </p>
+     */
+    @IsInteger
+    @IsPositiveNumber(includeZero = true)
+    public static final String TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER = "topology.ras.acker.executors.per.worker";
+
     /**
      * A list of classes implementing IEventLogger (See storm.yaml.example for exact config format). Each listed class will be routed all
      * the events sampled from emitting tuples. If there's no class provided to the option, default event logger will be initialized and

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1657,42 +1657,6 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                                      basicSupervisorDetailsMap(clusterState), metricsRegistry);
     }
 
-    @VisibleForTesting
-    static void validateTopologyWorkerMaxHeapSizeConfigs(
-        Map<String, Object> stormConf, StormTopology topology, double defaultWorkerMaxHeapSizeMb) throws InvalidTopologyException {
-        double largestMemReq = getMaxExecutorMemoryUsageForTopo(topology, stormConf);
-        double topologyWorkerMaxHeapSize =
-            ObjectReader.getDouble(stormConf.get(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB), defaultWorkerMaxHeapSizeMb);
-        if (topologyWorkerMaxHeapSize < largestMemReq) {
-            throw new InvalidTopologyException(
-                "Topology will not be able to be successfully scheduled: Config "
-                + "TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB="
-                + topologyWorkerMaxHeapSize
-                + " < " + largestMemReq + " (Largest memory requirement of a component in the topology)."
-                + " Perhaps set TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB to a larger amount");
-        }
-    }
-
-    private static double getMaxExecutorMemoryUsageForTopo(
-        StormTopology topology, Map<String, Object> topologyConf) {
-        double largestMemoryOperator = 0.0;
-        for (NormalizedResourceRequest entry :
-            ResourceUtils.getBoltsResources(topology, topologyConf).values()) {
-            double memoryRequirement = entry.getTotalMemoryMb();
-            if (memoryRequirement > largestMemoryOperator) {
-                largestMemoryOperator = memoryRequirement;
-            }
-        }
-        for (NormalizedResourceRequest entry :
-            ResourceUtils.getSpoutsResources(topology, topologyConf).values()) {
-            double memoryRequirement = entry.getTotalMemoryMb();
-            if (memoryRequirement > largestMemoryOperator) {
-                largestMemoryOperator = memoryRequirement;
-            }
-        }
-        return largestMemoryOperator;
-    }
-
     Map<String, Object> getConf() {
         return conf;
     }
@@ -1725,10 +1689,10 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
 
     private Set<List<Integer>> getOrUpdateExecutors(String topoId, StormBase base, Map<String, Object> topoConf,
                                                     StormTopology topology)
-        throws IOException, AuthorizationException, InvalidTopologyException, KeyNotFoundException {
+        throws InvalidTopologyException {
         Set<List<Integer>> executors = idToExecutors.get().get(topoId);
         if (null == executors) {
-            executors = new HashSet<>(computeExecutors(topoId, base, topoConf, topology));
+            executors = new HashSet<>(computeExecutors(base, topoConf, topology));
             idToExecutors.getAndUpdate(new Assoc<>(topoId, executors));
         }
         return executors;
@@ -2038,9 +2002,10 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         return heartbeatsCache.getAliveExecutors(topoId, allExecutors, assignment, getTopologyLaunchHeartbeatTimeoutSec(topoId));
     }
 
-    private List<List<Integer>> computeExecutors(String topoId, StormBase base, Map<String, Object> topoConf,
+    private List<List<Integer>> computeExecutors(StormBase base, Map<String, Object> topoConf,
                                                  StormTopology topology)
-        throws KeyNotFoundException, AuthorizationException, IOException, InvalidTopologyException {
+        throws InvalidTopologyException {
+
         assert (base != null);
 
         Map<String, Integer> compToExecutors = base.get_component_executors();
@@ -2049,11 +2014,12 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             Map<Integer, String> taskInfo = StormCommon.stormTaskInfo(topology, topoConf);
             Map<String, List<Integer>> compToTaskList = Utils.reverseMap(taskInfo);
             for (Entry<String, List<Integer>> entry : compToTaskList.entrySet()) {
-                List<Integer> comps = entry.getValue();
-                comps.sort(null);
-                Integer numExecutors = compToExecutors.get(entry.getKey());
+                String compId = entry.getKey();
+                List<Integer> tasks = entry.getValue();
+                tasks.sort(null);
+                Integer numExecutors = compToExecutors.get(compId);
                 if (numExecutors != null) {
-                    List<List<Integer>> partitioned = Utils.partitionFixed(numExecutors, comps);
+                    List<List<Integer>> partitioned = Utils.partitionFixed(numExecutors, tasks);
                     for (List<Integer> partition : partitioned) {
                         ret.add(Arrays.asList(partition.get(0), partition.get(partition.size() - 1)));
                     }
@@ -2065,7 +2031,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
 
     private Map<List<Integer>, String> computeExecutorToComponent(String topoId, StormBase base,
                                                                   Map<String, Object> topoConf, StormTopology topology)
-        throws KeyNotFoundException, AuthorizationException, InvalidTopologyException, IOException {
+        throws InvalidTopologyException {
         List<List<Integer>> executors = new ArrayList<>(getOrUpdateExecutors(topoId, base, topoConf, topology));
         Map<Integer, String> taskToComponent = StormCommon.stormTaskInfo(topology, topoConf);
         Map<List<Integer>, String> ret = new HashMap<>();
@@ -2649,7 +2615,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
 
     private void startTopology(String topoName, String topoId, TopologyStatus initStatus, String owner,
                                String principal, Map<String, Object> topoConf, StormTopology stormTopology)
-        throws KeyNotFoundException, AuthorizationException, IOException, InvalidTopologyException {
+        throws InvalidTopologyException {
         assert (TopologyStatus.ACTIVE == initStatus || TopologyStatus.INACTIVE == initStatus);
         Map<String, Integer> numExecutors = new HashMap<>();
         StormTopology topology = StormCommon.systemTopology(topoConf, stormTopology);
@@ -2672,7 +2638,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         IStormClusterState state = stormClusterState;
         state.activateStorm(topoId, base, topoConf);
         idToExecutors.getAndUpdate(new Assoc<>(topoId,
-            new HashSet<>(computeExecutors(topoId, base, topoConf, stormTopology))));
+            new HashSet<>(computeExecutors(base, topoConf, stormTopology))));
         notifyTopologyActionListener(topoName, "activate");
     }
 
@@ -3177,7 +3143,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                                                        + Config.TOPOLOGY_BLOBSTORE_MAP + " = " + blobMap);
                 }
             }
-            validateTopologyWorkerMaxHeapSizeConfigs(topoConf, topology,
+            ServerUtils.validateTopologyWorkerMaxHeapSizeConfigs(topoConf, topology,
                                                      ObjectReader.getDouble(conf.get(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB)));
             Utils.validateTopologyBlobStoreMap(topoConf, blobStore);
             long uniqueNum = submittedCount.incrementAndGet();
@@ -3240,14 +3206,15 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             // we might need to set the number of acker executors and eventlogger executors to be the estimated number of workers.
             if (ServerUtils.isRas(conf)) {
                 int estimatedNumWorker = ServerUtils.getEstimatedWorkerCountForRasTopo(totalConf, topology);
-                int numAckerExecs = ObjectReader.getInt(totalConf.get(Config.TOPOLOGY_ACKER_EXECUTORS), estimatedNumWorker);
+
+                setUpAckerExecutorConfigs(topoName, totalConfToSave, totalConf, estimatedNumWorker);
+                ServerUtils.validateTopologyAckerBundleResource(totalConfToSave, topology, topoName);
+
                 int numEventLoggerExecs = ObjectReader.getInt(totalConf.get(Config.TOPOLOGY_EVENTLOGGER_EXECUTORS), estimatedNumWorker);
-
-                totalConfToSave.put(Config.TOPOLOGY_ACKER_EXECUTORS, numAckerExecs);
                 totalConfToSave.put(Config.TOPOLOGY_EVENTLOGGER_EXECUTORS, numEventLoggerExecs);
+                LOG.info("Config {} set to: {} for topology: {}",
+                    Config.TOPOLOGY_EVENTLOGGER_EXECUTORS, numEventLoggerExecs, topoName);
 
-                LOG.debug("{} set to: {}", Config.TOPOLOGY_ACKER_EXECUTORS, numAckerExecs);
-                LOG.debug("{} set to: {}", Config.TOPOLOGY_EVENTLOGGER_EXECUTORS, numEventLoggerExecs);
             }
 
             //Remove any configs that are specific to a host that might mess with the running topology.
@@ -3318,6 +3285,36 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             }
             throw new RuntimeException(e);
         }
+    }
+
+    @VisibleForTesting
+    public static void setUpAckerExecutorConfigs(String topoName, Map<String, Object> totalConfToSave,
+                                                 Map<String, Object> totalConf, int estimatedNumWorker) {
+
+        int numAckerExecs;
+        int numAckerExecsPerWorker;
+
+        if (totalConf.get(Config.TOPOLOGY_ACKER_EXECUTORS) == null) {
+            numAckerExecsPerWorker = ObjectReader.getInt(
+                totalConf.get(Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER));
+            numAckerExecs = estimatedNumWorker * numAckerExecsPerWorker;
+        } else {
+            numAckerExecs = ObjectReader.getInt(totalConf.get(Config.TOPOLOGY_ACKER_EXECUTORS));
+            if (estimatedNumWorker == 0) {
+                numAckerExecsPerWorker = 0;
+            } else {
+                numAckerExecsPerWorker = (int) Math.ceil((double) numAckerExecs / (double) estimatedNumWorker);
+            }
+        }
+
+        totalConfToSave.put(Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER, numAckerExecsPerWorker);
+        totalConfToSave.put(Config.TOPOLOGY_ACKER_EXECUTORS, numAckerExecs);
+
+        LOG.info("Config {} set to: {} for topology: {}",
+            Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER, numAckerExecsPerWorker, topoName);
+        LOG.info("Config {} set to: {} for topology: {}",
+            Config.TOPOLOGY_ACKER_EXECUTORS, numAckerExecs, topoName);
+
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/Cluster.java
@@ -109,10 +109,10 @@ public class Cluster implements ISchedulingState {
         INimbus nimbus,
         ResourceMetrics resourceMetrics,
         Map<String, SupervisorDetails> supervisors,
-        Map<String, ? extends SchedulerAssignment> map,
+        Map<String, ? extends SchedulerAssignment> assignments,
         Topologies topologies,
         Map<String, Object> conf) {
-        this(nimbus, resourceMetrics, supervisors, map, topologies, conf, null, null, null, null,
+        this(nimbus, resourceMetrics, supervisors, assignments, topologies, conf, null, null, null, null,
             Double.NaN, Double.NaN, null);
     }
 

--- a/storm-server/src/main/java/org/apache/storm/scheduler/ISchedulingState.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/ISchedulingState.java
@@ -19,7 +19,6 @@
 package org.apache.storm.scheduler;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/storm-server/src/main/java/org/apache/storm/scheduler/TopologyDetails.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/TopologyDetails.java
@@ -57,6 +57,8 @@ public class TopologyDetails {
     private Double topologyWorkerMaxHeapSize;
     //topology priority
     private Integer topologyPriority;
+    // Only contains user topology specific executors
+    private Map<String, Component> userTopologyComponentsMap;
 
     public TopologyDetails(String topologyId, Map<String, Object> topologyConf, StormTopology topology, int numWorkers, String owner) {
         this(topologyId, topologyConf, topology, numWorkers, null, 0, owner);
@@ -172,7 +174,7 @@ public class TopologyDetails {
         for (ExecutorDetails exec : getExecutors()) {
             if (!resourceList.containsKey(exec)) {
                 LOG.debug(
-                    "Scheduling {} {} with resource requirement as {}",
+                    "Scheduling component: {} executor: {} with resource requirement as {} {}",
                     getExecutorToComponent().get(exec),
                     exec,
                     topologyConf.get(Config.TOPOLOGY_COMPONENT_RESOURCES_ONHEAP_MEMORY_MB),
@@ -202,17 +204,30 @@ public class TopologyDetails {
     }
 
     /**
-     * Returns a representation of the non-system components of the topology graph Each Component object in the returning map is populated
+     * Returns a representation of the non-system components of the topology graph. Each Component object in the returning map is populated
      * with the list of its parents, children and execs assigned to that component.
      *
      * @return a map of components
      */
-    public Map<String, Component> getComponents() {
+    public Map<String, Component> getUserTopolgyComponents() {
+        if (userTopologyComponentsMap == null) {
+            userTopologyComponentsMap = computeComponentMap(this.topology);
+        }
+        return userTopologyComponentsMap;
+    }
+
+    /**
+     * Compute a map of user topology specific components.
+     *
+     * @param topology                 userTopology
+     * @return a map of Component Id to Component
+     */
+    private Map<String, Component> computeComponentMap(StormTopology topology) {
         Map<String, Component> ret = new HashMap<>();
 
         Map<String, SpoutSpec> spouts = topology.get_spouts();
         Map<String, Bolt> bolts = topology.get_bolts();
-        //Add in all of the components
+
         if (spouts != null) {
             for (Map.Entry<String, SpoutSpec> entry : spouts.entrySet()) {
                 String compId = entry.getKey();

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
@@ -22,12 +22,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.storm.Config;
 import org.apache.storm.DaemonConfig;
+import org.apache.storm.daemon.Acker;
 import org.apache.storm.scheduler.Cluster;
 import org.apache.storm.scheduler.ExecutorDetails;
 import org.apache.storm.scheduler.SchedulerAssignment;
@@ -178,6 +180,7 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
         maxSchedulingTimeMs = computeMaxSchedulingTimeMs(topoConf);
 
         // From Cluster and TopologyDetails - and cleaned-up
+        // all unassigned executors including system components execs
         unassignedExecutors = Collections.unmodifiableSet(new HashSet<>(cluster.getUnassignedExecutors(topologyDetails)));
         int confMaxStateSearch = getMaxStateSearchFromTopoConf(topologyDetails.getConf());
         int daemonMaxStateSearch = ObjectReader.getInt(cluster.getConf().get(DaemonConfig.RESOURCE_AWARE_SCHEDULER_MAX_STATE_SEARCH));
@@ -259,9 +262,18 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
                 compCnts.put(compId, compCnts.getOrDefault(compId, 0) + 1); // increment
             });
         }
+        LinkedList<ExecutorDetails> unassignedAckers = new LinkedList<>();
+        if (compToExecs.containsKey(Acker.ACKER_COMPONENT_ID)) {
+            for (ExecutorDetails acker : compToExecs.get(Acker.ACKER_COMPONENT_ID)) {
+                if (unassignedExecutors.contains(acker)) {
+                    unassignedAckers.add(acker);
+                }
+            }
+        }
 
         return new SchedulingSearcherState(workerCompCnts, nodeCompCnts,
-                maxStateSearch, maxSchedulingTimeMs, new ArrayList<>(unassignedExecutors), topologyDetails, execToComp);
+                maxStateSearch, maxSchedulingTimeMs, new ArrayList<>(unassignedExecutors),
+                unassignedAckers, topologyDetails, execToComp);
     }
 
     /**
@@ -381,7 +393,14 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
      * @return SchedulingResult with success attribute set to true or false indicting whether ALL executors were assigned.
      */
     protected SchedulingResult scheduleExecutorsOnNodes(List<ExecutorDetails> orderedExecutors, Iterable<String> sortedNodesIter) {
-        long         startTimeMilli     = System.currentTimeMillis();
+        // isolate ackers and put it to the end of orderedExecutors
+        // the order of unassigned ackers in orderedExecutors and searcherState.getUnassignedAckers() are same
+        orderedExecutors.removeAll(searcherState.getUnassignedAckers());
+        orderedExecutors.addAll(searcherState.getUnassignedAckers());
+        LOG.info("For topology: {}, we have sorted execs: {} and unassigned ackers: {}",
+                    topoName, orderedExecutors, searcherState.getUnassignedAckers());
+
+        long         startTimeMilli     = Time.currentTimeMillis();
         searcherState.setSortedExecs(orderedExecutors);
         int          maxExecCnt         = searcherState.getExecSize();
 
@@ -410,6 +429,24 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
 
             int execIndex = searcherState.getExecIndex();
             ExecutorDetails exec = searcherState.currentExec();
+
+            // If current exec is found in searcherState assigned Ackers,
+            // it means it has been assigned as a bound acker already.
+            // So we skip to the next.
+            if (searcherState.getBoundAckers().contains(exec)) {
+                if (searcherState.areAllExecsScheduled()) {
+                    //Everything is scheduled correctly, so no need to search any more.
+                    LOG.info("scheduleExecutorsOnNodes: Done at loopCnt={} in {}ms, state.elapsedtime={}, backtrackCnt={}, topo={}",
+                        loopCnt, Time.currentTimeMillis() - startTimeMilli,
+                        Time.currentTimeMillis() - searcherState.startTimeMillis,
+                        searcherState.getNumBacktrack(),
+                        topoName);
+                    return searcherState.createSchedulingResult(true, this.getClass().getSimpleName());
+                }
+                searcherState = searcherState.nextExecutor();
+                continue OUTERMOST_LOOP;
+            }
+
             String comp = execToComp.get(exec);
             if (sortedNodesIter == null || (this.sortNodesForEachExecutor && searcherState.isExecCompDifferentFromPrior())) {
                 progressIdx = -1;
@@ -428,16 +465,39 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
                     }
                     progressIdxForExec[execIndex]++;
 
+                    int numBoundAckerAssigned
+                        = assignBoundAckersForNewWorkerSlot(exec, node, workerSlot);
+                    if (numBoundAckerAssigned == -1) {
+                        // This only happens when trying to assign bound ackers to the worker slot and failed.
+                        // Free the entire worker slot and put those bound ackers back to unassigned list
+                        LOG.debug("Failed to assign bound acker for exec: {} of topo: {} to worker: {}.  Backtracking.",
+                            exec, topoName, workerSlot);
+                        searcherState.freeWorkerSlotWithBoundAckers(node, workerSlot);
+                        continue;
+                    }
+
                     if (!isExecAssignmentToWorkerValid(exec, workerSlot)) {
+                        // This only happens when this exec can not fit in the workerSlot
+                        // and this is not the first exec to this workerSlot.
+                        // So just go to next workerSlot and don't free the worker.
+                        if (numBoundAckerAssigned > 0) {
+                            LOG.debug("Failed to assign exec: {} of topo: {} with bound ackers to worker: {}.  Backtracking.",
+                                exec, topoName, workerSlot);
+                            searcherState.freeWorkerSlotWithBoundAckers(node, workerSlot);
+                        }
                         continue;
                     }
 
                     searcherState.incStatesSearched();
                     searcherState.assignCurrentExecutor(execToComp, node, workerSlot);
+                    if (numBoundAckerAssigned > 0) {
+                        // This exec with its bounded ackers have all been successfully assigned
+                        searcherState.getExecsWithBoundAckers().add(exec);
+                    }
                     if (searcherState.areAllExecsScheduled()) {
                         //Everything is scheduled correctly, so no need to search any more.
                         LOG.info("scheduleExecutorsOnNodes: Done at loopCnt={} in {}ms, state.elapsedtime={}, backtrackCnt={}, topo={}",
-                                loopCnt, System.currentTimeMillis() - startTimeMilli,
+                                loopCnt, Time.currentTimeMillis() - startTimeMilli,
                                 Time.currentTimeMillis() - searcherState.startTimeMillis,
                                 searcherState.getNumBacktrack(),
                                 topoName);
@@ -464,9 +524,46 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
         }
         boolean success = searcherState.areAllExecsScheduled();
         LOG.info("scheduleExecutorsOnNodes: Scheduled={} in {} milliseconds, state.elapsedtime={}, backtrackCnt={}, topo={}",
-                success, System.currentTimeMillis() - startTimeMilli, Time.currentTimeMillis() - searcherState.startTimeMillis,
+                success, Time.currentTimeMillis() - startTimeMilli, Time.currentTimeMillis() - searcherState.startTimeMillis,
                 searcherState.getNumBacktrack(),
                 topoName);
         return searcherState.createSchedulingResult(success, this.getClass().getSimpleName());
+    }
+
+    /**
+     * <p>
+     * Determine how many bound ackers to put into the given workerSlot.
+     * Then try to assign the ackers one by one into this workerSlot.
+     *
+     * Return -1 only if the bound ackers assignment process failed.
+     * Return 0 if one of the conditions hold true:
+     *  1. No bound ackers are used.
+     *  2. This is not first exec assigned to this worker.
+     * Return positive int if all bound ackers assignments succeed.
+     * </p>
+     * @param exec              being scheduled.
+     * @param node              RasNode on which to schedule.
+     * @param workerSlot        WorkerSlot on which to schedule.
+     * @return                  If we successfully assigned bound worker for this exec
+     */
+
+    private int assignBoundAckersForNewWorkerSlot(ExecutorDetails exec, RasNode node, WorkerSlot workerSlot) {
+        int numOfAckersToBind = searcherState.getNumOfAckersToBind(exec, workerSlot);
+        if (numOfAckersToBind > 0) {
+            for (int i = 0; i < numOfAckersToBind; i++) {
+                if (!isExecAssignmentToWorkerValid(searcherState.peekUnassignedAckers(), workerSlot)) {
+                    return -1;
+                } else {
+                    try {
+                        searcherState.assignSingleBoundAcker(node, workerSlot);
+                    } catch (Exception e) {
+                        LOG.error("Exception happens when assigning {}th acker executor to workerSlot: {} for topology: {}",
+                                    i, workerSlot, topoName, e);
+                        return -1;
+                    }
+                }
+            }
+        }
+        return numOfAckersToBind;
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/IStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/IStrategy.java
@@ -13,6 +13,7 @@
 package org.apache.storm.scheduler.resource.strategies.scheduling;
 
 import java.util.Map;
+
 import org.apache.storm.scheduler.Cluster;
 import org.apache.storm.scheduler.TopologyDetails;
 import org.apache.storm.scheduler.resource.SchedulingResult;
@@ -22,9 +23,10 @@ import org.apache.storm.scheduler.resource.SchedulingResult;
  * Scheduler should call {@link #prepare(Map)} followed by {@link #schedule(Cluster, TopologyDetails)}.
  * <p>
  *     A fully functioning implementation is in the abstract class {@link BaseResourceAwareStrategy}.
- *     Subclasses classes should extend {@link BaseResourceAwareStrategy#BaseResourceAwareStrategy()}
- *     in their constructors as in {@link GenericResourceAwareStrategy}, {@link DefaultResourceAwareStrategy})
- *     and {@link ConstraintSolverStrategy}.
+ *     Subclasses classes should extend
+ *     {@link BaseResourceAwareStrategy#BaseResourceAwareStrategy(boolean, BaseResourceAwareStrategy.NodeSortType)}
+ *     in their constructors (as in {@link GenericResourceAwareStrategy}, {@link DefaultResourceAwareStrategy}
+ *     and {@link ConstraintSolverStrategy}).
  * </p>
  */
 public interface IStrategy {

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/SchedulingSearcherState.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/SchedulingSearcherState.java
@@ -18,19 +18,25 @@
 
 package org.apache.storm.scheduler.resource.strategies.scheduling;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.apache.storm.Config;
+import org.apache.storm.daemon.Acker;
 import org.apache.storm.scheduler.ExecutorDetails;
 import org.apache.storm.scheduler.TopologyDetails;
 import org.apache.storm.scheduler.WorkerSlot;
 import org.apache.storm.scheduler.resource.RasNode;
 import org.apache.storm.scheduler.resource.SchedulingResult;
 import org.apache.storm.scheduler.resource.SchedulingStatus;
+import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +49,7 @@ public class SchedulingSearcherState {
     // A map of the worker to the components in the worker to be able to enforce constraints.
     private final Map<WorkerSlot, Map<String, Integer>> workerCompAssignmentCnts;
     private final boolean[] okToRemoveFromWorker;
-    // for the currently tested assignment a Map of the node to the components on it to be able to enforce constraints
+    // for the currently tested assignment a Map of the node to the components on it to be able to enforce constraints.
     private final Map<RasNode, Map<String, Integer>> nodeCompAssignmentCnts;
     private final boolean[] okToRemoveFromNode;
     // Static State
@@ -64,9 +70,24 @@ public class SchedulingSearcherState {
     private int execIndex = 0;
     private final Map<ExecutorDetails, String> execToComp;
 
+    private boolean oneExecutorPerWorker;
+    private boolean oneComponentPerWorker;
+    // acker distributions info
+    private int ackersPerWorker;
+
+    // unassigned acker was also appended at the end of execs
+    // the order of this unassigned ackers list must be maintained on backtracking
+    private LinkedList<ExecutorDetails> unassignedAckers;
+    // ackers that not treated as common executors
+    private Set<ExecutorDetails> boundAckers;
+    private Map<WorkerSlot, List<ExecutorDetails>> workerSlotToBoundAckers;
+
+    private Set<ExecutorDetails> execsWithBoundAckers;
+
     public SchedulingSearcherState(Map<WorkerSlot, Map<String, Integer>> workerCompAssignmentCnts,
                                     Map<RasNode, Map<String, Integer>> nodeCompAssignmentCnts, int maxStatesSearched, long maxTimeMs,
-                                    List<ExecutorDetails> execs, TopologyDetails td, Map<ExecutorDetails, String> execToComp) {
+                                    List<ExecutorDetails> execs, LinkedList<ExecutorDetails> unassignedAckers,
+                                    TopologyDetails td, Map<ExecutorDetails, String> execToComp) {
         assert execs != null;
 
         this.workerCompAssignmentCnts = workerCompAssignmentCnts;
@@ -84,6 +105,16 @@ public class SchedulingSearcherState {
             maxEndTimeMs = startTimeMillis + maxTimeMs;
         }
         this.execToComp = execToComp;
+
+        this.oneExecutorPerWorker = ObjectReader.getBoolean(td.getConf().get(Config.TOPOLOGY_RAS_ONE_EXECUTOR_PER_WORKER), false);
+        this.oneComponentPerWorker =  ObjectReader.getBoolean(td.getConf().get(Config.TOPOLOGY_RAS_ONE_COMPONENT_PER_WORKER), false);
+
+        this.unassignedAckers = unassignedAckers;
+        this.boundAckers = new HashSet<>();
+        this.ackersPerWorker = ObjectReader.getInt(
+            td.getConf().get(Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER), 1);
+        this.workerSlotToBoundAckers = new HashMap<>();
+        this.execsWithBoundAckers = new HashSet<>();
     }
 
     /**
@@ -131,6 +162,30 @@ public class SchedulingSearcherState {
         return execIndex;
     }
 
+    public int getAckersPerWorker() {
+        return ackersPerWorker;
+    }
+
+    public LinkedList<ExecutorDetails> getUnassignedAckers() {
+        return unassignedAckers;
+    }
+
+    public ExecutorDetails peekUnassignedAckers() {
+        return unassignedAckers.peek();
+    }
+
+    public Set<ExecutorDetails> getBoundAckers() {
+        return boundAckers;
+    }
+
+    public Set<ExecutorDetails> getExecsWithBoundAckers() {
+        return execsWithBoundAckers;
+    }
+
+    public Map<WorkerSlot, List<ExecutorDetails>> getWorkerSlotToBoundAckers() {
+        return workerSlotToBoundAckers;
+    }
+
     public boolean areSearchLimitsExceeded() {
         return statesSearched > maxStatesSearched || Time.currentTimeMillis() > maxEndTimeMs;
     }
@@ -148,12 +203,16 @@ public class SchedulingSearcherState {
         return execIndex == execs.size() - 1;
     }
 
+    /**
+     * Get the current unassigned executor.
+     * @return the first unassigned executor in execs list.
+     */
     public ExecutorDetails currentExec() {
         return execs.get(execIndex);
     }
 
     /**
-      * Assign executor to worker and node.
+      * Attempt to assign current executor (execIndex points to) to worker and node.
       * Assignment validity check is done before calling this method.
       *
       * @param execToComp Mapping from executor to component name.
@@ -165,17 +224,70 @@ public class SchedulingSearcherState {
         String comp = execToComp.get(exec);
         LOG.trace("Topology {} Trying assignment of {} {} to {}", topoName, exec, comp, workerSlot);
         // It is possible that this component is already scheduled on this node or worker.  If so when we backtrack we cannot remove it
-        Map<String, Integer> oneMap = workerCompAssignmentCnts.computeIfAbsent(workerSlot, (k) -> new HashMap<>());
-        oneMap.put(comp, oneMap.getOrDefault(comp, 0) + 1); // increment assignment count
+        Map<String, Integer> compToAssignmentCount = workerCompAssignmentCnts.computeIfAbsent(workerSlot, (k) -> new HashMap<>());
+        compToAssignmentCount.put(comp, compToAssignmentCount.getOrDefault(comp, 0) + 1); // increment worker assignment count
         okToRemoveFromWorker[execIndex] = true;
-        oneMap = nodeCompAssignmentCnts.computeIfAbsent(node, (k) -> new HashMap<>());
-        oneMap.put(comp, oneMap.getOrDefault(comp, 0) + 1); // increment assignment count
+        Map<String, Integer> nodeToAssignmentCount = nodeCompAssignmentCnts.computeIfAbsent(node, (k) -> new HashMap<>());
+        nodeToAssignmentCount.put(comp, nodeToAssignmentCount.getOrDefault(comp, 0) + 1); // increment node assignment count
         okToRemoveFromNode[execIndex] = true;
+
         node.assignSingleExecutor(workerSlot, exec, td);
+    }
+
+    /**
+     * <p>
+     * Determine how many bound ackers to put in before assigning the executor to current workerSlot.
+     * Note that the worker slot must be a new worker to build on scheduling.
+     * </p>
+     * Return 0 if:
+     * 1. Either {@link Config#TOPOLOGY_RAS_ONE_COMPONENT_PER_WORKER}
+     *        or {@link Config#TOPOLOGY_RAS_ONE_EXECUTOR_PER_WORKER} is enabled.
+     * 2. The exec to assign is an acker.
+     * 3. The workerSlot is not a new worker.
+     * 4. No more unassigned ackers to use.
+     * <p>
+     * A special scenario:
+     *  If max heap limit is smaller than (this exec mem + {@link Config#TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER} ackers' mem),
+     *  scheduler will bind fewer ackers based on max heap limit.
+     * </p>
+     * @param exec          the exec to assign into the workerSlot.
+     * @param workerSlot    the new worker slot to build.
+     * @return              the num of bound ackers to assign.
+     */
+    public int getNumOfAckersToBind(ExecutorDetails exec, WorkerSlot workerSlot) {
+        if (!oneExecutorPerWorker && !oneComponentPerWorker
+            && !execToComp.get(exec).equals(Acker.ACKER_COMPONENT_ID)
+            && !workerSlotToBoundAckers.containsKey(workerSlot)) {
+
+            // no more available ackers to bind
+            if (unassignedAckers.isEmpty()) {
+                return 0;
+            }
+            // compute how many ackers can be bound with this exec based on worker max heap
+            double workerMaxHeapLimit
+                = ObjectReader.getDouble(td.getConf().get(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB));
+            double workerHeapSpace
+                =  workerMaxHeapLimit - td.getTotalResources(exec).getOnHeapMemoryMb();
+            double ackerOnHeapReq
+                = td.getTotalResources(unassignedAckers.peek()).getOnHeapMemoryMb();
+
+            int maxBoundAckers = (int) Math.floor(workerHeapSpace / ackerOnHeapReq);
+            if (maxBoundAckers < ackersPerWorker) {
+                LOG.warn("For exec {}, can only bind up to {} ackers due to {} limit. Acker Per worker setting: {}.",
+                    exec, maxBoundAckers, Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, ackersPerWorker);
+            }
+            int ret =  Math.min(Math.min(maxBoundAckers, unassignedAckers.size()), ackersPerWorker);
+            return ret;
+        }
+        return 0;
     }
 
     public void backtrack(Map<ExecutorDetails, String> execToComp, RasNode node, WorkerSlot workerSlot) {
         execIndex--;
+        // when backtrack, we need to skip over the bound ackers
+        while (execIndex >= 0 && boundAckers.contains(execs.get(execIndex))) {
+            execIndex--;
+        }
         if (execIndex < 0) {
             throw new IllegalStateException("Internal Error: Topology " + topoName + " exec index became negative");
         }
@@ -184,16 +296,91 @@ public class SchedulingSearcherState {
         String comp = execToComp.get(exec);
         LOG.trace("Topology {} Backtracking {} {} from {}", topoName, exec, comp, workerSlot);
         if (okToRemoveFromWorker[execIndex]) {
-            Map<String, Integer> oneMap = workerCompAssignmentCnts.get(workerSlot);
-            oneMap.put(comp, oneMap.getOrDefault(comp, 0) - 1); // decrement assignment count
+            Map<String, Integer> compToAssignmentCount = workerCompAssignmentCnts.get(workerSlot);
+            compToAssignmentCount.put(comp, compToAssignmentCount.getOrDefault(comp, 0) - 1); // decrement worker assignment count
+            if (compToAssignmentCount.get(comp) == 0) {
+                compToAssignmentCount.remove(comp);
+            }
             okToRemoveFromWorker[execIndex] = false;
         }
         if (okToRemoveFromNode[execIndex]) {
-            Map<String, Integer> oneMap = nodeCompAssignmentCnts.get(node);
-            oneMap.put(comp, oneMap.getOrDefault(comp, 0) - 1); // decrement assignment count
+            Map<String, Integer> nodeToAssignmentCount = nodeCompAssignmentCnts.get(node);
+            nodeToAssignmentCount.put(comp, nodeToAssignmentCount.getOrDefault(comp, 0) - 1); // decrement node assignment count
+            if (nodeToAssignmentCount.get(comp) == 0) {
+                nodeToAssignmentCount.remove(comp);
+            }
             okToRemoveFromNode[execIndex] = false;
         }
         node.freeSingleExecutor(exec, td);
+
+        // If this exec has bound ackers, we need to backtrack them as well
+        if (execsWithBoundAckers.remove(exec)) {
+            if (workerSlotToBoundAckers.containsKey(workerSlot)) {
+                freeWorkerSlotWithBoundAckers(node, workerSlot);
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Remove the head of unassigned ackers and attempt to assign it to a workerSlot as a bound acker.
+     * </p>
+     *
+     * @param node          RasNode on which to schedule.
+     * @param workerSlot    WorkerSlot on which to schedule.
+     */
+    public void assignSingleBoundAcker(RasNode node, WorkerSlot workerSlot) {
+        if (unassignedAckers.isEmpty()) {
+            String msg = String.format("No more available ackers to assign for the new worker: %s of topology: %s",
+                workerSlot, topoName);
+            throw new IllegalStateException(msg);
+        }
+        ExecutorDetails acker = unassignedAckers.removeFirst();
+        node.assignSingleExecutor(workerSlot, acker, td);
+        if (!workerSlotToBoundAckers.containsKey(workerSlot)) {
+            workerSlotToBoundAckers.put(workerSlot, new ArrayList<>());
+        }
+        workerSlotToBoundAckers.get(workerSlot).add(acker);
+        boundAckers.add(acker);
+        // bound ackers should not violate constraint solver
+        String ackerCompId = Acker.ACKER_COMPONENT_ID;
+        Map<String, Integer> compToAssignmentCount = workerCompAssignmentCnts.computeIfAbsent(workerSlot, (k) -> new HashMap<>());
+        compToAssignmentCount.put(ackerCompId, compToAssignmentCount.getOrDefault(ackerCompId, 0) + 1); // increment worker assignment count
+        Map<String, Integer> nodeToAssignmentCount = nodeCompAssignmentCnts.computeIfAbsent(node, (k) -> new HashMap<>());
+        nodeToAssignmentCount.put(ackerCompId, nodeToAssignmentCount.getOrDefault(ackerCompId, 0) + 1); // increment node assignment count
+    }
+
+    /**
+     * Free a given workerSlot and all the assigned bound ackers already there.
+     *
+     * @param node          RasNode which to be freed.
+     * @param workerSlot    WorkerSlot on which to schedule.
+     */
+    public void freeWorkerSlotWithBoundAckers(RasNode node, WorkerSlot workerSlot) {
+        List<ExecutorDetails> ackers = workerSlotToBoundAckers.get(workerSlot);
+        String ackerCompId = Acker.ACKER_COMPONENT_ID;
+        if (ackers != null && !ackers.isEmpty()) {
+            for (int i = ackers.size() - 1; i >= 0; i--) {
+                ExecutorDetails acker = ackers.get(i);
+                boundAckers.remove(acker);
+                unassignedAckers.addFirst(acker);
+                Map<String, Integer> compToAssignmentCount = workerCompAssignmentCnts.get(workerSlot);
+                compToAssignmentCount.put(ackerCompId,
+                    compToAssignmentCount.getOrDefault(ackerCompId, 0) - 1); // decrement worker assignment count
+                if (compToAssignmentCount.get(ackerCompId) == 0) {
+                    compToAssignmentCount.remove(ackerCompId);
+                }
+
+                Map<String, Integer> nodeToAssignmentCount = nodeCompAssignmentCnts.get(node);
+                nodeToAssignmentCount.put(ackerCompId,
+                    nodeToAssignmentCount.getOrDefault(ackerCompId, 0) - 1); // decrement node assignment count
+                if (nodeToAssignmentCount.get(ackerCompId) == 0) {
+                    nodeToAssignmentCount.remove(ackerCompId);
+                }
+            }
+            workerSlotToBoundAckers.remove(workerSlot);
+            node.free(workerSlot);
+        }
     }
 
     /**

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/ExecSorterByConnectionCount.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/ExecSorterByConnectionCount.java
@@ -51,7 +51,7 @@ public class ExecSorterByConnectionCount implements IExecSorter {
      * @return a list of executors in sorted order for scheduling.
      */
     public List<ExecutorDetails> sortExecutors(Set<ExecutorDetails> unassignedExecutors) {
-        Map<String, Component> componentMap = topologyDetails.getComponents(); // excludes system components
+        Map<String, Component> componentMap = topologyDetails.getUserTopolgyComponents(); // excludes system components
         LinkedHashSet<ExecutorDetails> orderedExecutorSet = new LinkedHashSet<>(); // in insert order
 
         Map<String, Queue<ExecutorDetails>> compToExecsToSchedule = new HashMap<>();

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/ExecSorterByProximity.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/ExecSorterByProximity.java
@@ -55,7 +55,7 @@ public class ExecSorterByProximity implements IExecSorter {
      * @return a list of executors in sorted order for scheduling.
      */
     public List<ExecutorDetails> sortExecutors(Set<ExecutorDetails> unassignedExecutors) {
-        Map<String, Component> componentMap = topologyDetails.getComponents(); // excludes system components
+        Map<String, Component> componentMap = topologyDetails.getUserTopolgyComponents(); // excludes system components
         LinkedHashSet<ExecutorDetails> orderedExecutorSet = new LinkedHashSet<>(); // in insert order
 
         Map<String, Queue<ExecutorDetails>> compToExecsToSchedule = new HashMap<>();

--- a/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
@@ -31,6 +31,7 @@ import org.apache.storm.scheduler.resource.strategies.priority.DefaultScheduling
 import org.apache.storm.scheduler.resource.strategies.scheduling.DefaultResourceAwareStrategy;
 import org.apache.storm.testing.TestWordSpout;
 import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.utils.ServerUtils;
 import org.apache.storm.utils.Time;
 import org.junit.Assert;
 import org.junit.Test;
@@ -61,7 +62,7 @@ public class NimbusTest {
         config1.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, 128.0);
         config1.put(Config.TOPOLOGY_COMPONENT_RESOURCES_ONHEAP_MEMORY_MB, 129.0);
         try {
-            Nimbus.validateTopologyWorkerMaxHeapSizeConfigs(config1, stormTopology1, 768.0);
+            ServerUtils.validateTopologyWorkerMaxHeapSizeConfigs(config1, stormTopology1, 768.0);
             fail("Expected exception not thrown");
         } catch (InvalidTopologyException e) {
             //Expected...

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestBackwardCompatibility.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestBackwardCompatibility.java
@@ -20,6 +20,7 @@ package org.apache.storm.scheduler.resource.strategies.scheduling;
 
 import org.apache.storm.TestRebalance;
 import org.apache.storm.daemon.nimbus.NimbusTest;
+import org.apache.storm.generated.InvalidTopologyException;
 import org.apache.storm.scheduler.blacklist.TestBlacklistScheduler;
 import org.apache.storm.scheduler.resource.TestResourceAwareScheduler;
 import org.apache.storm.scheduler.resource.TestUser;
@@ -362,13 +363,23 @@ public class TestBackwardCompatibility {
     }
 
     @Test
-    public void testDefaultResourceAwareStrategy() {
-        testDefaultResourceAwareStrategy.testDefaultResourceAwareStrategy();
+    public void testDefaultResourceAwareStrategy()
+        throws InvalidTopologyException {
+        testDefaultResourceAwareStrategy.testDefaultResourceAwareStrategyWithoutSettingAckerExecutors(0);
     }
 
     @Test
-    public void testDefaultResourceAwareStrategyInFavorOfShuffle() {
-        testDefaultResourceAwareStrategy.testDefaultResourceAwareStrategyInFavorOfShuffle();
+    public void testDefaultResourceAwareStrategyInFavorOfShuffleWithNewProximityConfig()
+        throws InvalidTopologyException {
+        boolean useDeprecatedConfigForProximity = false;
+        testDefaultResourceAwareStrategy.testDefaultResourceAwareStrategyInFavorOfShuffle(useDeprecatedConfigForProximity);
+    }
+
+    @Test
+    public void testDefaultResourceAwareStrategyInFavorOfShuffleWithDeprecatedProximityConfig()
+        throws InvalidTopologyException {
+        boolean useDeprecatedConfigForProximity = true;
+        testDefaultResourceAwareStrategy.testDefaultResourceAwareStrategyInFavorOfShuffle(useDeprecatedConfigForProximity);
     }
 
     @Test

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
@@ -20,7 +20,6 @@ package org.apache.storm.scheduler.resource.strategies.scheduling;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.storm.Config;
@@ -551,7 +550,7 @@ public class TestConstraintSolverStrategy {
     public void testZeroExecutorScheduling() {
         ConstraintSolverStrategy cs = new ConstraintSolverStrategy();
         cs.prepare(new HashMap<>());
-        Map<String, Object> topoConf = new HashMap<>();
+        Map<String, Object> topoConf = Utils.readDefaultConfig();
         topoConf.put(Config.TOPOLOGY_RAS_CONSTRAINT_MAX_STATE_SEARCH, 1_000);
         topoConf.put(Config.TOPOLOGY_RAS_ONE_EXECUTOR_PER_WORKER, false);
         topoConf.put(Config.TOPOLOGY_RAS_ONE_COMPONENT_PER_WORKER, false);

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java
@@ -18,7 +18,10 @@
 
 package org.apache.storm.scheduler.resource.strategies.scheduling;
 
+import org.apache.storm.daemon.StormCommon;
+import org.apache.storm.daemon.nimbus.Nimbus;
 import org.apache.storm.daemon.nimbus.TopologyResources;
+import org.apache.storm.generated.InvalidTopologyException;
 import org.apache.storm.scheduler.IScheduler;
 import org.apache.storm.scheduler.resource.TestUtilsForResourceAwareScheduler;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResourcesExtension;
@@ -45,6 +48,7 @@ import org.apache.storm.topology.SharedOffHeapWithinNode;
 import org.apache.storm.topology.SharedOffHeapWithinWorker;
 import org.apache.storm.topology.SharedOnHeap;
 import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.utils.ServerUtils;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -430,36 +434,69 @@ public class TestDefaultResourceAwareStrategy {
             assertThat(numNodes, is(1L));
         }
     }
-    
+
     /**
      * test if the scheduling logic for the DefaultResourceAwareStrategy is correct
+     * when topology.acker.executors.per.worker is set to different values.
+     *
+     * If {@link Config#TOPOLOGY_ACKER_EXECUTORS} is not set,
+     * it will be calculated by Nimbus as (num of estimated worker * topology.acker.executors.per.worker).
+     * In this test, {@link Config#TOPOLOGY_ACKER_EXECUTORS} is set to 2 (num of estimated workers based on topo resources usage)
+     *
+     * For different value for {@link Config#TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER}:
+     * -1: Note we don't really set it to be -1.
+     *     It is just a special case in this test that topology.acker.executors.per.worker is unset, nimbus will set to 1 by default.
+     * 0:  Since {@link Config#TOPOLOGY_ACKER_EXECUTORS} is not set either, acking is disabled.
+     * 1:  2 ackers in total. Distribute 1 acker per worker. With ackers being added, this topology will now need 3 workers.
+     *     Then first two worker will get 1 acker and last worker get 0.
+     * 2:  4 ackers in total. First two workers will get 2 acker per worker respectively.
      */
-    @Test
-    public void testDefaultResourceAwareStrategy() {
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 1, 2})
+    public void testDefaultResourceAwareStrategyWithoutSettingAckerExecutors(int numOfAckersPerWorker)
+        throws InvalidTopologyException {
         int spoutParallelism = 1;
         int boltParallelism = 2;
         TopologyBuilder builder = new TopologyBuilder();
         builder.setSpout("spout", new TestSpout(),
-                spoutParallelism);
+            spoutParallelism);
         builder.setBolt("bolt-1", new TestBolt(),
-                boltParallelism).shuffleGrouping("spout");
+            boltParallelism).shuffleGrouping("spout");
         builder.setBolt("bolt-2", new TestBolt(),
-                boltParallelism).shuffleGrouping("bolt-1");
+            boltParallelism).shuffleGrouping("bolt-1");
         builder.setBolt("bolt-3", new TestBolt(),
-                boltParallelism).shuffleGrouping("bolt-2");
+            boltParallelism).shuffleGrouping("bolt-2");
+
+        String topoName = "testTopology";
 
         StormTopology stormToplogy = builder.createTopology();
 
         INimbus iNimbus = new INimbusTest();
-        Map<String, SupervisorDetails> supMap = genSupervisors(4, 4, 150, 1500);
-        Config conf = createClusterConfig(50, 250, 250, null);
+        Map<String, SupervisorDetails> supMap = genSupervisors(4, 4, 200, 2000);
+        Config conf = createClusterConfig(50, 450, 0, null);
         conf.put(Config.TOPOLOGY_PRIORITY, 0);
-        conf.put(Config.TOPOLOGY_NAME, "testTopology");
-        conf.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, Double.MAX_VALUE);
+        conf.put(Config.TOPOLOGY_NAME, topoName);
+        conf.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, 2000);
         conf.put(Config.TOPOLOGY_SUBMITTER_USER, "user");
 
+        // Topology needs 2 workers (estimated by nimbus based on resources),
+        // but with ackers added, probably more worker will be launched.
+        // Parameterized test on different numOfAckersPerWorker
+        if (numOfAckersPerWorker == -1) {
+            // Both Config.TOPOLOGY_ACKER_EXECUTORS and Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER are not set
+            // Default will be 2 (estimate num of workers) and 1 respectively
+        } else {
+            conf.put(Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER, numOfAckersPerWorker);
+        }
+
+        int estimatedNumWorker = ServerUtils.getEstimatedWorkerCountForRasTopo(conf, stormToplogy);
+        Nimbus.setUpAckerExecutorConfigs(topoName, conf, conf, estimatedNumWorker);
+
+        conf.put(Config.TOPOLOGY_ACKER_RESOURCES_ONHEAP_MEMORY_MB, 250);
+        conf.put(Config.TOPOLOGY_ACKER_CPU_PCORE_PERCENT, 50);
+
         TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
-                genExecsAndComps(stormToplogy), CURRENT_TIME, "user");
+            genExecsAndComps(StormCommon.systemTopology(conf, stormToplogy)), CURRENT_TIME, "user");
 
         Topologies topologies = new Topologies(topo);
         Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, conf);
@@ -469,16 +506,141 @@ public class TestDefaultResourceAwareStrategy {
         scheduler.prepare(conf, new StormMetricsRegistry());
         scheduler.schedule(topologies, cluster);
 
+        // Ordered execs: [[6, 6], [2, 2], [4, 4], [5, 5], [1, 1], [3, 3], [0, 0], [8, 8], [7, 7]]
+        // Ackers: [[8, 8], [7, 7]] (+ [[9, 9], [10, 10]] when numOfAckersPerWorker=2)
         HashSet<HashSet<ExecutorDetails>> expectedScheduling = new HashSet<>();
-        expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(0, 0)))); //Spout
+        if (numOfAckersPerWorker == -1 || numOfAckersPerWorker == 1) {
+            // Setting topology.acker.executors = null and topology.acker.executors.per.worker = null
+            // are equivalent to topology.acker.executors = null and topology.acker.executors.per.worker = 1
+            expectedScheduling.add(new HashSet<>(Arrays.asList(
+                new ExecutorDetails(6, 6), //bolt-3
+                new ExecutorDetails(2, 2), //bolt-1
+                new ExecutorDetails(4, 4), //bolt-2
+                new ExecutorDetails(8, 8)))); //acker
+            expectedScheduling.add(new HashSet<>(Arrays.asList(
+                new ExecutorDetails(5, 5), //bolt-3
+                new ExecutorDetails(1, 1), //bolt-1
+                new ExecutorDetails(3, 3), //bolt-2
+                new ExecutorDetails(7, 7)))); //acker
+            expectedScheduling.add(new HashSet<>(Arrays.asList(
+                new ExecutorDetails(0, 0)))); //spout
+        } else if (numOfAckersPerWorker == 0) {
+            expectedScheduling.add(new HashSet<>(Arrays.asList(
+                new ExecutorDetails(6, 6), //bolt-3
+                new ExecutorDetails(2, 2), //bolt-1
+                new ExecutorDetails(4, 4), //bolt-2
+                new ExecutorDetails(5, 5)))); //bolt-3
+            expectedScheduling.add(new HashSet<>(Arrays.asList(
+                new ExecutorDetails(0, 0), //spout
+                new ExecutorDetails(3, 3), //bolt-2
+                new ExecutorDetails(1, 1)))); //bolt-1
+        } else if (numOfAckersPerWorker == 2) {
+            expectedScheduling.add(new HashSet<>(Arrays.asList(
+                new ExecutorDetails(6, 6), //bolt-3
+                new ExecutorDetails(2, 2), //bolt-1
+                new ExecutorDetails(7, 7), //acker
+                new ExecutorDetails(8, 8)))); //acker
+            expectedScheduling.add(new HashSet<>(Arrays.asList(
+                new ExecutorDetails(4, 4), //bolt-2
+                new ExecutorDetails(5, 5), //bolt-3
+                new ExecutorDetails(9, 9), //acker
+                new ExecutorDetails(10, 10)))); //acker
+            expectedScheduling.add(new HashSet<>(Arrays.asList(
+                new ExecutorDetails(1, 1), //bolt-1
+                new ExecutorDetails(3, 3), //bolt-2
+                new ExecutorDetails(0, 0)))); //spout
+        }
+        HashSet<HashSet<ExecutorDetails>> foundScheduling = new HashSet<>();
+        SchedulerAssignment assignment = cluster.getAssignmentById("testTopology-id");
+        for (Collection<ExecutorDetails> execs : assignment.getSlotToExecutors().values()) {
+            foundScheduling.add(new HashSet<>(execs));
+        }
+
+        Assert.assertEquals(expectedScheduling, foundScheduling);
+    }
+
+    /**
+     * test if the scheduling logic for the DefaultResourceAwareStrategy is correct
+     * when topology.acker.executors is set.
+     *
+     * If yes, topology.acker.executors.per.worker setting will be ignored and calculated as
+     * Math.ceil(topology.acker.executors / estimate num of workers) by Nimbus
+     */
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 2, 300})
+    public void testDefaultResourceAwareStrategyWithSettingAckerExecutors(int numOfAckersPerWorker)
+        throws InvalidTopologyException {
+
+        int spoutParallelism = 1;
+        int boltParallelism = 2;
+        TopologyBuilder builder = new TopologyBuilder();
+        builder.setSpout("spout", new TestSpout(),
+            spoutParallelism);
+        builder.setBolt("bolt-1", new TestBolt(),
+            boltParallelism).shuffleGrouping("spout");
+        builder.setBolt("bolt-2", new TestBolt(),
+            boltParallelism).shuffleGrouping("bolt-1");
+        builder.setBolt("bolt-3", new TestBolt(),
+            boltParallelism).shuffleGrouping("bolt-2");
+
+        String topoName = "testTopology";
+
+        StormTopology stormToplogy = builder.createTopology();
+
+        INimbus iNimbus = new INimbusTest();
+        Map<String, SupervisorDetails> supMap = genSupervisors(4, 4, 200, 2000);
+        Config conf = createClusterConfig(50, 450, 0, null);
+        conf.put(Config.TOPOLOGY_PRIORITY, 0);
+        conf.put(Config.TOPOLOGY_NAME, topoName);
+        conf.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, 2000);
+        conf.put(Config.TOPOLOGY_SUBMITTER_USER, "user");
+
+        conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, 4);
+        conf.put(Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER, numOfAckersPerWorker);
+
+
+        if (numOfAckersPerWorker == -1) {
+            // Leave topology.acker.executors.per.worker unset
+        } else {
+            conf.put(Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER, numOfAckersPerWorker);
+        }
+
+        int estimatedNumWorker = ServerUtils.getEstimatedWorkerCountForRasTopo(conf, stormToplogy);
+        Nimbus.setUpAckerExecutorConfigs(topoName, conf, conf, estimatedNumWorker);
+
+        conf.put(Config.TOPOLOGY_ACKER_RESOURCES_ONHEAP_MEMORY_MB, 250);
+        conf.put(Config.TOPOLOGY_ACKER_CPU_PCORE_PERCENT, 50);
+
+        TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
+            genExecsAndComps(StormCommon.systemTopology(conf, stormToplogy)), CURRENT_TIME, "user");
+
+        Topologies topologies = new Topologies(topo);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, conf);
+
+        scheduler = new ResourceAwareScheduler();
+
+        scheduler.prepare(conf, new StormMetricsRegistry());
+        scheduler.schedule(topologies, cluster);
+
+        // Sorted execs: [[6, 6], [2, 2], [4, 4], [5, 5], [1, 1], [3, 3], [0, 0], [8, 8], [7, 7], [10, 10], [9, 9]]
+        // Ackers: [[8, 8], [7, 7], [10, 10], [9, 9]]
+
+        HashSet<HashSet<ExecutorDetails>> expectedScheduling = new HashSet<>();
         expectedScheduling.add(new HashSet<>(Arrays.asList(
+            new ExecutorDetails(6, 6), //bolt-3
             new ExecutorDetails(2, 2), //bolt-1
-            new ExecutorDetails(4, 4), //bolt-2
-            new ExecutorDetails(6, 6)))); //bolt-3
+            new ExecutorDetails(7, 7), //acker
+            new ExecutorDetails(8, 8)))); //acker
         expectedScheduling.add(new HashSet<>(Arrays.asList(
-            new ExecutorDetails(1, 1), //bolt-1
+            new ExecutorDetails(5, 5), //bolt-3
+            new ExecutorDetails(4, 4), //bolt-2
+            new ExecutorDetails(9, 9), //acker
+            new ExecutorDetails(10, 10)))); //acker
+        expectedScheduling.add(new HashSet<>(Arrays.asList(
+            new ExecutorDetails(0, 0), //spout
             new ExecutorDetails(3, 3), //bolt-2
-            new ExecutorDetails(5, 5)))); //bolt-3
+            new ExecutorDetails(1, 1)))); //bolt-1
+
         HashSet<HashSet<ExecutorDetails>> foundScheduling = new HashSet<>();
         SchedulerAssignment assignment = cluster.getAssignmentById("testTopology-id");
         for (Collection<ExecutorDetails> execs : assignment.getSlotToExecutors().values()) {
@@ -491,7 +653,10 @@ public class TestDefaultResourceAwareStrategy {
     /**
      * test if the scheduling logic for the DefaultResourceAwareStrategy (when made by network proximity needs.) is correct
      */
-    public void testDefaultResourceAwareStrategyInFavorOfShuffle() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testDefaultResourceAwareStrategyInFavorOfShuffle(boolean useDeprecatedConfigForProximity)
+        throws InvalidTopologyException {
         int spoutParallelism = 1;
         int boltParallelism = 2;
         TopologyBuilder builder = new TopologyBuilder();
@@ -507,7 +672,7 @@ public class TestDefaultResourceAwareStrategy {
         StormTopology stormToplogy = builder.createTopology();
 
         INimbus iNimbus = new INimbusTest();
-        Map<String, SupervisorDetails> supMap = genSupervisors(4, 4, 150, 1500);
+        Map<String, SupervisorDetails> supMap = genSupervisors(4, 4, 200, 2000);
         Config conf = createClusterConfig(50, 250, 250, null);
         conf.put(Config.TOPOLOGY_PRIORITY, 0);
         conf.put(Config.TOPOLOGY_NAME, "testTopology");
@@ -516,7 +681,7 @@ public class TestDefaultResourceAwareStrategy {
         conf.put(Config.TOPOLOGY_RAS_ORDER_EXECUTORS_BY_PROXIMITY_NEEDS, true);
 
         TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
-            genExecsAndComps(stormToplogy), CURRENT_TIME, "user");
+            genExecsAndComps(StormCommon.systemTopology(conf, stormToplogy)), CURRENT_TIME, "user");
 
         Topologies topologies = new Topologies(topo);
         Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, conf);
@@ -525,15 +690,17 @@ public class TestDefaultResourceAwareStrategy {
 
         rs.prepare(conf, new StormMetricsRegistry());
         rs.schedule(topologies, cluster);
-        //:<[[[0, 0], [6, 6], [2, 2]], [[3, 3]], [[5, 5], [4, 4], [1, 1]]]>
+        // Sorted execs: [[0, 0], [2, 2], [6, 6], [4, 4], [1, 1], [5, 5], [3, 3], [7, 7]]
+        // Ackers: [[7, 7]]]
 
         HashSet<HashSet<ExecutorDetails>> expectedScheduling = new HashSet<>();
         expectedScheduling.add(new HashSet<>(Arrays.asList(
             new ExecutorDetails(0, 0), //spout
             new ExecutorDetails(6, 6), //bolt-2
-            new ExecutorDetails(2, 2)))); //bolt-1
-        expectedScheduling.add(new HashSet<>(Arrays.asList(new ExecutorDetails(3, 3)))); //bolt-3
+            new ExecutorDetails(2, 2), //bolt-1
+            new ExecutorDetails(7, 7)))); //acker
         expectedScheduling.add(new HashSet<>(Arrays.asList(
+            new ExecutorDetails(3, 3), //bolt-3
             new ExecutorDetails(5, 5), //bolt-2
             new ExecutorDetails(4, 4), //bolt-3
             new ExecutorDetails(1, 1)))); //bolt-1

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestLargeCluster.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestLargeCluster.java
@@ -37,7 +37,6 @@ import org.apache.storm.scheduler.resource.TestUtilsForResourceAwareScheduler;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResources;
 import org.apache.storm.scheduler.resource.normalization.NormalizedResourcesExtension;
 import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
-import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.Time;
 import org.apache.storm.utils.Utils;
 import org.junit.Assert;
@@ -237,6 +236,9 @@ public class TestLargeCluster {
             if (!conf.containsKey(Config.TOPOLOGY_RAS_CONSTRAINT_MAX_STATE_SEARCH)) {
                 conf.put(Config.TOPOLOGY_RAS_CONSTRAINT_MAX_STATE_SEARCH, 10_000);
             }
+            if (!conf.containsKey(Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER)) {
+                conf.put(Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER, 1);
+            }
 
             String topoId = nm;
             String topoName = (String) conf.getOrDefault(Config.TOPOLOGY_NAME, nm);
@@ -256,7 +258,7 @@ public class TestLargeCluster {
             int numWorkers = Integer.parseInt("" + conf.getOrDefault(Config.TOPOLOGY_WORKERS, "0"));
             TopologyDetails topo = new TopologyDetails(topoId, conf, stormTopology,  numWorkers,
                     execToComp, Time.currentTimeSecs(), "user");
-            topo.getComponents(); // sanity check - normally this should not fail
+            topo.getUserTopolgyComponents(); // sanity check - normally this should not fail
 
             topoDetailsList.add(topo);
         }


### PR DESCRIPTION
## What is the purpose of the change

Add topology config for RAS scheduler to attempt to schedule system components/executors across all workers evenly instead of scheduling them all together after having finished all topology components.

## How was the change tested

1. test with even distribution option:
`storm jar /home/y/lib64/jars/storm-starter.jar org.apache.storm.starter.WordCountTopology wc1 -c topology..system.components.even.distribution=true -c topology.acker.executors=8 -c topology.component.resources.onheap.memory.mb=100 -c topology.acker.resources.onheap.memory.mb=150 -c topology.workers=4 -c experimental.topology.ras.order.executors.by.proximity.needs=true -c topology.worker.max.heap.size.mb=1000`

![image](https://user-images.githubusercontent.com/15622046/84088095-5941a000-a9b1-11ea-87e0-26d3b75fc455.png)

2. test without even distribution option `storm jar /home/y/lib64/jars/storm-starter.jar org.apache.storm.starter.WordCountTopology wc-no-even-distribution -c topology.acker.executors=8 -c topology.component.resources.onheap.memory.mb=100 -c topology.acker.resources.onheap.memory.mb=150 -c topology.workers=4 -c experimental.topology.ras.order.executors.by.proximity.needs=true -c topology.worker.max.heap.size.mb=1000`
![image](https://user-images.githubusercontent.com/15622046/84088124-6bbbd980-a9b1-11ea-9839-b65b46329353.png)
