### PR TITLE
exclude org.glassfish.web:javax.servlet.jsp from storm-autocreds hbase-server dependency

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -596,11 +596,9 @@ List of third-party dependencies grouped by their license type.
     Common Development and Distribution License
 
         * Expression Language 3.0 (org.glassfish:javax.el:3.0.0 - http://el-spec.java.net)
-        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b12 - http://uel.java.net)
         * JavaServer Pages(TM) API (javax.servlet.jsp:javax.servlet.jsp-api:2.3.1 - http://jsp.java.net)
         * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
         * javax.annotation API (javax.annotation:javax.annotation-api:1.3.2 - http://jcp.org/en/jsr/detail?id=250)
-        * JSP implementation (org.glassfish.web:javax.servlet.jsp:2.3.2 - http://jsp.java.net)
 
     Common Development and Distribution License (CDDL) v1.0
 

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -964,10 +964,8 @@ The license texts of these dependencies can be found in the licenses directory.
     Common Development and Distribution License
 
         * Expression Language 3.0 (org.glassfish:javax.el:3.0.0 - http://el-spec.java.net)
-        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b12 - http://uel.java.net)
         * JavaServer Pages(TM) API (javax.servlet.jsp:javax.servlet.jsp-api:2.3.1 - http://jsp.java.net)
         * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
-        * JSP implementation (org.glassfish.web:javax.servlet.jsp:2.3.2 - http://jsp.java.net)
         * javax.annotation API (javax.annotation:javax.annotation-api:1.3.2 - http://jcp.org/en/jsr/detail?id=250)
 
     Common Development and Distribution License (CDDL) v1.0

--- a/external/storm-autocreds/pom.xml
+++ b/external/storm-autocreds/pom.xml
@@ -135,6 +135,10 @@
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.web</groupId>
+                    <artifactId>javax.servlet.jsp</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What is the purpose of the change

The failure is to avoid
`[ERROR] Failed to execute goal on project storm-autocreds: Could not resolve dependencies for project org.apache.storm:storm-autocreds:jar:2.3.0-SNAPSHOT: Failed to collect dependencies at org.apache.hbase:hbase-server:jar:2.1.3 -> org.glassfish.web:javax.servlet.jsp:jar:2.3.2 -> org.glassfish:javax.el:jar:3.0.1-b06-SNAPSHOT: Failed to read artifact descriptor for org.glassfish:javax.el:jar:3.0.1-b06-SNAPSHOT: Failure to transfer org.glassfish:javax.el:pom:3.0.1-b06-SNAPSHOT from https://maven.java.net/content/repositories/snapshots was cached in the local repository, resolution will not be reattempted until the update interval of jvnet-nexus-snapshots has elapsed or updates are forced. Original error: Could not transfer artifact org.glassfish:javax.el:pom:3.0.1-b06-SNAPSHOT from/to jvnet-nexus-snapshots (https://maven.java.net/content/repositories/snapshots): Transfer failed for https://maven.java.net/content/repositories/snapshots/org/glassfish/javax.el/3.0.1-b06-SNAPSHOT/javax.el-3.0.1-b06-SNAPSHOT.pom -> [Help 1]`


## How was the change tested

*(Explain what tests did you do to verify the code change)*