### PR TITLE
[STORM-3764] Fix NPE in SchedulingSearcherState.backtrack()

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
@@ -527,7 +527,7 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
             if (execIndex == 0) {
                 break;
             } else {
-                searcherState.backtrack(execToComp, nodeForExec[execIndex - 1], workerSlotForExec[execIndex - 1]);
+                searcherState.backtrack(execToComp, nodeForExec, workerSlotForExec);
                 progressIdxForExec[execIndex] = -1;
             }
         }

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/SchedulingSearcherState.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/SchedulingSearcherState.java
@@ -282,9 +282,34 @@ public class SchedulingSearcherState {
         return 0;
     }
 
-    public void backtrack(Map<ExecutorDetails, String> execToComp, RasNode node, WorkerSlot workerSlot) {
+    /**
+     * Backtrack to prior executor that was directly assigned. This excludes bound-ackers.
+     *
+     * @param execToComp map from executor to component.
+     * @param nodesForExec array of nodes for all execIndex - has null values for bound-acker indices.
+     * @param workerSlotForExec array of workerSlots for all execIndex - has null values for bound-acker indices.
+     */
+    public void backtrack(Map<ExecutorDetails, String> execToComp, RasNode[] nodesForExec, WorkerSlot[] workerSlotForExec) {
         execIndex--;
-        // when backtrack, we need to skip over the bound ackers
+        /*
+          After decrementing execIndex, it is expected to point to the target executor to backtrack to.
+          However, due to the way assignment occurs, this is not the case. Executors are ordered in the following
+          sequence
+                   - Non-Acker-Executor
+                   - Bound-Ackers
+                   - Unbound-Ackers
+          However, Assignment is in the following order:
+                   - repeated sequence of:
+                       - Non-Acker-Executor
+                       - Its-Bound-Ackers
+                   - Unbound-Ackers (if any left over)
+          Additionally, execIndex is only updated when Non-Acker-Executor and Unbound-Executors are assigned.
+          To ensure that the counting is correct, the execIndex is incremented when Bound-Ackers are encountered.
+          However, nodesForExec and workerSlotForExec are not set for bound-ackers, and the execIndex value gets in sync
+          after all the bound-ackers are skipped.
+         */
+
+        // back over any executors that were not assigned directly - i.e. bound-ackers
         while (execIndex >= 0 && boundAckers.contains(execs.get(execIndex))) {
             execIndex--;
         }
@@ -294,6 +319,8 @@ public class SchedulingSearcherState {
         numBacktrack++;
         ExecutorDetails exec = currentExec();
         String comp = execToComp.get(exec);
+        RasNode node = nodesForExec[execIndex];
+        WorkerSlot workerSlot = workerSlotForExec[execIndex];
         LOG.trace("Topology {} Backtracking {} {} from {}", topoName, exec, comp, workerSlot);
         if (okToRemoveFromWorker[execIndex]) {
             Map<String, Integer> compToAssignmentCount = workerCompAssignmentCnts.get(workerSlot);
@@ -316,6 +343,7 @@ public class SchedulingSearcherState {
         // If this exec has bound ackers, we need to backtrack them as well
         if (execsWithBoundAckers.remove(exec)) {
             if (workerSlotToBoundAckers.containsKey(workerSlot)) {
+                // Note that bound-ackers for this (and only this) executor are on the workerSlot
                 freeWorkerSlotWithBoundAckers(node, workerSlot);
             }
         }
@@ -351,10 +379,11 @@ public class SchedulingSearcherState {
     }
 
     /**
-     * Free a given workerSlot and all the assigned bound ackers already there.
+     * Free the bound-ackers for the given node and workerSlot.
+     * All the bound-ackers for an executor (and only that executor) are on the same workerSlot.
      *
-     * @param node          RasNode which to be freed.
-     * @param workerSlot    WorkerSlot on which to schedule.
+     * @param node          RasNode to be freed.
+     * @param workerSlot    WorkerSlot to be freed.
      */
     public void freeWorkerSlotWithBoundAckers(RasNode node, WorkerSlot workerSlot) {
         List<ExecutorDetails> ackers = workerSlotToBoundAckers.get(workerSlot);
@@ -378,6 +407,7 @@ public class SchedulingSearcherState {
                     nodeToAssignmentCount.remove(ackerCompId);
                 }
             }
+            // Note: all the bound-ackers for the same executor (and no other) are on one workerSlot
             workerSlotToBoundAckers.remove(workerSlot);
             node.free(workerSlot);
         }

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestGenericResourceAwareStrategy.java
@@ -608,4 +608,61 @@ public class TestGenericResourceAwareStrategy {
 
         //We don't really care too much about the scheduling of topology-gpu-0, because it was scheduled.
     }
+
+    @Test
+    public void testScheduleLeftOverAckers() throws Exception {
+        int spoutParallelism = 1;
+        TopologyBuilder builder = new TopologyBuilder();
+        builder.setSpout("spout", new TestSpout(), spoutParallelism);
+
+        String topoName = "testTopology";
+        StormTopology stormToplogy = builder.createTopology();
+
+        INimbus iNimbus = new INimbusTest();
+        Config conf = createGrasClusterConfig(50, 400, 0, null, Collections.emptyMap());
+
+        Map<String, SupervisorDetails> supMap = genSupervisors(1, 1, 100, 1100);
+        Map<String, SupervisorDetails> tmpSupMap = genSupervisors(2, 1, 100, 400);
+        supMap.put("r000s001", tmpSupMap.get("r000s001"));
+        LOG.info("{}",  tmpSupMap.get("r000s001"));
+
+        conf.put(Config.TOPOLOGY_PRIORITY, 0);
+        conf.put(Config.TOPOLOGY_NAME, topoName);
+        conf.put(Config.TOPOLOGY_WORKER_MAX_HEAP_SIZE_MB, 1000);
+        conf.put(Config.TOPOLOGY_SUBMITTER_USER, "user");
+        conf.put(Config.TOPOLOGY_ACKER_EXECUTORS, 2);
+        conf.put(Config.TOPOLOGY_RAS_ACKER_EXECUTORS_PER_WORKER, 1);
+
+        conf.put(Config.TOPOLOGY_ACKER_RESOURCES_ONHEAP_MEMORY_MB, 500);
+        conf.put(Config.TOPOLOGY_ACKER_CPU_PCORE_PERCENT, 0);
+
+        TopologyDetails topo = new TopologyDetails("testTopology-id", conf, stormToplogy, 0,
+            genExecsAndComps(StormCommon.systemTopology(conf, stormToplogy)), currentTime, "user");
+
+        Topologies topologies = new Topologies(topo);
+        Cluster cluster = new Cluster(iNimbus, new ResourceMetrics(new StormMetricsRegistry()), supMap, new HashMap<>(), topologies, conf);
+
+        scheduler = new ResourceAwareScheduler();
+
+        scheduler.prepare(conf, new StormMetricsRegistry());
+        scheduler.schedule(topologies, cluster);
+
+        // First it tries too schedule spout [0, 0] with a bound acker [1, 1] to sup1 r000s000.
+        // However, sup2 r000s001 only has 400 on-heap mem which can not fit the left over acker [2, 2]
+        // So it backtrack to [0, 0] and put it to sup2 r000s001.
+        // Then put two ackers both as left-over ackers to sup1 r000s000.
+        HashSet<HashSet<ExecutorDetails>> expectedScheduling = new HashSet<>();
+        expectedScheduling.add(new HashSet<>(Arrays.asList(
+            new ExecutorDetails(0, 0))));   // spout
+        expectedScheduling.add(new HashSet<>(Arrays.asList(
+            new ExecutorDetails(1, 1),      // acker
+            new ExecutorDetails(2, 2))));   // acker
+
+        HashSet<HashSet<ExecutorDetails>> foundScheduling = new HashSet<>();
+        SchedulerAssignment assignment = cluster.getAssignmentById("testTopology-id");
+        for (Collection<ExecutorDetails> execs : assignment.getSlotToExecutors().values()) {
+            foundScheduling.add(new HashSet<>(execs));
+        }
+        assertEquals(expectedScheduling, foundScheduling);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

*While backtracking in scheduling code, Ackers are skipped. However, under certain circumstances a null WorkerSlot is passed as parameter to SchedulingSearcherState.backtrack(). This null key is used to retrieve an entry from Map. The returned null map value causes NPE*

## How was the change tested

*new unit test TestGenericResourceAwareStrategy.testScheduleLeftOverAckers()*