### PR TITLE
STORM-3655: Worker should die if its assignment has changed

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -171,7 +171,6 @@ public class WorkerState {
         this.autoCredentials = autoCredentials;
         this.conf = conf;
         this.supervisorIfaceSupplier = supervisorIfaceSupplier;
-        this.localExecutors = new HashSet<>(readWorkerExecutors(stormClusterState, topologyId, assignmentId, port));
         this.mqContext = (null != mqContext) ? mqContext : TransportFactory.makeContext(topologyConf);
         this.topologyId = topologyId;
         this.assignmentId = assignmentId;
@@ -179,6 +178,8 @@ public class WorkerState {
         this.workerId = workerId;
         this.stateStorage = stateStorage;
         this.stormClusterState = stormClusterState;
+        this.localExecutors =
+            new HashSet<>(readWorkerExecutors(assignmentId, port, getLocalAssignment(this.stormClusterState, topologyId)));
         this.isWorkerActive = new CountDownLatch(1);
         this.isTopologyActive = new AtomicBoolean(false);
         this.stormComponentToDebug = new AtomicReference<>();
@@ -377,7 +378,23 @@ public class WorkerState {
     public SmartThread makeTransferThread() {
         return workerTransfer.makeTransferThread();
     }
-    
+
+    public void suicideIfLocalAssignmentsChanged(Assignment assignment) {
+        if (assignment != null) {
+            Set<List<Long>> assignedExecutors = new HashSet<>(readWorkerExecutors(assignmentId, port, assignment));
+            if (!localExecutors.equals(assignedExecutors)) {
+                LOG.info("Found conflicting assignments. We shouldn't be alive!"
+                         + " Assigned: " + assignedExecutors + ", Current: "
+                         + localExecutors);
+                if (!ConfigUtils.isLocalMode(conf)) {
+                    suicideCallback.run();
+                } else {
+                    LOG.info("Local worker tried to commit suicide!");
+                }
+            }
+        }
+    }
+
     public void refreshConnections() {
         Assignment assignment = null;
         try {
@@ -386,6 +403,7 @@ public class WorkerState {
             LOG.warn("Failed to read assignment. This should only happen when topology is shutting down.", e);
         }
 
+        suicideIfLocalAssignmentsChanged(assignment);
         Set<NodeInfo> neededConnections = new HashSet<>();
         Map<Integer, NodeInfo> newTaskToNodePort = new HashMap<>();
         if (null != assignment) {
@@ -634,13 +652,11 @@ public class WorkerState {
         return this.autoCredentials;
     }
 
-    private List<List<Long>> readWorkerExecutors(IStormClusterState stormClusterState, String topologyId, String assignmentId,
-                                                 int port) {
-        LOG.info("Reading assignments");
+    private List<List<Long>> readWorkerExecutors(String assignmentId, int port, Assignment assignment) {
         List<List<Long>> executorsAssignedToThisWorker = new ArrayList<>();
         executorsAssignedToThisWorker.add(Constants.SYSTEM_EXECUTOR_ID);
         Map<List<Long>, NodeInfo> executorToNodePort = 
-            getLocalAssignment(stormClusterState, topologyId).get_executor_node_port();
+            assignment.get_executor_node_port();
         for (Map.Entry<List<Long>, NodeInfo> entry : executorToNodePort.entrySet()) {
             NodeInfo nodeInfo = entry.getValue();
             if (nodeInfo.get_node().equals(assignmentId) && nodeInfo.get_port().iterator().next() == port) {


### PR DESCRIPTION
## What is the purpose of the change

The assignment change should lead to worker suicide. This is specially critical if Supervisor is down for some reason

## How was the change tested

1. Launcher WordCountTopology, wait for worker to start
2. Stop the supervisor
3. Re-balance topology so worker is assigned to next supervisor
4. Worker should kill itself with worker.log entries similar to below.
```
2020-06-22 06:55:40.527 o.a.s.d.w.WorkerState refresh-connections-timer [INFO] Found conflicting assignments. We shouldn't be alive! Assigned: [[-1, -1]], Current: [[-1, -1], [14, 14], [12, 12], [10, 10], [8, 8], [6, 6], [4, 4], [2, 2], [7, 7], [5, 5], [3, 3], [1, 1], [13, 13], [11, 11], [9, 9]]
2020-06-22 06:55:40.529 o.a.s.u.Utils refresh-connections-timer [ERROR] Halting process: Worker died
java.lang.RuntimeException: Halting process: Worker died
        at org.apache.storm.utils.Utils.exitProcess(Utils.java:518) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.daemon.worker.WorkerState.suicideIfLocalAssignmentsChanged(WorkerState.java:390) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.daemon.worker.WorkerState.refreshConnections(WorkerState.java:421) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.StormTimer$1.run(StormTimer.java:110) [storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.StormTimer$StormTimerTask.run(StormTimer.java:226) [storm-client-2.3.0.y.jar:2.3.0.y]
2020-06-22 06:55:40.552 o.a.s.d.w.Worker Thread-32 [INFO] Shutting down worker fwc2-1-1592662435 44c0bd8e-bd3c-4317-b09f-1f0deb3f2a7c 6700
