### PR TITLE
[STORM-3670] Separate configurations for daemon metric reporters and topology metrics reporters

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -409,26 +409,3 @@ worker.metrics:
 
 # The number of buckets for running statistics
 num.stat.buckets: 20
-
-# Metrics v2 configuration (optional)
-#storm.metrics.reporters:
-#  # Graphite Reporter
-#  - class: "org.apache.storm.metrics2.reporters.GraphiteStormReporter"
-#    daemons:
-#        - "supervisor"
-#        - "nimbus"
-#        - "worker"
-#    report.period: 60
-#    report.period.units: "SECONDS"
-#    graphite.host: "localhost"
-#    graphite.port: 2003
-#
-#  # Console Reporter
-#  - class: "org.apache.storm.metrics2.reporters.ConsoleStormReporter"
-#    daemons:
-#        - "worker"
-#    report.period: 10
-#    report.period.units: "SECONDS"
-#    filter:
-#        class: "org.apache.storm.metrics2.filters.RegexFilter"
-#        expression: ".*my_component.*emitted.*"

--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -82,14 +82,10 @@
 #     arguments:
 #       endpoint: "event-logger.mycompany.org"
 
-# Metrics v2 configuration (optional)
-#storm.metrics.reporters:
+# Topology metrics v2 configuration (optional)
+#topology.metrics.reporters:
 #  # Graphite Reporter
 #  - class: "org.apache.storm.metrics2.reporters.GraphiteStormReporter"
-#    daemons:
-#        - "supervisor"
-#        - "nimbus"
-#        - "worker"
 #    report.period: 60
 #    report.period.units: "SECONDS"
 #    graphite.host: "localhost"
@@ -97,8 +93,6 @@
 #
 #  # Console Reporter
 #  - class: "org.apache.storm.metrics2.reporters.ConsoleStormReporter"
-#    daemons:
-#        - "worker"
 #    report.period: 10
 #    report.period.units: "SECONDS"
 #    filter:

--- a/docs/ClusterMetrics.md
+++ b/docs/ClusterMetrics.md
@@ -4,13 +4,13 @@ layout: documentation
 documentation: true
 ---
 
-#Cluster Metrics
+# Cluster Metrics
 
 There are lots of metrics to help you monitor a running cluster.  Many of these metrics are still a work in progress and so is the metrics system itself so any of them may change, even between minor version releases.  We will try to keep them as stable as possible, but they should all be considered somewhat unstable. Some of the metrics may also be for experimental features, or features that are not complete yet, so please read the description of the metric before using it for monitoring or alerting.
 
 Also be aware that depending on the metrics system you use, the names are likely to be translated into a different format that is compatible with the system.  Typically this means that the ':' separating character will be replaced with a '.' character.
 
-Most metrics should have the units that they are reported in as a part of the description.  For Timers often this is configured by the reporter that is uploading them to your system.  Pay attention because even if the metric name has a time unit in it, it may be false.
+Most metrics should have the units that they are reported in as a part of the description. For Timers often this is configured by the reporter that is uploading them to your system.  Pay attention because even if the metric name has a time unit in it, it may be false.
 
 Also most metrics, except for gauges and counters, are a collection of numbers, and not a single value.  Often these result in multiple metrics being uploaded to a reporting system, such as percentiles for a histogram, or rates for a meter.  It is dependent on the configured metrics reporter how this happens, or how the name here corresponds to the metric in your reporting system.
 
@@ -259,3 +259,16 @@ The pacemaker process is deprecated and only still exists for backwards compatib
 | pacemaker:size-total-keys | gauge | total number of keys in this pacemaker instance |
 | pacemaker:total-receive-size | meter | total size in bytes of heartbeats received |
 | pacemaker:total-sent-size | meter | total size in bytes of heartbeats read |
+
+
+## Metric Reporters
+
+For metrics to be reported, configure reporters using `storm.daemon.metrics.reporter.plugins`. The following metric reporters are supported:
+  * Console Reporter (`org.apache.storm.daemon.metrics.reporters.ConsolePreparableReporter`):
+    Reports metrics to `System.out`.
+  * CSV Reporter (`org.apache.storm.daemon.metrics.reporters.CsvPreparableReporter`):
+    Reports metrics to a CSV file.
+  * JMX Reporter (`org.apache.storm.daemon.metrics.reporters.JmxPreparableReporter`):
+    Exposes metrics via JMX.
+
+Custom reporter can be created by implementing `org.apache.storm.daemon.metrics.reporters.PreparableReporter` interface.

--- a/docs/metrics_v2.md
+++ b/docs/metrics_v2.md
@@ -4,7 +4,7 @@ layout: documentation
 documentation: true
 ---
 Apache Storm version 1.2 introduced a new metrics system for reporting
-internal statistics (e.g. acked, failed, emitted, transferred, disruptor queue metrics, etc.) as well as a 
+internal statistics (e.g. acked, failed, emitted, transferred, queue metrics, etc.) as well as a 
 new API for user defined metrics.
 
 The new metrics system is based on [Dropwizard Metrics](http://metrics.dropwizard.io).
@@ -72,7 +72,7 @@ public class TupleCountingBolt extends BaseRichBolt {
  For metrics to be useful they must be *reported*, in other words sent somewhere where they can be consumed and analyzed.
  That can be as simple as writing them to a log file, sending them to a time series database, or exposing them via JMX.
  
- As of Storm 1.2.0 the following metric reporters are supported
+Since Storm 1.2.0, the following metric reporters are supported
  
   * Console Reporter (`org.apache.storm.metrics2.reporters.ConsoleStormReporter`):
     Reports metrics to `System.out`.
@@ -83,21 +83,19 @@ public class TupleCountingBolt extends BaseRichBolt {
   * JMX Reporter (`org.apache.storm.metrics2.reporters.JmxStormReporter`):
     Exposes metrics via JMX.
   
+ Custom metrics reporters can be created by implementing `org.apache.storm.metrics2.reporters.StormReporter` interface 
+ or extending `org.apache.storm.metrics2.reporters.ScheduledStormReporter` class.
   
- Metrics reporters are configured in the `storm.yaml` file. By default, Storm will collect metrics but not "report" or
- send the collected metrics anywhere. To enable metrics reporting, add a `storm.metrics.reporters` section to `storm.yaml`
- and configure one or more reporters.
+ By default, Storm will collect metrics but not "report" or
+ send the collected metrics anywhere. To enable metrics reporting, add a `topology.metrics.reporters` section to `storm.yaml`
+ or in topology configuration and configure one or more reporters.
  
  The following example configuration sets up two reporters: a Graphite Reporter and a Console Reporter:
  
  ```yaml
-storm.metrics.reporters:
+topology.metrics.reporters:
   # Graphite Reporter
   - class: "org.apache.storm.metrics2.reporters.GraphiteStormReporter"
-    daemons:
-        - "supervisor"
-        - "nimbus"
-        - "worker"
     report.period: 60
     report.period.units: "SECONDS"
     graphite.host: "localhost"
@@ -105,20 +103,15 @@ storm.metrics.reporters:
 
   # Console Reporter
   - class: "org.apache.storm.metrics2.reporters.ConsoleStormReporter"
-    daemons:
-        - "worker"
     report.period: 10
     report.period.units: "SECONDS"
     filter:
         class: "org.apache.storm.metrics2.filters.RegexFilter"
         expression: ".*my_component.*emitted.*"
-
 ```
 
 Each reporter section begins with a `class` parameter representing the fully-qualified class name of the reporter 
-implementation. The `daemons` section determines which daemons the reporter will apply to (in the example Graphite
-Reporter is configured to report metrics from all Storm daemons, while the Console reporter will only report worker and
-topology metrics).
+implementation. 
 
 Many reporter implementations are *scheduled*, meaning they report metrics at regular intervals. The reporting interval
 is determined by the `report.period` and `report.period.units` parameters.
@@ -145,5 +138,35 @@ public interface StormMetricsFilter extends MetricFilter {
 }
 ```
 
-V2 metrics can also be reported to the Metrics Consumers registered with topology.metrics.consumer.register by enabling the topology.enable.v2.metrics.tick configuration.
+## Backwards Compatibility Notes
 
+1. V2 metrics can also be reported to the Metrics Consumers registered with `topology.metrics.consumer.register` by enabling the `topology.enable.v2.metrics.tick` configuration.
+
+2. Starting from storm 2.3, the config `storm.metrics.reporters` is deprecated in favor of `topology.metrics.reporters`.
+
+3. Starting from storm 2.3, the `daemons` section is removed from `topology.metrics.reporters` (or `storm.metrics.reporters`).
+   Before storm 2.3, a `daemons` section is required in the reporter conf to determine which daemons the reporters will apply to. 
+However, the reporters configured with `topology.metrics.reporters` (or `storm.metrics.reporters`) actually only apply to workers. They are never really used in daemons like nimbus, supervisor and etc. 
+   For daemon metrics, please refer to [Cluster Metrics](ClusterMetrics.html).
+
+4. **Backwards Compatibility Breakage**: starting from storm 2.3, the following configs no longer apply to `topology.metrics.reporters`:
+   ```yaml
+   storm.daemon.metrics.reporter.plugin.locale
+   storm.daemon.metrics.reporter.plugin.rate.unit
+   storm.daemon.metrics.reporter.plugin.duration.unit
+   ```
+
+    They only apply to daemon metric reporters configured via `storm.daemon.metrics.reporter.plugins` for storm daemons.
+    The corresponding configs for `topology.metrics.reporters` can be configured in reporter conf with `locale`, `rate.unit`, `duration.unit` respectively, for example,
+    ```yaml
+    topology.metrics.reporters:
+      # Console Reporter
+      - class: "org.apache.storm.metrics2.reporters.ConsoleStormReporter"
+        report.period: 10
+        report.period.units: "SECONDS"
+        locale: "en-US"
+        rate.unit: "SECONDS"
+        duration.unit: "SECONDS"
+    ```
+   Default values will be used if they are not set or set to `null`.
+   

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -1172,8 +1172,21 @@ public class Config extends HashMap<String, Object> {
      */
     @IsString
     public static final String STORM_META_SERIALIZATION_DELEGATE = "storm.meta.serialization.delegate";
+
+    /**
+     * Configure the topology metrics reporters to be used on workers.
+     */
+    @IsListEntryCustom(entryValidatorClasses = { MetricReportersValidator.class })
+    public static final String TOPOLOGY_METRICS_REPORTERS = "topology.metrics.reporters";
+
+    /**
+     * Configure the topology metrics reporters to be used on workers.
+     * @deprecated Use {@link Config#TOPOLOGY_METRICS_REPORTERS} instead.
+     */
+    @Deprecated
     @IsListEntryCustom(entryValidatorClasses = { MetricReportersValidator.class })
     public static final String STORM_METRICS_REPORTERS = "storm.metrics.reporters";
+
     /**
      * What blobstore implementation the storm client should use.
      */
@@ -1731,21 +1744,28 @@ public class Config extends HashMap<String, Object> {
     @IsInteger
     @IsPositiveNumber
     public static final String WORKER_BLOB_UPDATE_POLL_INTERVAL_SECS = "worker.blob.update.poll.interval.secs";
+
     /**
-     * A specify Locale for daemon metrics reporter plugin. Use the specified IETF BCP 47 language tag string for a Locale.
+     * Specify the Locale for daemon metrics reporter plugin. Use the specified IETF BCP 47 language tag string for a Locale.
+     * This config should have been placed in the DaemonConfig class. Keeping it here only for backwards compatibility.
      */
     @IsString
     public static final String STORM_DAEMON_METRICS_REPORTER_PLUGIN_LOCALE = "storm.daemon.metrics.reporter.plugin.locale";
+
     /**
-     * A specify rate-unit in TimeUnit to specify reporting frequency for daemon metrics reporter plugin.
+     * Specify the rate unit in TimeUnit for daemon metrics reporter plugin.
+     * This config should have been placed in the DaemonConfig class. Keeping it here only for backwards compatibility.
      */
     @IsString
     public static final String STORM_DAEMON_METRICS_REPORTER_PLUGIN_RATE_UNIT = "storm.daemon.metrics.reporter.plugin.rate.unit";
+
     /**
-     * A specify duration-unit in TimeUnit to specify reporting window for daemon metrics reporter plugin.
+     * Specify the duration unit in TimeUnit for daemon metrics reporter plugin.
+     * This config should have been placed in the DaemonConfig class. Keeping it here only for backwards compatibility.
      */
     @IsString
     public static final String STORM_DAEMON_METRICS_REPORTER_PLUGIN_DURATION_UNIT = "storm.daemon.metrics.reporter.plugin.duration.unit";
+
     //DO NOT CHANGE UNLESS WE ADD IN STATE NOT STORED IN THE PARENT CLASS
     private static final long serialVersionUID = -1550278723792864455L;
 

--- a/storm-client/src/jvm/org/apache/storm/daemon/metrics/ClientMetricsUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/metrics/ClientMetricsUtils.java
@@ -20,26 +20,31 @@ import org.apache.storm.utils.ObjectReader;
 
 public class ClientMetricsUtils {
 
-    public static TimeUnit getMetricsRateUnit(Map<String, Object> topoConf) {
-        return getTimeUnitForCofig(topoConf, Config.STORM_DAEMON_METRICS_REPORTER_PLUGIN_RATE_UNIT);
+    private static final String RATE_UNIT = "rate.unit";
+    private static final String DURATION_UNIT = "duration.unit";
+    // Use the specified IETF BCP 47 language tag string for a Locale
+    private static final String LOCALE = "locale";
+
+    public static TimeUnit getMetricsRateUnit(Map<String, Object> reporterConf) {
+        return getTimeUnitForConfig(reporterConf, RATE_UNIT);
     }
 
-    public static TimeUnit getMetricsDurationUnit(Map<String, Object> topoConf) {
-        return getTimeUnitForCofig(topoConf, Config.STORM_DAEMON_METRICS_REPORTER_PLUGIN_DURATION_UNIT);
+    public static TimeUnit getMetricsDurationUnit(Map<String, Object> reporterConf) {
+        return getTimeUnitForConfig(reporterConf, DURATION_UNIT);
     }
 
-    public static Locale getMetricsReporterLocale(Map<String, Object> topoConf) {
-        String languageTag = ObjectReader.getString(topoConf.get(Config.STORM_DAEMON_METRICS_REPORTER_PLUGIN_LOCALE), null);
+    public static Locale getMetricsReporterLocale(Map<String, Object> reporterConf) {
+        String languageTag = ObjectReader.getString(reporterConf.get(LOCALE), null);
         if (languageTag != null) {
             return Locale.forLanguageTag(languageTag);
         }
         return null;
     }
 
-    private static TimeUnit getTimeUnitForCofig(Map<String, Object> topoConf, String configName) {
-        String rateUnitString = ObjectReader.getString(topoConf.get(configName), null);
-        if (rateUnitString != null) {
-            return TimeUnit.valueOf(rateUnitString);
+    public static TimeUnit getTimeUnitForConfig(Map<String, Object> conf, String configName) {
+        String timeUnitString = ObjectReader.getString(conf.get(configName), null);
+        if (timeUnitString != null) {
+            return TimeUnit.valueOf(timeUnitString);
         }
         return null;
     }

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -180,7 +180,7 @@ public class Worker implements Shutdownable, DaemonCommon {
         IStateStorage stateStorage = ClusterUtils.mkStateStorage(conf, topologyConf, csContext);
         IStormClusterState stormClusterState = ClusterUtils.mkStormClusterState(stateStorage, null, csContext);
 
-        metricRegistry.start(conf, DaemonType.WORKER);
+        metricRegistry.start(topologyConf);
 
         Credentials initialCredentials = stormClusterState.credentials(topologyId, null);
         Map<String, String> initCreds = new HashMap<>();

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ConsoleStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ConsoleStormReporter.java
@@ -26,22 +26,22 @@ public class ConsoleStormReporter extends ScheduledStormReporter {
     private static final Logger LOG = LoggerFactory.getLogger(ConsoleStormReporter.class);
 
     @Override
-    public void prepare(MetricRegistry registry, Map stormConf, Map reporterConf) {
+    public void prepare(MetricRegistry registry, Map<String, Object> topoConf, Map<String, Object> reporterConf) {
         LOG.debug("Preparing ConsoleReporter");
         ConsoleReporter.Builder builder = ConsoleReporter.forRegistry(registry);
 
         builder.outputTo(System.out);
-        Locale locale = ClientMetricsUtils.getMetricsReporterLocale(stormConf);
+        Locale locale = ClientMetricsUtils.getMetricsReporterLocale(reporterConf);
         if (locale != null) {
             builder.formattedFor(locale);
         }
 
-        TimeUnit rateUnit = ClientMetricsUtils.getMetricsRateUnit(stormConf);
+        TimeUnit rateUnit = ClientMetricsUtils.getMetricsRateUnit(reporterConf);
         if (rateUnit != null) {
             builder.convertRatesTo(rateUnit);
         }
 
-        TimeUnit durationUnit = ClientMetricsUtils.getMetricsDurationUnit(stormConf);
+        TimeUnit durationUnit = ClientMetricsUtils.getMetricsDurationUnit(reporterConf);
         if (durationUnit != null) {
             builder.convertDurationsTo(durationUnit);
         }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/CsvStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/CsvStormReporter.java
@@ -53,7 +53,7 @@ public class CsvStormReporter extends ScheduledStormReporter {
     }
 
     @Override
-    public void prepare(MetricRegistry metricsRegistry, Map stormConf, Map reporterConf) {
+    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf, Map<String, Object> reporterConf) {
         LOG.debug("Preparing...");
         CsvReporter.Builder builder = CsvReporter.forRegistry(metricsRegistry);
 
@@ -83,7 +83,7 @@ public class CsvStormReporter extends ScheduledStormReporter {
         //defaults to seconds
         reportingPeriodUnit = getReportPeriodUnit(reporterConf);
 
-        File csvMetricsDir = getCsvLogDir(stormConf, reporterConf);
+        File csvMetricsDir = getCsvLogDir(topoConf, reporterConf);
         reporter = builder.build(csvMetricsDir);
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/GraphiteStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/GraphiteStormReporter.java
@@ -32,24 +32,24 @@ public class GraphiteStormReporter extends ScheduledStormReporter {
     public static final String GRAPHITE_TRANSPORT = "graphite.transport";
     private static final Logger LOG = LoggerFactory.getLogger(GraphiteStormReporter.class);
 
-    private static String getMetricsPrefixedWith(Map reporterConf) {
+    private static String getMetricsPrefixedWith(Map<String, Object> reporterConf) {
         return ObjectReader.getString(reporterConf.get(GRAPHITE_PREFIXED_WITH), null);
     }
 
-    private static String getMetricsTargetHost(Map reporterConf) {
+    private static String getMetricsTargetHost(Map<String, Object> reporterConf) {
         return ObjectReader.getString(reporterConf.get(GRAPHITE_HOST), null);
     }
 
-    private static Integer getMetricsTargetPort(Map reporterConf) {
+    private static Integer getMetricsTargetPort(Map<String, Object> reporterConf) {
         return ObjectReader.getInt(reporterConf.get(GRAPHITE_PORT), null);
     }
 
-    private static String getMetricsTargetTransport(Map reporterConf) {
+    private static String getMetricsTargetTransport(Map<String, Object> reporterConf) {
         return ObjectReader.getString(reporterConf.get(GRAPHITE_TRANSPORT), "tcp");
     }
 
     @Override
-    public void prepare(MetricRegistry metricsRegistry, Map stormConf, Map reporterConf) {
+    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf,  Map<String, Object> reporterConf) {
         LOG.debug("Preparing...");
         GraphiteReporter.Builder builder = GraphiteReporter.forRegistry(metricsRegistry);
 

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/JmxStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/JmxStormReporter.java
@@ -32,7 +32,7 @@ public class JmxStormReporter implements StormReporter {
     }
 
     @Override
-    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> stormConf, Map<String, Object> reporterConf) {
+    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf,  Map<String, Object> reporterConf) {
         LOG.info("Preparing...");
         JmxReporter.Builder builder = JmxReporter.forRegistry(metricsRegistry);
 

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ScheduledStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ScheduledStormReporter.java
@@ -15,6 +15,7 @@ package org.apache.storm.metrics2.reporters;
 import com.codahale.metrics.ScheduledReporter;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.storm.daemon.metrics.ClientMetricsUtils;
 import org.apache.storm.metrics2.filters.StormMetricsFilter;
 import org.apache.storm.utils.ObjectReader;
 import org.apache.storm.utils.ReflectionUtils;
@@ -28,25 +29,17 @@ public abstract class ScheduledStormReporter implements StormReporter {
     protected TimeUnit reportingPeriodUnit;
 
     public static TimeUnit getReportPeriodUnit(Map<String, Object> reporterConf) {
-        TimeUnit unit = getTimeUnitForConfig(reporterConf, REPORT_PERIOD_UNITS);
+        TimeUnit unit = ClientMetricsUtils.getTimeUnitForConfig(reporterConf, REPORT_PERIOD_UNITS);
         return unit == null ? TimeUnit.SECONDS : unit;
     }
 
-    private static TimeUnit getTimeUnitForConfig(Map reporterConf, String configName) {
-        String rateUnitString = ObjectReader.getString(reporterConf.get(configName), null);
-        if (rateUnitString != null) {
-            return TimeUnit.valueOf(rateUnitString);
-        }
-        return null;
-    }
-
-    public static long getReportPeriod(Map reporterConf) {
+    public static long getReportPeriod(Map<String, Object> reporterConf) {
         return ObjectReader.getInt(reporterConf.get(REPORT_PERIOD), 10).longValue();
     }
 
-    public static StormMetricsFilter getMetricsFilter(Map reporterConf) {
+    public static StormMetricsFilter getMetricsFilter(Map<String, Object> reporterConf) {
         StormMetricsFilter filter = null;
-        Map<String, Object> filterConf = (Map) reporterConf.get("filter");
+        Map<String, Object> filterConf = (Map<String, Object>) reporterConf.get("filter");
         if (filterConf != null) {
             String clazz = (String) filterConf.get("class");
             if (clazz != null) {

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/StormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/StormReporter.java
@@ -20,7 +20,7 @@ public interface StormReporter extends Reporter {
     String REPORT_PERIOD = "report.period";
     String REPORT_PERIOD_UNITS = "report.period.units";
 
-    void prepare(MetricRegistry metricsRegistry, Map<String, Object> conf, Map<String, Object> reporterConf);
+    void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf, Map<String, Object> reporterConf);
 
     void start();
 

--- a/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
+++ b/storm-client/src/jvm/org/apache/storm/validation/ConfigValidation.java
@@ -763,12 +763,8 @@ public class ConfigValidation {
     }
 
     public static class MetricReportersValidator extends Validator {
-        private static final String NIMBUS = "nimbus";
-        private static final String SUPERVISOR = "supervisor";
-        private static final String WORKER = "worker";
         private static final String CLASS = "class";
         private static final String FILTER = "filter";
-        private static final String DAEMONS = "daemons";
 
         @Override
         public void validateField(String name, Object o) {
@@ -778,25 +774,6 @@ public class ConfigValidation {
             SimpleTypeValidator.validateField(name, Map.class, o);
             if (!((Map) o).containsKey(CLASS)) {
                 throw new IllegalArgumentException("Field " + name + " must have map entry with key: class");
-            }
-            if (!((Map) o).containsKey(DAEMONS)) {
-                throw new IllegalArgumentException("Field " + name + " must have map entry with key: daemons");
-            } else {
-                // daemons can only be 'nimbus', 'supervisor', or 'worker'
-                Object list = ((Map) o).get(DAEMONS);
-                if (!(list instanceof List)) {
-                    throw new IllegalArgumentException("Field 'daemons' must be a non-null list.");
-                }
-                List daemonList = (List) list;
-                for (Object string : daemonList) {
-                    if (string instanceof String
-                        && (string.equals(NIMBUS) || string.equals(SUPERVISOR) || string.equals(WORKER))) {
-                        continue;
-                    }
-                    throw new IllegalArgumentException("Field 'daemons' must contain at least one of the following:"
-                                                       + " \"nimbus\", \"supervisor\", or \"worker\"");
-                }
-
             }
             if (((Map) o).containsKey(FILTER)) {
                 Map filterMap = (Map) ((Map) o).get(FILTER);

--- a/storm-client/test/jvm/org/apache/storm/daemon/metrics/ClientMetricsUtilsTest.java
+++ b/storm-client/test/jvm/org/apache/storm/daemon/metrics/ClientMetricsUtilsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.daemon.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class ClientMetricsUtilsTest {
+
+    @Test
+    public void getMetricsRateUnit() {
+        Map<String, Object> reporterConf = new HashMap<>();
+
+        assertNull(ClientMetricsUtils.getMetricsRateUnit(reporterConf));
+
+        reporterConf.put("rate.unit", "SECONDS");
+        assertEquals(TimeUnit.SECONDS, ClientMetricsUtils.getMetricsRateUnit(reporterConf));
+
+        reporterConf.put("rate.unit", "MINUTES");
+        assertEquals(TimeUnit.MINUTES, ClientMetricsUtils.getMetricsRateUnit(reporterConf));
+    }
+
+    @Test
+    public void getMetricsDurationUnit() {
+        Map<String, Object> reporterConf = new HashMap<>();
+
+        assertNull(ClientMetricsUtils.getMetricsDurationUnit(reporterConf));
+
+        reporterConf.put("duration.unit", "SECONDS");
+        assertEquals(TimeUnit.SECONDS, ClientMetricsUtils.getMetricsDurationUnit(reporterConf));
+
+        reporterConf.put("duration.unit", "MINUTES");
+        assertEquals(TimeUnit.MINUTES, ClientMetricsUtils.getMetricsDurationUnit(reporterConf));
+    }
+
+    @Test
+    public void getMetricsReporterLocale() {
+        Map<String, Object> reporterConf = new HashMap<>();
+
+        assertNull(ClientMetricsUtils.getMetricsReporterLocale(reporterConf));
+
+        reporterConf.put("locale", "en-US");
+        assertEquals(Locale.US, ClientMetricsUtils.getMetricsReporterLocale(reporterConf));
+    }
+
+    @Test
+    public void getTimeUnitForConfig() {
+        Map<String, Object> reporterConf = new HashMap<>();
+        String dummyKey = "dummy.unit";
+
+        assertNull(ClientMetricsUtils.getTimeUnitForConfig(reporterConf, dummyKey));
+
+        reporterConf.put(dummyKey, "SECONDS");
+        assertEquals(TimeUnit.SECONDS, ClientMetricsUtils.getTimeUnitForConfig(reporterConf, dummyKey));
+
+        reporterConf.put(dummyKey, "MINUTES");
+        assertEquals(TimeUnit.MINUTES, ClientMetricsUtils.getTimeUnitForConfig(reporterConf, dummyKey));
+    }
+}

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -70,13 +70,13 @@ public class DaemonConfig implements Validated {
     public static final String STORM_DAEMON_METRICS_REPORTER_PLUGINS = "storm.daemon.metrics.reporter.plugins";
 
     /**
-     * A specify domain for daemon metrics reporter plugin to limit reporting to specific domain.
+     * Specify the domain for daemon metrics reporter plugin to limit reporting to specific domain.
      */
     @IsString
     public static final String STORM_DAEMON_METRICS_REPORTER_PLUGIN_DOMAIN = "storm.daemon.metrics.reporter.plugin.domain";
 
     /**
-     * A specify csv reporter directory for CvsPreparableReporter daemon metrics reporter.
+     * Specify the csv reporter directory for CvsPreparableReporter daemon metrics reporter.
      */
     @IsString
     public static final String STORM_DAEMON_METRICS_REPORTER_CSV_LOG_DIR = "storm.daemon.metrics.reporter.csv.log.dir";

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/ConsolePreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/ConsolePreparableReporter.java
@@ -17,7 +17,7 @@ import com.codahale.metrics.MetricRegistry;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.apache.storm.daemon.metrics.ClientMetricsUtils;
+import org.apache.storm.daemon.metrics.MetricsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,22 +26,22 @@ public class ConsolePreparableReporter implements PreparableReporter {
     ConsoleReporter reporter = null;
 
     @Override
-    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf) {
+    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> daemonConf) {
         LOG.debug("Preparing...");
         ConsoleReporter.Builder builder = ConsoleReporter.forRegistry(metricsRegistry);
 
         builder.outputTo(System.out);
-        Locale locale = ClientMetricsUtils.getMetricsReporterLocale(topoConf);
+        Locale locale = MetricsUtils.getMetricsReporterLocale(daemonConf);
         if (locale != null) {
             builder.formattedFor(locale);
         }
 
-        TimeUnit rateUnit = ClientMetricsUtils.getMetricsRateUnit(topoConf);
+        TimeUnit rateUnit = MetricsUtils.getMetricsRateUnit(daemonConf);
         if (rateUnit != null) {
             builder.convertRatesTo(rateUnit);
         }
 
-        TimeUnit durationUnit = ClientMetricsUtils.getMetricsDurationUnit(topoConf);
+        TimeUnit durationUnit = MetricsUtils.getMetricsDurationUnit(daemonConf);
         if (durationUnit != null) {
             builder.convertDurationsTo(durationUnit);
         }

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/CsvPreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/CsvPreparableReporter.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.apache.storm.daemon.metrics.ClientMetricsUtils;
 import org.apache.storm.daemon.metrics.MetricsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,26 +27,26 @@ public class CsvPreparableReporter implements PreparableReporter {
     CsvReporter reporter = null;
 
     @Override
-    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf) {
+    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> daemonConf) {
         LOG.debug("Preparing...");
         CsvReporter.Builder builder = CsvReporter.forRegistry(metricsRegistry);
 
-        Locale locale = ClientMetricsUtils.getMetricsReporterLocale(topoConf);
+        Locale locale = MetricsUtils.getMetricsReporterLocale(daemonConf);
         if (locale != null) {
             builder.formatFor(locale);
         }
 
-        TimeUnit rateUnit = ClientMetricsUtils.getMetricsRateUnit(topoConf);
+        TimeUnit rateUnit = MetricsUtils.getMetricsRateUnit(daemonConf);
         if (rateUnit != null) {
             builder.convertRatesTo(rateUnit);
         }
 
-        TimeUnit durationUnit = ClientMetricsUtils.getMetricsDurationUnit(topoConf);
+        TimeUnit durationUnit = MetricsUtils.getMetricsDurationUnit(daemonConf);
         if (durationUnit != null) {
             builder.convertDurationsTo(durationUnit);
         }
 
-        File csvMetricsDir = MetricsUtils.getCsvLogDir(topoConf);
+        File csvMetricsDir = MetricsUtils.getCsvLogDir(daemonConf);
         reporter = builder.build(csvMetricsDir);
     }
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/JmxPreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/JmxPreparableReporter.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.storm.DaemonConfig;
 import org.apache.storm.daemon.metrics.ClientMetricsUtils;
+import org.apache.storm.daemon.metrics.MetricsUtils;
 import org.apache.storm.utils.ObjectReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,19 +28,18 @@ public class JmxPreparableReporter implements PreparableReporter {
     JmxReporter reporter = null;
 
     @Override
-    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf) {
+    public void prepare(MetricRegistry metricsRegistry, Map<String, Object> daemonConf) {
         LOG.info("Preparing...");
         JmxReporter.Builder builder = JmxReporter.forRegistry(metricsRegistry);
-        String domain = ObjectReader.getString(topoConf.get(DaemonConfig.STORM_DAEMON_METRICS_REPORTER_PLUGIN_DOMAIN), null);
+        String domain = ObjectReader.getString(daemonConf.get(DaemonConfig.STORM_DAEMON_METRICS_REPORTER_PLUGIN_DOMAIN), null);
         if (domain != null) {
             builder.inDomain(domain);
         }
-        TimeUnit rateUnit = ClientMetricsUtils.getMetricsRateUnit(topoConf);
+        TimeUnit rateUnit = MetricsUtils.getMetricsRateUnit(daemonConf);
         if (rateUnit != null) {
             builder.convertRatesTo(rateUnit);
         }
         reporter = builder.build();
-
     }
 
     @Override

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/PreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/PreparableReporter.java
@@ -15,9 +15,8 @@ package org.apache.storm.daemon.metrics.reporters;
 import com.codahale.metrics.MetricRegistry;
 import java.util.Map;
 
-
 public interface PreparableReporter {
-    void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf);
+    void prepare(MetricRegistry metricsRegistry, Map<String, Object> daemonConf);
 
     void start();
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1136,6 +1136,10 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             enforceNettyAuth);
         ret.put(Config.STORM_MESSAGING_NETTY_AUTHENTICATION, enforceNettyAuth);
 
+        if (!mergedConf.containsKey(Config.TOPOLOGY_METRICS_REPORTERS) && mergedConf.containsKey(Config.STORM_METRICS_REPORTERS)) {
+            ret.put(Config.TOPOLOGY_METRICS_REPORTERS, mergedConf.get(Config.STORM_METRICS_REPORTERS));
+        }
+
         // Don't allow topoConf to override various cluster-specific properties.
         // Specifically adding the cluster settings to the topoConf here will make sure these settings
         // also override the subsequently generated conf picked up locally on the classpath.

--- a/storm-server/src/test/java/org/apache/storm/daemon/metrics/MetricsUtilsTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/metrics/MetricsUtilsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.daemon.metrics;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.storm.Config;
+import org.apache.storm.DaemonConfig;
+import org.apache.storm.daemon.metrics.reporters.ConsolePreparableReporter;
+import org.apache.storm.daemon.metrics.reporters.CsvPreparableReporter;
+import org.apache.storm.daemon.metrics.reporters.JmxPreparableReporter;
+import org.apache.storm.daemon.metrics.reporters.PreparableReporter;
+import org.junit.Test;
+
+public class MetricsUtilsTest {
+
+    @Test
+    public void getPreparableReporters() {
+        Map<String, Object> daemonConf = new HashMap<>();
+
+        List<PreparableReporter> reporters = MetricsUtils.getPreparableReporters(daemonConf);
+        assertEquals(1, reporters.size());
+        assertTrue(reporters.get(0) instanceof JmxPreparableReporter);
+
+        List<String> reporterPlugins = Arrays.asList("org.apache.storm.daemon.metrics.reporters.ConsolePreparableReporter",
+            "org.apache.storm.daemon.metrics.reporters.CsvPreparableReporter");
+
+        daemonConf.put(DaemonConfig.STORM_DAEMON_METRICS_REPORTER_PLUGINS, reporterPlugins);
+        reporters = MetricsUtils.getPreparableReporters(daemonConf);
+        assertEquals(2, reporters.size());
+        assertTrue(reporters.get(0) instanceof ConsolePreparableReporter);
+        assertTrue(reporters.get(1) instanceof CsvPreparableReporter);
+    }
+
+    @Test
+    public void getCsvLogDir() {
+        Map<String, Object> daemonConf = new HashMap<>();
+
+        String currentPath = new File("").getAbsolutePath();
+        daemonConf.put(Config.STORM_LOCAL_DIR, currentPath);
+        File dir = new File(currentPath, "csvmetrics");
+        assertEquals(dir, MetricsUtils.getCsvLogDir(daemonConf));
+
+        daemonConf.put(DaemonConfig.STORM_DAEMON_METRICS_REPORTER_CSV_LOG_DIR, "./");
+        assertEquals(new File("./"), MetricsUtils.getCsvLogDir(daemonConf));
+    }
+
+    @Test
+    public void getMetricsRateUnit() {
+        Map<String, Object> daemonConf = new HashMap<>();
+
+        assertNull(MetricsUtils.getMetricsRateUnit(daemonConf));
+
+        daemonConf.put(Config.STORM_DAEMON_METRICS_REPORTER_PLUGIN_RATE_UNIT, "SECONDS");
+        assertEquals(TimeUnit.SECONDS, MetricsUtils.getMetricsRateUnit(daemonConf));
+
+        daemonConf.put(Config.STORM_DAEMON_METRICS_REPORTER_PLUGIN_RATE_UNIT, "MINUTES");
+        assertEquals(TimeUnit.MINUTES, MetricsUtils.getMetricsRateUnit(daemonConf));
+    }
+
+    @Test
+    public void getMetricsDurationUnit() {
+        Map<String, Object> daemonConf = new HashMap<>();
+
+        assertNull(MetricsUtils.getMetricsDurationUnit(daemonConf));
+
+        daemonConf.put(Config.STORM_DAEMON_METRICS_REPORTER_PLUGIN_DURATION_UNIT, "SECONDS");
+        assertEquals(TimeUnit.SECONDS, MetricsUtils.getMetricsDurationUnit(daemonConf));
+
+        daemonConf.put(Config.STORM_DAEMON_METRICS_REPORTER_PLUGIN_DURATION_UNIT, "MINUTES");
+        assertEquals(TimeUnit.MINUTES, MetricsUtils.getMetricsDurationUnit(daemonConf));
+    }
+
+    @Test
+    public void getMetricsReporterLocale() {
+        Map<String, Object> daemonConf = new HashMap<>();
+
+        assertNull(MetricsUtils.getMetricsReporterLocale(daemonConf));
+
+        daemonConf.put(Config.STORM_DAEMON_METRICS_REPORTER_PLUGIN_LOCALE, "en-US");
+        assertEquals(Locale.US, MetricsUtils.getMetricsReporterLocale(daemonConf));
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

The configuration system on metrics reporters is messy. This PR cleans up configs and separate them as topology worker metrics vs daemon metrics.

## How was the change tested

1. Add unit tests

2. Tested daemon metric reporters on nimbus with `ConsolePreparableReporter` and `CsvPreparableReporter` to make sure daemon metric reporters still work properly

`CsvPreparableReporter`:
```
-bash-4.2$ ls -ltrh /home/y/var/storm/csvmetrics/ |tail
-rw-r--r-- 1 xx yy  494 Aug  4 02:01 nimbus:num-uploadChunk-calls.csv
-rw-r--r-- 1 xx yy  494 Aug  4 02:01 nimbus:num-submitTopologyWithOpts-calls.csv
...
```
`ConsolePreparableReporter`:
```
8/4/20 1:49:01 AM ==============================================================
-- Gauges ----------------------------------------------------------------------
MetricsCleaner:purgeTimestamp
value = 0
nimbus:available-cpu-non-negative
value = 400.0
```

3. Tested worker metric reporters, for example, with this configuration 

```
topology.metrics.reporters:
  - class: "org.apache.storm.metrics2.reporters.ConsoleStormReporter"
    report.period: 10
    report.period.units: "SECONDS"
    rate.unit: "SECONDS"
    locale: "en-US"
  - class: "org.apache.storm.metrics2.reporters.CsvStormReporter"
    report.period: 10
    report.period.units: "SECONDS"
    rate.unit: "SECONDS"
    locale: "en-US"
    csv.log.dir: "./"
```
`ConsoleStormReporter`:
```
2020-08-04 02:33:17.738 c.c.m.ConsoleReporter metrics-console-reporter-1-thread-1 [INFO] -- Counters --------------------------------------------------------------------
2020-08-04 02:33:17.738 c.c.m.ConsoleReporter metrics-console-reporter-1-thread-1 [INFO] storm.worker.wc13-4-1596508362.hostname.count.default.2.6701-acked
2020-08-04 02:33:17.738 c.c.m.ConsoleReporter metrics-console-reporter-1-thread-1 [INFO]              count = 840
```
`CsvStormReporter`:
```
-bash-4.2$ sudo ls -l /home/y/var/storm/workers/4d6259dc-ea7c-4048-a44d-be69adceecdd |tail -f
-rw-r----- 1 xx yy   143 Aug  4 02:34 storm.worker.wc13-4-1596508362.hostname.__system.3.6701-receive-queue-sojourn_time_ms.csv
-rw-r----- 1 xx yy   175 Aug  4 02:34 storm.worker.wc13-4-1596508362.hostname.__system.4.6701-receive-queue-arrival_rate_secs.csv
```
