### PR TITLE
MINOR: Remove unwanted creds update check at worker start

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -265,8 +265,6 @@ public class Worker implements Shutdownable, DaemonCommon {
 
         establishLogSettingCallback();
 
-        workerState.stormClusterState.credentials(topologyId, Worker.this::checkCredentialsChanged);
-
         workerState.refreshCredentialsTimer.scheduleRecurring(0,
                                                               (Integer) conf.get(Config.TASK_CREDENTIALS_POLL_SECS), () -> {
                 checkCredentialsChanged();


### PR DESCRIPTION
## What is the purpose of the change

The callback method to request credentials in the _loadWorker_ method is not required as it receives _initialCredentials_ as parameter. and within _TASK_CREDENTIALS_POLL_SECS_ schedule recurring call to _checkCredentialsChanged_ is setup. Also, all executors at init time receive initial credentials so no need for this additional call. 

## How was the change tested

Manually launched topology to verify if _setCredentials_ is called on all executors correctly on the start of workers.