### PR TITLE
[STORM-3679] Fix the misuse of nodeId as hostname in LoadAwareShuffleGrouping

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/task/WorkerTopologyContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/WorkerTopologyContext.java
@@ -32,6 +32,7 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
     private String pidDir;
     private AtomicReference<Map<Integer, NodeInfo>> taskToNodePort;
     private String assignmentId;
+    private final AtomicReference<Map<String, String>> nodeToHost;
 
     public WorkerTopologyContext(
         StormTopology topology,
@@ -47,7 +48,8 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
         Map<String, Object> defaultResources,
         Map<String, Object> userResources,
         AtomicReference<Map<Integer, NodeInfo>> taskToNodePort,
-        String assignmentId
+        String assignmentId,
+        AtomicReference<Map<String, String>> nodeToHost
     ) {
         super(topology, topoConf, taskToComponent, componentToSortedTasks, componentToStreamToFields, stormId);
         this.codeDir = codeDir;
@@ -66,6 +68,7 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
         this.workerTasks = workerTasks;
         this.taskToNodePort = taskToNodePort;
         this.assignmentId = assignmentId;
+        this.nodeToHost = nodeToHost;
 
     }
 
@@ -83,7 +86,7 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
         Map<String, Object> defaultResources,
         Map<String, Object> userResources) {
         this(topology, topoConf, taskToComponent, componentToSortedTasks, componentToStreamToFields, stormId,
-             codeDir, pidDir, workerPort, workerTasks, defaultResources, userResources, null, null);
+             codeDir, pidDir, workerPort, workerTasks, defaultResources, userResources, null, null, null);
     }
 
     /**
@@ -97,7 +100,7 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
         return workerPort;
     }
 
-    public String getThisWorkerHost() {
+    public String getAssignmentId() {
         return assignmentId;
     }
 
@@ -108,6 +111,14 @@ public class WorkerTopologyContext extends GeneralTopologyContext {
      */
     public AtomicReference<Map<Integer, NodeInfo>> getTaskToNodePort() {
         return taskToNodePort;
+    }
+
+    /**
+     * Get a map from nodeId to hostname.
+     * @return a map from nodeId to hostname
+     */
+    public AtomicReference<Map<String, String>> getNodeToHost() {
+        return nodeToHost;
     }
 
     /**

--- a/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/grouping/LoadAwareShuffleGroupingTest.java
@@ -66,8 +66,10 @@ public class LoadAwareShuffleGroupingTest {
         NodeInfo nodeInfo = new NodeInfo("node-id", Sets.newHashSet(6700L));
         availableTaskIds.forEach(e -> taskNodeToPort.put(e, nodeInfo));
         when(context.getTaskToNodePort()).thenReturn(new AtomicReference<>(taskNodeToPort));
-        when(context.getThisWorkerHost()).thenReturn("node-id");
+        when(context.getAssignmentId()).thenReturn("node-id");
         when(context.getThisWorkerPort()).thenReturn(6700);
+        AtomicReference<Map<String, String>> nodeToHost = new AtomicReference<>(Collections.singletonMap("node-id", "hostname1"));
+        when(context.getNodeToHost()).thenReturn(nodeToHost);
         return context;
     }
 
@@ -566,8 +568,14 @@ public class LoadAwareShuffleGroupingTest {
         taskNodeToPort.put(3, new NodeInfo("node-id2", Sets.newHashSet(6703L)));
 
         when(context.getTaskToNodePort()).thenReturn(new AtomicReference<>(taskNodeToPort));
-        when(context.getThisWorkerHost()).thenReturn("node-id");
+        when(context.getAssignmentId()).thenReturn("node-id");
         when(context.getThisWorkerPort()).thenReturn(6701);
+
+        Map<String, String> nodeToHost = new HashMap<>();
+        nodeToHost.put("node-id", "hostname1");
+        nodeToHost.put("node-id2", "hostname2");
+        when(context.getNodeToHost()).thenReturn(new AtomicReference<>(nodeToHost));
+
         return context;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

LoadAwareShuffleGrouping misuses nodeId as the hostname to cause consistent invalid DNS queries for "hostnames" like 2a1f2cf3-c701-4621-9e93-640b4e63be48-10.215.73.209.

This causes excessive unnecessary loads on nscd and DNS. Also because of this bug, every target tasks will be treated as at least RACK_LOCAL because if an ip address can't be determined, YahooDNSToSwitchMapping treats it as DEFAULT_RACK. This doesn't impact WORKER_LOCAL and HOST_LOCAL though.

## How was the change tested
Before the change,

added logs and showed that the "hostname" is actually an ID. And tcp dump
```
18:42:21.913688 IP <host1>.42462 > <dns>: 43104+ A? 2a1f2cf3-c701-4621-9e93-640b4e63be48-<ip1>. (68)
18:42:21.914181 IP <dns> > <host1>.42462: 43104 NXDomain 0/1/0 (143)
```

After the change, 
determined from additional added debug logs (removed after the coding is done) that the hostnames are correct and no invalid queries shown in TCP dump.