### PR TITLE
MINOR: Adding Supervisor StormTimer thread names

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -181,11 +181,11 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
             throw Utils.wrapInRuntime(e);
         }
 
-        this.heartbeatTimer = new StormTimer(null, new DefaultUncaughtExceptionHandler());
+        this.heartbeatTimer = new StormTimer("HBTimer", new DefaultUncaughtExceptionHandler());
 
-        this.workerHeartbeatTimer = new StormTimer(null, new DefaultUncaughtExceptionHandler());
+        this.workerHeartbeatTimer = new StormTimer("WorkerHBTimer", new DefaultUncaughtExceptionHandler());
 
-        this.eventTimer = new StormTimer(null, new DefaultUncaughtExceptionHandler());
+        this.eventTimer = new StormTimer("EventTimer", new DefaultUncaughtExceptionHandler());
         
         this.supervisorThriftInterface = createSupervisorIface();
     }


### PR DESCRIPTION
## What is the purpose of the change

* _StormTimer_ threads are not names properly on Supervisor.

## How was the change tested

Running unit test and jstack shows Thread names

```"EventTimer" #22 daemon prio=10 os_prio=0 tid=0x00007f92cce67800 nid=0x58a3 waiting on condition [0x00007f92b59d6000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at org.apache.storm.utils.Time.sleep(Time.java:100)
	at org.apache.storm.StormTimer$StormTimerTask.run(StormTimer.java:236)

"WorkerHBTimer" #21 daemon prio=10 os_prio=0 tid=0x00007f92cce62800 nid=0x58a2 waiting on condition [0x00007f92b5ad7000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at org.apache.storm.utils.Time.sleep(Time.java:100)
	at org.apache.storm.StormTimer$StormTimerTask.run(StormTimer.java:236)

"HBTimer" #20 daemon prio=10 os_prio=0 tid=0x00007f92cce61000 nid=0x58a1 waiting on condition [0x00007f92b5bd8000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at org.apache.storm.utils.Time.sleep(Time.java:100)
	at org.apache.storm.StormTimer$StormTimerTask.run(StormTimer.java:236)
```