### PR TITLE
[STORM-3683] Check if JVM options used for launching worker are valid.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -528,6 +528,7 @@ public class StormSubmitter {
         InvalidTopologyException, AuthorizationException {
         ConfigValidation.validateTopoConf(topoConf);
         Utils.validateTopologyBlobStoreMap(topoConf);
+        Utils.validateWorkerLaunchOptions(null, topoConf, null, true);
     }
 
     /**

--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -1911,8 +1911,8 @@ public class Utils {
     }
 
     /**
-     * Return path to the Java command "x", prefixing with $}{JAVA_HOME}/bin/ if JAVA_HOME system property is defined.
-     * Otherwie return the supplied Java command unmodified.
+     * Return path to the Java command "x", prefixing with ${JAVA_HOME}/bin/ if JAVA_HOME system property is defined.
+     * Otherwise return the supplied Java command unmodified.
      *
      * @param cmd Java command, e.g. "java", "jar" etc.
      * @return command string to use.

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/BasicContainer.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/BasicContainer.java
@@ -427,19 +427,21 @@ public class BasicContainer extends Container {
     private String substituteChildOptsInternal(String string, int memOnheap, int memOffheap) {
         if (StringUtils.isNotBlank(string)) {
             String p = String.valueOf(port);
-            string = string.replace("%ID%", p);
-            string = string.replace("%WORKER-ID%", workerId);
-            string = string.replace("%TOPOLOGY-ID%", topologyId);
-            string = string.replace("%WORKER-PORT%", p);
+            Map<String, Object> varSubstitutions = new HashMap<>();
+            varSubstitutions.put(Utils.WellKnownRuntimeSubstitutionVars.ID.getVarName(), p);
+            varSubstitutions.put(Utils.WellKnownRuntimeSubstitutionVars.WORKER_ID.getVarName(), workerId);
+            varSubstitutions.put(Utils.WellKnownRuntimeSubstitutionVars.TOPOLOGY_ID.getVarName(), topologyId);
+            varSubstitutions.put(Utils.WellKnownRuntimeSubstitutionVars.WORKER_PORT.getVarName(), p);
             if (memOnheap > 0) {
-                string = string.replace("%HEAP-MEM%", String.valueOf(memOnheap));
+                varSubstitutions.put(Utils.WellKnownRuntimeSubstitutionVars.HEAP_MEM.getVarName(), String.valueOf(memOnheap));
             }
             if (memOffheap > 0) {
-                string = string.replace("%OFF-HEAP-MEM%", String.valueOf(memOffheap));
+                varSubstitutions.put(Utils.WellKnownRuntimeSubstitutionVars.OFF_HEAP_MEM.getVarName(), String.valueOf(memOffheap));
             }
             if (memoryLimitMb > 0) {
-                string = string.replace("%LIMIT-MEM%", String.valueOf(memoryLimitMb));
+                varSubstitutions.put(Utils.WellKnownRuntimeSubstitutionVars.LIMIT_MEM.getVarName(), String.valueOf(memoryLimitMb));
             }
+            string = Utils.substituteVarNames(string, varSubstitutions);
         }
         return string;
     }
@@ -568,14 +570,7 @@ public class BasicContainer extends Container {
     }
 
     protected String javaCmd(String cmd) {
-        String ret = null;
-        String javaHome = System.getenv().get("JAVA_HOME");
-        if (StringUtils.isNotBlank(javaHome)) {
-            ret = javaHome + File.separator + "bin" + File.separator + cmd;
-        } else {
-            ret = cmd;
-        }
-        return ret;
+        return Utils.getJavaCmd(cmd);
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

*Error in JVM options can cause the worker launch to fail. This change will detect the erroneous options to be detected early when topology is submitted.*

## How was the change tested

*With new unit tests*