### PR TITLE
[STORM-3723] Fix isAnyPosixProcessPidDirAlive for PID reassignment

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
@@ -1295,9 +1295,9 @@ public class ServerUtils {
                     LOG.debug("Process {} is alive and owned by expectedUser {}/{}", pid, expectedUser, expectedUid);
                     return true;
                 }
-                LOG.info("Prior process is dead, since directory {} owner {} is not same as expected expectedUser {}/{}, "
-                        + "likely pid {} was reused for a new process for uid {}",
-                        pidDir, actualUser, expectedUser, expectedUid, pid, actualUid);
+                LOG.info("Prior process is dead, since directory {} owner {} is not same as expectedUser {}/{}, "
+                        + "likely pid {} was reused for a new process for uid {}, {}",
+                        pidDir, actualUser, expectedUser, expectedUid, pid, actualUid, getProcessDesc(pidDir));
             } else {
                 // actualUser is a string
                 LOG.debug("Process directory {} owner is {}", pidDir, actualUser);
@@ -1305,12 +1305,37 @@ public class ServerUtils {
                     LOG.debug("Process {} is alive and owned by expectedUser {}", pid, expectedUser);
                     return true;
                 }
-                LOG.info("Prior process is dead, since directory {} owner {} is not same as expected expectedUser {}, "
-                        + "likely pid {} was reused for a new process for expectedUser {}",
-                        pidDir, actualUser, expectedUser, pid, actualUser);
+                LOG.info("Prior process is dead, since directory {} owner {} is not same as expectedUser {}, "
+                        + "likely pid {} was reused for a new process for actualUser {}, {}}",
+                        pidDir, actualUser, expectedUser, pid, actualUser, getProcessDesc(pidDir));
             }
         }
         LOG.info("None of the processes {} are alive AND owned by expectedUser {}", pids, expectedUser);
         return false;
+    }
+
+    /**
+     * Support method to obtain additional log info for the process. Use the contents of comm and cmdline
+     * in the process directory. Note that this method works properly only on posix systems with /proc directory.
+     *
+     * @param pidDir PID directory (/proc/&lt;pid&gt;)
+     * @return process description string
+     */
+    private static String getProcessDesc(File pidDir) {
+        String comm = "";
+        Path p = pidDir.toPath().resolve("comm");
+        try {
+            comm = String.join(", ", Files.readAllLines(p));
+        } catch (IOException ex) {
+            LOG.warn("Cannot get contents of " + p, ex);
+        }
+        String cmdline = "";
+        p = pidDir.toPath().resolve("cmdline");
+        try {
+            cmdline = String.join(", ", Files.readAllLines(p)).replace('\0', ' ');
+        } catch (IOException ex) {
+            LOG.warn("Cannot get contents of " + p, ex);
+        }
+        return String.format("process(comm=\"%s\", cmdline=\"%s\")", comm, cmdline);
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
@@ -1309,8 +1309,6 @@ public class ServerUtils {
                         + "likely pid {} was reused for a new process for expectedUser {}",
                         pidDir, actualUser, expectedUser, pid, actualUser);
             }
-            LOG.debug("Process {} is alive and owned by user {}", pid, expectedUser);
-            return true;
         }
         LOG.info("None of the processes {} are alive AND owned by expectedUser {}", pids, expectedUser);
         return false;

--- a/storm-server/src/test/java/org/apache/storm/utils/ServerUtilsTest.java
+++ b/storm-server/src/test/java/org/apache/storm/utils/ServerUtilsTest.java
@@ -116,15 +116,15 @@ public class ServerUtilsTest {
                     continue;
                 }
                 try {
-                     String pidStr = line.split("\\s")[0];
-                     if (pidStr.equalsIgnoreCase("pid")) {
-                         continue; // header line
-                     }
-                     if (!StringUtils.isNumeric(pidStr)) {
-                         LOG.debug("Ignoring line \"{}\" while looking for PIDs in output of \"{}\"", line, cmd);
-                         continue;
-                     }
-                     pids.add(Long.parseLong(pidStr));
+                    String pidStr = line.split("\\s")[0];
+                    if (pidStr.equalsIgnoreCase("pid")) {
+                        continue; // header line
+                    }
+                    if (!StringUtils.isNumeric(pidStr)) {
+                        LOG.debug("Ignoring line \"{}\" while looking for PIDs in output of \"{}\"", line, cmd);
+                        continue;
+                    }
+                    pids.add(Long.parseLong(pidStr));
                 } catch (Exception ex) {
                     ex.printStackTrace();
                 }


### PR DESCRIPTION
## What is the purpose of the change

*Fix isAnyPosixProcessPidDirAlive to return correct value when all PIDs are reassigned to different user*

## How was the change tested

*Modify ServerUtilsTest to add this new condition*