### PR TITLE
STORM-3696 don't ignore InterruptedException

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/supervisor/ClientSupervisorUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/supervisor/ClientSupervisorUtils.java
@@ -71,7 +71,10 @@ public class ClientSupervisorUtils {
         try {
             process.waitFor();
         } catch (InterruptedException e) {
-            LOG.info("{} interrupted.", logPreFix);
+            LOG.warn("{} interrupted.", logPreFix);
+            Thread.currentThread().interrupt();
+            process.destroy();
+            throw new IOException(logPreFix + " interrupted", e);
         }
         ret = process.exitValue();
         return ret;


### PR DESCRIPTION
## What is the purpose of the change

It's not safe to assume InterruptedException is ignorable.

## How was the change tested

Rebuilt storm-client