### PR TITLE
STORM-3748 use ConcurrentHashMap for taskId metrics

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/metrics2/StormMetricRegistry.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/StormMetricRegistry.java
@@ -198,7 +198,7 @@ public class StormMetricRegistry implements MetricRegistryProvider {
 
     private static <T extends Metric> void saveMetricTaskIdMapping(Integer taskId, MetricNames names, T metric, Map<Integer,
             Map<String, T>> taskIdMetrics) {
-        Map<String, T> metrics = taskIdMetrics.computeIfAbsent(taskId, (tid) -> new HashMap<>());
+        Map<String, T> metrics = taskIdMetrics.computeIfAbsent(taskId, (tid) -> new ConcurrentHashMap<>());
         metrics.put(names.getShortName(), metric);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Prevent ConcurrentModificationExceptions when reporting metrics while adding a new metric.

## How was the change tested

built storm-client