### PR TITLE
[STORM-3744] Change pom.xml so that shaded classes are visible within IntelliJ IDE

### DIFF
--- a/storm-shaded-deps/pom.xml
+++ b/storm-shaded-deps/pom.xml
@@ -297,6 +297,28 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${basedir}/target/storm-shaded-deps-${project.version}.jar</file>
+                                    <type>jar</type>
+                                    <classifier>optional</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION

## What is the purpose of the change

*Shaded classes are not visible within IntelliJ IDE*

## How was the change tested

*Debug a test class in storm-server within the IntelliJ IDE*