### PR TITLE
[STORM-3689] Add license for ASM-5.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,7 @@ matrix:
   include:
     - arch: s390x
       jdk: openjdk11
-    - arch: arm64
-      jdk: openjdk11
-
+      
 before_install:
   - rvm reload
   - rvm use 2.4.2 --install
@@ -54,7 +52,6 @@ before_install:
   - export MVN_HOME=$HOME/apache-maven-3.6.3
   - if [ ! -d $MVN_HOME/bin ]; then wget https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -P $HOME; tar xzvf $HOME/apache-maven-3.6.3-bin.tar.gz -C $HOME; fi
   - export PATH=$MVN_HOME/bin:$PATH
-  - f=$(which javac); while [[ -L $f ]]; do f=$(readlink $f);done; export JAVA_HOME=${f%/bin/*}
 
 install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
 script:

--- a/THIRD-PARTY.properties
+++ b/THIRD-PARTY.properties
@@ -27,6 +27,9 @@ oro--oro--2.0.8=Apache License version 2.0
 asm--asm--3.1=BSD 3-Clause License
 asm--asm-commons--3.1=BSD 3-Clause License
 asm--asm-tree--3.1=BSD 3-Clause License
+asm--asm--5.0.3=BSD 3-Clause License
+asm--asm-commons--5.0.3=BSD 3-Clause License
+asm--asm-tree--5.0.3=BSD 3-Clause License
 
 javax.jms--jms--1.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 javax.servlet--jsp-api--2.0=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1

--- a/THIRD-PARTY.properties
+++ b/THIRD-PARTY.properties
@@ -38,3 +38,4 @@ javax.servlet.jsp--jsp-api--2.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDD
 javax.transaction--jta--1.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 javax.transaction--transaction-api--1.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 org.glassfish.jersey--jersey-bom--2.27=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
+jakarta.annotation--annotation-api--1.3.4=Eclipse Public License 2.0

--- a/THIRD-PARTY.properties
+++ b/THIRD-PARTY.properties
@@ -39,3 +39,4 @@ javax.transaction--jta--1.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) V
 javax.transaction--transaction-api--1.1=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 org.glassfish.jersey--jersey-bom--2.27=COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 jakarta.annotation--annotation-api--1.3.4=Eclipse Public License 2.0
+com.github.stephenc.jcip--jcip-annotations--1.0-1=Apache License version 2.0


### PR DESCRIPTION
## What is the purpose of the change

*Storm build fails when checking for third party license for ASM-5.0.3*

## How was the change tested

*Creating a pull request and checking if Travis build succeeded*