### PR TITLE
[STORM-3711] Fix ARM CI with wrong usage of "arm64-graviton2" resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
 
 arch:
   - amd64
-  - arm64-graviton2
 
 env:
   - MODULES=Client
@@ -41,6 +40,48 @@ matrix:
   include:
     - arch: s390x
       jdk: openjdk11
+    - dist: focal
+      group: edge
+      arch: arm64-graviton2
+      language: java
+      jdk: openjdk11
+      virt: lxd
+      env: MODULES=Client
+    - dist: focal
+      group: edge
+      arch: arm64-graviton2
+      language: java
+      jdk: openjdk11
+      virt: lxd
+      env: MODULES=Server
+    - dist: focal
+      group: edge
+      arch: arm64-graviton2
+      language: java
+      jdk: openjdk11
+      virt: lxd
+      env: MODULES=Core
+    - dist: focal
+      group: edge
+      arch: arm64-graviton2
+      language: java
+      jdk: openjdk11
+      virt: lxd
+      env: MODULES=External
+    - dist: focal
+      group: edge
+      arch: arm64-graviton2
+      language: java
+      jdk: openjdk11
+      virt: lxd
+      env: MODULES=Integration-Test
+    - dist: focal
+      group: edge
+      arch: arm64-graviton2
+      language: java
+      jdk: openjdk11
+      virt: lxd
+      env: MODULES=Check-Updated-License-Files
 
 before_install:
   - rvm reload

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
 
 arch:
   - amd64
+  - arm64
 
 env:
   - MODULES=Client
@@ -24,7 +25,7 @@ env:
   - MODULES=Integration-Test
   - MODULES=Check-Updated-License-Files
 
-dist: trusty
+dist: xenial
 sudo: required
 
 before_cache:
@@ -33,55 +34,16 @@ before_cache:
 
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11
   
 matrix:
   include:
     - arch: s390x
       jdk: openjdk11
-    - dist: focal
-      group: edge
-      arch: arm64-graviton2
-      language: java
-      jdk: openjdk11
-      virt: lxd
-      env: MODULES=Client
-    - dist: focal
-      group: edge
-      arch: arm64-graviton2
-      language: java
-      jdk: openjdk11
-      virt: lxd
-      env: MODULES=Server
-    - dist: focal
-      group: edge
-      arch: arm64-graviton2
-      language: java
-      jdk: openjdk11
-      virt: lxd
-      env: MODULES=Core
-    - dist: focal
-      group: edge
-      arch: arm64-graviton2
-      language: java
-      jdk: openjdk11
-      virt: lxd
-      env: MODULES=External
-    - dist: focal
-      group: edge
-      arch: arm64-graviton2
-      language: java
-      jdk: openjdk11
-      virt: lxd
-      env: MODULES=Integration-Test
-    - dist: focal
-      group: edge
-      arch: arm64-graviton2
-      language: java
-      jdk: openjdk11
-      virt: lxd
-      env: MODULES=Check-Updated-License-Files
+  exclude:
+    - arch: arm64
+      jdk: openjdk8
 
 before_install:
   - rvm reload

--- a/integration-test/run-it.sh
+++ b/integration-test/run-it.sh
@@ -36,10 +36,13 @@ then
   chmod o+rx /home/travis
 fi
 list_storm_processes || true
-# increasing swap space so we can run lots of workers
-sudo dd if=/dev/zero of=/swapfile.img bs=4096 count=1M
-sudo mkswap /swapfile.img
-sudo swapon /swapfile.img
+if [ "$(uname -m)" != aarch64 ]; then
+  # increasing swap space so we can run lots of workers
+  sudo dd if=/dev/zero of=/swapfile.img bs=4096 count=1M
+  sudo mkswap /swapfile.img
+  sudo swapon /swapfile.img
+fi
+
 
 if [[ "${USER}" == "vagrant" ]]; then # install oracle jdk8 or openjdk11
     sudo apt-get update

--- a/integration-test/run-it.sh
+++ b/integration-test/run-it.sh
@@ -104,3 +104,7 @@ for i in {1..20} ; do
 done
 list_storm_processes
 mvn test -DfailIfNoTests=false -DskipTests=false -Dstorm.version=${STORM_VERSION} -Dui.url=http://localhost:8744
+
+# Kill all storm processes after tests running, otherwise the Travis CI(ARM) will still wait and then fail by
+# timeout error even though all the tests passed
+sudo pkill -9 -u storm


### PR DESCRIPTION
In # apache/storm/pull/3344, we have enabled ARM CI with all Storm
modules enabled and switched to use the "arm64-graviton2" resources, but
I have made a mistak that the ARM CI actually still run on x86 than
ARM even the CI job shows the label "arm64-graviton2", details can be
found in the CI job logs[1]. Because the "arm64-graviton2" requires
explicit virt: [lxd|vm] tag, see[2].

Addtionally, we have skip the increasing swap space statement in
intergration test because it will raise error on ARM. And we only
enabled openjdk11 for ARM jobs because the jdk8 is unsupported, see[3].

[1] https://travis-ci.org/github/apache/storm/jobs/741780900
[2] https://docs.travis-ci.com/user/multi-cpu-architectures#testing-on-multiple-cpu-architectures
[3] https://travis-ci.com/github/liusheng/storm/jobs/430934514
