### PR TITLE
STORM-3733 fix AsyncLocalizer from updating dead topology blobs

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedBlob.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedBlob.java
@@ -221,7 +221,8 @@ public abstract class LocallyCachedBlob {
      * @param cb an optional callback indicating that they want to know/synchronize when a blob is updated.
      */
     public void addReference(final PortAndAssignment pna, BlobChangingCallback cb) {
-        LOG.debug("Adding reference {}", pna);
+        touch();
+        LOG.info("Adding reference {} with timestamp {} to {}", pna, getLastUsed(), blobDescription);
         if (cb == null) {
             cb = NOOP_CB;
         }
@@ -235,9 +236,10 @@ public abstract class LocallyCachedBlob {
      * @param pna the slot + assignment that no longer needs this blob.
      */
     public void removeReference(final PortAndAssignment pna) {
-        LOG.debug("Removing reference {}", pna);
+        LOG.info("Removing reference {} from {}", pna, blobDescription);
         if (references.remove(pna) == null) {
-            LOG.warn("{} had no reservation for {}", pna, blobDescription);
+            LOG.warn("{} had no reservation for {}, current references are {} with last update at {}",
+                    pna, blobDescription, getDependencies(), getLastUsed());
         }
         touch();
     }

--- a/storm-server/src/main/java/org/apache/storm/localizer/PortAndAssignment.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/PortAndAssignment.java
@@ -15,6 +15,7 @@
 package org.apache.storm.localizer;
 
 import org.apache.storm.generated.LocalAssignment;
+import org.apache.storm.utils.EquivalenceUtils;
 
 public interface PortAndAssignment {
     String getToplogyId();
@@ -26,6 +27,12 @@ public interface PortAndAssignment {
     LocalAssignment getAssignment();
 
     default void complete() {
+    }
 
+    default boolean isEquivalentTo(PortAndAssignment other) {
+        if (getPort() == other.getPort()) {
+            return EquivalenceUtils.areLocalAssignmentsEquivalent(getAssignment(), other.getAssignment());
+        }
+        return false;
     }
 }

--- a/storm-server/src/main/java/org/apache/storm/utils/EquivalenceUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/EquivalenceUtils.java
@@ -73,6 +73,9 @@ public class EquivalenceUtils {
         if (first == null) {
             return false;
         }
+        if (second == null) {
+            return false;
+        }
         if (first == second) {
             return true;
         }

--- a/storm-server/src/main/java/org/apache/storm/utils/EquivalenceUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/EquivalenceUtils.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.storm.generated.ExecutorInfo;
+import org.apache.storm.generated.LocalAssignment;
+import org.apache.storm.generated.WorkerResources;
+
+public class EquivalenceUtils {
+
+    /**
+     * Decide the equivalence of two local assignments, ignoring the order of executors This is different from #equal method.
+     *
+     * @param first  Local assignment A
+     * @param second Local assignment B
+     * @return True if A and B are equivalent, ignoring the order of the executors
+     */
+    public static boolean areLocalAssignmentsEquivalent(LocalAssignment first, LocalAssignment second) {
+        if (first == null && second == null) {
+            return true;
+        }
+        if (first != null && second != null) {
+            if (first.get_topology_id().equals(second.get_topology_id())) {
+                Set<ExecutorInfo> aexec = new HashSet<>(first.get_executors());
+                Set<ExecutorInfo> bexec = new HashSet<>(second.get_executors());
+                if (aexec.equals(bexec)) {
+                    boolean firstHasResources = first.is_set_resources();
+                    boolean secondHasResources = second.is_set_resources();
+                    if (!firstHasResources && !secondHasResources) {
+                        return true;
+                    }
+                    if (firstHasResources && secondHasResources) {
+                        WorkerResources firstResources = first.get_resources();
+                        WorkerResources secondResources = second.get_resources();
+                        return customWorkerResourcesEquality(firstResources, secondResources);
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This method compares WorkerResources while considering any resources are NULL to be 0.0
+     *
+     * @param first  WorkerResources A
+     * @param second WorkerResources B
+     * @return True if A and B are equivalent, treating the absent resources as 0.0
+     */
+    @VisibleForTesting
+    static boolean customWorkerResourcesEquality(WorkerResources first, WorkerResources second) {
+        if (first == null) {
+            return false;
+        }
+        if (first == second) {
+            return true;
+        }
+        if (first.equals(second)) {
+            return true;
+        }
+
+        if (first.get_cpu() != second.get_cpu()) {
+            return false;
+        }
+        if (first.get_mem_on_heap() != second.get_mem_on_heap()) {
+            return false;
+        }
+        if (first.get_mem_off_heap() != second.get_mem_off_heap()) {
+            return false;
+        }
+        if (first.get_shared_mem_off_heap() != second.get_shared_mem_off_heap()) {
+            return false;
+        }
+        if (first.get_shared_mem_on_heap() != second.get_shared_mem_on_heap()) {
+            return false;
+        }
+        if (!customResourceMapEquality(first.get_resources(), second.get_resources())) {
+            return false;
+        }
+        if (!customResourceMapEquality(first.get_shared_resources(), second.get_shared_resources())) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * This method compares Resource Maps while considering any resources are NULL to be 0.0
+     *
+     * @param firstMap  Resource Map A
+     * @param secondMap Resource Map B
+     * @return True if A and B are equivalent, treating the absent resources as 0.0
+     */
+    private static boolean customResourceMapEquality(Map<String, Double> firstMap, Map<String, Double> secondMap) {
+        if (firstMap == null && secondMap == null) {
+            return true;
+        }
+        if (firstMap == null) {
+            firstMap = new HashMap<>();
+        }
+        if (secondMap == null) {
+            secondMap = new HashMap<>();
+        }
+
+        Set<String> keys = new HashSet<>(firstMap.keySet());
+        keys.addAll(secondMap.keySet());
+        for (String key : keys) {
+            if (firstMap.getOrDefault(key, 0.0).doubleValue() != secondMap.getOrDefault(key, 0.0).doubleValue()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/storm-server/src/test/java/org/apache/storm/daemon/supervisor/SlotTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/supervisor/SlotTest.java
@@ -15,13 +15,10 @@ package org.apache.storm.daemon.supervisor;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 
-import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -80,14 +77,6 @@ public class SlotTest {
         return resources;
     }
 
-    static WorkerResources mkWorkerResources(Double cpu, Double mem_on_heap, Double mem_off_heap, Map<String, Double> resources) {
-        WorkerResources workerResources = mkWorkerResources(cpu, mem_on_heap, mem_off_heap);
-        if (resources != null) {
-            workerResources.set_resources(resources);
-        }
-        return workerResources;
-    }
-
     static LSWorkerHeartbeat mkWorkerHB(String id, int port, List<ExecutorInfo> exec, Integer timeSecs) {
         LSWorkerHeartbeat ret = new LSWorkerHeartbeat();
         ret.set_topology_id(id);
@@ -116,77 +105,6 @@ public class SlotTest {
             ret.set_resources(resources);
         }
         return ret;
-    }
-
-    @Test
-    public void testWorkerResourceEquality() {
-        WorkerResources resourcesRNull = mkWorkerResources(100.0, 100.0, 100.0, null);
-        WorkerResources resourcesREmpty = mkWorkerResources(100.0, 100.0, 100.0, Maps.newHashMap());
-        assertTrue(Slot.customWorkerResourcesEquality(resourcesRNull,resourcesREmpty));
-
-        Map resources = new HashMap<String, Double>();
-        resources.put("network.resource.units", 0.0);
-        WorkerResources resourcesRNetwork = mkWorkerResources(100.0, 100.0, 100.0,resources);
-        assertTrue(Slot.customWorkerResourcesEquality(resourcesREmpty, resourcesRNetwork));
-
-
-        Map resourcesNetwork = new HashMap<String, Double>();
-        resourcesNetwork.put("network.resource.units", 50.0);
-        WorkerResources resourcesRNetworkNonZero = mkWorkerResources(100.0, 100.0, 100.0,resourcesNetwork);
-        assertFalse(Slot.customWorkerResourcesEquality(resourcesREmpty, resourcesRNetworkNonZero));
-
-        Map resourcesNetworkOne = new HashMap<String, Double>();
-        resourcesNetworkOne.put("network.resource.units", 50.0);
-        WorkerResources resourcesRNetworkOne = mkWorkerResources(100.0, 100.0, 100.0,resourcesNetworkOne);
-        assertTrue(Slot.customWorkerResourcesEquality(resourcesRNetworkOne, resourcesRNetworkNonZero));
-
-        Map resourcesNetworkTwo = new HashMap<String, Double>();
-        resourcesNetworkTwo.put("network.resource.units", 100.0);
-        WorkerResources resourcesRNetworkTwo = mkWorkerResources(100.0, 100.0, 100.0,resourcesNetworkTwo);
-        assertFalse(Slot.customWorkerResourcesEquality(resourcesRNetworkOne, resourcesRNetworkTwo));
-
-        WorkerResources resourcesCpuNull = mkWorkerResources(null, 100.0,100.0);
-        WorkerResources resourcesCPUZero = mkWorkerResources(0.0, 100.0,100.0);
-        assertTrue(Slot.customWorkerResourcesEquality(resourcesCpuNull, resourcesCPUZero));
-
-        WorkerResources resourcesOnHeapMemNull = mkWorkerResources(100.0, null,100.0);
-        WorkerResources resourcesOnHeapMemZero = mkWorkerResources(100.0, 0.0,100.0);
-        assertTrue(Slot.customWorkerResourcesEquality(resourcesOnHeapMemNull, resourcesOnHeapMemZero));
-
-        WorkerResources resourcesOffHeapMemNull = mkWorkerResources(100.0, 100.0,null);
-        WorkerResources resourcesOffHeapMemZero = mkWorkerResources(100.0, 100.0,0.0);
-        assertTrue(Slot.customWorkerResourcesEquality(resourcesOffHeapMemNull, resourcesOffHeapMemZero));
-
-    }
-
-    @Test
-    public void testEquivalent() {
-        LocalAssignment a = mkLocalAssignment("A", mkExecutorInfoList(1, 2, 3, 4, 5), mkWorkerResources(100.0, 100.0, 100.0));
-        LocalAssignment aResized = mkLocalAssignment("A", mkExecutorInfoList(1, 2, 3, 4, 5), mkWorkerResources(100.0, 200.0, 100.0));
-        LocalAssignment b = mkLocalAssignment("B", mkExecutorInfoList(1, 2, 3, 4, 5, 6), mkWorkerResources(100.0, 100.0, 100.0));
-        LocalAssignment bReordered = mkLocalAssignment("B", mkExecutorInfoList(6, 5, 4, 3, 2, 1), mkWorkerResources(100.0, 100.0, 100.0));
-
-        LocalAssignment c = mkLocalAssignment("C", mkExecutorInfoList(188, 261),mkWorkerResources(400.0,10000.0,0.0));
-
-        WorkerResources workerResources = mkWorkerResources(400.0, 10000.0, 0.0);
-        Map<String, Double> additionalResources = workerResources.get_resources();
-        if( additionalResources == null) additionalResources = new HashMap<>();
-        additionalResources.put("network.resource.units", 0.0);
-
-        workerResources.set_resources(additionalResources);
-        LocalAssignment cReordered = mkLocalAssignment("C", mkExecutorInfoList(188, 261), workerResources);
-
-        assertTrue(Slot.equivalent(c,cReordered));
-        assertTrue(Slot.equivalent(null, null));
-        assertTrue(Slot.equivalent(a, a));
-        assertTrue(Slot.equivalent(b, bReordered));
-        assertTrue(Slot.equivalent(bReordered, b));
-
-        assertFalse(Slot.equivalent(a, aResized));
-        assertFalse(Slot.equivalent(aResized, a));
-        assertFalse(Slot.equivalent(a, null));
-        assertFalse(Slot.equivalent(null, b));
-        assertFalse(Slot.equivalent(a, b));
     }
 
     @Test

--- a/storm-server/src/test/java/org/apache/storm/utils/EquivalenceUtilsTest.java
+++ b/storm-server/src/test/java/org/apache/storm/utils/EquivalenceUtilsTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.utils;
+
+import com.google.common.collect.Maps;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.storm.generated.ExecutorInfo;
+import org.apache.storm.generated.LocalAssignment;
+import org.apache.storm.generated.WorkerResources;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class EquivalenceUtilsTest {
+
+    static WorkerResources mkWorkerResources(Double cpu, Double mem_on_heap, Double mem_off_heap, Map<String, Double> resources) {
+        WorkerResources workerResources = mkWorkerResources(cpu, mem_on_heap, mem_off_heap);
+        if (resources != null) {
+            workerResources.set_resources(resources);
+        }
+        return workerResources;
+    }
+
+    static WorkerResources mkWorkerResources(Double cpu, Double mem_on_heap, Double mem_off_heap) {
+        WorkerResources resources = new WorkerResources();
+        if (cpu != null) {
+            resources.set_cpu(cpu);
+        }
+
+        if (mem_on_heap != null) {
+            resources.set_mem_on_heap(mem_on_heap);
+        }
+
+        if (mem_off_heap != null) {
+            resources.set_mem_off_heap(mem_off_heap);
+        }
+        return resources;
+    }
+
+    static LocalAssignment mkLocalAssignment(String id, List<ExecutorInfo> exec, WorkerResources resources) {
+        LocalAssignment ret = new LocalAssignment();
+        ret.set_topology_id(id);
+        ret.set_executors(exec);
+        if (resources != null) {
+            ret.set_resources(resources);
+        }
+        return ret;
+    }
+
+    static List<ExecutorInfo> mkExecutorInfoList(int... executors) {
+        ArrayList<ExecutorInfo> ret = new ArrayList<>(executors.length);
+        for (int exec : executors) {
+            ExecutorInfo execInfo = new ExecutorInfo();
+            execInfo.set_task_start(exec);
+            execInfo.set_task_end(exec);
+            ret.add(execInfo);
+        }
+        return ret;
+    }
+
+    @Test
+    public void testWorkerResourceEquality() {
+        WorkerResources resourcesRNull = mkWorkerResources(100.0, 100.0, 100.0, null);
+        WorkerResources resourcesREmpty = mkWorkerResources(100.0, 100.0, 100.0, Maps.newHashMap());
+        assertTrue(EquivalenceUtils.customWorkerResourcesEquality(resourcesRNull,resourcesREmpty));
+
+        Map resources = new HashMap<String, Double>();
+        resources.put("network.resource.units", 0.0);
+        WorkerResources resourcesRNetwork = mkWorkerResources(100.0, 100.0, 100.0,resources);
+        assertTrue(EquivalenceUtils.customWorkerResourcesEquality(resourcesREmpty, resourcesRNetwork));
+
+
+        Map resourcesNetwork = new HashMap<String, Double>();
+        resourcesNetwork.put("network.resource.units", 50.0);
+        WorkerResources resourcesRNetworkNonZero = mkWorkerResources(100.0, 100.0, 100.0,resourcesNetwork);
+        assertFalse(EquivalenceUtils.customWorkerResourcesEquality(resourcesREmpty, resourcesRNetworkNonZero));
+
+        Map resourcesNetworkOne = new HashMap<String, Double>();
+        resourcesNetworkOne.put("network.resource.units", 50.0);
+        WorkerResources resourcesRNetworkOne = mkWorkerResources(100.0, 100.0, 100.0,resourcesNetworkOne);
+        assertTrue(EquivalenceUtils.customWorkerResourcesEquality(resourcesRNetworkOne, resourcesRNetworkNonZero));
+
+        Map resourcesNetworkTwo = new HashMap<String, Double>();
+        resourcesNetworkTwo.put("network.resource.units", 100.0);
+        WorkerResources resourcesRNetworkTwo = mkWorkerResources(100.0, 100.0, 100.0,resourcesNetworkTwo);
+        assertFalse(EquivalenceUtils.customWorkerResourcesEquality(resourcesRNetworkOne, resourcesRNetworkTwo));
+
+        WorkerResources resourcesCpuNull = mkWorkerResources(null, 100.0,100.0);
+        WorkerResources resourcesCPUZero = mkWorkerResources(0.0, 100.0,100.0);
+        assertTrue(EquivalenceUtils.customWorkerResourcesEquality(resourcesCpuNull, resourcesCPUZero));
+
+        WorkerResources resourcesOnHeapMemNull = mkWorkerResources(100.0, null,100.0);
+        WorkerResources resourcesOnHeapMemZero = mkWorkerResources(100.0, 0.0,100.0);
+        assertTrue(EquivalenceUtils.customWorkerResourcesEquality(resourcesOnHeapMemNull, resourcesOnHeapMemZero));
+
+        WorkerResources resourcesOffHeapMemNull = mkWorkerResources(100.0, 100.0,null);
+        WorkerResources resourcesOffHeapMemZero = mkWorkerResources(100.0, 100.0,0.0);
+        assertTrue(EquivalenceUtils.customWorkerResourcesEquality(resourcesOffHeapMemNull, resourcesOffHeapMemZero));
+    }
+
+    @Test
+    public void testEquivalent() {
+        LocalAssignment a = mkLocalAssignment("A", mkExecutorInfoList(1, 2, 3, 4, 5), mkWorkerResources(100.0, 100.0, 100.0));
+        LocalAssignment aResized = mkLocalAssignment("A", mkExecutorInfoList(1, 2, 3, 4, 5), mkWorkerResources(100.0, 200.0, 100.0));
+        LocalAssignment b = mkLocalAssignment("B", mkExecutorInfoList(1, 2, 3, 4, 5, 6), mkWorkerResources(100.0, 100.0, 100.0));
+        LocalAssignment bReordered = mkLocalAssignment("B", mkExecutorInfoList(6, 5, 4, 3, 2, 1), mkWorkerResources(100.0, 100.0, 100.0));
+
+        LocalAssignment c = mkLocalAssignment("C", mkExecutorInfoList(188, 261),mkWorkerResources(400.0,10000.0,0.0));
+
+        WorkerResources workerResources = mkWorkerResources(400.0, 10000.0, 0.0);
+        Map<String, Double> additionalResources = workerResources.get_resources();
+        if( additionalResources == null) additionalResources = new HashMap<>();
+        additionalResources.put("network.resource.units", 0.0);
+
+        workerResources.set_resources(additionalResources);
+        LocalAssignment cReordered = mkLocalAssignment("C", mkExecutorInfoList(188, 261), workerResources);
+
+        assertTrue(EquivalenceUtils.areLocalAssignmentsEquivalent(c,cReordered));
+        assertTrue(EquivalenceUtils.areLocalAssignmentsEquivalent(null, null));
+        assertTrue(EquivalenceUtils.areLocalAssignmentsEquivalent(a, a));
+        assertTrue(EquivalenceUtils.areLocalAssignmentsEquivalent(b, bReordered));
+        assertTrue(EquivalenceUtils.areLocalAssignmentsEquivalent(bReordered, b));
+
+        assertFalse(EquivalenceUtils.areLocalAssignmentsEquivalent(a, aResized));
+        assertFalse(EquivalenceUtils.areLocalAssignmentsEquivalent(aResized, a));
+        assertFalse(EquivalenceUtils.areLocalAssignmentsEquivalent(a, null));
+        assertFalse(EquivalenceUtils.areLocalAssignmentsEquivalent(null, b));
+        assertFalse(EquivalenceUtils.areLocalAssignmentsEquivalent(a, b));
+    }
+}

--- a/storm-server/src/test/java/org/apache/storm/utils/EquivalenceUtilsTest.java
+++ b/storm-server/src/test/java/org/apache/storm/utils/EquivalenceUtilsTest.java
@@ -116,6 +116,8 @@ public class EquivalenceUtilsTest {
         WorkerResources resourcesOffHeapMemNull = mkWorkerResources(100.0, 100.0,null);
         WorkerResources resourcesOffHeapMemZero = mkWorkerResources(100.0, 100.0,0.0);
         assertTrue(EquivalenceUtils.customWorkerResourcesEquality(resourcesOffHeapMemNull, resourcesOffHeapMemZero));
+
+        assertFalse(EquivalenceUtils.customWorkerResourcesEquality(resourcesOffHeapMemNull, null));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

When a local assignment changes for a slot, the blob references are not updated. This causes a mismatch between the slot PNA and the blob reference PNA. When the topology is killed, the blob tries to remove the slot PNA and cannot find the reference. The AsyncLocalizer still has the old slot PNA as a reference, so cannot release the blob.

The local assignment could change due to a reordering of the same executors on a nimbus restart or something similar.

The fix is basically removeReference() changes in LocallyCachedBlob.  We make sure that we are checking for an equivalent PNA object instead of equals.  Additional logging was also added to track down this issue.  I think it's not excessive and considering how long this problem has existed, important to have.

## How was the change tested

Ran storm-server unit tests.  This change has been tested internally by running integration tests and on our staging clusters for a couple weeks and validated that we no longer get AsyncLocalizer alerts for this condition. 
