### PR TITLE
STORM-3759 Additonal Trident Kafka Spout Metrics

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutEmitter.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutEmitter.java
@@ -115,7 +115,7 @@ public class KafkaTridentSpoutEmitter<K, V> implements Serializable {
     }
 
     /**
-     * Acquires metric instances through registration with the TopologyContext
+     * Acquires metric instances through registration with the TopologyContext.
      */
     private void registerMetric() {
         LOG.info("Registering Spout Metrics");
@@ -193,10 +193,12 @@ public class KafkaTridentSpoutEmitter<K, V> implements Serializable {
                     break;
                 }
                 if (record.offset() > currBatchMeta.getLastOffset()) {
-                    throw new RuntimeException(String.format("Error when re-emitting batch. Overshot the end of the batch."
-                                                             + " The batch end offset was [{%d}], but received [{%d}]."
-                                                             + " Ensure log compaction is disabled in Kafka, since it is incompatible with non-opaque transactional spouts.",
-                                                             currBatchMeta.getLastOffset(), record.offset()));
+                    throw new RuntimeException(String.format(
+                        "Error when re-emitting batch. Overshot the end of the batch."
+                        + " The batch end offset was [{%d}], but received [{%d}]."
+                        + " Ensure log compaction is disabled in Kafka, since it is"
+                        + " incompatible with non-opaque transactional spouts.",
+                        currBatchMeta.getLastOffset(), record.offset()));
                 }
                 emitTuple(collector, record);
             }
@@ -269,9 +271,10 @@ public class KafkaTridentSpoutEmitter<K, V> implements Serializable {
     private void throwIfEmittingForUnassignedPartition(TopicPartition currBatchTp) {
         final Set<TopicPartition> assignments = consumer.assignment();
         if (!assignments.contains(currBatchTp)) {
-            throw new IllegalStateException("The spout is asked to emit tuples on a partition it is not assigned."
-                                            + " This indicates a bug in the TopicFilter or ManualPartitioner implementations."
-                                            + " The current partition is [" + currBatchTp + "], the assigned partitions are [" + assignments + "].");
+            throw new IllegalStateException(
+                "The spout is asked to emit tuples on a partition it is not assigned."
+                + " This indicates a bug in the TopicFilter or ManualPartitioner implementations."
+                + " The current partition is [" + currBatchTp + "], the assigned partitions are [" + assignments + "].");
         }
     }
 

--- a/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutEmitterEmitTest.java
+++ b/external/storm-kafka-client/src/test/java/org/apache/storm/kafka/spout/trident/KafkaTridentSpoutEmitterEmitTest.java
@@ -85,7 +85,7 @@ public class KafkaTridentSpoutEmitterEmitTest {
     @BeforeEach
     public void setUp() {
         when(topologyContextMock.getStormId()).thenReturn(topologyId);
-        when(topologyContextMock.registerMeter(KafkaTridentSpoutEmitter.EVENT_COUNT_METRIC_NAME))
+        when(topologyContextMock.registerMeter(KafkaTridentSpoutEmitter.EVENT_EMIT_METRIC_NAME))
             .thenReturn(new Meter());
         consumer.assign(Collections.singleton(partition));
         consumer.updateBeginningOffsets(Collections.singletonMap(partition, firstOffsetInKafka));


### PR DESCRIPTION
## What is the purpose of the change

The Trident Kafka Spout/Emitter does not measure a few metrics that my team has found useful over the years using the spout.  This PR adds these couple metrics back to the open source.

1. **Event emit rate**
Having a count of how many events are being emitted by the spout can track the rate at which the spout is consuming from the kafka topic(s).  If this rate decreases, it signals performance issues to investigate.
(@kishorvpatil suggested using a meter here.  The initial thought was to just use a Counter or a Gauge which resets to 0 every time getValue() is called)

2. **Kafka Spout Max Lag**
This gauge value monitors the backlog of events to determine if the spout is not emitting fast enough to keep up with the incoming data or if the spout is current and Kafka topic delayed.  This metric can be used to distinguish between these two cases and determine the source of the slowdown.

## How was the change tested
The unit tests for the emitter verify the counts match the expected values.
Additionally, my team compiled the storm-kafka-client package and included it as a dependency in our project.  After launching our topologies, we verified that the metric values on our YAMAS charts matched the equivalent metrics we had hardcoded into our custom Kafka emitter.
