### PR TITLE
[STORM-3685] Detect and prevent cycles when Topology is submitted.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.apache.storm.dependency.DependencyPropertiesParser;
 import org.apache.storm.dependency.DependencyUploader;
 import org.apache.storm.generated.AlreadyAliveException;
@@ -49,6 +51,7 @@ import org.apache.storm.utils.Utils;
 import org.apache.storm.validation.ConfigValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.net.ProgressListener;
 
 /**
  * Use this class to submit topologies to run on the Storm cluster. You should run your program with the "storm jar" command from the
@@ -233,7 +236,7 @@ public class StormSubmitter {
         conf.putAll(topoConf);
         topoConf.putAll(prepareZookeeperAuthentication(conf));
 
-        validateConfs(conf, topology);
+        validateConfs(conf, topology, name);
 
         Map<String, String> passedCreds = new HashMap<>();
         if (opts != null) {
@@ -524,10 +527,19 @@ public class StormSubmitter {
         }
     }
 
-    private static void validateConfs(Map<String, Object> topoConf, StormTopology topology) throws IllegalArgumentException,
+    private static void validateConfs(Map<String, Object> topoConf, StormTopology topology, String name) throws IllegalArgumentException,
         InvalidTopologyException, AuthorizationException {
         ConfigValidation.validateTopoConf(topoConf);
         Utils.validateTopologyBlobStoreMap(topoConf);
+
+        List<List<String>> cycles = Utils.findComponentCycles(topology, name);
+        if (!cycles.isEmpty()) {
+            String err = String.format("Topology %s contains cycles in components \"%s\"", name,
+                    cycles.stream()
+                            .map(x -> String.join(",", x))
+                            .collect(Collectors.joining(" ; ")));
+            throw new InvalidTopologyException(err);
+        }
     }
 
     /**

--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -51,7 +51,6 @@ import org.apache.storm.utils.Utils;
 import org.apache.storm.validation.ConfigValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.net.ProgressListener;
 
 /**
  * Use this class to submit topologies to run on the Storm cluster. You should run your program with the "storm jar" command from the
@@ -538,7 +537,7 @@ public class StormSubmitter {
                     cycles.stream()
                             .map(x -> String.join(",", x))
                             .collect(Collectors.joining(" ; ")));
-            throw new InvalidTopologyException(err);
+            LOG.warn(err);
         }
     }
 

--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.storm.daemon.StormCommon;
 import org.apache.storm.dependency.DependencyPropertiesParser;
@@ -52,7 +51,6 @@ import org.apache.storm.utils.Utils;
 import org.apache.storm.validation.ConfigValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.net.ProgressListener;
 
 /**
  * Use this class to submit topologies to run on the Storm cluster. You should run your program with the "storm jar" command from the
@@ -135,7 +133,7 @@ public class StormSubmitter {
      */
     public static boolean pushCredentials(String name, Map<String, Object> topoConf, Map<String, String> credentials, String expectedUser)
         throws AuthorizationException, NotAliveException, InvalidTopologyException {
-        topoConf = new HashMap(topoConf);
+        topoConf = new HashMap<>(topoConf);
         topoConf.putAll(Utils.readCommandLineOpts());
         Map<String, Object> conf = Utils.readStormConfig();
         conf.putAll(topoConf);
@@ -170,7 +168,7 @@ public class StormSubmitter {
      * @throws AlreadyAliveException    if a topology with this name is already running
      * @throws InvalidTopologyException if an invalid topology was submitted
      * @throws AuthorizationException   if authorization is failed
-     * @thorws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
+     * @throws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
      */
     public static void submitTopology(String name, Map<String, Object> topoConf, StormTopology topology)
         throws AlreadyAliveException, InvalidTopologyException, AuthorizationException {
@@ -187,7 +185,7 @@ public class StormSubmitter {
      * @throws AlreadyAliveException    if a topology with this name is already running
      * @throws InvalidTopologyException if an invalid topology was submitted
      * @throws AuthorizationException   if authorization is failed
-     * @thorws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
+     * @throws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
      */
     public static void submitTopology(String name, Map<String, Object> topoConf, StormTopology topology, SubmitOptions opts)
         throws AlreadyAliveException, InvalidTopologyException, AuthorizationException {
@@ -201,11 +199,11 @@ public class StormSubmitter {
      * @param topoConf         the topology-specific configuration. See {@link Config}.
      * @param topology         the processing to execute.
      * @param opts             to manipulate the starting of the topology
-     * @param progressListener to track the progress of the jar upload process
+     * @param progressListener to track the progress of the jar upload process {@link ProgressListener}
      * @throws AlreadyAliveException    if a topology with this name is already running
      * @throws InvalidTopologyException if an invalid topology was submitted
      * @throws AuthorizationException   if authorization is failed
-     * @thorws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
+     * @throws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
      */
     @SuppressWarnings("unchecked")
     public static void submitTopology(String name, Map<String, Object> topoConf, StormTopology topology, SubmitOptions opts,
@@ -219,7 +217,7 @@ public class StormSubmitter {
      *
      * @param asUser The user as which this topology should be submitted.
      * @throws IllegalArgumentException thrown if configs will yield an unschedulable topology. validateConfs validates confs
-     * @thorws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
+     * @throws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
      */
     public static void submitTopologyAs(String name, Map<String, Object> topoConf, StormTopology topology, SubmitOptions opts,
                                         ProgressListener progressListener, String asUser)
@@ -231,7 +229,7 @@ public class StormSubmitter {
         if (!Utils.isValidConf(topoConf)) {
             throw new IllegalArgumentException("Storm conf is not valid. Must be json-serializable");
         }
-        topoConf = new HashMap(topoConf);
+        topoConf = new HashMap<>(topoConf);
         topoConf.putAll(Utils.readCommandLineOpts());
         Map<String, Object> conf = Utils.readStormConfig();
         conf.putAll(topoConf);
@@ -243,7 +241,6 @@ public class StormSubmitter {
             StormCommon.validateCycleFree(topology, name);
         } catch (InvalidTopologyException ex) {
             LOG.warn(ex.get_msg(), ex);
-            System.out.println(ex.get_msg());
         }
 
         Map<String, String> passedCreds = new HashMap<>();
@@ -366,7 +363,7 @@ public class StormSubmitter {
 
     /**
      * Invoke submitter hook.
-     * @thorws SubmitterHookException This is thrown when any Exception occurs during initialization or invocation of registered {@link
+     * @throws SubmitterHookException This is thrown when any Exception occurs during initialization or invocation of registered {@link
      *     ISubmitterHook}
      */
     private static void invokeSubmitterHook(String name, String asUser, Map<String, Object> topoConf, StormTopology topology) {
@@ -418,7 +415,7 @@ public class StormSubmitter {
      * @throws AlreadyAliveException    if a topology with this name is already running
      * @throws InvalidTopologyException if an invalid topology was submitted
      * @throws AuthorizationException   if authorization is failed
-     * @thorws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
+     * @throws SubmitterHookException if any Exception occurs during initialization or invocation of registered {@link ISubmitterHook}
      */
     public static void submitTopologyWithProgressBar(String name, Map<String, Object> topoConf, StormTopology topology,
                                                      SubmitOptions opts) throws AlreadyAliveException, InvalidTopologyException,
@@ -453,10 +450,6 @@ public class StormSubmitter {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static String submitJar(Map<String, Object> conf, ProgressListener listener) {
-        return submitJar(conf, System.getProperty("storm.jar"), listener);
     }
 
     /**

--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.storm.daemon.StormCommon;
 import org.apache.storm.dependency.DependencyPropertiesParser;
 import org.apache.storm.dependency.DependencyUploader;
 import org.apache.storm.generated.AlreadyAliveException;
@@ -238,9 +237,9 @@ public class StormSubmitter {
         validateConfs(conf);
 
         try {
-            StormCommon.validateCycleFree(topology, name);
+            Utils.validateCycleFree(topology, name);
         } catch (InvalidTopologyException ex) {
-            LOG.warn(ex.get_msg(), ex);
+            LOG.warn("", ex);
         }
 
         Map<String, String> passedCreds = new HashMap<>();

--- a/storm-client/src/jvm/org/apache/storm/daemon/StormCommon.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/StormCommon.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+
 import org.apache.storm.Config;
 import org.apache.storm.Constants;
 import org.apache.storm.Thrift;
@@ -577,5 +579,21 @@ public class StormCommon {
         }
 
         return aznHandler;
+    }
+
+    /**
+     * Validate that the topology is cycle free. If not, then throw an InvalidTopologyException describing the cycle(s).
+     *
+     * @param topology StormTopology instance to examine.
+     * @param name Name of the topology, used in exception error message.
+     * @throws InvalidTopologyException if there are cycles, with message describing the cycles encountered.
+     */
+    public static void validateCycleFree(StormTopology topology, String name) throws InvalidTopologyException {
+        List<List<String>> cycles = Utils.findComponentCycles(topology, name);
+        if (!cycles.isEmpty()) {
+            String err = String.format("Topology %s contains cycles in components \"%s\"", name,
+                    cycles.stream().map(x -> String.join(",", x)).collect(Collectors.joining(" ; ")));
+            throw new InvalidTopologyException(err);
+        }
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -1958,7 +1958,7 @@ public class Utils {
                 List<String> possibleCycle = new ArrayList<>();
                 if (compId1.equals(compId2)) {
                     possibleCycle.add(compId2);
-                } else if (edgesOut.get(compId2).contains(compId1)) {
+                } else if (edgesOut.get(compId2) != null && edgesOut.get(compId2).contains(compId1)) {
                     possibleCycle.addAll(Arrays.asList(compId1, compId2));
                 } else {
                     List<String> tmp = Collections.list(stack.elements());

--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -2002,7 +2002,6 @@ public class Utils {
 
         if (topology.get_spouts_size() == 0) {
             LOG.error("Topology {} does not contain any spouts, cannot traverse graph to determine cycles", topoId);
-            ret.add(new ArrayList(edgesOut.keySet()));
             return ret;
         }
 

--- a/storm-client/test/jvm/org/apache/storm/utils/UtilsTest.java
+++ b/storm-client/test/jvm/org/apache/storm/utils/UtilsTest.java
@@ -21,11 +21,9 @@ package org.apache.storm.utils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
@@ -38,7 +36,6 @@ import org.apache.storm.testing.TestWordCounter;
 import org.apache.storm.testing.TestWordSpout;
 import org.apache.storm.thrift.transport.TTransportException;
 import org.apache.storm.topology.BoltDeclarer;
-import org.apache.storm.topology.SpoutDeclarer;
 import org.apache.storm.topology.TopologyBuilder;
 import org.junit.Assert;
 import org.junit.Test;
@@ -92,9 +89,7 @@ public class UtilsTest {
     }
 
     private void doParseJvmHeapMemByChildOptsTest(String message, List<String> opts, double expected) {
-        Assert.assertEquals(
-            message,
-            Utils.parseJvmHeapMemByChildOpts(opts, 123.0).doubleValue(), expected, 0);
+        Assert.assertEquals(message, Utils.parseJvmHeapMemByChildOpts(opts, 123.0), expected, 0);
     }
 
     @Test
@@ -473,7 +468,7 @@ public class UtilsTest {
                                     x.testName, loops.size(), x.expectedCycles, x.testDescription));
                     if (!loops.isEmpty()) {
                         testFailures.add(
-                                String.format("\t\tdetected loops are \"{}\"",
+                                String.format("\t\tdetected loops are \"%s\"",
                                         loops.stream()
                                                 .map(y -> String.join(",", y))
                                                 .collect(Collectors.joining(" ; "))

--- a/storm-client/test/jvm/org/apache/storm/utils/UtilsTest.java
+++ b/storm-client/test/jvm/org/apache/storm/utils/UtilsTest.java
@@ -18,22 +18,39 @@
 
 package org.apache.storm.utils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.stream.Collectors;
+
 import org.apache.storm.Config;
+import org.apache.storm.generated.StormTopology;
 import org.apache.storm.shade.com.google.common.collect.ImmutableList;
 import org.apache.storm.shade.com.google.common.collect.ImmutableMap;
 import org.apache.storm.shade.com.google.common.collect.ImmutableSet;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.state.State;
+import org.apache.storm.task.TopologyContext;
 import org.apache.storm.thrift.transport.TTransportException;
+import org.apache.storm.topology.IRichSpout;
+import org.apache.storm.topology.IStatefulBolt;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.topology.base.BaseRichSpout;
+import org.apache.storm.topology.base.BaseStatefulBolt;
+import org.apache.storm.tuple.Tuple;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.*;
 
 public class UtilsTest {
+    public static final Logger LOG = LoggerFactory.getLogger(UtilsTest.class);
 
     @Test
     public void isZkAuthenticationConfiguredTopologyTest() {
@@ -236,5 +253,185 @@ public class UtilsTest {
         IVersionInfo found = alternativeVersions.get(key);
         assertNotNull(found);
         assertEquals(key, found.getVersion());
+    }
+
+    @Test
+    public void testFindComponentCycles() {
+        class CycleDetectionScenario {
+            final String testName;
+            final String testDescription;
+            final StormTopology topology;
+            final int expectedCycles;
+
+            CycleDetectionScenario() {
+                testName = "dummy";
+                testDescription = "dummy test";
+                topology = null;
+                expectedCycles = 0;
+            }
+
+            CycleDetectionScenario(String testName, String testDescription, StormTopology topology, int expectedCycles) {
+                this.testName = testName;
+                this.testDescription = testDescription;
+                this.topology = topology;
+                this.expectedCycles = expectedCycles;
+            }
+
+            private IRichSpout makeDummySpout() {
+                return new BaseRichSpout() {
+                    @Override
+                    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+                    }
+
+                    @Override
+                    public void open(Map<String, Object> conf, TopologyContext context, SpoutOutputCollector collector) {
+                    }
+
+                    @Override
+                    public void nextTuple() {
+                    }
+
+                    private void writeObject(java.io.ObjectOutputStream stream) {
+                    }
+                };
+            }
+
+            private IStatefulBolt makeDummyStatefulBolt() {
+                return new BaseStatefulBolt() {
+                    @Override
+                    public void execute(Tuple input) {
+                    }
+
+                    @Override
+                    public void initState(State state) {
+                    }
+
+                    private void writeObject(java.io.ObjectOutputStream stream) {
+                    }
+                };
+            }
+
+            public List<CycleDetectionScenario> createTestScenarios() {
+                List<CycleDetectionScenario> ret = new ArrayList<>();
+                int testNo = 0;
+                CycleDetectionScenario s;
+                TopologyBuilder tb;
+
+                // Base case
+                {
+                    testNo++;
+                    tb = new TopologyBuilder();
+                    tb.setSpout("spout1", makeDummySpout(), 10);
+                    tb.setBolt("bolt1", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1");
+                    tb.setBolt("bolt2", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1");
+                    tb.setBolt("bolt11", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt1");
+                    tb.setBolt("bolt12", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt1");
+                    tb.setBolt("bolt21", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt2");
+                    tb.setBolt("bolt22", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt2");
+                    s = new CycleDetectionScenario(String.format("(%d) Base", testNo),
+                            "Three level component hierarchy with no loops",
+                            tb.createTopology(),
+                            0);
+                    ret.add(s);
+                }
+
+                // single loop with one bolt
+                {
+                    testNo++;
+                    tb = new TopologyBuilder();
+                    tb.setSpout("spout1", makeDummySpout(), 10);
+                    tb.setBolt("bolt1", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1");
+                    tb.setBolt("bolt2", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1");
+                    tb.setBolt("bolt11", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt1");
+                    tb.setBolt("bolt12", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt1");
+                    tb.setBolt("bolt21", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt2");
+                    tb.setBolt("bolt22", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt2");
+                    // loop bolt 3  (also connect bolt3 to spout 1)
+                    tb.setBolt("bolt3", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1").shuffleGrouping("bolt3");
+                    ret.add(new CycleDetectionScenario(String.format("(%d) Base", testNo),
+                            "Four level component hierarchy with 1 cycle in bolt3",
+                            tb.createTopology(),
+                            1));
+                }
+
+                // single loop with three bolts
+                {
+                    testNo++;
+                    tb = new TopologyBuilder();
+                    tb.setSpout("spout1", makeDummySpout(), 10);
+                    tb.setBolt("bolt1", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1");
+                    tb.setBolt("bolt2", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1");
+                    tb.setBolt("bolt11", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt1");
+                    tb.setBolt("bolt12", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt1");
+                    tb.setBolt("bolt21", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt2");
+                    tb.setBolt("bolt22", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt2");
+                    // loop bolt 3 -> 4 -> 5 -> 3 (also connect bolt3 to spout1)
+                    tb.setBolt("bolt3", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1").shuffleGrouping("bolt5");
+                    tb.setBolt("bolt4", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt3");
+                    tb.setBolt("bolt5", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt4");
+                    ret.add(new CycleDetectionScenario(String.format("(%d) Base", testNo),
+                            "Four level component hierarchy with 1 cycle in bolt3,bolt4,bolt5",
+                            tb.createTopology(),
+                            1));
+                }
+
+                // two loops with three bolts, and one bolt
+                {
+                    testNo++;
+                    tb = new TopologyBuilder();
+                    tb.setSpout("spout1", makeDummySpout(), 10);
+                    tb.setBolt("bolt1", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1");
+                    tb.setBolt("bolt2", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1");
+                    tb.setBolt("bolt11", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt1");
+                    tb.setBolt("bolt12", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt1");
+                    tb.setBolt("bolt21", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt2");
+                    tb.setBolt("bolt22", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt2");
+                    // loop bolt 3 -> 4 -> 5 -> 3 (also connect bolt3 to spout1)
+                    tb.setBolt("bolt3", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1").shuffleGrouping("bolt5");
+                    tb.setBolt("bolt4", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt3");
+                    tb.setBolt("bolt5", makeDummyStatefulBolt(), 10).shuffleGrouping("bolt4");
+                    // loop bolt 6  (also connect bolt6 to spout 1)
+                    tb.setBolt("bolt6", makeDummyStatefulBolt(), 10).shuffleGrouping("spout1").shuffleGrouping("bolt6");
+                    ret.add(new CycleDetectionScenario(String.format("(%d) Base", testNo),
+                            "Four level component hierarchy with 2 cycles in bolt3,bolt4,bolt5 and bolt6",
+                            tb.createTopology(),
+                            2));
+                }
+
+                return ret;
+            }
+        }
+        List<String> testFailures = new ArrayList<>();
+
+        new CycleDetectionScenario().createTestScenarios().forEach(x -> {
+            LOG.info("==================== Running Test Scenario: {} =======================", x.testName);
+            LOG.info("{}: {}", x.testName, x.testDescription);
+
+            List<List<String>> loops = Utils.findComponentCycles(x.topology, x.testName);
+            if (!loops.isEmpty()) {
+                LOG.info("{} detected loops are \"{}\"", x.testName,
+                        loops.stream()
+                                .map(y -> String.join(",", y))
+                                .collect(Collectors.joining(" ; "))
+                );
+            }
+            if (loops.size() != x.expectedCycles) {
+                testFailures.add(
+                        String.format("Test \"%s\" failed, detected cycles=%d does not match expected=%d for \"%s\"",
+                                x.testName, loops.size(), x.expectedCycles, x.testDescription));
+                if (!loops.isEmpty()) {
+                    testFailures.add(
+                            String.format("\t\tdetected loops are \"{}\"",
+                                    loops.stream()
+                                            .map(y -> String.join(",", y))
+                                            .collect(Collectors.joining(" ; "))
+                            )
+                    );
+                }
+            }
+        });
+        if (!testFailures.isEmpty()) {
+            fail(String.join("\n", testFailures));
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*Topology is expected to be a Directed Acyclic Graph. Cycles in component flow can cause unexpected behavior, for example a deadlock when one of the loop components signals a back-pressure. Or properly detecting proximity when scheduling.*

## How was the change tested

*New test to create topology with and without cycles and test detection.*