### PR TITLE
STORM-3724 use blobstore modtime to prevent querying each remote file on update

### DIFF
--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
@@ -405,17 +405,17 @@ public class HdfsBlobStore extends BlobStore {
         hbs.fullCleanup(age);
     }
 
-    public long getLastModeTime() throws IOException {
-        return hbs.getLastModTime();
+    public long getLastBlobUpdateTime() throws IOException {
+        return hbs.getLastBlobUpdateTime();
     }
 
     @Override
-    public void updateLastModTime() throws IOException {
-        hbs.updateLastModTime();
+    public void updateLastBlobUpdateTime() throws IOException {
+        hbs.updateLastBlobUpdateTime();
     }
 
     @Override
-    public void validateModTime() throws IOException {
-        hbs.validateModTime();
+    public void validateBlobUpdateTime() throws IOException {
+        hbs.validateBlobUpdateTime();
     }
 }

--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
@@ -404,4 +404,13 @@ public class HdfsBlobStore extends BlobStore {
     public void fullCleanup(long age) throws IOException {
         hbs.fullCleanup(age);
     }
+
+    public long getLastModeTime() throws IOException {
+        return hbs.getLastModTime();
+    }
+
+    @Override
+    public void updateLastModTime() throws IOException {
+        hbs.updateLastModTime();
+    }
 }

--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStore.java
@@ -413,4 +413,9 @@ public class HdfsBlobStore extends BlobStore {
     public void updateLastModTime() throws IOException {
         hbs.updateLastModTime();
     }
+
+    @Override
+    public void validateModTime() throws IOException {
+        hbs.validateModTime();
+    }
 }

--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImpl.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImpl.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.storm.Config;
 import org.apache.storm.blobstore.BlobStoreFile;
 import org.apache.storm.utils.ObjectReader;
+import org.apache.storm.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -311,5 +312,27 @@ public class HdfsBlobStoreImpl {
         if (timer != null) {
             timer.cancel();
         }
+    }
+
+    /**
+     * Get the last modification time of any blob.
+     *
+     * @return the last modification time of blobs within the blobstore.
+     * @throws IOException on any error
+     */
+    public long getLastModTime() throws IOException {
+        long modtime =  fileSystem.getFileStatus(fullPath).getModificationTime();
+        return modtime;
+    }
+
+    /**
+     * Updates the modification time of the blobstore to the current time.
+     *
+     * @throws IOException on any error
+     */
+    public void updateLastModTime() throws IOException {
+        long timestamp = Time.currentTimeMillis();
+        fileSystem.setTimes(fullPath, timestamp, timestamp);
+        LOG.debug("Updated blobstore modtime of {} to {}", fullPath, timestamp);
     }
 }

--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImpl.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImpl.java
@@ -329,18 +329,18 @@ public class HdfsBlobStoreImpl {
      * @throws IOException on any error
      */
     public long getLastBlobUpdateTime() throws IOException {
-        Path modTimeFile = new Path(fullPath, BLOBSTORE_UPDATE_TIME_FILE);
-        if (!fileSystem.exists(modTimeFile)) {
+        Path updateTimeFile = new Path(fullPath, BLOBSTORE_UPDATE_TIME_FILE);
+        if (!fileSystem.exists(updateTimeFile)) {
             return -1L;
         }
-        FSDataInputStream inputStream = fileSystem.open(modTimeFile);
+        FSDataInputStream inputStream = fileSystem.open(updateTimeFile);
         String timestamp = IOUtils.toString(inputStream, "UTF-8");
         inputStream.close();
         try {
-            long modTime = Long.parseLong(timestamp);
-            return modTime;
+            long updateTime = Long.parseLong(timestamp);
+            return updateTime;
         } catch (NumberFormatException e) {
-            LOG.error("Invalid blobstore modtime {} in file {}", timestamp, modTimeFile);
+            LOG.error("Invalid blobstore update time {} in file {}", timestamp, updateTimeFile);
             return -1L;
         }
     }
@@ -352,12 +352,12 @@ public class HdfsBlobStoreImpl {
      */
     public synchronized void updateLastBlobUpdateTime() throws IOException {
         Long timestamp = Time.currentTimeMillis();
-        Path modTimeFile = new Path(fullPath, BLOBSTORE_UPDATE_TIME_FILE);
-        FSDataOutputStream fsDataOutputStream = fileSystem.create(modTimeFile, true);
+        Path updateTimeFile = new Path(fullPath, BLOBSTORE_UPDATE_TIME_FILE);
+        FSDataOutputStream fsDataOutputStream = fileSystem.create(updateTimeFile, true);
         BufferedWriter bufferedWriter = new BufferedWriter(new OutputStreamWriter(fsDataOutputStream, StandardCharsets.UTF_8));
         bufferedWriter.write(timestamp.toString());
         bufferedWriter.close();
-        LOG.debug("Updated blobstore update time of {} to {}", modTimeFile, timestamp);
+        LOG.debug("Updated blobstore update time of {} to {}", updateTimeFile, timestamp);
     }
 
     /**

--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsClientBlobStore.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsClientBlobStore.java
@@ -136,7 +136,7 @@ public class HdfsClientBlobStore extends ClientBlobStore {
     }
 
     @Override
-    public long getRemoteBlobstoreModtime() throws IOException {
-        return blobStore.getLastModeTime();
+    public long getRemoteBlobstoreUpdateTime() throws IOException {
+        return blobStore.getLastBlobUpdateTime();
     }
 }

--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsClientBlobStore.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsClientBlobStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.storm.hdfs.blobstore;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -132,5 +133,10 @@ public class HdfsClientBlobStore extends ClientBlobStore {
             client.close();
             client = null;
         }
+    }
+
+    @Override
+    public long getRemoteBlobstoreModtime() throws IOException {
+        return blobStore.getLastModeTime();
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
@@ -319,20 +319,20 @@ public abstract class BlobStore implements Shutdownable, AutoCloseable {
     }
 
     /**
-     * Updates the modification time of the blobstore to the current time.
+     * Updates the last update time of existing blobs in the blobstore to the current time.
      *
      * @throws IOException on any error
      */
-    public void updateLastModTime() throws IOException {
+    public void updateLastBlobUpdateTime() throws IOException {
         // default implementation is a NOOP.
     }
 
     /**
-     * Validates that the modification time of the blobstore is up to date with the current existing blobs.
+     * Validates that the blob update time of the blobstore is up to date with the current existing blobs.
      *
      * @throws IOException on any error
      */
-    public void validateModTime() throws IOException {
+    public void validateBlobUpdateTime() throws IOException {
         // default implementation is a NOOP.
     }
 

--- a/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
@@ -319,6 +319,15 @@ public abstract class BlobStore implements Shutdownable, AutoCloseable {
     }
 
     /**
+     * Updates the modification time of the blobstore to the current time.
+     *
+     * @throws IOException on any error
+     */
+    public void updateLastModTime() throws IOException {
+        // default implementation is a NOOP.
+    }
+
+    /**
      * Blob store implements its own version of iterator to list the blobs.
      */
     public static class KeyTranslationIterator implements Iterator<String> {

--- a/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
@@ -328,6 +328,15 @@ public abstract class BlobStore implements Shutdownable, AutoCloseable {
     }
 
     /**
+     * Validates that the modification time of the blobstore is up to date with the current existing blobs.
+     *
+     * @throws IOException on any error
+     */
+    public void validateModTime() throws IOException {
+        // default implementation is a NOOP.
+    }
+
+    /**
      * Blob store implements its own version of iterator to list the blobs.
      */
     public static class KeyTranslationIterator implements Iterator<String> {

--- a/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
@@ -184,10 +184,10 @@ public abstract class ClientBlobStore implements Shutdownable, AutoCloseable {
     }
 
     /**
-     * Client facing API to get the last update time of existing blobs in a blobstore.  This only required for use on
+     * Client facing API to get the last update time of existing blobs in a blobstore.  This is only required for use on
      * supervisors.
      *
-     * @return the timestamp of when the blobstore was last modified.  -1L if the blobstore
+     * @return the timestamp of when the blobstore was last updated.  -1L if the blobstore
      *     does not support this.
      */
     public abstract long getRemoteBlobstoreUpdateTime() throws IOException;

--- a/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
@@ -184,10 +184,11 @@ public abstract class ClientBlobStore implements Shutdownable, AutoCloseable {
     }
 
     /**
-     * Client facing API to get the last modification time of a blobstore.  This only required for use on supervisors.
+     * Client facing API to get the last update time of existing blobs in a blobstore.  This only required for use on
+     * supervisors.
      *
      * @return the timestamp of when the blobstore was last modified.  -1L if the blobstore
      *     does not support this.
      */
-    public abstract long getRemoteBlobstoreModtime() throws IOException;
+    public abstract long getRemoteBlobstoreUpdateTime() throws IOException;
 }

--- a/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/ClientBlobStore.java
@@ -12,6 +12,7 @@
 
 package org.apache.storm.blobstore;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 import org.apache.storm.daemon.Shutdownable;
@@ -182,5 +183,11 @@ public abstract class ClientBlobStore implements Shutdownable, AutoCloseable {
         void run(ClientBlobStore blobStore) throws Exception;
     }
 
-
+    /**
+     * Client facing API to get the last modification time of a blobstore.  This only required for use on supervisors.
+     *
+     * @return the timestamp of when the blobstore was last modified.  -1L if the blobstore
+     *     does not support this.
+     */
+    public abstract long getRemoteBlobstoreModtime() throws IOException;
 }

--- a/storm-client/src/jvm/org/apache/storm/blobstore/LocalModeClientBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/LocalModeClientBlobStore.java
@@ -12,6 +12,7 @@
 
 package org.apache.storm.blobstore;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 import org.apache.storm.generated.AuthorizationException;
@@ -122,5 +123,10 @@ public class LocalModeClientBlobStore extends ClientBlobStore {
     @Override
     public void close() {
         wrapped.shutdown();
+    }
+
+    @Override
+    public long getRemoteBlobstoreModtime() throws IOException {
+        return -1L; // not supported
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/blobstore/LocalModeClientBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/LocalModeClientBlobStore.java
@@ -126,7 +126,7 @@ public class LocalModeClientBlobStore extends ClientBlobStore {
     }
 
     @Override
-    public long getRemoteBlobstoreModtime() throws IOException {
+    public long getRemoteBlobstoreUpdateTime() throws IOException {
         return -1L; // not supported
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/blobstore/NimbusBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/NimbusBlobStore.java
@@ -218,7 +218,7 @@ public class NimbusBlobStore extends ClientBlobStore implements AutoCloseable {
     }
 
     @Override
-    public long getRemoteBlobstoreModtime() throws IOException {
+    public long getRemoteBlobstoreUpdateTime() throws IOException {
         return -1L; // not supported
     }
 

--- a/storm-client/src/jvm/org/apache/storm/blobstore/NimbusBlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/NimbusBlobStore.java
@@ -217,6 +217,11 @@ public class NimbusBlobStore extends ClientBlobStore implements AutoCloseable {
         shutdown();
     }
 
+    @Override
+    public long getRemoteBlobstoreModtime() throws IOException {
+        return -1L; // not supported
+    }
+
     public class NimbusKeyIterator implements Iterator<String> {
         private ListBlobsResult listBlobs = null;
         private int offset = 0;

--- a/storm-client/test/jvm/org/apache/storm/blobstore/ClientBlobStoreTest.java
+++ b/storm-client/test/jvm/org/apache/storm/blobstore/ClientBlobStoreTest.java
@@ -188,7 +188,7 @@ public class ClientBlobStoreTest {
         }
 
         @Override
-        public long getRemoteBlobstoreModtime() throws IOException {
+        public long getRemoteBlobstoreUpdateTime() throws IOException {
             return -1L; // not supported
         }
     }

--- a/storm-client/test/jvm/org/apache/storm/blobstore/ClientBlobStoreTest.java
+++ b/storm-client/test/jvm/org/apache/storm/blobstore/ClientBlobStoreTest.java
@@ -12,6 +12,7 @@
 
 package org.apache.storm.blobstore;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -184,6 +185,11 @@ public class ClientBlobStoreTest {
 
         @Override
         public void createStateInZookeeper(String key) {
+        }
+
+        @Override
+        public long getRemoteBlobstoreModtime() throws IOException {
+            return -1L; // not supported
         }
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3768,6 +3768,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             os.close();
             LOG.info("Finished uploading blob for session {}. Closing session.", session);
             blobUploaders.remove(session);
+            blobStore.updateLastModTime();
         } catch (Exception e) {
             LOG.warn("finish blob upload exception.", e);
             if (e instanceof TException) {
@@ -3815,6 +3816,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         throws AuthorizationException, KeyNotFoundException, TException {
         try {
             blobStore.setBlobMeta(key, meta, getSubject());
+            blobStore.updateLastModTime();
         } catch (Exception e) {
             LOG.warn("set blob meta exception.", e);
             if (e instanceof TException) {
@@ -4038,6 +4040,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             channel.close();
             LOG.info("Finished uploading file from client: {}", location);
             uploaders.remove(location);
+            blobStore.updateLastModTime();
         } catch (Exception e) {
             LOG.warn("finish file upload exception.", e);
             if (e instanceof TException) {

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1427,8 +1427,8 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                     }
                 });
 
-            // Periodically make sure the blobstore modtime is up to date.  This could have failed if Nimbus encountered
-            // an exception updating the mod time, or due to bugs causing a missed update of the blobstore mod time on a blob
+            // Periodically make sure the blobstore update time is up to date.  This could have failed if Nimbus encountered
+            // an exception updating the update time, or due to bugs causing a missed update of the blobstore mod time on a blob
             // update.
             timer.scheduleRecurring(30, ServerConfigUtils.getLocalizerUpdateBlobInterval(conf) * 5,
                 () -> {
@@ -3969,7 +3969,9 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     public int updateBlobReplication(String key, int replication)
         throws AuthorizationException, KeyNotFoundException, TException {
         try {
-            return blobStore.updateBlobReplication(key, replication, getSubject());
+            int result = blobStore.updateBlobReplication(key, replication, getSubject());
+            blobStore.updateLastBlobUpdateTime();
+            return result;
         } catch (Exception e) {
             LOG.warn("update blob replication exception.", e);
             if (e instanceof TException) {

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1433,7 +1433,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             timer.scheduleRecurring(30, ServerConfigUtils.getLocalizerUpdateBlobInterval(conf) * 5,
                 () -> {
                     try {
-                        blobStore.validateModTime();
+                        blobStore.validateBlobUpdateTime();
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -3780,7 +3780,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             os.close();
             LOG.info("Finished uploading blob for session {}. Closing session.", session);
             blobUploaders.remove(session);
-            blobStore.updateLastModTime();
+            blobStore.updateLastBlobUpdateTime();
         } catch (Exception e) {
             LOG.warn("finish blob upload exception.", e);
             if (e instanceof TException) {
@@ -3828,7 +3828,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         throws AuthorizationException, KeyNotFoundException, TException {
         try {
             blobStore.setBlobMeta(key, meta, getSubject());
-            blobStore.updateLastModTime();
+            blobStore.updateLastBlobUpdateTime();
         } catch (Exception e) {
             LOG.warn("set blob meta exception.", e);
             if (e instanceof TException) {
@@ -4052,7 +4052,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             channel.close();
             LOG.info("Finished uploading file from client: {}", location);
             uploaders.remove(location);
-            blobStore.updateLastModTime();
+            blobStore.updateLastBlobUpdateTime();
         } catch (Exception e) {
             LOG.warn("finish file upload exception.", e);
             if (e instanceof TException) {

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1430,7 +1430,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             // Periodically make sure the blobstore modtime is up to date.  This could have failed if Nimbus encountered
             // an exception updating the mod time, or due to bugs causing a missed update of the blobstore mod time on a blob
             // update.
-            timer.scheduleRecurring(30, (int) ServerConfigUtils.getLocalizerUpdateBlobInterval(conf) * 5,
+            timer.scheduleRecurring(30, ServerConfigUtils.getLocalizerUpdateBlobInterval(conf) * 5,
                 () -> {
                     try {
                         blobStore.validateModTime();

--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -99,7 +99,7 @@ public class AsyncLocalizer implements AutoCloseable {
     private final ScheduledExecutorService downloadExecService;
     private final ScheduledExecutorService taskExecService;
     private final long cacheCleanupPeriod;
-    private final long updateBlobPeriod;
+    private final int updateBlobPeriod;
     private final StormMetricsRegistry metricsRegistry;
     // cleanup
     @VisibleForTesting

--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -59,6 +59,7 @@ import org.apache.storm.thrift.transport.TTransportException;
 import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.utils.NimbusLeaderNotFoundException;
 import org.apache.storm.utils.ObjectReader;
+import org.apache.storm.utils.ServerConfigUtils;
 import org.apache.storm.utils.ServerUtils;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.utils.WrappedKeyNotFoundException;
@@ -123,8 +124,7 @@ public class AsyncLocalizer implements AutoCloseable {
         cacheCleanupPeriod = ObjectReader.getInt(conf.get(
             DaemonConfig.SUPERVISOR_LOCALIZER_CACHE_CLEANUP_INTERVAL_MS), 30 * 1000).longValue();
 
-        updateBlobPeriod = ObjectReader.getInt(conf.get(
-                DaemonConfig.SUPERVISOR_LOCALIZER_UPDATE_BLOB_INTERVAL_SECS), 30).longValue();
+        updateBlobPeriod = ServerConfigUtils.getLocalizerUpdateBlobInterval(conf);
 
         blobDownloadRetries = ObjectReader.getInt(conf.get(
             DaemonConfig.SUPERVISOR_BLOBSTORE_DOWNLOAD_MAX_RETRIES), 3);

--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -258,7 +258,7 @@ public class AsyncLocalizer implements AutoCloseable {
 
     private CompletableFuture<Void> downloadOrUpdate(Collection<? extends LocallyCachedBlob> blobs) {
 
-        final long remoteBlobstoreModTime = getRemoteBlobstoreUpdateTime();
+        final long remoteBlobstoreUpdateTime = getRemoteBlobstoreUpdateTime();
 
         CompletableFuture<Void>[] all = new CompletableFuture[blobs.size()];
         int i = 0;
@@ -270,7 +270,7 @@ public class AsyncLocalizer implements AutoCloseable {
                     long failures = 0;
                     while (!done) {
                         try {
-                            blob.update(blobStore, remoteBlobstoreModTime);
+                            blob.update(blobStore, remoteBlobstoreUpdateTime);
                             done = true;
                         } catch (Exception e) {
                             failures++;
@@ -294,7 +294,7 @@ public class AsyncLocalizer implements AutoCloseable {
             try {
                 return blobStore.getRemoteBlobstoreUpdateTime();
             } catch (IOException e) {
-                LOG.error("Failed to get remote blobstore modtime", e);
+                LOG.error("Failed to get remote blobstore update time", e);
                 return -1L;
             }
         }

--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -258,7 +258,7 @@ public class AsyncLocalizer implements AutoCloseable {
 
     private CompletableFuture<Void> downloadOrUpdate(Collection<? extends LocallyCachedBlob> blobs) {
 
-        final long remoteBlobstoreModTime = getRemoteBlobstoreModtime();
+        final long remoteBlobstoreModTime = getRemoteBlobstoreUpdateTime();
 
         CompletableFuture<Void>[] all = new CompletableFuture[blobs.size()];
         int i = 0;
@@ -289,10 +289,10 @@ public class AsyncLocalizer implements AutoCloseable {
         return CompletableFuture.allOf(all);
     }
 
-    private long getRemoteBlobstoreModtime() {
+    private long getRemoteBlobstoreUpdateTime() {
         try (ClientBlobStore blobStore = getClientBlobStore()) {
             try {
-                return blobStore.getRemoteBlobstoreModtime();
+                return blobStore.getRemoteBlobstoreUpdateTime();
             } catch (IOException e) {
                 LOG.error("Failed to get remote blobstore modtime", e);
                 return -1L;

--- a/storm-server/src/main/java/org/apache/storm/utils/ServerConfigUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerConfigUtils.java
@@ -159,8 +159,8 @@ public class ServerConfigUtils {
         return new LocalState((masterLocalDir(conf) + FILE_SEPARATOR + "history"), true);
     }
 
-    public static long getLocalizerUpdateBlobInterval(Map<String, Object> conf) {
+    public static int getLocalizerUpdateBlobInterval(Map<String, Object> conf) {
         return ObjectReader.getInt(conf.get(
-                DaemonConfig.SUPERVISOR_LOCALIZER_UPDATE_BLOB_INTERVAL_SECS), 30).longValue();
+                DaemonConfig.SUPERVISOR_LOCALIZER_UPDATE_BLOB_INTERVAL_SECS), 30);
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/utils/ServerConfigUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerConfigUtils.java
@@ -158,4 +158,9 @@ public class ServerConfigUtils {
     public LocalState nimbusTopoHistoryStateImpl(Map<String, Object> conf) throws IOException {
         return new LocalState((masterLocalDir(conf) + FILE_SEPARATOR + "history"), true);
     }
+
+    public static long getLocalizerUpdateBlobInterval(Map<String, Object> conf) {
+        return ObjectReader.getInt(conf.get(
+                DaemonConfig.SUPERVISOR_LOCALIZER_UPDATE_BLOB_INTERVAL_SECS), 30).longValue();
+    }
 }

--- a/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
@@ -120,7 +120,7 @@ public class AsyncLocalizerTest {
             final int port = 8080;
 
             ClientBlobStore blobStore = mock(ClientBlobStore.class);
-            when(blobStore.getRemoteBlobstoreModtime()).thenReturn(-1L);
+            when(blobStore.getRemoteBlobstoreUpdateTime()).thenReturn(-1L);
 
             LocallyCachedTopologyBlob jarBlob = mock(LocallyCachedTopologyBlob.class);
             doReturn(jarBlob).when(victim).getTopoJar(topoId, localAssignment.get_owner());

--- a/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
@@ -120,6 +120,7 @@ public class AsyncLocalizerTest {
             final int port = 8080;
 
             ClientBlobStore blobStore = mock(ClientBlobStore.class);
+            when(blobStore.getRemoteBlobstoreModtime()).thenReturn(-1L);
 
             LocallyCachedTopologyBlob jarBlob = mock(LocallyCachedTopologyBlob.class);
             doReturn(jarBlob).when(victim).getTopoJar(topoId, localAssignment.get_owner());
@@ -148,9 +149,9 @@ public class AsyncLocalizerTest {
             Future<Void> f = victim.requestDownloadBaseTopologyBlobs(pna, null);
             f.get(20, TimeUnit.SECONDS);
 
-            verify(jarBlob).update(eq(blobStore));
-            verify(codeBlob).update(eq(blobStore));
-            verify(confBlob).update(eq(blobStore));
+            verify(jarBlob).update(eq(blobStore), eq(-1L));
+            verify(codeBlob).update(eq(blobStore), eq(-1L));
+            verify(confBlob).update(eq(blobStore), eq(-1L));
         } finally {
             ReflectionUtils.setInstance(previousReflectionUtils);
             ServerUtils.setInstance(previousServerUtils);

--- a/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/AsyncLocalizerTest.java
@@ -148,18 +148,9 @@ public class AsyncLocalizerTest {
             Future<Void> f = victim.requestDownloadBaseTopologyBlobs(pna, null);
             f.get(20, TimeUnit.SECONDS);
 
-            verify(jarBlob).fetchUnzipToTemp(any());
-            verify(jarBlob).informReferencesAndCommitNewVersion(100L);
-            verify(jarBlob).cleanupOrphanedData();
-
-            verify(codeBlob).fetchUnzipToTemp(any());
-            verify(codeBlob).informReferencesAndCommitNewVersion(200L);
-            verify(codeBlob).cleanupOrphanedData();
-
-            verify(confBlob).fetchUnzipToTemp(any());
-            verify(confBlob).informReferencesAndCommitNewVersion(300L);
-            verify(confBlob).cleanupOrphanedData();
-
+            verify(jarBlob).update(eq(blobStore));
+            verify(codeBlob).update(eq(blobStore));
+            verify(confBlob).update(eq(blobStore));
         } finally {
             ReflectionUtils.setInstance(previousReflectionUtils);
             ServerUtils.setInstance(previousServerUtils);

--- a/storm-server/src/test/java/org/apache/storm/localizer/LocallyCachedBlobTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/LocallyCachedBlobTest.java
@@ -61,16 +61,16 @@ public class LocallyCachedBlobTest {
         // validate blob needs update due to version mismatch
         Assert.assertTrue(blob.requiresUpdate(blobStore, -1L));
 
-        // when blob update time matches remote blobstore modtime, validate blob
+        // when blob update time matches remote blobstore update time, validate blob
         // will skip looking at remote version and assume it's up to date
         blob.localUpdateTime = 101L;
         Assert.assertFalse(blob.requiresUpdate(blobStore, 101L));
 
-        // now when the mod time on the remote blobstore differs, we should again see that the
+        // now when the update time on the remote blobstore differs, we should again see that the
         // blob version differs from the remote blobstore
         Assert.assertTrue(blob.requiresUpdate(blobStore, 102L));
 
-        // now validate we don't need any update as versions match, regardless of remote blobstore mod time
+        // now validate we don't need any update as versions match, regardless of remote blobstore update time
         blob.localVersion = blob.getRemoteVersion(blobStore);
         Assert.assertFalse(blob.requiresUpdate(blobStore, -1L));
         Assert.assertFalse(blob.requiresUpdate(blobStore, 101L));

--- a/storm-server/src/test/java/org/apache/storm/localizer/LocallyCachedBlobTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/LocallyCachedBlobTest.java
@@ -63,7 +63,7 @@ public class LocallyCachedBlobTest {
 
         // when blob update time matches remote blobstore modtime, validate blob
         // will skip looking at remote version and assume it's up to date
-        blob.updatedModTime = 101L;
+        blob.localUpdateTime = 101L;
         Assert.assertFalse(blob.requiresUpdate(blobStore, 101L));
 
         // now when the mod time on the remote blobstore differs, we should again see that the

--- a/storm-server/src/test/java/org/apache/storm/localizer/LocallyCachedBlobTest.java
+++ b/storm-server/src/test/java/org/apache/storm/localizer/LocallyCachedBlobTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.localizer;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.storm.blobstore.ClientBlobStore;
+import org.apache.storm.daemon.supervisor.AdvancedFSOps;
+import org.apache.storm.daemon.supervisor.IAdvancedFSOps;
+import org.apache.storm.generated.AuthorizationException;
+import org.apache.storm.generated.KeyNotFoundException;
+import org.apache.storm.generated.LocalAssignment;
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class LocallyCachedBlobTest {
+    private static ClientBlobStore blobStore = Mockito.mock(ClientBlobStore.class);
+    private static PortAndAssignment pna = new PortAndAssignmentImpl(6077, new LocalAssignment());
+    private static Map<String, Object> conf = new HashMap<>();
+
+    @Test
+    public void testNotUsed() throws KeyNotFoundException, AuthorizationException {
+        LocallyCachedBlob blob = new LocalizedResource("key", Paths.get("/bogus"), false,
+                AdvancedFSOps.make(conf), conf, "user1", new StormMetricsRegistry());
+        Assert.assertFalse(blob.isUsed());
+        Assert.assertFalse(blob.requiresUpdate(blobStore));
+    }
+
+    @Test
+    public void testNotDownloaded() throws KeyNotFoundException, AuthorizationException {
+        LocallyCachedBlob blob = new LocalizedResource("key", Paths.get("/bogus"), false,
+                AdvancedFSOps.make(conf), conf, "user1", new StormMetricsRegistry());
+        blob.addReference(pna, null);
+        Assert.assertTrue(blob.isUsed());
+        Assert.assertFalse(blob.isFullyDownloaded());
+        Assert.assertTrue(blob.requiresUpdate(blobStore));
+    }
+
+    @Test
+    public void testOutOfDate() throws KeyNotFoundException, AuthorizationException {
+        TestableBlob blob = new TestableBlob("key", Paths.get("/bogus"), false,
+                AdvancedFSOps.make(conf), conf, "user1", new StormMetricsRegistry());
+        blob.addReference(pna, null);
+        Assert.assertTrue(blob.isUsed());
+        Assert.assertTrue(blob.isFullyDownloaded());
+
+        // validate blob needs update due to version mismatch
+        Assert.assertTrue(blob.requiresUpdate(blobStore));
+    }
+
+    public class TestableBlob extends LocalizedResource {
+        long localVersion = 9L;
+
+        TestableBlob(String key, Path localBaseDir, boolean shouldUncompress, IAdvancedFSOps fsOps, Map<String, Object> conf, String user, StormMetricsRegistry metricRegistry) {
+            super(key, localBaseDir, shouldUncompress, fsOps, conf, user, metricRegistry);
+        }
+
+        @Override
+        public boolean isFullyDownloaded() {
+            return true;
+        }
+
+        @Override
+        public long getRemoteVersion(ClientBlobStore store) throws KeyNotFoundException, AuthorizationException {
+            return 10L;
+        }
+
+        @Override
+        public long getLocalVersion() {
+            return localVersion;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Reduce the impact of listing files on a Hadoop name node by checking a single timestamp first when updating blobstores.  The Hadoop blobstore will update the modTime on the base blobstore directory anytime a blob is updated.  Supervisors will fetch that timestamp once during AsyncLocalizer updateBlobs().  For each local blob, if the last check matches this modTime, they will not query the remote Hadoop blob.  This reduces polling on the namenode.

## How was the change tested

Ran code with debug logs on internal dev clusters with Hadoop and ran blobstore related integration tests with topologies.  Ran storm-client/server/hdfs-blobstore unit tests.  Ran a word count topology on a local cluster setup for 15 minutes.
