### PR TITLE
[STORM-3657] set storm.messaging.netty.authentication to topoConf OR daemonConf

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -57,8 +57,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.security.auth.Subject;
 
@@ -3164,6 +3162,16 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             if (!(Boolean) conf.getOrDefault(DaemonConfig.STORM_TOPOLOGY_CLASSPATH_BEGINNING_ENABLED, false)) {
                 topoConf.remove(Config.TOPOLOGY_CLASSPATH_BEGINNING);
             }
+
+            // storm.messaging.netty.authentication is about inter-worker communication
+            // enforce netty authentication when either topo or daemon set it to true
+            boolean enforceNettyAuth = (Boolean) topoConf.getOrDefault(Config.STORM_MESSAGING_NETTY_AUTHENTICATION, false)
+                                    || (Boolean) conf.getOrDefault(Config.STORM_MESSAGING_NETTY_AUTHENTICATION, false);
+            LOG.debug("For netty authentication, topo conf is: {}, cluster conf is: {}, Enforce netty auth: {}",
+                topoConf.getOrDefault(Config.STORM_MESSAGING_NETTY_AUTHENTICATION, false),
+                conf.getOrDefault(Config.STORM_MESSAGING_NETTY_AUTHENTICATION, false),
+                enforceNettyAuth);
+            topoConf.put(Config.STORM_MESSAGING_NETTY_AUTHENTICATION, enforceNettyAuth);
 
             String topoVersionString = topology.get_storm_version();
             if (topoVersionString == null) {


### PR DESCRIPTION
## What is the purpose of the change

In most of times of conf merging, we simply prefer topo conf over daemon conf. But as for netty authentication, we believe we want to set it true either cluster or topo owner want it.

We did notice some strange cases where we set this setting true in cluster side while user set it false when submitting topology. And when host-ip mapping changed, netty server of the worker with false setting receive message from other topology with true setting. The ControlMessage received at StormServerHandler can not be processed properly since false setting only expects `List<TaskMessage>`.

In the future, we should probably handle config better in storm since it would be weird for some config to be different between server and topo. 

## How was the change tested

Tested with setting server side to true and submit a WordCount topo with false `-c` setting.
`storm jar storm-starter-2.3.0-SNAPSHOT.jar org.apache.storm.starter.WordCountTopology -c topology.debug=true -c storm.messaging.netty.authentication=false wc2`

Additional log:
```
2020-06-24 00:57:25.737 o.a.s.d.n.Nimbus pool-29-thread-47 [INFO] Topo conf: false, nimbus conf: true, Enforce netty auth: true
```