### PR TITLE
STORM-3693: Pending tuples expired only once per tick.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/Executor.java
@@ -278,6 +278,8 @@ public abstract class Executor implements Callable, JCQueue.Consumer {
         int taskId = addressedTuple.getDest();
 
         TupleImpl tuple = (TupleImpl) addressedTuple.getTuple();
+        String streamId = tuple.getSourceStreamId();
+        boolean isSpout = this instanceof SpoutExecutor;
         if (isDebug) {
             LOG.info("Processing received TUPLE: {} for TASK: {} ", tuple, taskId);
         }
@@ -285,6 +287,9 @@ public abstract class Executor implements Callable, JCQueue.Consumer {
         try {
             if (taskId != AddressedTuple.BROADCAST_DEST) {
                 tupleActionFn(taskId, tuple);
+            } else if (isSpout && streamId.equals(Constants.SYSTEM_TICK_STREAM_ID)) {
+                //taskId is irrelevant here. Ensures pending.rotate() is called once per tick. 
+                tupleActionFn(taskIds.get(0), tuple);
             } else {
                 for (Integer t : taskIds) {
                     tupleActionFn(t, tuple);


### PR DESCRIPTION
## What is the purpose of the change

*(To ensure spout pending tuples are expired only once per tick. Otherwise, tuples get expired prematurely when one spout executor has multiple tasks.)*

## How was the change tested

*(1.  mvn clean install -P '!examples,!externals' 2. Used a dummy topology to test the correct behavior.)*