### PR TITLE
[STORM-3681] Enable basic ARM64 CI task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ matrix:
   include:
     - arch: s390x
       jdk: openjdk11
-      
+    - arch: arm64
+      jdk: openjdk11
+
 before_install:
   - rvm reload
   - rvm use 2.4.2 --install
@@ -52,6 +54,7 @@ before_install:
   - export MVN_HOME=$HOME/apache-maven-3.6.3
   - if [ ! -d $MVN_HOME/bin ]; then wget https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -P $HOME; tar xzvf $HOME/apache-maven-3.6.3-bin.tar.gz -C $HOME; fi
   - export PATH=$MVN_HOME/bin:$PATH
+  - f=$(which javac); while [[ -L $f ]]; do f=$(readlink $f);done; export JAVA_HOME=${f%/bin/*}
 
 install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
 script:


### PR DESCRIPTION
## What is the purpose of the change

This change propose to add a basic ARM64 CI job into Travis configuration. 

## How was the change tested
After the rocksdb version up[1] and some minor fixes[3], now the STROM can be built and test successfully, So we propose to added a basic ARM64 CI task as first step, which only run the "Client" module of Storm. As the JIRA STORM-3681 descirbed, there are some existed problems of Travis CI itself about ARM64 support, which will cause some other modules of Storm run failed. We will continue to track the issues of Travis ARM support, once the issues solved, we will try to enable all the Storm modules for ARM CI.

[1] https://issues.apache.org/jira/browse/STORM-3599
[2] https://issues.apache.org/jira/browse/STORM-3674
[3] https://issues.apache.org/jira/browse/STORM-3401
[4] https://github.com/liusheng/storm/pull/7/checks
