### PR TITLE
[STORM-3704] - Cosmetic: fix table header alignment in "Topology summary" table.

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/templates/topology-page-template.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/templates/topology-page-template.html
@@ -74,12 +74,12 @@
             Assigned CPU (%)
           </span>
         </th>
-        {{/schedulerDisplayResource}}
         <th>
           <span data-toggle="tooltip" data-placement="top" title="Assigned Generic Rescources by Scheduler.">
             Assigned Generic Resources
           </span>
         </th>
+        {{/schedulerDisplayResource}}
         <th>
           <span data-toggle="tooltip" data-placement="left" title="This shows information from the scheduler about the latest attempt to schedule the Topology on the cluster.">
             Scheduler Info


### PR DESCRIPTION
## What is the purpose of the change

As part of STORM-3534 (https://github.com/apache/storm/pull/3163) new column was added to this table, however the header for it was added outside "if schedulerDisplayResource" logic while rows are inside, causing misalignment.

## How was the change tested

The change is cosmetic and was tested in a local installation.