### PR TITLE
[STORM-3690] fix Ui index page null pointer error

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/normalization/NormalizedResourceRequest.java
@@ -192,9 +192,11 @@ public class NormalizedResourceRequest implements NormalizedResourcesWithMemory 
      */
     public static Map<String, Double> addResourceMap(Map<String, Double> resources1, Map<String, Double> resources2) {
         Map<String, Double> sum = new HashMap<>(resources1);
-        for (Map.Entry<String, Double> me : resources2.entrySet()) {
-            Double cur = sum.getOrDefault(me.getKey(), 0.0) + me.getValue();
-            sum.put(me.getKey(), cur);
+        if (resources2 != null) {
+            for (Map.Entry<String, Double> me : resources2.entrySet()) {
+                Double cur = sum.getOrDefault(me.getKey(), 0.0) + me.getValue();
+                sum.put(me.getKey(), cur);
+            }
         }
         return sum;
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix the UI null pointer error if resource aware scheduler is not used.

## How was the change tested

Launch a local cluster and a word count topology.
UI error was fixed.