### PR TITLE
[STORM-3675] Check worker process death using /proc/<pid> directory

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
@@ -1239,9 +1239,10 @@ public class ServerUtils {
             // check if existing process is owned by the specified user, if not, the process is dead
             try {
                 String pidUser = Files.getOwner(pidDir.toPath()).getName();
-                LOG.info("Process directory {} owner is {}", pidDir, pidUser);
+                LOG.debug("Process directory {} owner is {}", pidDir, pidUser);
                 if (!user.equals(pidUser)) {
-                    LOG.debug("Process is dead, since directory {} owner {} is not same as expected user {}", pidDir, pidUser, user);
+                    LOG.info("Prior process is dead, since directory {} owner {} is not same as expected user {}, "
+                            + "likely pid {} was reused for a new process for user {}", pidDir, pidUser, user, pid, pidUser);
                     continue;
                 }
             } catch (NoSuchFileException ex) {

--- a/storm-server/src/test/java/org/apache/storm/utils/ServerUtilsTest.java
+++ b/storm-server/src/test/java/org/apache/storm/utils/ServerUtilsTest.java
@@ -193,13 +193,11 @@ public class ServerUtilsTest {
         if (!parentDir.toFile().exists()) {
             LOG.info("{}: test cannot be run on system without process directory {}, os.name={}",
                     testName, parentDir, System.getProperty("os.name"));
-            {
-                // check if we can get process id on this Posix system - testing test code, useful on Mac
-                String cmd = "/bin/sleep 10";
-                if (getPidOfPosixProcess(Runtime.getRuntime().exec(cmd), errors) < 0) {
-                    fail(String.format("%s: Cannot obtain process id for executed command \"%s\"\n%s",
-                            testName, cmd, String.join("\n\t", errors)));
-                }
+            // check if we can get process id on this Posix system - testing test code, useful on Mac
+            String cmd = "/bin/sleep 10";
+            if (getPidOfPosixProcess(Runtime.getRuntime().exec(cmd), errors) < 0) {
+                fail(String.format("%s: Cannot obtain process id for executed command \"%s\"\n%s",
+                        testName, cmd, String.join("\n\t", errors)));
             }
             return;
         }
@@ -223,7 +221,7 @@ public class ServerUtilsTest {
         // now kill processes one by one
         List<Long> pidList = new ArrayList<>(observables);
         final long processKillIntervalMs = 2000;
-        for (int i = 0 ; i < pidList.size() ; i++) {
+        for (int i = 0; i < pidList.size(); i++) {
             long pid = pidList.get(i);
             LOG.info("{}: ({}) Sleeping for {} milliseconds before kill", testName, i, processKillIntervalMs);
             if (sleepInterrupted(processKillIntervalMs)) {
@@ -284,7 +282,7 @@ public class ServerUtilsTest {
                 if (!f.getName().equalsIgnoreCase("pid")) {
                     continue;
                 }
-                LOG.info("ServerUtilsTest.getPidOfPosixProcess(): found attribute {}}#{}}", pclassName, f.getName());
+                LOG.info("ServerUtilsTest.getPidOfPosixProcess(): found attribute {}#{}", pclassName, f.getName());
                 f.setAccessible(true);
                 long pid = f.getLong(p);
                 f.setAccessible(false);
@@ -296,7 +294,7 @@ public class ServerUtilsTest {
             // post JDK 9 there should be getPid() - future JDK-11 compatibility only for the sake of Travis test in community
             try {
                 Method m = pClass.getDeclaredMethod("getPid");
-                LOG.info("ServerUtilsTest.getPidOfPosixProcess(): found method {}}#getPid()\n", pclassName);
+                LOG.info("ServerUtilsTest.getPidOfPosixProcess(): found method {}#getPid()\n", pclassName);
                 long pid = (Long)m.invoke(p);
                 if (pid < 0) {
                     errors.add("\t \"getPid()\" method in Process class " + pclassName + " returned -1, process=" + pObjStr);

--- a/storm-server/src/test/java/org/apache/storm/utils/ServerUtilsTest.java
+++ b/storm-server/src/test/java/org/apache/storm/utils/ServerUtilsTest.java
@@ -98,7 +98,7 @@ public class ServerUtilsTest {
             String line;
             while ((line = input.readLine()) != null) {
                 line = line.trim();
-                if (line.isEmpty()) {
+                if (line.isEmpty() || line.startsWith("PID")) {
                     continue;
                 }
                 try {
@@ -180,7 +180,7 @@ public class ServerUtilsTest {
     @Test
     public void testIsAnyProcessPosixProcessPidDirAlive() throws IOException {
         final String testName = "testIsAnyProcessPosixProcessPidDirAlive";
-        int errCnt = 0;
+        List<String> errors = new ArrayList<>();
         int maxPidCnt = 5;
         if (ServerUtils.IS_ON_WINDOWS) {
             LOG.info("{}: test cannot be run on Windows. Marked as successful", testName);
@@ -201,8 +201,9 @@ public class ServerUtilsTest {
             long pid = getPidOfUnixProcess(process);
             LOG.info("{}: ({}) ran process \"{}\" with pid={}", testName, i, cmd, pid);
             if (pid < 0) {
-                errCnt++;
-                LOG.error("{}: ({}) Cannot obtain process id for executed command \"{}\"", testName, i, cmd);
+                String e = String.format("%s: (%d) Cannot obtain process id for executed command \"%s\"", testName, i, cmd);
+                errors.add(e);
+                LOG.error(e);
                 continue;
             }
             observables.add(pid);
@@ -227,20 +228,22 @@ public class ServerUtilsTest {
                 if (pidDirsAvailable) {
                     LOG.info("{}: ({}) Found existing process directories before killing last process", testName, i);
                 } else {
-                    errCnt++;
-                    LOG.error("{}: ({}) Found no existing process directories before killing last process", testName, i);
+                    String e = String.format("%s: (%d) Found no existing process directories before killing last process", testName, i);
+                    errors.add(e);
+                    LOG.error(e);
                 }
             } else {
                 if (pidDirsAvailable) {
-                    errCnt++;
-                    LOG.error("{}: ({}) Found existing process directories after killing last process", testName, i);
+                    String e = String.format("%s: (%d) Found existing process directories after killing last process", testName, i);
+                    errors.add(e);
+                    LOG.error(e);
                 } else {
                     LOG.info("{}: ({}) Found no existing process directories after killing last process", testName, i);
                 }
             }
         }
-        if (errCnt > 0) {
-            fail("There are " + errCnt + " failures in test");
+        if (!errors.isEmpty()) {
+            fail(String.format("There are %d failures in test:\n\t%s", errors.size(), String.join("\n\t", errors)));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*This function can replace a system "ps" command with existence/ownership check on /proc/ directory. In additional, on loaded nodes, ps command can take a few seconds. java.io.File.exists() is expected to be much faster. Note that File watcher does not work on /proc file system and the event based approach was coded/tested and then discarded.*

## How was the change tested

*new test methods in ServerUtilsTest. Also run storm, kill worker and observe log to ensure proper detection*