### PR TITLE
[STORM-3684] use real compId instead of constant _system for receive-queue V2 metrics

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -705,7 +705,7 @@ public class WorkerState {
     }
 
     private Map<List<Long>, JCQueue> mkReceiveQueueMap(Map<String, Object> topologyConf,
-                                                       Set<List<Long>> executors,  Map<Integer, String> taskToComponent) {
+                                                       Set<List<Long>> executors, Map<Integer, String> taskToComponent) {
         Integer recvQueueSize = ObjectReader.getInt(topologyConf.get(Config.TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE));
         Integer recvBatchSize = ObjectReader.getInt(topologyConf.get(Config.TOPOLOGY_PRODUCER_BATCH_SIZE));
         Integer overflowLimit = ObjectReader.getInt(topologyConf.get(Config.TOPOLOGY_EXECUTOR_OVERFLOW_LIMIT));

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -186,6 +186,9 @@ public class WorkerState {
         this.isWorkerActive = new CountDownLatch(1);
         this.isTopologyActive = new AtomicBoolean(false);
         this.stormComponentToDebug = new AtomicReference<>();
+        this.topology = ConfigUtils.readSupervisorTopology(conf, topologyId, AdvancedFSOps.make(conf));
+        this.taskToComponent = StormCommon.stormTaskInfo(topology, topologyConf);
+        // mkReceiveQueueMap relies on taskToComponent which relies on topology above
         this.executorReceiveQueueMap = mkReceiveQueueMap(topologyConf, localExecutors);
         this.localTaskIds = new ArrayList<>();
         this.taskToExecutorQueue = new HashMap<>();
@@ -199,9 +202,7 @@ public class WorkerState {
         }
         Collections.sort(localTaskIds);
         this.topologyConf = topologyConf;
-        this.topology = ConfigUtils.readSupervisorTopology(conf, topologyId, AdvancedFSOps.make(conf));
         this.systemTopology = StormCommon.systemTopology(topologyConf, topology);
-        this.taskToComponent = StormCommon.stormTaskInfo(topology, topologyConf);
         this.componentToStreamToFields = new HashMap<>();
         for (String c : ThriftTopologyUtils.getComponentIds(systemTopology)) {
             Map<String, Fields> streamToFields = new HashMap<>();
@@ -704,7 +705,8 @@ public class WorkerState {
         }
     }
 
-    private Map<List<Long>, JCQueue> mkReceiveQueueMap(Map<String, Object> topologyConf, Set<List<Long>> executors) {
+    private Map<List<Long>, JCQueue> mkReceiveQueueMap(Map<String, Object> topologyConf,
+                                                       Set<List<Long>> executors) throws InvalidTopologyException {
         Integer recvQueueSize = ObjectReader.getInt(topologyConf.get(Config.TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE));
         Integer recvBatchSize = ObjectReader.getInt(topologyConf.get(Config.TOPOLOGY_PRODUCER_BATCH_SIZE));
         Integer overflowLimit = ObjectReader.getInt(topologyConf.get(Config.TOPOLOGY_EXECUTOR_OVERFLOW_LIMIT));
@@ -717,11 +719,19 @@ public class WorkerState {
 
         IWaitStrategy backPressureWaitStrategy = IWaitStrategy.createBackPressureWaitStrategy(topologyConf);
         Map<List<Long>, JCQueue> receiveQueueMap = new HashMap<>();
+
         for (List<Long> executor : executors) {
             List<Integer> taskIds = StormCommon.executorIdToTasks(executor);
+            int taskId = taskIds.get(0);
+            String compId;
+            if (taskId == -1) {
+                compId = Constants.SYSTEM_COMPONENT_ID;
+            } else {
+                compId = taskToComponent.get(taskId);
+            }
             receiveQueueMap.put(executor, new JCQueue("receive-queue" + executor.toString(), "receive-queue",
                                                       recvQueueSize, overflowLimit, recvBatchSize, backPressureWaitStrategy,
-                this.getTopologyId(), Constants.SYSTEM_COMPONENT_ID, taskIds, this.getPort(), metricRegistry));
+                this.getTopologyId(), compId, taskIds, this.getPort(), metricRegistry));
 
         }
         return receiveQueueMap;


### PR DESCRIPTION

## What is the purpose of the change

When registering receive-queue V2 metrics for each executor, we should use the its correspondent component Id instead of constant system component Id.

## How was the change tested
Launch a local cluster with a WordCount topology. Enable `org.apache.storm.metrics2.reporters.ConsoleStormReporter` to output metrics to worker log. We will see the long name as :
`storm.worker.<topoName>.<hostname>.<compId>.<taskId>.<port>.<metric-name>`
The compId part now reflects the correct component for the taskId.
```
2020-08-04 14:22:44.911 c.c.m.ConsoleReporter metrics-console-reporter-1-thread-1 [INFO] storm.worker.wc1-1-1596568923.192_168_0_19.count.10.6700-receive-queue-pct_full
2020-08-04 14:22:44.911 c.c.m.ConsoleReporter metrics-console-reporter-1-thread-1 [INFO]              value = 0.0
2020-08-04 14:22:44.912 c.c.m.ConsoleReporter metrics-console-reporter-1-thread-1 [INFO] storm.worker.wc1-1-1596568923.192_168_0_19.count.10.6700-receive-queue-population
2020-08-04 14:22:44.912 c.c.m.ConsoleReporter metrics-console-reporter-1-thread-1 [INFO]              value = 0
2020-08-04 14:22:44.912 c.c.m.ConsoleReporter metrics-console-reporter-1-thread-1 [INFO] storm.worker.wc1-1-1596568923.192_168_0_19.count.10.6700-receive-queue-sojourn_time_ms
2020-08-04 14:22:44.912 c.c.m.ConsoleReporter metrics-console-reporter-1-thread-1 [INFO]              value = 0.0
```