### PR TITLE
[STORM-3666] Validate component name in rebalance command

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -782,7 +782,7 @@ def initialize_rebalance_subcommand(subparsers):
 
     sub_parser.add_argument(
         "-e", "--executors", action="append", default=[],
-        help="change the number of executors for a given component e.g component_name:5"
+        help="change the number of executors for a given component e.g. --executors component_name=6"
     )
 
     sub_parser.add_argument(

--- a/bin/storm.py
+++ b/bin/storm.py
@@ -781,8 +781,8 @@ def initialize_rebalance_subcommand(subparsers):
     )
 
     sub_parser.add_argument(
-        "-e", "--executors", action="append", default=[],
-        help="change the number of executors for a given component e.g. --executors component_name=6"
+        "-e", "--executor", action="append", default=[],
+        help="change the number of executors for a given component e.g. --executor component_name=6"
     )
 
     sub_parser.add_argument(
@@ -1204,7 +1204,7 @@ def deactivate(args):
 
 
 def rebalance(args):
-    for executor in args.executors:
+    for executor in args.executor:
         try:
             _, new_value = executor.split("=")
             new_value = int(new_value)

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2671,18 +2671,12 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
 
     private Map<String, Object> tryReadTopoConfFromName(final String topoName) throws NotAliveException,
         AuthorizationException, IOException {
-        IStormClusterState state = stormClusterState;
-        String topoId = state.getTopoId(topoName)
-                             .orElseThrow(() -> new WrappedNotAliveException(topoName + " is not alive"));
-        return tryReadTopoConf(topoId, topoCache);
+        return tryReadTopoConf(toTopoId(topoName), topoCache);
     }
 
     private StormTopology tryReadTopologyFromName(final String topoName) throws NotAliveException,
             AuthorizationException, IOException {
-        IStormClusterState state = stormClusterState;
-        String topoId = state.getTopoId(topoName)
-                .orElseThrow(() -> new WrappedNotAliveException(topoName + " is not alive"));
-        return tryReadTopology(topoId, topoCache);
+        return tryReadTopology(toTopoId(topoName), topoCache);
     }
 
     @VisibleForTesting
@@ -4766,8 +4760,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
 
                 for (StormBase base : ownerToBasesEntry.getValue()) {
                     try {
-                        String topoId = state.getTopoId(base.get_name())
-                                             .orElseThrow(() -> new WrappedNotAliveException(base.get_name() + " is not alive"));
+                        String topoId = toTopoId(base.get_name());
                         TopologyResources resources = getResourcesForTopology(topoId, base);
                         totalResourcesAggregate = totalResourcesAggregate.add(resources);
                         Assignment ownerAssignment = topoIdToAssignments.get(topoId);


### PR DESCRIPTION
## What is the purpose of the change

Rebalance command completes successfully when --executor option has invalid component name. This gives
the impression that command was successful. Change this behavior to throw an exception. In addition, fix the help
text for --executor options to show correct format.

## How was the change tested

Run storm and rebalance using various correct and incorrect formats like:
  bin/storm rebalance --help   # to show corrected help text
  bin/storm rebalance --executor spout:3 -w 1 word-count ## fail because of spout:3
  bin/storm rebalance --executor spout=3 -w 1 word-count ## verify correct rebalance in Storm UI with spout=3
  bin/storm rebalance -e spout=4 -w 1 word-count  ## verify correct rebalance in Storm UI with spout=4
  