### PR TITLE
STORM-3656 handle worker NPE from Hadoop auto renewal thread

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -146,7 +146,7 @@ public class Worker implements Shutdownable, DaemonCommon {
         String portStr = args[3];
         String workerId = args[4];
         Map<String, Object> conf = ConfigUtils.readStormConfig();
-        Utils.setupDefaultUncaughtExceptionHandler();
+        Utils.setupWorkerUncaughtExceptionHandler();
         StormCommon.validateDistributedMode(conf);
         int supervisorPortInt = Integer.parseInt(supervisorPort);
         Worker worker = new Worker(conf, null, stormId, assignmentId, supervisorPortInt, Integer.parseInt(portStr), workerId);

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/StormServerHandler.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/StormServerHandler.java
@@ -63,7 +63,7 @@ public class StormServerHandler extends ChannelInboundHandlerAdapter {
             // Doing nothing (probably due to an oom issue) and hoping Utils.handleUncaughtException will handle it
         }
         try {
-            Utils.handleUncaughtException(cause, ALLOWED_EXCEPTIONS);
+            Utils.handleUncaughtException(cause, ALLOWED_EXCEPTIONS, false);
             ctx.close();
         } catch (Error error) {
             LOG.info("Received error in netty thread.. terminating server...");


### PR DESCRIPTION
## What is the purpose of the change

Prevent worker from dying from Hadoop auto renewal thread NPE while reducing use of reflection.

## How was the change tested

Tested on our internal clusters by reducing TGT ticket lifetime and uploading credentials before auto renewal thread triggers.  Validated Hadoop exception is triggered and handled by the worker, allowing it to remain up.