### PR TITLE
[STORM-3735] Register NodeInfo class to Kyro

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/serialization/SerializationFactory.java
+++ b/storm-client/src/jvm/org/apache/storm/serialization/SerializationFactory.java
@@ -32,6 +32,7 @@ import java.util.ServiceLoader;
 import java.util.TreeMap;
 import org.apache.storm.Config;
 import org.apache.storm.generated.ComponentCommon;
+import org.apache.storm.generated.NodeInfo;
 import org.apache.storm.generated.StormTopology;
 import org.apache.storm.messaging.netty.BackPressureStatus;
 import org.apache.storm.serialization.types.ArrayListSerializer;
@@ -75,6 +76,7 @@ public class SerializationFactory {
         k.register(org.apache.storm.metric.api.IMetricsConsumer.TaskInfo.class);
         k.register(ConsList.class);
         k.register(BackPressureStatus.class);
+        k.register(NodeInfo.class);
 
         synchronized (loader) {
             for (SerializationRegister sr : loader) {


### PR DESCRIPTION
## What is the purpose of the change

Explained in https://issues.apache.org/jira/browse/STORM-3735. 
```
2021-01-13 20:16:37.030 o.a.s.u.Utils Thread-16-__system-executor[-1, -1] [ERROR] Async loop died!
java.lang.RuntimeException: com.esotericsoftware.kryo.KryoException: java.lang.IllegalArgumentException: Class is not registered: org.apache.storm.generated.NodeInfo
Note: To register this class use: kryo.register(org.apache.storm.generated.NodeInfo.class);
Serialization trace:
value (org.apache.storm.metric.api.IMetricsConsumer$DataPoint)
        at org.apache.storm.executor.Executor.accept(Executor.java:294) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.utils.JCQueue.consumeImpl(JCQueue.java:113) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.utils.JCQueue.consume(JCQueue.java:89) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.executor.bolt.BoltExecutor$1.call(BoltExecutor.java:159) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.executor.bolt.BoltExecutor$1.call(BoltExecutor.java:145) ~[storm-client-2.3.0.y.jar:2.3.0.y]
        at org.apache.storm.utils.Utils$1.run(Utils.java:401) [storm-client-2.3.0.y.jar:2.3.0.y]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_262]
Caused by: com.esotericsoftware.kryo.KryoException: java.lang.IllegalArgumentException: Class is not registered: org.apache.storm.generated.NodeInfo
Note: To register this class use: kryo.register(org.apache.storm.generated.NodeInfo.class);
Serialization trace:
value (org.apache.storm.metric.api.IMetricsConsumer$DataPoint)
...
```

## How was the change tested

With the same steps to reproduce this issue, it worked after applying this code change.
