### PR TITLE
[MINOR] use project.version for storm-core dep in storm-webapp

### DIFF
--- a/storm-webapp/pom.xml
+++ b/storm-webapp/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-core</artifactId>
-            <version>2.3.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>${provided.scope}</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What is the purpose of the change

Changing to use `${project.version}` property.

## How was the change tested

Re-ran build.