### PR TITLE
[STORM-3741] change version of surefire plugin to 2.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
         <joda-time.version>2.3</joda-time.version>
         <thrift.version>0.13.0</thrift.version>
         <junit.jupiter.version>5.5.1</junit.jupiter.version>
-        <surefire.version>2.22.1</surefire.version>
+        <surefire.version>2.22.2</surefire.version>
         <awaitility.version>3.1.0</awaitility.version>
         <hdrhistogram.version>2.1.10</hdrhistogram.version>
         <hamcrest.version>2.0.0.0</hamcrest.version>


### PR DESCRIPTION
## What is the purpose of the change

*Older version causes corruption in STDOUT and copious output with reuseForks=true*

## How was the change tested

*Run "mvn test"*