### PR TITLE
[MINOR] Fix dependency licenses

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -597,7 +597,7 @@ List of third-party dependencies grouped by their license type.
     Common Development and Distribution License
 
         * Expression Language 3.0 (org.glassfish:javax.el:3.0.0 - http://el-spec.java.net)
-        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b11 - http://uel.java.net)
+        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b12 - http://uel.java.net)
         * JavaServer Pages(TM) API (javax.servlet.jsp:javax.servlet.jsp-api:2.3.1 - http://jsp.java.net)
         * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
         * javax.annotation API (javax.annotation:javax.annotation-api:1.3.2 - http://jcp.org/en/jsr/detail?id=250)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -966,7 +966,7 @@ The license texts of these dependencies can be found in the licenses directory.
     Common Development and Distribution License
 
         * Expression Language 3.0 (org.glassfish:javax.el:3.0.0 - http://el-spec.java.net)
-        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b11 - http://uel.java.net)
+        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b12 - http://uel.java.net)
         * JavaServer Pages(TM) API (javax.servlet.jsp:javax.servlet.jsp-api:2.3.1 - http://jsp.java.net)
         * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
         * JSP implementation (org.glassfish.web:javax.servlet.jsp:2.3.2 - http://jsp.java.net)


### PR DESCRIPTION
## What is the purpose of the change

Travis build failed due to 
```
Checking DEPENDENCY-LICENSES
DEPENDENCY-LICENSES and target/DEPENDENCY-LICENSES are different. Please update DEPENDENCY-LICENSES by running 'mvn license:aggregate-add-third-party@generate-and-check-licenses -Dlicense.skipAggregateAddThirdParty=false -B' in the project root
Dependencies in LICENSE-binary that appear unused: 
org.glassfish:javax.el:3.0.1-b11
Dependencies missing from LICENSE-binary: 
org.glassfish:javax.el:3.0.1-b12
LICENSE-binary needs to be updated. Please remove any unnecessary dependencies from LICENSE-binary, and add any that are missing. You can copy any missing dependencies from DEPENDENCY-LICENSES
Some license files are not up to date, see above for the relevant error message
```
https://travis-ci.com/github/apache/storm/jobs/491820158


## How was the change tested

Run `mvn license:aggregate-add-third-party@generate-and-check-licenses -Dlicense.skipAggregateAddThirdParty=false -B` as suggested to regenerate DEPENDENCY-LICENSES. And fix LICENSE-binary according to DEPENDENCY-LICENSES