### PR TITLE
[STORM-3712] Update version of dependency in license file

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -597,7 +597,7 @@ List of third-party dependencies grouped by their license type.
     Common Development and Distribution License
 
         * Expression Language 3.0 (org.glassfish:javax.el:3.0.0 - http://el-spec.java.net)
-        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b11 - http://uel.java.net)
+        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b12 - http://uel.java.net)
         * JavaServer Pages(TM) API (javax.servlet.jsp:javax.servlet.jsp-api:2.3.1 - http://jsp.java.net)
         * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
         * javax.annotation API (javax.annotation:javax.annotation-api:1.3.2 - http://jcp.org/en/jsr/detail?id=250)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -966,7 +966,7 @@ The license texts of these dependencies can be found in the licenses directory.
     Common Development and Distribution License
 
         * Expression Language 3.0 (org.glassfish:javax.el:3.0.0 - http://el-spec.java.net)
-        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b11 - http://uel.java.net)
+        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b12 - http://uel.java.net)
         * JavaServer Pages(TM) API (javax.servlet.jsp:javax.servlet.jsp-api:2.3.1 - http://jsp.java.net)
         * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
         * JSP implementation (org.glassfish.web:javax.servlet.jsp:2.3.2 - http://jsp.java.net)


### PR DESCRIPTION
## What is the purpose of the change

Currently, the CI job of "Check-Updated-License-Files" has failed due to
the dependency "org.glassfish:javax.el" version out-of-date.

## How was the change tested

This change will be tested by Travis CI