### PR TITLE
STORM-3674 Explicitly specify pip2 and pip3 in travis-install.sh

### DIFF
--- a/dev-tools/travis/travis-install.sh
+++ b/dev-tools/travis/travis-install.sh
@@ -13,7 +13,7 @@
 
 echo "Python version :  " `python -V 2>&1`
 echo "Python3 version :  " `python3 -V 2>&1`
-echo "Pip version :  " `pip --version 2>&1`
+echo "Pip2 version :  " `pip2 --version 2>&1`
 echo "Pip3 version :  " `pip3 --version 2>&1`
 
 
@@ -23,7 +23,7 @@ STORM_SRC_ROOT_DIR=$1
 
 TRAVIS_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-pip install --user -r ${TRAVIS_SCRIPT_DIR}/requirements.txt
+pip2 install --user -r ${TRAVIS_SCRIPT_DIR}/requirements.txt
 pip3 install --user -r ${TRAVIS_SCRIPT_DIR}/requirements.txt
 
 python ${TRAVIS_SCRIPT_DIR}/save-logs.py "storm-shaded-deps/install-shade.txt" mvn clean install --batch-mode -pl storm-shaded-deps -am


### PR DESCRIPTION
##  What is the purpose of the change

Try to make Storm support running tests with Travis CI on ARM platform.

## How was the change tested

In Travis ARM building, the "pip" command refer to the "pip3" binary,
that will cause the python2 packages installation missed. This change
modify the travis-install.sh to explicitly specify pip2 and pip3.
I have tried to config Storm with Travis CI ARM platform, please see:
https://github.com/liusheng/storm/pull/4/checks