### PR TITLE
[STORM-3709] Topology without spout should fail submission.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
+++ b/storm-client/src/jvm/org/apache/storm/StormSubmitter.java
@@ -47,6 +47,7 @@ import org.apache.storm.thrift.TException;
 import org.apache.storm.utils.BufferFileInputStream;
 import org.apache.storm.utils.NimbusClient;
 import org.apache.storm.utils.Utils;
+import org.apache.storm.utils.WrappedInvalidTopologyException;
 import org.apache.storm.validation.ConfigValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -228,6 +229,11 @@ public class StormSubmitter {
         if (!Utils.isValidConf(topoConf)) {
             throw new IllegalArgumentException("Storm conf is not valid. Must be json-serializable");
         }
+
+        if (topology.get_spouts_size() == 0) {
+            throw new WrappedInvalidTopologyException("Topology " + name + " does not have any spout");
+        }
+
         topoConf = new HashMap<>(topoConf);
         topoConf.putAll(Utils.readCommandLineOpts());
         Map<String, Object> conf = Utils.readStormConfig();

--- a/storm-client/test/jvm/org/apache/storm/TestStormSubmitter.java
+++ b/storm-client/test/jvm/org/apache/storm/TestStormSubmitter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm;
+
+import org.apache.storm.generated.InvalidTopologyException;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.generated.SubmitOptions;
+import org.apache.storm.generated.TopologyInitialStatus;
+import org.apache.storm.testing.TestWordCounter;
+import org.apache.storm.topology.TopologyBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class TestStormSubmitter {
+
+    @Test
+    public void invalidTopologyWithoutSpout() {
+        String expectedExceptionMsgFragment = "does not have any spout";
+        TopologyBuilder tb = new TopologyBuilder();
+        tb.setBolt("bolt1", new TestWordCounter(), 10).shuffleGrouping("spout1");
+        tb.setBolt("bolt11", new TestWordCounter(), 10).shuffleGrouping("bolt1");
+        tb.setBolt("bolt12", new TestWordCounter(), 10).shuffleGrouping("bolt1");
+        StormTopology topology = tb.createTopology();
+        Map<String, Object> topoConf = null;
+        SubmitOptions opts = new SubmitOptions(TopologyInitialStatus.INACTIVE);
+
+        try {
+            StormSubmitter.submitTopologyAs("test-topo-without-spout", topoConf, topology, opts, null, "none");
+            Assert.fail("Topology without spout should fail in submission");
+        } catch (InvalidTopologyException ex) {
+            if (!ex.getMessage().contains(expectedExceptionMsgFragment)) {
+                String err = String.format("Topology submit failure should contain string \"%s\", but is \"%s\"",
+                        expectedExceptionMsgFragment, ex.getMessage());
+                Assert.fail(err);
+            }
+        } catch (Throwable ex) {
+            ex.printStackTrace();
+            Assert.fail("Unexpected exception submitting topology without spout: " + ex);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*Topology without spout cannot be scheduled. We should just not allow this to be submitted if we will never schedule it.*

## How was the change tested

*New unit test TestStormSubmitter.invalidTopologyWithoutSpout()*