### PR TITLE
[STORM-3699] fix flight.bash to support flight recording on openJDK8u262 or newer

### DIFF
--- a/bin/flight.bash
+++ b/bin/flight.bash
@@ -51,23 +51,48 @@ else
 	BINPATH=""
 fi
 
+export RECORDING_NAME_PREFIX="storm-recording-"
+
 function start_record {
     # start_record pid
-    already_recording=false
-    for rid in `get_recording_ids $1`; do
-        already_recording=true
-        break;
-    done
-    if [ "$already_recording" = false ]; then
-        ${BINPATH}jcmd $1 JFR.start settings=${SETTINGS}
+    timestamps=`get_recording_timestamps $1`
+    if [ -z "${timestamps}" ]; then
+        # append timestamp to ${RECORDING_NAME_PREFIX} to form a recording name
+        ${BINPATH}jcmd $1 JFR.start name=${RECORDING_NAME_PREFIX}${NOW} settings=${SETTINGS}
+    else
+        echo "Another recoding session is already in progress; skipping"
     fi
 }
 
 function dump_record {
-    for rid in `get_recording_ids $1`; do
-        FILENAME=recording-$1-${rid}-${NOW}.jfr
-        ${BINPATH}jcmd $1 JFR.dump recording=$rid filename="$2/${FILENAME}"
-    done
+    timestamps=`get_recording_timestamps $1`
+    if [ -z "${timestamps}" ]; then
+        echo "No exsiting recording session to stop"
+    else
+        for start_timestamp in ${timestamps}; do
+            FILENAME=recording-$1-${start_timestamp}-${NOW}.jfr
+            ${BINPATH}jcmd $1 JFR.dump name=${RECORDING_NAME_PREFIX}${start_timestamp} filename="$2/${FILENAME}"
+        done
+    fi
+}
+
+function stop_record {
+    timestamps=`get_recording_timestamps $1`
+    if [ -z "${timestamps}" ]; then
+        echo "No exsiting recording session to stop"
+    else
+        for start_timestamp in ${timestamps}; do
+            FILENAME=recording-$1-${start_timestamp}-${NOW}.jfr
+            ${BINPATH}jcmd $1 JFR.dump name=${RECORDING_NAME_PREFIX}${start_timestamp} filename="$2/${FILENAME}"
+            ${BINPATH}jcmd $1 JFR.stop name=${RECORDING_NAME_PREFIX}${start_timestamp}
+        done
+    fi
+}
+
+# recoding name is coded as ${RECORDING_NAME_PREFIX}${start_timestamp}, see start_record.
+# On different JFR version (e.g. 5.4 vs 5.5), the output format is different: 5.4 has double quotes for the recording name, 5.5 doesn't have double quotes.
+function get_recording_timestamps {
+    ${BINPATH}jcmd $1 JFR.check | perl -n -e '/name=(")?$ENV{RECORDING_NAME_PREFIX}([0-9]+)(?(1)\1|)/ && print "$2 "'
 }
 
 function jstack_record {
@@ -79,18 +104,6 @@ function jmap_record {
     FILENAME=recording-$1-${NOW}.bin
     ${BINPATH}jmap -dump:format=b,file="$2/${FILENAME}" $1
     /bin/chmod g+r "$2/${FILENAME}"
-}
-
-function stop_record {
-    for rid in `get_recording_ids $1`; do
-        FILENAME=recording-$1-${rid}-${NOW}.jfr
-        ${BINPATH}jcmd $1 JFR.dump recording=$rid filename="$2/${FILENAME}"
-        ${BINPATH}jcmd $1 JFR.stop recording=$rid
-    done
-}
-
-function get_recording_ids {
-    ${BINPATH}jcmd $1 JFR.check | perl -n -e '/recording=([0-9]+)/ && print "$1 "'
 }
 
 function usage_and_quit {
@@ -137,7 +150,7 @@ if [ "$CMD" != "start" ] && [ "$CMD" != "kill" ]; then
     fi
 fi
 
-NOW=`date +'%Y%m%d-%H%M%S'`
+NOW=`date +'%Y%m%d%H%M%S'`
 if [ "$CMD" = "" ]; then
     usage_and_quit
 elif [ "$CMD" = "kill" ]; then


### PR DESCRIPTION
## What is the purpose of the change

JFR on openJDK8u262 or newer is different from oracle jdk-1.8.0_131 or older. flight.bash needs to updated to support both old and new commands.

## How was the change tested

Tested by running start/dump/stop commands using flight.bash

**openJDK8u262**
```
# check java version
bash-4.2$ java -version
openjdk version "1.8.0_262"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_262-b10)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.262-b10, mixed mode)

# check JFR state:
bash-4.2$ jcmd 20 JFR.check
20:
No available recordings.

Use jcmd 20 JFR.start to start a recording.

# start a new session
bash-4.2$ ./flight.bash 20 start
/<root-dir>/share/jdk/java/bin/java found. Will use java utils from /<root-dir>/share/jdk/java/bin/
20:
Started recording 4. No limit specified, using maxsize=250MB as default.

Use jcmd 20 JFR.dump name=storm-recording-20200915204300 filename=FILEPATH to copy recording data to file.

# start a new session: skipped because there is already a session running
bash-4.2$ ./flight.bash 20 start
/<root-dir>/share/jdk/java/bin/java found. Will use java utils from /<root-dir>/share/jdk/java/bin/
Another recoding session is already in progress; skipping

# dump a recording
bash-4.2$ ./flight.bash 20 dump artifacts/
/<root-dir>/share/jdk/java/bin/java found. Will use java utils from /<root-dir>/share/jdk/java/bin/
Capturing dump in dir artifacts/
20:
Dumped recording "storm-recording-20200915204300", 1.1 MB written to:

/<root-dir>/var/storm/workers/9f8dc36d-b075-4fb9-9027-77b1052565bb/artifacts/recording-20-20200915204300-20200915204310.jfr

# stop a recording (will dump first)
bash-4.2$ ./flight.bash 20 stop artifacts/
/<root-dir>/share/jdk/java/bin/java found. Will use java utils from /<root-dir>/share/jdk/java/bin/
Capturing dump before stopping in dir artifacts/
20:
Dumped recording "storm-recording-20200915204300", 2.0 MB written to:

/<root-dir>/var/storm/workers/9f8dc36d-b075-4fb9-9027-77b1052565bb/artifacts/recording-20-20200915204300-20200915204317.jfr
20:
Stopped recording "storm-recording-20200915204300".

# check files
bash-4.2$ ls -ltrh artifacts/ |grep jfr
-rw-r----- 1 ethan users 1.2M Sep 15 20:43 recording-20-20200915204300-20200915204310.jfr
-rw-r----- 1 ethan users 2.1M Sep 15 20:43 recording-20-20200915204300-20200915204317.jfr


bash-4.2$ ./flight.bash 20 stop artifacts/
/<root-dir>/share/jdk/java/bin/java found. Will use java utils from /<root-dir>/share/jdk/java/bin/
Capturing dump before stopping in dir artifacts/
No exsiting recording session to stop

bash-4.2$ ./flight.bash 20 dump artifacts/
/<root-dir>/share/jdk/java/bin/java found. Will use java utils from /<root-dir>/share/jdk/java/bin/
Capturing dump in dir artifacts/
No exsiting recording session to stop
```

**Oracle JDK 1.8.0_131**
```
bash$ java -version
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)


bash$ bin/flight.bash 48512 start                 
/usr/bin/java found. Will use java utils from /usr/bin/
48512:
Started recording 14. No limit (duration/maxsize/maxage) in use.

Use JFR.dump name=storm-recording-20200915154828 filename=FILEPATH to copy recording data to file.

bash$ bin/flight.bash 48512 start
/usr/bin/java found. Will use java utils from /usr/bin/
Another recoding session is already in progress; skipping

bash$ bin/flight.bash 48512 dump .
/usr/bin/java found. Will use java utils from /usr/bin/
Capturing dump in dir .
48512:
Dumped recording "storm-recording-20200915154828", 375.0 kB written to:

/tmp/test/recording-48512-20200915154828-20200915154841.jfr

bash$ bin/flight.bash 48512 stop .
/usr/bin/java found. Will use java utils from /usr/bin/
Capturing dump before stopping in dir .
48512:
Dumped recording "storm-recording-20200915154828", 747.8 kB written to:

/tmp/test/recording-48512-20200915154828-20200915154845.jfr
48512:
Stopped recording "storm-recording-20200915154828".

bash$ ls -ltrh /tmp/test/
-rw-r--r--   1 ethan  staff   748K Sep 15 15:48 recording-48512-20200915154828-20200915154845.jfr
-rw-r--r--   1 ethan  staff   375K Sep 15 15:48 recording-48512-20200915154828-20200915154841.jfr

bash$ bin/flight.bash 48512 stop .                               
/usr/bin/java found. Will use java utils from /usr/bin/
Capturing dump before stopping in dir .
No exsiting recording session to stop

bash$ bin/flight.bash 48512 dump .
/usr/bin/java found. Will use java utils from /usr/bin/
Capturing dump in dir .
No exsiting recording session to stop

```