### PR TITLE
STORM-3694 allow reporting V2 metrics with dimensions and short names

### DIFF
--- a/docs/metrics_v2.md
+++ b/docs/metrics_v2.md
@@ -138,6 +138,10 @@ public interface StormMetricsFilter extends MetricFilter {
 }
 ```
 
+V2 metrics can be reported with a long name (such as storm.topology.mytopologyname-17-1595349167.hostname.__system.-1.6700-memory.pools.Code-Cache.max) or with a short
+name and dimensions (such as memory.pools.Code-Cache.max with dimensions task Id of -1 and component Id of __system) if reporters support this.  Each reporter defaults
+to using the long metric name, but can report the short name by configuring report.dimensions.enabled to true for the reporter.
+
 ## Backwards Compatibility Notes
 
 1. V2 metrics can also be reported to the Metrics Consumers registered with `topology.metrics.consumer.register` by enabling the `topology.enable.v2.metrics.tick` configuration.

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -180,7 +180,7 @@ public class Worker implements Shutdownable, DaemonCommon {
         IStateStorage stateStorage = ClusterUtils.mkStateStorage(conf, topologyConf, csContext);
         IStormClusterState stormClusterState = ClusterUtils.mkStormClusterState(stateStorage, null, csContext);
 
-        metricRegistry.start(topologyConf);
+        metricRegistry.start(topologyConf, port);
 
         Credentials initialCredentials = stormClusterState.credentials(topologyId, null);
         Map<String, String> initCreds = new HashMap<>();

--- a/storm-client/src/jvm/org/apache/storm/metrics2/DimensionalReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/DimensionalReporter.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.metrics2;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Timer;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class that allows using a ScheduledReporter to report V2 task metrics with support for dimensions.
+ * <p></p>
+ * This reporter will be started and scheduled with the MetricRegistry.  Once it is called on to report,
+ * it will query the StormMetricRegistry for various sets of task metrics with unique dimensions.  The
+ * underlying ScheduledReporter will perform the actual reporting with the help of a DimensionHandler to
+ * deal with the dimensions.
+ */
+public class DimensionalReporter extends ScheduledReporter {
+    private ScheduledReporter underlyingReporter;
+    private MetricRegistryProvider metricRegistryProvider;
+    private MetricFilter filter;
+    private DimensionHandler dimensionHandler;
+
+    /**
+     * Constructor.
+     *
+     * @param metricRegistryProvider MetricRegistryProvider tracking task-specific metrics.
+     * @param unstartedReporter      ScheduledReporter to perform the actual reporting.  It should NOT be started.
+     * @param dimensionHandler       class to handle setting dimensions before reporting a set of metrics.
+     * @param name                   the reporter's name.
+     * @param filter                 the filter for which metrics to report.
+     * @param rateUnit               rate unit for the reporter.
+     * @param durationUnit           duration unit for the reporter.
+     * @param executor               the executor to use while scheduling reporting of metrics.
+     * @param shutdownExecutorOnStop if true, then executor will be stopped in same time with this reporter.
+     */
+    public DimensionalReporter(MetricRegistryProvider metricRegistryProvider,
+                               ScheduledReporter unstartedReporter,
+                               DimensionHandler dimensionHandler,
+                               String name,
+                               MetricFilter filter,
+                               TimeUnit rateUnit,
+                               TimeUnit durationUnit,
+                               ScheduledExecutorService executor,
+                               boolean shutdownExecutorOnStop) {
+        super(metricRegistryProvider.getRegistry(), name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop);
+        underlyingReporter = unstartedReporter;
+        this.metricRegistryProvider = metricRegistryProvider;
+        this.filter = filter;
+        this.dimensionHandler = dimensionHandler;
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
+        report();
+    }
+
+    @Override
+    public void report() {
+        for (Map.Entry<TaskMetricDimensions, TaskMetricRepo> entry : metricRegistryProvider.getTaskMetrics().entrySet()) {
+            TaskMetricRepo repo = entry.getValue();
+            if (dimensionHandler != null) {
+                TaskMetricDimensions dimensions = entry.getKey();
+                dimensionHandler.setDimensions(dimensions.getDimensions());
+            }
+            repo.report(underlyingReporter, filter);
+        }
+    }
+
+    public interface DimensionHandler {
+        /**
+         * Sets dimensions to be used for reporting on the next batch of metrics.
+         *
+         * @param dimensions    dimensions valid for use in the next scheduled report.
+         */
+        void setDimensions(Map<String, String> dimensions);
+    }
+}

--- a/storm-client/src/jvm/org/apache/storm/metrics2/MetricRegistryProvider.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/MetricRegistryProvider.java
@@ -10,28 +10,14 @@
  * and limitations under the License.
  */
 
-package org.apache.storm.metrics2.reporters;
+package org.apache.storm.metrics2;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Reporter;
 import java.util.Map;
-import org.apache.storm.metrics2.MetricRegistryProvider;
 
+public interface MetricRegistryProvider {
 
-public interface StormReporter extends Reporter {
-    String REPORT_PERIOD = "report.period";
-    String REPORT_PERIOD_UNITS = "report.period.units";
-    String REPORT_DIMENSIONS_ENABLED = "report.dimensions.enabled";
+    MetricRegistry getRegistry();
 
-    @Deprecated
-    void prepare(MetricRegistry metricsRegistry, Map<String, Object> topoConf, Map<String, Object> reporterConf);
-
-    default void prepare(MetricRegistryProvider metricRegistryProvider, Map<String, Object> topoConf,
-                         Map<String, Object> reporterConf) {
-        prepare(metricRegistryProvider.getRegistry(), topoConf, reporterConf);
-    }
-
-    void start();
-
-    void stop();
+    Map<TaskMetricDimensions, TaskMetricRepo> getTaskMetrics();
 }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/TaskMetricDimensions.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/TaskMetricDimensions.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.metrics2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class to store task-related V2 metrics dimensions.
+ */
+public class TaskMetricDimensions {
+    private int taskId;
+    private String componentId;
+    private String streamId;
+    private Map<String, String> dimensions = new HashMap<>();
+
+    public TaskMetricDimensions(int taskId, String componentId, String streamId, StormMetricRegistry metricRegistry) {
+        this.taskId = taskId;
+        dimensions.put("taskid", Integer.toString(this.taskId));
+
+        this.componentId = componentId;
+        if (this.componentId == null) {
+            this.componentId = "";
+        } else {
+            dimensions.put("componentId", this.componentId);
+        }
+
+        this.streamId = streamId;
+        if (this.streamId == null) {
+            this.streamId = "";
+        } else {
+            dimensions.put("streamId", this.streamId);
+        }
+
+        dimensions.put("hostname", metricRegistry.getHostName());
+        dimensions.put("topologyId", metricRegistry.getTopologyId());
+        dimensions.put("port", metricRegistry.getPort().toString());
+    }
+
+    public Map<String, String> getDimensions() {
+        return dimensions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TaskMetricDimensions otherD = (TaskMetricDimensions) o;
+        return (taskId == otherD.taskId && componentId.equals(otherD.componentId)
+                && streamId.equals(otherD.streamId));
+    }
+
+    @Override
+    public int hashCode() {
+        return taskId + componentId.hashCode() + streamId.hashCode();
+    }
+}

--- a/storm-client/src/jvm/org/apache/storm/metrics2/TaskMetricRepo.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/TaskMetricRepo.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.metrics2;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Timer;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Metric repository to allow reporting of task-specific metrics.
+ */
+public class TaskMetricRepo {
+    private SortedMap<String, Gauge> gauges = new TreeMap<>();
+    private SortedMap<String, Counter> counters = new TreeMap<>();
+    private SortedMap<String, Histogram> histograms = new TreeMap<>();
+    private SortedMap<String, Meter> meters = new TreeMap<>();
+    private SortedMap<String, Timer> timers = new TreeMap<>();
+
+    public void addCounter(String name, Counter counter) {
+        counters.put(name, counter);
+    }
+
+    public void addGauge(String name, Gauge gauge) {
+        gauges.put(name, gauge);
+    }
+
+    public void addMeter(String name, Meter meter) {
+        meters.put(name, meter);
+    }
+
+    public void addHistogram(String name, Histogram histogram) {
+        histograms.put(name, histogram);
+    }
+
+    public void addTimer(String name, Timer timer) {
+        timers.put(name, timer);
+    }
+
+    public void report(ScheduledReporter reporter, MetricFilter filter) {
+        if (filter != null) {
+            SortedMap<String, Gauge> filteredGauges = new TreeMap<>();
+            SortedMap<String, Counter> filteredCounters = new TreeMap<>();
+            SortedMap<String, Histogram> filteredHistograms = new TreeMap<>();
+            SortedMap<String, Meter> filteredMeters = new TreeMap<>();
+            SortedMap<String, Timer> filteredTimers = new TreeMap<>();
+
+            for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+                if (filter.matches(entry.getKey(), entry.getValue())) {
+                    filteredGauges.put(entry.getKey(), entry.getValue());
+                }
+            }
+            for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+                if (filter.matches(entry.getKey(), entry.getValue())) {
+                    filteredCounters.put(entry.getKey(), entry.getValue());
+                }
+            }
+            for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+                if (filter.matches(entry.getKey(), entry.getValue())) {
+                    filteredHistograms.put(entry.getKey(), entry.getValue());
+                }
+            }
+            for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+                if (filter.matches(entry.getKey(), entry.getValue())) {
+                    filteredMeters.put(entry.getKey(), entry.getValue());
+                }
+            }
+            for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+                if (filter.matches(entry.getKey(), entry.getValue())) {
+                    filteredTimers.put(entry.getKey(), entry.getValue());
+                }
+            }
+            reporter.report(filteredGauges, filteredCounters, filteredHistograms, filteredMeters, filteredTimers);
+        } else {
+            reporter.report(gauges, counters, histograms, meters, timers);
+        }
+    }
+}

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ConsoleStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ConsoleStormReporter.java
@@ -14,19 +14,35 @@ package org.apache.storm.metrics2.reporters;
 
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.storm.Config;
 import org.apache.storm.daemon.metrics.ClientMetricsUtils;
+import org.apache.storm.metrics2.DimensionalReporter;
+import org.apache.storm.metrics2.MetricRegistryProvider;
+import org.apache.storm.metrics2.StormMetricRegistry;
 import org.apache.storm.metrics2.filters.StormMetricsFilter;
+import org.apache.storm.utils.ObjectReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConsoleStormReporter extends ScheduledStormReporter {
+public class ConsoleStormReporter extends ScheduledStormReporter implements DimensionalReporter.DimensionHandler {
     private static final Logger LOG = LoggerFactory.getLogger(ConsoleStormReporter.class);
 
     @Override
     public void prepare(MetricRegistry registry, Map<String, Object> topoConf, Map<String, Object> reporterConf) {
+        init(registry, null, reporterConf);
+    }
+
+    @Override
+    public void prepare(MetricRegistryProvider metricRegistryProvider, Map<String, Object> topoConf,
+                        Map<String, Object> reporterConf) {
+        init(metricRegistryProvider.getRegistry(), metricRegistryProvider, reporterConf);
+    }
+
+    private void init(MetricRegistry registry, MetricRegistryProvider metricRegistryProvider, Map<String, Object> reporterConf) {
         LOG.debug("Preparing ConsoleReporter");
         ConsoleReporter.Builder builder = ConsoleReporter.forRegistry(registry);
 
@@ -57,7 +73,34 @@ public class ConsoleStormReporter extends ScheduledStormReporter {
         //defaults to seconds
         reportingPeriodUnit = getReportPeriodUnit(reporterConf);
 
-        reporter = builder.build();
+        ScheduledReporter consoleReporter = builder.build();
+
+        boolean reportDimensions = isReportDimensionsEnabled(reporterConf);
+        if (reportDimensions) {
+            if (metricRegistryProvider == null) {
+                throw new RuntimeException("MetricRegistryProvider is required to enable reporting dimensions");
+            }
+            if (rateUnit == null) {
+                rateUnit = TimeUnit.SECONDS;
+            }
+            if (durationUnit == null) {
+                durationUnit = TimeUnit.MILLISECONDS;
+            }
+            DimensionalReporter dimensionalReporter = new DimensionalReporter(metricRegistryProvider, consoleReporter, this,
+                    "ConsoleDimensionalReporter",
+                    filter, rateUnit, durationUnit, null, true);
+            reporter = dimensionalReporter;
+        } else {
+            reporter = consoleReporter;
+        }
     }
 
+    // We're unable to extend ConsoleReporter to handle dimensions, so we'll report dimensions here
+    @Override
+    public void setDimensions(Map<String, String> dimensions) {
+        System.out.println("Using dimensions: ");
+        for (Map.Entry<String, String> entry : dimensions.entrySet()) {
+            System.out.println(entry.getKey() + " : " + entry.getValue());
+        }
+    }
 }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ScheduledStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ScheduledStormReporter.java
@@ -37,6 +37,10 @@ public abstract class ScheduledStormReporter implements StormReporter {
         return ObjectReader.getInt(reporterConf.get(REPORT_PERIOD), 10).longValue();
     }
 
+    public static boolean isReportDimensionsEnabled(Map<String, Object> reporterConf) {
+        return ObjectReader.getBoolean(reporterConf.get(REPORT_DIMENSIONS_ENABLED), false);
+    }
+
     public static StormMetricsFilter getMetricsFilter(Map<String, Object> reporterConf) {
         StormMetricsFilter filter = null;
         Map<String, Object> filterConf = (Map<String, Object>) reporterConf.get("filter");


### PR DESCRIPTION
## What is the purpose of the change

Allow V2 metric reporters to report metrics with long names or with a short name and set of dimensions.  ConsoleStormReporter was modified to allow both options.

Long metric names get stored in a metrics registry as previously.  Additionally, we create a map of Task/component/stream dimensions to a TaskMetricRepo that contains task specific metrics.  

If a reporter supports and is configured for short metric names, it will receive the metrics one repo at a time, first setting the dimensions for the repo, and then reporting the metrics for that Task set.

## How was the change tested

Ran a topology with ConsoleStormReporters set to report both long and short metrics.

./bin/storm jar ~/storm/storm-starter.jar org.apache.storm.starter.WordCountTopology wc -c topology.metrics.consumer.register="[{\"argument\":null,\"class\":\"org.apache.storm.metric.LoggingMetricsConsumer\",\"parallelism.hint\":1}]" -c topology.metrics.reporters="[{\"report.period\": 11,\"class\": \"org.apache.storm.metrics2.reporters.ConsoleStormReporter\", \"report.dimensions.enabled\": true }, { \"report.period\": 9, \"class\": \"org.apache.storm.metrics2.reporters.ConsoleStormReporter\", \"report.dimensions.enabled\": false } ]"

long metric name logging:

```
2020-09-02 13:10:01.280 c.c.m.ConsoleReporter metrics-console-reporter-3-thread-1 [INFO] storm.topology.wc-1-1599070178.worker_hostname.__system.-1.6701-memory.pools.PS-Old-Gen.committed
2020-09-02 13:10:01.280 c.c.m.ConsoleReporter metrics-console-reporter-3-thread-1 [INFO]              value = 133693440
2020-09-02 13:10:01.281 c.c.m.ConsoleReporter metrics-console-reporter-3-thread-1 [INFO] storm.topology.wc-1-1599070178.worker_hostname.__system.-1.6701-memory.pools.PS-Old-Gen.init
2020-09-02 13:10:01.281 c.c.m.ConsoleReporter metrics-console-reporter-3-thread-1 [INFO]              value = 179306496
2020-09-02 13:10:01.281 c.c.m.ConsoleReporter metrics-console-reporter-3-thread-1 [INFO] storm.topology.wc-1-1599070178.worker_hostname.__system.-1.6701-memory.pools.PS-Old-Gen.max
2020-09-02 13:10:01.281 c.c.m.ConsoleReporter metrics-console-reporter-3-thread-1 [INFO]              value = 894959616
```

Short metric names with dimensions:

```
2020-09-02 13:10:03.259 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] Using dimensions: 
2020-09-02 13:10:03.260 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] hostname : worker_hostname
2020-09-02 13:10:03.260 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] componentId : count
2020-09-02 13:10:03.260 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] topologyName : wc
2020-09-02 13:10:03.260 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] streamId : default
2020-09-02 13:10:03.261 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] port : 6701
2020-09-02 13:10:03.261 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] taskid : 11
2020-09-02 13:10:03.261 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] 9/2/20 1:10:03 PM ==============================================================
2020-09-02 13:10:03.261 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] 
2020-09-02 13:10:03.261 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] -- Counters --------------------------------------------------------------------
2020-09-02 13:10:03.261 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] __ack-count-split:default
2020-09-02 13:10:03.261 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              count = 200
2020-09-02 13:10:03.261 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] __emit-count-default
2020-09-02 13:10:03.262 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              count = 200
2020-09-02 13:10:03.262 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] __execute-count-split:default
2020-09-02 13:10:03.262 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              count = 180
2020-09-02 13:10:03.262 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] __transfer-count-default
2020-09-02 13:10:03.262 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              count = 0
2020-09-02 13:10:03.262 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]
2020-09-02 13:10:03.262 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]    
2020-09-02 13:10:03.262 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] Using dimensions: 
2020-09-02 13:10:03.262 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] hostname : worker_hostname
2020-09-02 13:10:03.262 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] componentId : spout
2020-09-02 13:10:03.263 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] topologyName : wc
2020-09-02 13:10:03.263 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] port : 6701
2020-09-02 13:10:03.263 o.a.s.m.r.ConsoleStormReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] taskid : 26
2020-09-02 13:10:03.263 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] 9/2/20 1:10:03 PM ==============================================================
2020-09-02 13:10:03.263 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]
2020-09-02 13:10:03.263 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] -- Gauges ----------------------------------------------------------------------
2020-09-02 13:10:03.263 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] receive-queue-arrival_rate_secs
2020-09-02 13:10:03.263 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              value = 0.0
2020-09-02 13:10:03.263 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] receive-queue-capacity
2020-09-02 13:10:03.264 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              value = 32768
2020-09-02 13:10:03.264 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] receive-queue-dropped_messages
2020-09-02 13:10:03.264 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              value = 0
2020-09-02 13:10:03.264 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] receive-queue-insert_failures
2020-09-02 13:10:03.264 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              value = 0.0
2020-09-02 13:10:03.264 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] receive-queue-overflow
2020-09-02 13:10:03.264 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              value = 0
2020-09-02 13:10:03.264 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] receive-queue-pct_full
2020-09-02 13:10:03.264 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              value = 0.0
2020-09-02 13:10:03.265 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] receive-queue-population
2020-09-02 13:10:03.265 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              value = 0
2020-09-02 13:10:03.265 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO] receive-queue-sojourn_time_ms
2020-09-02 13:10:03.265 c.c.m.ConsoleReporter metrics-ConsoleDimensionalReporter-2-thread-1 [INFO]              value = 0.0

```

