### PR TITLE
[STORM-3680] Upgrade Jedis Library

### DIFF
--- a/examples/storm-redis-examples/src/main/java/org/apache/storm/redis/tools/Base64ToBinaryStateMigrationUtil.java
+++ b/examples/storm-redis-examples/src/main/java/org/apache/storm/redis/tools/Base64ToBinaryStateMigrationUtil.java
@@ -35,8 +35,7 @@ import org.apache.storm.redis.common.container.RedisCommandsContainerBuilder;
 import org.apache.storm.redis.common.container.RedisCommandsInstanceContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class Base64ToBinaryStateMigrationUtil {
     private static final Logger LOG = LoggerFactory.getLogger(Base64ToBinaryStateMigrationUtil.class);

--- a/external/storm-redis/pom.xml
+++ b/external/storm-redis/pom.xml
@@ -77,6 +77,19 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
         </dependency>
+        <!-- Test Containers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/AbstractRedisBolt.java
@@ -16,11 +16,10 @@ import java.util.Map;
 import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.apache.storm.redis.common.config.JedisPoolConfig;
 import org.apache.storm.redis.common.container.JedisCommandsContainerBuilder;
-import org.apache.storm.redis.common.container.JedisCommandsInstanceContainer;
+import org.apache.storm.redis.common.container.JedisCommandsContainer;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.base.BaseTickTupleAwareRichBolt;
-import redis.clients.jedis.JedisCommands;
 
 /**
  * AbstractRedisBolt class is for users to implement custom bolts which makes interaction with Redis.
@@ -45,7 +44,7 @@ import redis.clients.jedis.JedisCommands;
 public abstract class AbstractRedisBolt extends BaseTickTupleAwareRichBolt {
     protected OutputCollector collector;
 
-    private transient JedisCommandsInstanceContainer container;
+    private transient JedisCommandsContainer container;
 
     private JedisPoolConfig jedisPoolConfig;
     private JedisClusterConfig jedisClusterConfig;
@@ -89,18 +88,10 @@ public abstract class AbstractRedisBolt extends BaseTickTupleAwareRichBolt {
      * Borrow JedisCommands instance from container.<p/>
      * JedisCommands is an interface which contains single key operations.
      * @return implementation of JedisCommands
-     * @see JedisCommandsInstanceContainer#getInstance()
+     * @see JedisCommandsContainer
      */
-    protected JedisCommands getInstance() {
-        return this.container.getInstance();
-    }
-
-    /**
-     * Return borrowed instance to container.
-     * @param instance borrowed object
-     */
-    protected void returnInstance(JedisCommands instance) {
-        this.container.returnInstance(instance);
+    protected JedisCommandsContainer getInstance() {
+        return this.container;
     }
 
     @Override

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisFilterBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisFilterBolt.java
@@ -15,12 +15,12 @@ package org.apache.storm.redis.bolt;
 import java.util.List;
 import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.apache.storm.redis.common.config.JedisPoolConfig;
+import org.apache.storm.redis.common.container.JedisCommandsContainer;
 import org.apache.storm.redis.common.mapper.RedisDataTypeDescription;
 import org.apache.storm.redis.common.mapper.RedisFilterMapper;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Tuple;
 import redis.clients.jedis.GeoCoordinate;
-import redis.clients.jedis.JedisCommands;
 
 /**
  * Basic bolt for querying from Redis and filters out if key/field doesn't exist.
@@ -85,7 +85,7 @@ public class RedisFilterBolt extends AbstractRedisBolt {
         String key = filterMapper.getKeyFromTuple(input);
 
         boolean found;
-        JedisCommands jedisCommand = null;
+        JedisCommandsContainer jedisCommand = null;
         try {
             jedisCommand = getInstance();
 
@@ -127,8 +127,6 @@ public class RedisFilterBolt extends AbstractRedisBolt {
         } catch (Exception e) {
             this.collector.reportError(e);
             this.collector.fail(input);
-        } finally {
-            returnInstance(jedisCommand);
         }
     }
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisFilterBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisFilterBolt.java
@@ -13,6 +13,8 @@
 package org.apache.storm.redis.bolt;
 
 import java.util.List;
+import java.util.Objects;
+
 import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.apache.storm.redis.common.config.JedisPoolConfig;
 import org.apache.storm.redis.common.container.JedisCommandsContainer;
@@ -112,7 +114,13 @@ public class RedisFilterBolt extends AbstractRedisBolt {
 
                 case GEO:
                     List<GeoCoordinate> geopos = jedisCommand.geopos(additionalKey, key);
-                    found = (geopos != null && geopos.size() > 0);
+                    if (geopos == null || geopos.isEmpty()) {
+                        found = false;
+                    } else {
+                        // If any entry is NOT null, then we have a match.
+                        found = geopos.stream()
+                            .anyMatch(Objects::nonNull);
+                    }
                     break;
 
                 default:

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisLookupBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisLookupBolt.java
@@ -15,12 +15,12 @@ package org.apache.storm.redis.bolt;
 import java.util.List;
 import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.apache.storm.redis.common.config.JedisPoolConfig;
+import org.apache.storm.redis.common.container.JedisCommandsContainer;
 import org.apache.storm.redis.common.mapper.RedisDataTypeDescription;
 import org.apache.storm.redis.common.mapper.RedisLookupMapper;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.tuple.Values;
-import redis.clients.jedis.JedisCommands;
 
 /**
  * Basic bolt for querying from Redis and emits response as tuple.
@@ -70,7 +70,7 @@ public class RedisLookupBolt extends AbstractRedisBolt {
         String key = lookupMapper.getKeyFromTuple(input);
         Object lookupValue;
 
-        JedisCommands jedisCommand = null;
+        JedisCommandsContainer jedisCommand = null;
         try {
             jedisCommand = getInstance();
 
@@ -116,8 +116,6 @@ public class RedisLookupBolt extends AbstractRedisBolt {
         } catch (Exception e) {
             this.collector.reportError(e);
             this.collector.fail(input);
-        } finally {
-            returnInstance(jedisCommand);
         }
     }
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisStoreBolt.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/bolt/RedisStoreBolt.java
@@ -14,11 +14,11 @@ package org.apache.storm.redis.bolt;
 
 import org.apache.storm.redis.common.config.JedisClusterConfig;
 import org.apache.storm.redis.common.config.JedisPoolConfig;
+import org.apache.storm.redis.common.container.JedisCommandsContainer;
 import org.apache.storm.redis.common.mapper.RedisDataTypeDescription;
 import org.apache.storm.redis.common.mapper.RedisStoreMapper;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Tuple;
-import redis.clients.jedis.JedisCommands;
 
 /**
  * Basic bolt for writing to Redis.
@@ -66,7 +66,7 @@ public class RedisStoreBolt extends AbstractRedisBolt {
         String key = storeMapper.getKeyFromTuple(input);
         String value = storeMapper.getValueFromTuple(input);
 
-        JedisCommands jedisCommand = null;
+        JedisCommandsContainer jedisCommand = null;
         try {
             jedisCommand = getInstance();
 
@@ -114,8 +114,6 @@ public class RedisStoreBolt extends AbstractRedisBolt {
         } catch (Exception e) {
             this.collector.reportError(e);
             this.collector.fail(input);
-        } finally {
-            returnInstance(jedisCommand);
         }
     }
 

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisClusterContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisClusterContainer.java
@@ -12,16 +12,17 @@
 
 package org.apache.storm.redis.common.container;
 
-import java.io.IOException;
+import redis.clients.jedis.GeoCoordinate;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.JedisCommands;
+
+import java.util.List;
 
 /**
  * Container for managing JedisCluster.
  * <p/>
  * Note that JedisCluster doesn't need to be pooled since it's thread-safe and it stores pools internally.
  */
-public class JedisClusterContainer implements JedisCommandsInstanceContainer {
+public class JedisClusterContainer implements JedisCommandsContainer {
 
     private JedisCluster jedisCluster;
 
@@ -33,20 +34,94 @@ public class JedisClusterContainer implements JedisCommandsInstanceContainer {
         this.jedisCluster = jedisCluster;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public JedisCommands getInstance() {
-        return this.jedisCluster;
+    public Boolean exists(final String key) {
+        return jedisCluster.exists(key);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public void returnInstance(JedisCommands jedisCommands) {
-        // do nothing
+    public String get(final String key) {
+        return jedisCluster.get(key);
+    }
+
+    @Override
+    public String hget(final String key, final String field) {
+        return jedisCluster.hget(key, field);
+    }
+
+    @Override
+    public Long geoadd(final String key, final double longitude, final double latitude, final String member) {
+        return jedisCluster.geoadd(key, longitude, latitude, member);
+    }
+
+    @Override
+    public List<GeoCoordinate> geopos(final String key, final String... members) {
+        return jedisCluster.geopos(key, members);
+    }
+
+    @Override
+    public Boolean hexists(final String key, final String field) {
+        return jedisCluster.hexists(key, field);
+    }
+
+    @Override
+    public Long hset(final String key, final String field, final String value) {
+        return jedisCluster.hset(key, field, value);
+    }
+
+    @Override
+    public String lpop(final String key) {
+        return jedisCluster.lpop(key);
+    }
+
+    @Override
+    public Long pfadd(final String key, final String... elements) {
+        return jedisCluster.pfadd(key, elements);
+    }
+
+    @Override
+    public long pfcount(final String key) {
+        return jedisCluster.pfcount(key);
+    }
+
+    @Override
+    public Long rpush(final String key, final String... string) {
+        return jedisCluster.rpush(key, string);
+    }
+
+    @Override
+    public Long sadd(final String key, final String... member) {
+        return jedisCluster.sadd(key, member);
+    }
+
+    @Override
+    public Long scard(final String key) {
+        return jedisCluster.scard(key);
+    }
+
+    @Override
+    public String set(final String key, final String value) {
+        return jedisCluster.set(key, value);
+    }
+
+    @Override
+    public Boolean sismember(final String key, final String member) {
+        return jedisCluster.sismember(key, member);
+    }
+
+    @Override
+    public Long zadd(final String key, final double score, final String member) {
+        return jedisCluster.zadd(key, score, member);
+    }
+
+    @Override
+    public Long zrank(final String key, final String member) {
+        return jedisCluster.zrank(key, member);
+    }
+
+    @Override
+    public Double zscore(final String key, final String member) {
+        return jedisCluster.zscore(key, member);
     }
 
     /**
@@ -54,10 +129,6 @@ public class JedisClusterContainer implements JedisCommandsInstanceContainer {
      */
     @Override
     public void close() {
-        try {
-            this.jedisCluster.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        this.jedisCluster.close();
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsContainer.java
@@ -12,24 +12,57 @@
 
 package org.apache.storm.redis.common.container;
 
+import redis.clients.jedis.GeoCoordinate;
+
 import java.io.Closeable;
-import redis.clients.jedis.JedisCommands;
+import java.util.List;
+
 
 /**
  * Interfaces for containers which stores instances implementing JedisCommands.
  */
-public interface JedisCommandsInstanceContainer extends Closeable {
-    /**
-     * Borrows instance from container.
-     * @return instance which implements JedisCommands
-     */
-    JedisCommands getInstance();
+public interface JedisCommandsContainer extends Closeable {
+    Boolean exists(String key);
 
-    /**
-     * Returns instance to container.
-     * @param jedisCommands borrowed instance
-     */
-    void returnInstance(JedisCommands jedisCommands);
+    String get(String key);
+
+    String hget(String key, String field);
+
+    Long geoadd(String key, double longitude, double latitude, String member);
+
+    List<GeoCoordinate> geopos(String key, String... members);
+
+    Boolean hexists(String key, String field);
+
+    Long hset(String key, String field, String value);
+
+    String lpop(String key);
+
+    Long pfadd(String key, String... elements);
+
+    long pfcount(String key);
+
+    Long rpush(String key, String... string);
+
+    Long sadd(String key, String... member);
+
+    Long scard(String key);
+
+    String set(String key, String value);
+
+    Boolean sismember(String key, String member);
+
+    Long zadd(String key, double score, String member);
+
+    Long zrank(String key, String member);
+
+    Double zscore(String key, String member);
+
+
+
+
+
+
 
     /**
      * Release Container.

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsContainer.java
@@ -58,12 +58,6 @@ public interface JedisCommandsContainer extends Closeable {
 
     Double zscore(String key, String member);
 
-
-
-
-
-
-
     /**
      * Release Container.
      */

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsContainerBuilder.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisCommandsContainerBuilder.java
@@ -31,7 +31,7 @@ public class JedisCommandsContainerBuilder {
      * @param config configuration for JedisPool
      * @return container for single Redis environment
      */
-    public static JedisCommandsInstanceContainer build(JedisPoolConfig config) {
+    public static JedisCommandsContainer build(JedisPoolConfig config) {
         JedisPool jedisPool =
             new JedisPool(DEFAULT_POOL_CONFIG, config.getHost(), config.getPort(), config.getTimeout(), config.getPassword(),
                           config.getDatabase());
@@ -43,7 +43,7 @@ public class JedisCommandsContainerBuilder {
      * @param config configuration for JedisCluster
      * @return container for Redis Cluster environment
      */
-    public static JedisCommandsInstanceContainer build(JedisClusterConfig config) {
+    public static JedisCommandsContainer build(JedisClusterConfig config) {
         JedisCluster jedisCluster =
             new JedisCluster(config.getNodes(), config.getTimeout(), config.getTimeout(), config.getMaxRedirections(), config.getPassword(),
                              DEFAULT_POOL_CONFIG);

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/JedisContainer.java
@@ -14,15 +14,19 @@ package org.apache.storm.redis.common.container;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.JedisCommands;
+import redis.clients.jedis.GeoCoordinate;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.commands.JedisCommands;
 
 /**
- * Container for managing Jedis instances.
+ * Adapter for providing a unified interface for running commands over both Jedis and JedisCluster instances.
  */
-public class JedisContainer implements JedisCommandsInstanceContainer {
+public class JedisContainer implements JedisCommandsContainer {
     private static final Logger LOG = LoggerFactory.getLogger(JedisContainer.class);
 
     private JedisPool jedisPool;
@@ -35,27 +39,16 @@ public class JedisContainer implements JedisCommandsInstanceContainer {
         this.jedisPool = jedisPool;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public JedisCommands getInstance() {
-        return jedisPool.getResource();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void returnInstance(JedisCommands jedisCommands) {
-        if (jedisCommands == null) {
-            return;
-        }
-
+    private <T> T runCommand(Function<JedisCommands, T> command) {
+        final JedisCommands jedisCommands = jedisPool.getResource();
         try {
-            ((Closeable) jedisCommands).close();
-        } catch (IOException e) {
-            LOG.error("Failed to close (return) instance to pool");
+            return command.apply(jedisCommands);
+        } finally {
+            try {
+                ((Closeable) jedisCommands).close();
+            } catch (IOException e) {
+                LOG.error("Failed to close (return) instance to pool");
+            }
         }
     }
 
@@ -65,5 +58,95 @@ public class JedisContainer implements JedisCommandsInstanceContainer {
     @Override
     public void close() {
         jedisPool.close();
+    }
+
+    @Override
+    public Boolean exists(final String key) {
+        return runCommand((jedisCommands) -> jedisCommands.exists(key));
+    }
+
+    @Override
+    public String get(final String key) {
+        return runCommand((jedisCommands) -> jedisCommands.get(key));
+    }
+
+    @Override
+    public String hget(final String key, final String field) {
+        return runCommand((jedisCommands) -> jedisCommands.hget(key, field));
+    }
+
+    @Override
+    public Long geoadd(final String key, final double longitude, final double latitude, final String member) {
+        return runCommand((jedisCommands) -> jedisCommands.geoadd(key, longitude, latitude, member));
+    }
+
+    @Override
+    public List<GeoCoordinate> geopos(final String key, final String... members) {
+        return runCommand((jedisCommands) -> jedisCommands.geopos(key, members));
+    }
+
+    @Override
+    public Boolean hexists(final String key, final String field) {
+        return runCommand((jedisCommands) -> jedisCommands.hexists(key, field));
+    }
+
+    @Override
+    public Long hset(final String key, final String field, final String value) {
+        return runCommand((jedisCommands) -> jedisCommands.hset(key, field, value));
+    }
+
+    @Override
+    public String lpop(final String key) {
+        return runCommand((jedisCommands) -> jedisCommands.lpop(key));
+    }
+
+    @Override
+    public Long pfadd(final String key, final String... elements) {
+        return runCommand((jedisCommands) -> jedisCommands.pfadd(key, elements));
+    }
+
+    @Override
+    public long pfcount(final String key) {
+        return runCommand((jedisCommands) -> jedisCommands.pfcount(key));
+    }
+
+    @Override
+    public Long rpush(final String key, final String... string) {
+        return runCommand((jedisCommands) -> jedisCommands.rpush(key, string));
+    }
+
+    @Override
+    public Long sadd(final String key, final String... member) {
+        return runCommand((jedisCommands) -> jedisCommands.sadd(key, member));
+    }
+
+    @Override
+    public Long scard(final String key) {
+        return runCommand((jedisCommands) -> jedisCommands.scard(key));
+    }
+
+    @Override
+    public String set(final String key, final String value) {
+        return runCommand((jedisCommands) -> jedisCommands.set(key, value));
+    }
+
+    @Override
+    public Boolean sismember(final String key, final String member) {
+        return runCommand((jedisCommands) -> jedisCommands.sismember(key, member));
+    }
+
+    @Override
+    public Long zadd(final String key, final double score, final String member) {
+        return runCommand((jedisCommands) -> jedisCommands.zadd(key, score, member));
+    }
+
+    @Override
+    public Long zrank(final String key, final String member) {
+        return runCommand((jedisCommands) -> jedisCommands.zrank(key, member));
+    }
+
+    @Override
+    public Double zscore(final String key, final String member) {
+        return runCommand((jedisCommands) -> jedisCommands.zscore(key, member));
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/RedisClusterContainer.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/common/container/RedisClusterContainer.java
@@ -18,7 +18,6 @@
 
 package org.apache.storm.redis.common.container;
 
-import java.io.IOException;
 import org.apache.storm.redis.common.adapter.RedisCommandsAdapterJedisCluster;
 import org.apache.storm.redis.common.commands.RedisCommands;
 import redis.clients.jedis.JedisCluster;
@@ -60,11 +59,7 @@ public class RedisClusterContainer implements RedisCommandsInstanceContainer {
      * {@inheritDoc}
      */
     @Override
-    public void close() throws IOException {
-        try {
-            this.jedisCluster.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+    public void close() {
+        this.jedisCluster.close();
     }
 }

--- a/external/storm-redis/src/main/java/org/apache/storm/redis/state/RedisKeyValueState.java
+++ b/external/storm-redis/src/main/java/org/apache/storm/redis/state/RedisKeyValueState.java
@@ -35,7 +35,7 @@ import org.apache.storm.state.KeyValueState;
 import org.apache.storm.state.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 /**
  * A redis based implementation that persists the state in Redis.

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/bolt/RedisFilterBoltTest.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/bolt/RedisFilterBoltTest.java
@@ -1,0 +1,491 @@
+package org.apache.storm.redis.bolt;
+
+import org.apache.storm.redis.common.config.JedisPoolConfig;
+import org.apache.storm.redis.common.mapper.RedisDataTypeDescription;
+import org.apache.storm.redis.common.mapper.RedisFilterMapper;
+import org.apache.storm.redis.util.JedisTestHelper;
+import org.apache.storm.redis.util.StubTuple;
+import org.apache.storm.redis.util.TupleTestHelper;
+import org.apache.storm.redis.util.outputcollector.EmittedTuple;
+import org.apache.storm.redis.util.outputcollector.StubOutputCollector;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.ITuple;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.utils.Utils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.storm.redis.common.mapper.RedisDataTypeDescription.RedisDataType.GEO;
+import static org.apache.storm.redis.common.mapper.RedisDataTypeDescription.RedisDataType.HASH;
+import static org.apache.storm.redis.common.mapper.RedisDataTypeDescription.RedisDataType.HYPER_LOG_LOG;
+import static org.apache.storm.redis.common.mapper.RedisDataTypeDescription.RedisDataType.SET;
+import static org.apache.storm.redis.common.mapper.RedisDataTypeDescription.RedisDataType.SORTED_SET;
+import static org.apache.storm.redis.common.mapper.RedisDataTypeDescription.RedisDataType.STRING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@Testcontainers
+class RedisFilterBoltTest {
+
+    @Container
+    public GenericContainer container = new GenericContainer("redis:6.0.5-alpine")
+        .withExposedPorts(6379);
+
+    private JedisTestHelper jedisHelper;
+
+    private JedisPoolConfig.Builder configBuilder;
+    private StubOutputCollector outputCollector;
+    private TopologyContext topologyContext;
+
+    @BeforeEach
+    void setup() {
+        configBuilder = new JedisPoolConfig.Builder();
+        configBuilder
+            .setHost(container.getHost())
+            .setPort(container.getFirstMappedPort())
+            .setTimeout(10);
+
+        outputCollector = new StubOutputCollector();
+        topologyContext = mock(TopologyContext.class);
+        jedisHelper = new JedisTestHelper(container);
+    }
+
+    @AfterEach
+    void cleanup() {
+        verifyNoMoreInteractions(topologyContext);
+        jedisHelper.close();
+    }
+
+    /**
+     * Smoke test the exists check when the key is NOT found.
+     * Expectation is tuple is acked, and nothing is emitted.
+     */
+    @Test
+    void smokeTest_exists_keyNotFound() {
+        // Define input key
+        final String inputKey = "ThisIsMyKey";
+
+        // Ensure key does not exist in redis
+        jedisHelper.delete(inputKey);
+        assertFalse(jedisHelper.exists(inputKey), "Sanity check key should not exist");
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(STRING);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify the bolt filtered the input tuple.
+        verifyTupleFiltered();
+    }
+
+    /**
+     * Smoke test the exists check when the key IS found.
+     * Expectation is tuple is acked, and tuple is emitted.
+     */
+    @Test
+    void smokeTest_exists_keyFound() {
+        // Define input key
+        final String inputKey = "ThisIsMyKey";
+
+        // Ensure key does exist in redis
+        jedisHelper.set(inputKey, "some-value");
+        assertTrue(jedisHelper.exists(inputKey), "Sanity check key exists.");
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(STRING);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify Tuple passed through the bolt
+        verifyTuplePassed(tuple);
+    }
+
+    /**
+     * Smoke test the sismember check when the key is NOT found in the set.
+     * Expectation is tuple is acked, and nothing is emitted.
+     */
+    @Test
+    void smokeTest_sismember_notMember() {
+        // Define input key
+        final String setKey = "ThisIsMySet";
+        final String inputKey = "ThisIsMyKey";
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(SET, setKey);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify the bolt filtered the input tuple.
+        verifyTupleFiltered();
+    }
+
+    /**
+     * Smoke test the exists check when the key IS found.
+     * Expectation is tuple is acked, and tuple is emitted.
+     */
+    @Test
+    void smokeTest_sismember_isMember() {
+        // Define input key
+        final String setKey = "ThisIsMySet";
+        final String inputKey = "ThisIsMyKey";
+
+        // Ensure key does exist in redis
+        jedisHelper.smember(setKey, inputKey);
+        assertTrue(jedisHelper.sismember(setKey, inputKey), "Sanity check, should be a member");
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(SET, setKey);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify Tuple passed through the bolt
+        verifyTuplePassed(tuple);
+    }
+
+    /**
+     * Smoke test the hexists check when the key is NOT found in the set.
+     * Expectation is tuple is acked, and nothing is emitted.
+     */
+    @Test
+    void smokeTest_hexists_notMember() {
+        // Define input key
+        final String hashKey = "ThisIsMyHash";
+        final String inputKey = "ThisIsMyKey";
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(HASH, hashKey);
+
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify the bolt filtered the input tuple.
+        verifyTupleFiltered();
+    }
+
+    /**
+     * Smoke test the hexists check when the key IS found.
+     * Expectation is tuple is acked, and tuple is emitted.
+     */
+    @Test
+    void smokeTest_hexists_isMember() {
+        // Define input key
+        final String hashKey = "ThisIsMyHash";
+        final String inputKey = "ThisIsMyKey";
+
+        // Ensure key does exist in redis
+        jedisHelper.hset(hashKey, inputKey, "value");
+        assertTrue(jedisHelper.hexists(hashKey, inputKey), "Sanity check, should be a member");
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(HASH, hashKey);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify Tuple passed through the bolt
+        verifyTuplePassed(tuple);
+    }
+
+    /**
+     * Smoke test the zrank check when the key is NOT found in the set.
+     * Expectation is tuple is acked, and nothing is emitted.
+     */
+    @Test
+    void smokeTest_zrank_notMember() {
+        // Define input key
+        final String setKey = "ThisIsMySetKey";
+        final String inputKey = "ThisIsMyKey";
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(SORTED_SET, setKey);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify the bolt filtered the input tuple.
+        verifyTupleFiltered();
+    }
+
+    /**
+     * Smoke test the zrank check when the key IS found.
+     * Expectation is tuple is acked, and tuple is emitted.
+     */
+    @Test
+    void smokeTest_zrank_isMember() {
+        // Define input key
+        final String setKey = "ThisIsMySetKey";
+        final String inputKey = "ThisIsMyKey";
+
+        // Ensure key does exist in redis
+        jedisHelper.zrank(setKey, 2, inputKey);
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(SORTED_SET, setKey);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify Tuple passed through the bolt
+        verifyTuplePassed(tuple);
+    }
+
+    /**
+     * Smoke test the pfcount check when the key is NOT found in the set.
+     * Expectation is tuple is acked, and nothing is emitted.
+     */
+    @Test
+    void smokeTest_pfcount_notMember() {
+        // Define input key
+        final String inputKey = "ThisIsMyKey";
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(HYPER_LOG_LOG);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify the bolt filtered the input tuple.
+        verifyTupleFiltered();
+    }
+
+    /**
+     * Smoke test the pfcount check when the key IS found.
+     * Expectation is tuple is acked, and tuple is emitted.
+     */
+    @Test
+    void smokeTest_pfcount_isMember() {
+        // Define input key
+        final String inputKey = "ThisIsMyKey";
+
+        // Ensure key does exist in redis
+        jedisHelper.pfadd(inputKey, "my value");
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(HYPER_LOG_LOG);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify Tuple passed through the bolt
+        verifyTuplePassed(tuple);
+    }
+
+    /**
+     * Smoke test the geopos check when the key is NOT found in the set.
+     * Expectation is tuple is acked, and nothing is emitted.
+     */
+    @Test
+    void smokeTest_geopos_notMember() {
+        // Define input key
+        final String geoKey = "ThisIsMyGeoKey";
+        final String inputKey = "ThisIsMyKey";
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(GEO, geoKey);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify the bolt filtered the input tuple.
+        verifyTupleFiltered();
+    }
+
+    /**
+     * Smoke test the geopos check when the key IS found.
+     * Expectation is tuple is acked, and tuple is emitted.
+     */
+    @Test
+    void smokeTest_geopos_isMember() {
+        // Define input key
+        final String geoKey = "ThisIsMyGeoKey";
+        final String inputKey = "ThisIsMyKey";
+
+        // Ensure key does exist in redis
+        jedisHelper.geoadd(geoKey, 139.731992, 35.709026, inputKey);
+
+        // Create an input tuple
+        final Map<String, Object> values = new HashMap<>();
+        values.put("key", inputKey);
+        values.put("value", "ThisIsMyValue");
+        final Tuple tuple = new StubTuple(values);
+
+        final JedisPoolConfig config = configBuilder.build();
+        final TestMapper mapper = new TestMapper(GEO, geoKey);
+
+        final RedisFilterBolt bolt = new RedisFilterBolt(config, mapper);
+        bolt.prepare(new HashMap<>(), topologyContext, new OutputCollector(outputCollector));
+        bolt.process(tuple);
+
+        // Verify Tuple passed through the bolt
+        verifyTuplePassed(tuple);
+    }
+
+    /**
+     * Utility method to help verify that a tuple passed throught hte RedisFilterBolt properly.
+     * @param expectedTuple The tuple we expected to pass through the bolt.
+     */
+    private void verifyTuplePassed(final Tuple expectedTuple) {
+        // Verify no errors or failed tuples
+        assertTrue(outputCollector.getReportedErrors().isEmpty(), "Should have no reported errors");
+        assertTrue(outputCollector.getFailedTuples().isEmpty(), "Should have no failed tuples");
+
+        // We should have a single acked tuple
+        assertEquals(1, outputCollector.getAckedTuples().size(), "Should have a single acked tuple");
+
+        // We should have a single emitted tuple.
+        assertEquals(1, outputCollector.getEmittedTuples().size(), "Should have a single emitted tuple");
+
+        // Verify the tuple is what we expected
+        final EmittedTuple emittedTuple = outputCollector.getEmittedTuples().get(0);
+        assertEquals("default", emittedTuple.getStreamId());
+        TupleTestHelper.verifyAnchors(emittedTuple, expectedTuple);
+        TupleTestHelper.verifyEmittedTuple(emittedTuple, expectedTuple.getValues());
+    }
+
+    /**
+     * Utility method to help verify that no tuples were passed through the RedisFilterBolt.
+     */
+    private void verifyTupleFiltered() {
+        // Verify no errors or failed tuples
+        assertTrue(outputCollector.getReportedErrors().isEmpty(), "Should have no reported errors");
+        assertTrue(outputCollector.getFailedTuples().isEmpty(), "Should have no failed tuples");
+
+        // We should have a single acked tuple
+        assertEquals(1, outputCollector.getAckedTuples().size(), "Should have a single acked tuple");
+
+        // We should have no emitted tuple.
+        assertTrue(outputCollector.getEmittedTuples().isEmpty(), "Should have no emitted tuples");
+    }
+
+    /**
+     * Test Implementation.
+     */
+    private static class TestMapper implements RedisFilterMapper {
+        private final RedisDataTypeDescription.RedisDataType dataType;
+        private final String additionalKey;
+
+        private TestMapper(final RedisDataTypeDescription.RedisDataType dataType) {
+            this(dataType, null);
+        }
+
+        private TestMapper(final RedisDataTypeDescription.RedisDataType dataType, final String additionalKey) {
+            this.dataType = dataType;
+            this.additionalKey = additionalKey;
+        }
+
+        @Override
+        public void declareOutputFields(final OutputFieldsDeclarer declarer) {
+            declarer.declareStream(Utils.DEFAULT_STREAM_ID, new Fields("key", "value"));
+        }
+
+        @Override
+        public RedisDataTypeDescription getDataTypeDescription() {
+            return new RedisDataTypeDescription(dataType, additionalKey);
+        }
+
+        @Override
+        public String getKeyFromTuple(final ITuple tuple) {
+            return tuple.getStringByField("key");
+        }
+
+        @Override
+        public String getValueFromTuple(final ITuple tuple) {
+            return tuple.getStringByField("value");
+        }
+    }
+}

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/state/RedisKeyValueStateTest.java
@@ -28,7 +28,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/util/JedisTestHelper.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/util/JedisTestHelper.java
@@ -1,0 +1,70 @@
+package org.apache.storm.redis.util;
+
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.Jedis;
+
+import java.util.Objects;
+
+/**
+ * Utility class for helping interact with a Redis service in tests.
+ */
+public class JedisTestHelper {
+    private final Jedis jedis;
+
+    /**
+     * Constructor.
+     * @param container Container instance to create a redis client against.
+     */
+    public JedisTestHelper(final GenericContainer container) {
+        Objects.requireNonNull(container);
+
+        jedis = new Jedis(
+            container.getHost(),
+            container.getFirstMappedPort()
+        );
+    }
+
+    public void delete(final String key) {
+        jedis.del(key);
+    }
+
+    public void geoadd(final String key, final double longitude, final double latitude, final String value) {
+        jedis.geoadd(key, longitude, latitude, value);
+    }
+
+    public boolean hexists(final String hash, final String key) {
+        return jedis.hexists(hash, key);
+    }
+
+    public void hset(final String hash, final String key, final String value) {
+        jedis.hset(hash, key, value);
+    }
+
+    public boolean exists(final String key) {
+        return jedis.exists(key);
+    }
+
+    public void pfadd(final String key, final String value) {
+        jedis.pfadd(key, value);
+    }
+
+    public void set(final String key, final String value) {
+        jedis.set(key, value);
+    }
+
+    public void smember(final String set, final String value) {
+        jedis.sadd(set, value);
+    }
+
+    public boolean sismember(final String set, final String value) {
+        return jedis.sismember(set, value);
+    }
+
+    public void zrank(final String set, final double score, final String value) {
+        jedis.zadd(set, score, value);
+    }
+
+    public void close() {
+        jedis.close();
+    }
+}

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/util/StubTuple.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/util/StubTuple.java
@@ -1,0 +1,190 @@
+package org.apache.storm.redis.util;
+
+import org.apache.storm.generated.GlobalStreamId;
+import org.apache.storm.shade.org.apache.commons.lang.NotImplementedException;
+import org.apache.storm.task.GeneralTopologyContext;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.ITuple;
+import org.apache.storm.tuple.MessageId;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Partial Implementation of the Tuple interface for tests.
+ */
+public class StubTuple implements Tuple {
+
+    final Map<String, Object> values;
+
+    public StubTuple(final Map<String, Object> values) {
+        this.values = Collections.unmodifiableMap(new HashMap<>(Objects.requireNonNull(values)));
+    }
+
+    @Override
+    public int size() {
+        return values.size();
+    }
+
+    @Override
+    public boolean contains(final String field) {
+        return values.containsKey(field);
+    }
+
+    @Override
+    public Fields getFields() {
+        return new Fields(values.keySet().toArray(new String[0]));
+    }
+
+    @Override
+    public int fieldIndex(final String field) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public List<Object> select(final Fields selector) {
+        return null;
+    }
+
+    @Override
+    public Object getValue(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public String getString(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Integer getInteger(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Long getLong(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Boolean getBoolean(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Short getShort(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Byte getByte(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Double getDouble(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Float getFloat(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public byte[] getBinary(final int i) {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public Object getValueByField(final String field) {
+        return values.get(field);
+    }
+
+    @Override
+    public String getStringByField(final String field) {
+        return values.get(field).toString();
+    }
+
+    @Override
+    public Integer getIntegerByField(final String field) {
+        return (Integer) values.get(field);
+    }
+
+    @Override
+    public Long getLongByField(final String field) {
+        return (Long) values.get(field);
+    }
+
+    @Override
+    public Boolean getBooleanByField(final String field) {
+        return (Boolean) values.get(field);
+    }
+
+    @Override
+    public Short getShortByField(final String field) {
+        return (Short) values.get(field);
+    }
+
+    @Override
+    public Byte getByteByField(final String field) {
+        return (Byte) values.get(field);
+    }
+
+    @Override
+    public Double getDoubleByField(final String field) {
+        return (Double) values.get(field);
+    }
+
+    @Override
+    public Float getFloatByField(final String field) {
+        return (Float) values.get(field);
+    }
+
+    @Override
+    public byte[] getBinaryByField(final String field) {
+        return (byte[]) values.get(field);
+    }
+
+    @Override
+    public List<Object> getValues() {
+        return new ArrayList<>(values.values());
+    }
+
+    @Override
+    public GlobalStreamId getSourceGlobalStreamId() {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public String getSourceComponent() {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public int getSourceTask() {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public String getSourceStreamId() {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public MessageId getMessageId() {
+        throw new NotImplementedException("Not implemented");
+    }
+
+    @Override
+    public GeneralTopologyContext getContext() {
+        throw new NotImplementedException("Not implemented");
+    }
+}

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/util/TupleTestHelper.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/util/TupleTestHelper.java
@@ -1,0 +1,36 @@
+package org.apache.storm.redis.util;
+
+import org.apache.storm.redis.util.outputcollector.EmittedTuple;
+import org.apache.storm.tuple.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ *
+ */
+public class TupleTestHelper {
+
+    public static void verifyAnchors(final EmittedTuple emittedTuple, final Tuple expectedAnchor) {
+        Objects.requireNonNull(emittedTuple);
+        Objects.requireNonNull(expectedAnchor);
+        assertEquals(1, emittedTuple.getAnchors().size(), "Should have a single anchor");
+
+        final Tuple anchor = emittedTuple.getAnchors().get(0);
+        assertNotNull(anchor, "Should be non-null");
+        assertEquals(expectedAnchor, anchor);
+    }
+
+    public static void verifyEmittedTuple(final EmittedTuple emittedTuple, final List<Object> expectedValues) {
+        Objects.requireNonNull(emittedTuple);
+        Objects.requireNonNull(expectedValues);
+
+        assertEquals(expectedValues.size(), emittedTuple.getTuple().size());
+        assertEquals(expectedValues, emittedTuple.getTuple());
+    }
+}

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/util/outputcollector/EmittedTuple.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/util/outputcollector/EmittedTuple.java
@@ -1,0 +1,44 @@
+package org.apache.storm.redis.util.outputcollector;
+
+import org.apache.storm.tuple.Tuple;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Used with StubOutputCollector for testing.
+ */
+public class EmittedTuple {
+    private final String streamId;
+    private final List<Object> tuple;
+    private final List<Tuple> anchors;
+
+    public EmittedTuple(final String streamId, final List<Object> tuple, final Collection<Tuple> anchors) {
+        this.streamId = streamId;
+        this.tuple = tuple;
+        this.anchors = new ArrayList<>(anchors);
+    }
+
+    public String getStreamId() {
+        return streamId;
+    }
+
+    public List<Object> getTuple() {
+        return tuple;
+    }
+
+    public List<Tuple> getAnchors() {
+        return Collections.unmodifiableList(anchors);
+    }
+
+    @Override
+    public String toString() {
+        return "EmittedTuple{"
+            + "streamId='" + streamId + '\''
+            + ", tuple=" + tuple
+            + ", anchors=" + anchors
+            + '}';
+    }
+}

--- a/external/storm-redis/src/test/java/org/apache/storm/redis/util/outputcollector/StubOutputCollector.java
+++ b/external/storm-redis/src/test/java/org/apache/storm/redis/util/outputcollector/StubOutputCollector.java
@@ -1,0 +1,83 @@
+package org.apache.storm.redis.util.outputcollector;
+
+import org.apache.storm.task.IOutputCollector;
+import org.apache.storm.tuple.Tuple;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Stub implementation for testing.
+ */
+public class StubOutputCollector implements IOutputCollector {
+
+    final List<EmittedTuple> emittedTuples = new ArrayList<>();
+    final List<Tuple> ackedTuples = new ArrayList<>();
+    final List<Tuple> failedTuples = new ArrayList<>();
+    final List<Throwable> reportedErrors = new ArrayList<>();
+
+    @Override
+    public List<Integer> emit(final String streamId, final Collection<Tuple> anchors, final List<Object> tuple) {
+        emittedTuples.add(
+            new EmittedTuple(streamId, tuple, anchors)
+        );
+
+        // Dummy value.
+        return Collections.singletonList(1);
+    }
+
+    @Override
+    public void emitDirect(final int taskId, final String streamId, final Collection<Tuple> anchors, final List<Object> tuple) {
+        throw new RuntimeException("Not implemented yet!");
+    }
+
+    @Override
+    public void ack(final Tuple input) {
+        ackedTuples.add(input);
+    }
+
+    @Override
+    public void fail(final Tuple input) {
+        failedTuples.add(input);
+    }
+
+    @Override
+    public void resetTimeout(final Tuple input) {
+        throw new RuntimeException("Not implemented yet!");
+    }
+
+    @Override
+    public void flush() {
+        throw new RuntimeException("Not implemented yet!");
+    }
+
+    @Override
+    public void reportError(final Throwable error) {
+        reportedErrors.add(error);
+    }
+
+    public List<EmittedTuple> getEmittedTuples() {
+        return Collections.unmodifiableList(emittedTuples);
+    }
+
+    public List<Throwable> getReportedErrors() {
+        return Collections.unmodifiableList(reportedErrors);
+    }
+
+    public List<Tuple> getFailedTuples() {
+        return Collections.unmodifiableList(failedTuples);
+    }
+
+    public List<Tuple> getAckedTuples() {
+        return Collections.unmodifiableList(ackedTuples);
+    }
+
+    public void reset() {
+        emittedTuples.clear();
+        ackedTuples.clear();
+        reportedErrors.clear();
+        failedTuples.clear();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         <mongodb.version>3.2.0</mongodb.version>
         <solr.version>5.2.1</solr.version>
         <jpmml.version>1.0.22</jpmml.version>
-        <jedis.version>2.9.0</jedis.version>
+        <jedis.version>3.2.0</jedis.version>
         <activemq.version>5.15.8</activemq.version>
         <rocketmq.version>4.2.0</rocketmq.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -320,10 +320,9 @@
         <jedis.version>3.2.0</jedis.version>
         <activemq.version>5.15.8</activemq.version>
         <rocketmq.version>4.2.0</rocketmq.version>
-
         <jackson.version>2.9.8</jackson.version>
-        
         <storm.kafka.client.version>0.11.0.3</storm.kafka.client.version>
+        <testcontainers.version>1.14.3</testcontainers.version>
 
         <!-- Java and clojure build lifecycle test properties are defined here to avoid having to create a default profile -->
         <java.unit.test.exclude.groups>PerformanceTest</java.unit.test.exclude.groups>


### PR DESCRIPTION
## What is the purpose of the change

To support future improvements to the storm-redis package, lets upgrade its underlying library (Jedis) it uses to communicate with Redis.

Upgrading will clear the way for [STORM-3665](https://issues.apache.org/jira/browse/STORM-3665) as Stream support in the Jedis library was not added until version 3.x

## How was the change tested

As no previous test coverage existed for the bolts provided by `storm-redis` I've started to add integration tests using TestContainers.  Let me know if this is an acceptable way to provide test coverage and I will build out tests for the remaining bolts.