### PR TITLE
STORM-3682 Upgrade netty client metrics to use V2 API

### DIFF
--- a/docs/Metrics.md
+++ b/docs/Metrics.md
@@ -273,7 +273,12 @@ Be aware that the `__system` bolt is an actual bolt so regular bolt metrics desc
 
 ##### Send (Netty Client)
 
-The `__send-iconnection` metric holds information about all of the clients for this worker.  It is of the form
+There are `send-connection` meter metrics for each of the clients for this worker.  The metric names below exist and have a suffix for the destination host and port:
+
+    * send-connection-reconnects
+    * send-connection-sent
+    * send-connection-pending
+    * send-connection-lostOnSend
 
 ```
 {

--- a/storm-client/src/jvm/org/apache/storm/daemon/metrics/BuiltinMetricsUtil.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/metrics/BuiltinMetricsUtil.java
@@ -12,41 +12,18 @@
 
 package org.apache.storm.daemon.metrics;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.storm.Config;
-import org.apache.storm.generated.NodeInfo;
-import org.apache.storm.messaging.IConnection;
 import org.apache.storm.metric.api.IMetric;
 import org.apache.storm.metric.api.IStatefulObject;
 import org.apache.storm.metric.api.StateMetric;
 import org.apache.storm.task.TopologyContext;
-import org.apache.storm.utils.JCQueue;
 
 public class BuiltinMetricsUtil {
     public static void registerIconnectionServerMetric(Object server, Map<String, Object> topoConf, TopologyContext context) {
         if (server instanceof IStatefulObject) {
             registerMetric("__recv-iconnection", new StateMetric((IStatefulObject) server), topoConf, context);
         }
-    }
-
-    public static void registerIconnectionClientMetrics(final Map<NodeInfo, IConnection> nodePortToSocket, Map<String, Object> topoConf,
-                                                        TopologyContext context) {
-        IMetric metric = new IMetric() {
-            @Override
-            public Object getValueAndReset() {
-                Map<Object, Object> ret = new HashMap<>();
-                for (Map.Entry<NodeInfo, IConnection> entry : nodePortToSocket.entrySet()) {
-                    NodeInfo nodePort = entry.getKey();
-                    IConnection connection = entry.getValue();
-                    if (connection instanceof IStatefulObject) {
-                        ret.put(nodePort, ((IStatefulObject) connection).getState());
-                    }
-                }
-                return ret;
-            }
-        };
-        registerMetric("__send-iconnection", metric, topoConf, context);
     }
 
     public static void registerMetric(String name, IMetric metric, Map<String, Object> topoConf, TopologyContext context) {

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -174,7 +174,7 @@ public class WorkerState {
         this.credentialsAtom = new AtomicReference(initialCredentials);
         this.conf = conf;
         this.supervisorIfaceSupplier = supervisorIfaceSupplier;
-        this.mqContext = (null != mqContext) ? mqContext : TransportFactory.makeContext(topologyConf);
+        this.mqContext = (null != mqContext) ? mqContext : TransportFactory.makeContext(topologyConf, metricRegistry, topologyId, port);
         this.topologyId = topologyId;
         this.assignmentId = assignmentId;
         this.port = port;

--- a/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/bolt/BoltExecutor.java
@@ -123,7 +123,6 @@ public class BoltExecutor extends Executor {
             }
             if (Constants.SYSTEM_COMPONENT_ID.equals(componentId)) {
                 Map<NodeInfo, IConnection> cachedNodePortToSocket = workerData.getCachedNodeToPortSocket().get();
-                BuiltinMetricsUtil.registerIconnectionClientMetrics(cachedNodePortToSocket, topoConf, userContext);
                 BuiltinMetricsUtil.registerIconnectionServerMetric(workerData.getReceiver(), topoConf, userContext);
 
                 // add any autocredential expiry metrics from the worker

--- a/storm-client/src/jvm/org/apache/storm/messaging/IContext.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/IContext.java
@@ -15,6 +15,7 @@ package org.apache.storm.messaging;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import org.apache.storm.metrics2.StormMetricRegistry;
 
 /**
  * This interface needs to be implemented for messaging plugin.
@@ -29,8 +30,11 @@ public interface IContext {
      * This method is invoked at the startup of messaging plugin.
      *
      * @param topoConf storm configuration
+     * @param metricRegistry metric registry
+     * @param topologyId topology Id
+     * @param workerPort worker port
      */
-    void prepare(Map<String, Object> topoConf);
+    void prepare(Map<String, Object> topoConf, StormMetricRegistry metricRegistry, String topologyId, int workerPort);
 
     /**
      * This method is invoked when a worker is unloading a messaging plugin.

--- a/storm-client/src/jvm/org/apache/storm/messaging/TransportFactory.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/TransportFactory.java
@@ -15,13 +15,15 @@ package org.apache.storm.messaging;
 import java.lang.reflect.Method;
 import java.util.Map;
 import org.apache.storm.Config;
+import org.apache.storm.metrics2.StormMetricRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TransportFactory {
     public static final Logger LOG = LoggerFactory.getLogger(TransportFactory.class);
 
-    public static IContext makeContext(Map<String, Object> topoConf) {
+    public static IContext makeContext(Map<String, Object> topoConf, StormMetricRegistry metricRegistry,
+                                       String topologyId, int workerPort) {
 
         //get factory class name
         String transportPluginClassName = (String) topoConf.get(Config.STORM_MESSAGING_TRANSPORT);
@@ -37,7 +39,7 @@ public class TransportFactory {
                 //case 1: plugin is a IContext class
                 transport = (IContext) obj;
                 //initialize with storm configuration
-                transport.prepare(topoConf);
+                transport.prepare(topoConf, metricRegistry, topologyId, workerPort);
             } else {
                 //case 2: Non-IContext plugin must have a makeContext(topoConf) method that returns IContext object
                 Method method = klass.getMethod("makeContext", Map.class);

--- a/storm-client/src/jvm/org/apache/storm/messaging/local/Context.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/local/Context.java
@@ -32,6 +32,7 @@ import org.apache.storm.messaging.IConnectionCallback;
 import org.apache.storm.messaging.IContext;
 import org.apache.storm.messaging.TaskMessage;
 import org.apache.storm.messaging.netty.BackPressureStatus;
+import org.apache.storm.metrics2.StormMetricRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public class Context implements IContext {
     }
 
     @Override
-    public void prepare(Map<String, Object> topoConf) {
+    public void prepare(Map<String, Object> topoConf, StormMetricRegistry metricRegistry, String topologyId, int workerPort) {
         //NOOP
     }
 

--- a/storm-client/src/jvm/org/apache/storm/metrics2/StormMetricRegistry.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/StormMetricRegistry.java
@@ -95,6 +95,13 @@ public class StormMetricRegistry {
         return meter;
     }
 
+    public Meter meter(String name, String topologyId, String componentId, Integer taskId, Integer workerPort) {
+        MetricNames metricNames = workerMetricName(name, topologyId, componentId, taskId, workerPort);
+        Meter meter = registry.meter(metricNames.getLongName());
+        saveMetricTaskIdMapping(taskId, metricNames, meter, taskIdMeters);
+        return meter;
+    }
+
     public Counter counter(String name, WorkerTopologyContext context, String componentId, Integer taskId, String streamId) {
         MetricNames metricNames = workerMetricName(name, context.getStormId(), componentId, streamId, taskId, context.getThisWorkerPort());
         Counter counter = registry.counter(metricNames.getLongName());

--- a/storm-core/test/jvm/org/apache/storm/messaging/netty/NettyTest.java
+++ b/storm-core/test/jvm/org/apache/storm/messaging/netty/NettyTest.java
@@ -44,6 +44,7 @@ import org.apache.storm.messaging.IConnectionCallback;
 import org.apache.storm.messaging.IContext;
 import org.apache.storm.messaging.TaskMessage;
 import org.apache.storm.messaging.TransportFactory;
+import org.apache.storm.metrics2.StormMetricRegistry;
 import org.apache.storm.utils.Utils;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -110,7 +111,7 @@ public class NettyTest {
     private void doTestBasic(Map<String, Object> stormConf) throws Exception {
         LOG.info("1. Should send and receive a basic message");
         String reqMessage = "0123456789abcdefghijklmnopqrstuvwxyz";
-        IContext context = TransportFactory.makeContext(stormConf);
+        IContext context = TransportFactory.makeContext(stormConf, new StormMetricRegistry(), "unusedTopoId", -1);
         try {
             AtomicReference<TaskMessage> response = new AtomicReference<>();
             try (IConnection server = context.bind(null, 0, mkConnectionCallback(response::set), null);
@@ -171,7 +172,7 @@ public class NettyTest {
     private void doTestLoad(Map<String, Object> stormConf) throws Exception {
         LOG.info("2 test load");
         String reqMessage = "0123456789abcdefghijklmnopqrstuvwxyz";
-        IContext context = TransportFactory.makeContext(stormConf);
+        IContext context = TransportFactory.makeContext(stormConf, new StormMetricRegistry(), "unusedTopoId", -1);
         try {
             AtomicReference<TaskMessage> response = new AtomicReference<>();
             try (IConnection server = context.bind(null, 0, mkConnectionCallback(response::set), null);
@@ -225,7 +226,7 @@ public class NettyTest {
     private void doTestLargeMessage(Map<String, Object> stormConf) throws Exception {
         LOG.info("3 Should send and receive a large message");
         String reqMessage = StringUtils.repeat("c", 2_048_000);
-        IContext context = TransportFactory.makeContext(stormConf);
+        IContext context = TransportFactory.makeContext(stormConf, new StormMetricRegistry(), "unusedTopoId", -1);
         try {
             AtomicReference<TaskMessage> response = new AtomicReference<>();
             try (IConnection server = context.bind(null, 0, mkConnectionCallback(response::set), null);
@@ -264,7 +265,7 @@ public class NettyTest {
     private void doTestServerDelayed(Map<String, Object> stormConf) throws Exception {
         LOG.info("4. test server delayed");
         String reqMessage = "0123456789abcdefghijklmnopqrstuvwxyz";
-        IContext context = TransportFactory.makeContext(stormConf);
+        IContext context = TransportFactory.makeContext(stormConf, new StormMetricRegistry(), "unusedTopoId", -1);
         try {
             AtomicReference<TaskMessage> response = new AtomicReference<>();
             int port = Utils.getAvailablePort(6700);
@@ -315,7 +316,7 @@ public class NettyTest {
         LOG.info("Should send and receive many messages (testing with " + numMessages + " messages)");
         ArrayList<TaskMessage> responses = new ArrayList<>();
         AtomicInteger received = new AtomicInteger();
-        IContext context = TransportFactory.makeContext(stormConf);
+        IContext context = TransportFactory.makeContext(stormConf, new StormMetricRegistry(), "unusedTopoId", -1);
         try {
             try (IConnection server = context.bind(null, 0, mkConnectionCallback((message) -> {
                     responses.add(message);
@@ -362,7 +363,7 @@ public class NettyTest {
     private void doTestServerAlwaysReconnects(Map<String, Object> stormConf) throws Exception {
         LOG.info("6. test server always reconnects");
         String reqMessage = "0123456789abcdefghijklmnopqrstuvwxyz";
-        IContext context = TransportFactory.makeContext(stormConf);
+        IContext context = TransportFactory.makeContext(stormConf, new StormMetricRegistry(), "unusedTopoId", -1);
         try {
             AtomicReference<TaskMessage> response = new AtomicReference<>();
             int port = Utils.getAvailablePort(6700);
@@ -396,7 +397,7 @@ public class NettyTest {
     private void connectToFixedPort(Map<String, Object> stormConf, int port) throws Exception {
         LOG.info("7. Should be able to rebind to a port quickly");
         String reqMessage = "0123456789abcdefghijklmnopqrstuvwxyz";
-        IContext context = TransportFactory.makeContext(stormConf);
+        IContext context = TransportFactory.makeContext(stormConf, new StormMetricRegistry(), "unusedTopoId", -1);
         try {
             AtomicReference<TaskMessage> response = new AtomicReference<>();
             try (IConnection server = context.bind(null, port, mkConnectionCallback(response::set), null);

--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -86,6 +86,7 @@ import org.apache.storm.generated.WorkerMetrics;
 import org.apache.storm.messaging.IContext;
 import org.apache.storm.messaging.local.Context;
 import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.metrics2.StormMetricRegistry;
 import org.apache.storm.nimbus.ILeaderElector;
 import org.apache.storm.scheduler.INimbus;
 import org.apache.storm.scheduler.ISupervisor;
@@ -254,7 +255,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
             IContext context = null;
             if (!ObjectReader.getBoolean(this.daemonConf.get(Config.STORM_LOCAL_MODE_ZMQ), false)) {
                 context = new Context();
-                context.prepare(this.daemonConf);
+                context.prepare(this.daemonConf, new StormMetricRegistry(), "unusedTopoId", -1);
             }
             this.sharedContext = context;
             this.thriftServer = builder.nimbusDaemon ? startNimbusDaemon(this.daemonConf, this.nimbus) : null;


### PR DESCRIPTION
## What is the purpose of the change

This change switches the Netty Client send connection metrics to the V2 metrics API.

## How was the change tested

Ran a topology LoggingMetricsConsumer enabled and validated metrics appeared.