### PR TITLE
STORM-3720 get correct results for BlobStoreFile getModTime()

### DIFF
--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreFile.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreFile.java
@@ -45,7 +45,6 @@ public class HdfsBlobStoreFile extends BlobStoreFile {
     private final String key;
     private final boolean isTmp;
     private final Path path;
-    private Long modTime = null;
     private final boolean mustBeNew;
     private final Configuration hadoopConf;
     private final FileSystem fileSystem;
@@ -106,11 +105,7 @@ public class HdfsBlobStoreFile extends BlobStoreFile {
 
     @Override
     public long getModTime() throws IOException {
-        if (modTime == null) {
-            FileSystem fs = path.getFileSystem(hadoopConf);
-            modTime = fs.getFileStatus(path).getModificationTime();
-        }
-        return modTime;
+        return fileSystem.getFileStatus(path).getModificationTime();
     }
 
     private void checkIsNotTmp() {

--- a/external/storm-hdfs-blobstore/src/test/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImplTest.java
+++ b/external/storm-hdfs-blobstore/src/test/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImplTest.java
@@ -104,6 +104,14 @@ public class HdfsBlobStoreImplTest {
                 ios.write(testString.getBytes(StandardCharsets.UTF_8));
             }
 
+            // test modTime can change
+            Long initialModTime = pfile.getModTime();
+            try (OutputStream ios = pfile.getOutputStream()) {
+                ios.write(testString.getBytes(StandardCharsets.UTF_8));
+            }
+            Long nextModTime = pfile.getModTime();
+            assertTrue(nextModTime > initialModTime);
+
             // test commit creates properly
             assertTrue("BlobStore key dir wasn't created", fs.exists(fullKeyDir));
             pfile.commit();

--- a/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStoreFile.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStoreFile.java
@@ -29,7 +29,6 @@ public class LocalFsBlobStoreFile extends BlobStoreFile {
     private final boolean isTmp;
     private final File path;
     private final boolean mustBeNew;
-    private Long modTime = null;
     private SettableBlobMeta meta;
 
     public LocalFsBlobStoreFile(File base, String name) {
@@ -75,10 +74,7 @@ public class LocalFsBlobStoreFile extends BlobStoreFile {
 
     @Override
     public long getModTime() throws IOException {
-        if (modTime == null) {
-            modTime = path.lastModified();
-        }
-        return modTime;
+        return path.lastModified();
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

If we call getModTime() multiple times before and after a blobstore file changes, we will get an incorrect timestamp.

## How was the change tested

Built storm.  Ran HdfsBlobStoreImplTest.