### PR TITLE
[STORM-3667] make exceptions more understandable to submitters when topology submission fails due to incorrect worker max heap size config

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1642,12 +1642,12 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
 
     @VisibleForTesting
     static void validateTopologyWorkerMaxHeapSizeConfigs(
-        Map<String, Object> stormConf, StormTopology topology, double defaultWorkerMaxHeapSizeMb) {
+        Map<String, Object> stormConf, StormTopology topology, double defaultWorkerMaxHeapSizeMb) throws InvalidTopologyException {
         double largestMemReq = getMaxExecutorMemoryUsageForTopo(topology, stormConf);
         double topologyWorkerMaxHeapSize =
             ObjectReader.getDouble(stormConf.get(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB), defaultWorkerMaxHeapSizeMb);
         if (topologyWorkerMaxHeapSize < largestMemReq) {
-            throw new IllegalArgumentException(
+            throw new InvalidTopologyException(
                 "Topology will not be able to be successfully scheduled: Config "
                 + "TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB="
                 + topologyWorkerMaxHeapSize

--- a/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.apache.storm.Config;
 import org.apache.storm.DaemonConfig;
+import org.apache.storm.generated.InvalidTopologyException;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.scheduler.resource.strategies.priority.DefaultSchedulingPriorityStrategy;
 import org.apache.storm.scheduler.resource.strategies.scheduling.DefaultResourceAwareStrategy;
@@ -58,7 +59,7 @@ public class NimbusTest {
         try {
             Nimbus.validateTopologyWorkerMaxHeapSizeConfigs(config1, stormTopology1, 768.0);
             fail("Expected exception not thrown");
-        } catch (IllegalArgumentException e) {
+        } catch (InvalidTopologyException e) {
             //Expected...
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

https://issues.apache.org/jira/browse/STORM-3667

When submitting a topology failed because of incorrect max worker heap size config, the exception returned to submitter is not easy to understand: "Internal error processing submitTopology"


## How was the change tested

With 
```
bin/storm jar /home/y/lib64/jars/storm-starter.jar  org.apache.storm.starter.WordCountTopology -c topology.worker.max.heap.size.mb=100  -c topology.component.resources.onheap.memory.mb=120 wc
```
the exception message is much more clear to submitters now:
```
22:34:43.683 [main] ERROR o.a.s.StormSubmitter - Topology submission exception: Topology will not be able to be successfully scheduled: Config TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB=100.0 < 120.0 (Largest memory requirement of a component in the topology). Perhaps set TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB to a larger amount
java.lang.RuntimeException: InvalidTopologyException(msg:Topology will not be able to be successfully scheduled: Config TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB=100.0 < 120.0 (Largest memory requirement of a component in the topology). Perhaps set TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB to a larger amount)
	at org.apache.storm.StormSubmitter.submitTopologyAs(StormSubmitter.java:291)
	at org.apache.storm.StormSubmitter.submitTopology(StormSubmitter.java:210)
	at org.apache.storm.StormSubmitter.submitTopology(StormSubmitter.java:173)
	at org.apache.storm.topology.ConfigurableTopology.submit(ConfigurableTopology.java:119)
	at org.apache.storm.starter.WordCountTopology.run(WordCountTopology.java:58)
	at org.apache.storm.topology.ConfigurableTopology.start(ConfigurableTopology.java:68)
	at org.apache.storm.starter.WordCountTopology.main(WordCountTopology.java:36)
Caused by: InvalidTopologyException(msg:Topology will not be able to be successfully scheduled: Config TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB=100.0 < 120.0 (Largest memory requirement of a component in the topology). Perhaps set TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB to a larger amount)
	at org.apache.storm.generated.Nimbus$submitTopology_result$submitTopology_resultStandardScheme.read(Nimbus.java:9427)
	at org.apache.storm.generated.Nimbus$submitTopology_result$submitTopology_resultStandardScheme.read(Nimbus.java:9404)
	at org.apache.storm.generated.Nimbus$submitTopology_result.read(Nimbus.java:9338)
	at org.apache.storm.thrift.TServiceClient.receiveBase(TServiceClient.java:88)
	at org.apache.storm.generated.Nimbus$Client.recv_submitTopology(Nimbus.java:319)
	at org.apache.storm.generated.Nimbus$Client.submitTopology(Nimbus.java:303)
	at org.apache.storm.StormSubmitter.submitTopologyInDistributeMode(StormSubmitter.java:344)
	at org.apache.storm.StormSubmitter.submitTopologyAs(StormSubmitter.java:279)
	... 6 more
```