### PR TITLE
[STORM-3728] Fix Worker LoginException issue with pacemaker when pacemaker.auth.method is KERBEROS

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -121,7 +121,9 @@ public class Worker implements Shutdownable, DaemonCommon {
 
         this.topologyConf = ConfigUtils.overrideLoginConfigWithSystemProperty(ConfigUtils.readSupervisorStormConf(conf, topologyId));
 
-        // see STORM-3728.
+        // See STORM-3728.
+        // Writes to Pacemaker are currently always allowed.
+        // Ignore Config.PACEMAKER_AUTH_METHOD on Workers.
         topologyConf.put(Config.PACEMAKER_AUTH_METHOD, "NONE");
         conf.put(Config.PACEMAKER_AUTH_METHOD, "NONE");
 

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -121,6 +121,10 @@ public class Worker implements Shutdownable, DaemonCommon {
 
         this.topologyConf = ConfigUtils.overrideLoginConfigWithSystemProperty(ConfigUtils.readSupervisorStormConf(conf, topologyId));
 
+        // see STORM-3728.
+        topologyConf.put(Config.PACEMAKER_AUTH_METHOD, "NONE");
+        conf.put(Config.PACEMAKER_AUTH_METHOD, "NONE");
+
         if (supervisorIfaceSupplier == null) {
             this.supervisorIfaceSupplier = () -> {
                 try {


### PR DESCRIPTION
## What is the purpose of the change

Described in https://issues.apache.org/jira/browse/STORM-3728. Workers have issue connecting to pacemaker when pacemaker.auth.method is KERBEROS

## How was the change tested

This issue is easy to reproduce when pacemaker is set up with Kerberos and `pacemaker.auth.method` set to `KERBEROS`.
Applied this change and validated that workers can heartbeat to Pacemakers properly. 
