### PR TITLE
[STORM-3701] clean-up topo directory with the check against latest topo blob cache

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -467,8 +467,8 @@ public class AsyncLocalizer implements AutoCloseable {
         // Will need further investigation if the race condition happens again
         List<LocalResource> localResources;
         try {
-            // Precondition1: Base blob stormconf.ser and stormcode.ser have been localized
-            // Precondition2: Both these two blob files are fully downloaded and proper permission been set
+            // Precondition1: Base blob stormconf.ser and stormcode.ser are available
+            // Precondition2: Both files have proper permission
             localResources = getLocalResources(pna);
         } catch (IOException e) {
             LOG.info("Port and assignment info: {}", pna);


### PR DESCRIPTION
## What is the purpose of the change

When AsyncLocalizer cleanup happens, make sure it check against the latest topology cache information.
Currently, the `safeTopologyIds` set might become stale due to delay at around https://github.com/apache/storm/blob/master/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java#L641 . Newly created topology entries might not appear here and clean-up will delete them by fault and cause further FNF issue.

## How was the change tested
Reproduce the FNF issue with additional sleep. After the change, same delay won't cause the FNF anymore.