### PR TITLE
STORM-3727 handle long values for SUPERVISOR_SLOTS_PORTS

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/SupervisorUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/SupervisorUtils.java
@@ -92,8 +92,13 @@ public class SupervisorUtils {
     }
 
     public static List<Integer> getSlotsPorts(Map<String, Object> supervisorConf) {
-        List<Integer> slotsPorts = (List<Integer>) supervisorConf.getOrDefault(DaemonConfig.SUPERVISOR_SLOTS_PORTS,
+        List<Integer> slotsPorts = new ArrayList<>();
+        List<Number> ports = (List<Number>) supervisorConf.getOrDefault(DaemonConfig.SUPERVISOR_SLOTS_PORTS,
                 new ArrayList<>());
+        for (Number port : ports) {
+            slotsPorts.add(port.intValue());
+        }
+
         // It's possible we have numaPorts specified that weren't configured in SUPERVISOR_SLOTS_PORTS.  Make
         // sure we handle these ports as well.
         Set<Integer> numaPorts = SupervisorUtils.getNumaPorts(supervisorConf);


### PR DESCRIPTION
## What is the purpose of the change

Apparently it is possible for supervisorConf.getOrDefault(DaemonConfig.SUPERVISOR_SLOTS_PORTS) to return a list of Long values, which caused a ClassCastException.

## How was the change tested

Built storm-server jar.