### PR TITLE
STORM-3677: Fix suicide function if assignment is null

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -381,17 +381,23 @@ public class WorkerState {
     }
 
     public void suicideIfLocalAssignmentsChanged(Assignment assignment) {
+        boolean shouldHalt = false;
         if (assignment != null) {
             Set<List<Long>> assignedExecutors = new HashSet<>(readWorkerExecutors(assignmentId, port, assignment));
             if (!localExecutors.equals(assignedExecutors)) {
-                LOG.info("Found conflicting assignments. We shouldn't be alive!"
-                         + " Assigned: " + assignedExecutors + ", Current: "
-                         + localExecutors);
-                if (!ConfigUtils.isLocalMode(conf)) {
-                    suicideCallback.run();
-                } else {
-                    LOG.info("Local worker tried to commit suicide!");
-                }
+                LOG.info("Found conflicting assignments. We shouldn't be alive!" + " Assigned: " + assignedExecutors
+                         + ", Current: " + localExecutors);
+                shouldHalt = true;
+            }
+        } else {
+            LOG.info("Assigment is null. We should not be alive!");
+            shouldHalt = true;
+        }
+        if (shouldHalt) {
+            if (!ConfigUtils.isLocalMode(conf)) {
+                suicideCallback.run();
+            } else {
+                LOG.info("Local worker tried to commit suicide!");
             }
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

In refresh-connection thread, if we do get localAssignment, we try to get it from Zookeeper, if assignment is still null it suggests the worker should not exist.

## How was the change tested

Manually tested this:

1. Launch topology.
2. Stop supervisor, validate that worker stays up - as it reads assignment from ZK
3. Kill topology
4. Worker suicide function recognizes null assignment and kills itself.


Here is worker log after change..

```
2020-07-17 17:53:24.494 o.a.s.d.w.WorkerState refresh-connections-timer [WARN] Failed to read assignment. This should only happen when topology is shutting down.
java.lang.RuntimeException: Failed to read worker assignment. Supervisor client threw exception, and assignment in Zookeeper was null
2020-07-17 17:53:24.503 o.a.s.d.w.WorkerState refresh-connections-timer [INFO] Assigment is null. We should not be alive!
2020-07-17 17:53:24.503 o.a.s.u.Utils refresh-connections-timer [ERROR] Halting process: Worker died
java.lang.RuntimeException: Halting process: Worker died
        at org.apache.storm.utils.Utils.exitProcess(Utils.java:518) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.utils.Utils$3.run(Utils.java:870) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.daemon.worker.WorkerState.suicideIfLocalAssignmentsChanged(WorkerState.java:398) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.daemon.worker.WorkerState.refreshConnections(WorkerState.java:413) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.StormTimer$1.run(StormTimer.java:110) [storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.StormTimer$StormTimerTask.run(StormTimer.java:226) [storm-client-2.3.0.y.jar:2.3.0.y]

```