### PR TITLE
[STORM-3711] ARM CI switch to use arm64-graviton2 and enable all modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ addons:
   hosts:
     - node1
 
+arch:
+  - amd64
+  - arm64-graviton2
+
 env:
   - MODULES=Client
   - MODULES=Server
@@ -36,8 +40,6 @@ jdk:
 matrix:
   include:
     - arch: s390x
-      jdk: openjdk11
-    - arch: arm64
       jdk: openjdk11
 
 before_install:


### PR DESCRIPTION
Previously, we have enabled the ARM 64 CI with only "Client" module
configured, because there are some issues about Travis CI due to its ARM
resources performance, now Travis CI has the new ARM resources
"arm64-graviton2" provided by AWS, please see[1]. Now we can switch to
use the "arm64-graviton2" resources and enable all the modules on ARM
CI.

https://docs.travis-ci.com/user/multi-cpu-architectures
