### PR TITLE
[STORM-3765] fix NPE when drpc.authorizer.acl has no values

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/DRPCSimpleACLAuthorizer.java
@@ -52,25 +52,28 @@ public class DRPCSimpleACLAuthorizer extends DRPCAuthorizerBase {
             Map<String, AclFunctionEntry> acl = new HashMap<>();
             Map<String, Object> conf = Utils.findAndReadConfigFile(aclFileName);
             if (conf.containsKey(Config.DRPC_AUTHORIZER_ACL)) {
-                Map<String, Map<String, ?>> confAcl =
-                    (Map<String, Map<String, ?>>)
-                        conf.get(Config.DRPC_AUTHORIZER_ACL);
+                Map<String, Map<String, ?>> confAcl = (Map<String, Map<String, ?>>) conf.get(Config.DRPC_AUTHORIZER_ACL);
 
-                for (Map.Entry<String, Map<String, ?>> entry : confAcl.entrySet()) {
-                    Map<String, ?> val = entry.getValue();
-                    Collection<String> clientUsers = val.containsKey(CLIENT_USERS_KEY)
-                            ? (Collection<String>) val.get(CLIENT_USERS_KEY)
-                            : null;
-                    String invocationUser = val.containsKey(INVOCATION_USER_KEY)
-                            ? (String) val.get(INVOCATION_USER_KEY)
-                            : null;
-                    acl.put(entry.getKey(),
-                            new AclFunctionEntry(clientUsers, invocationUser));
+                if (confAcl != null) {
+                    for (Map.Entry<String, Map<String, ?>> entry : confAcl.entrySet()) {
+                        Map<String, ?> val = entry.getValue();
+                        Collection<String> clientUsers = val.containsKey(CLIENT_USERS_KEY)
+                                ? (Collection<String>) val.get(CLIENT_USERS_KEY)
+                                : null;
+                        String invocationUser = val.containsKey(INVOCATION_USER_KEY)
+                                ? (String) val.get(INVOCATION_USER_KEY)
+                                : null;
+                        acl.put(entry.getKey(),
+                                new AclFunctionEntry(clientUsers, invocationUser));
+                    }
                 }
-            } else if (!permitWhenMissingFunctionEntry) {
+            }
+
+            this.acl = acl;
+            if (this.acl.isEmpty() && !permitWhenMissingFunctionEntry) {
                 LOG.warn("Requiring explicit ACL entries, but none given. Therefore, all operations will be denied.");
             }
-            this.acl = acl;
+
             lastUpdate = System.currentTimeMillis();
         }
         return acl;


### PR DESCRIPTION
## What is the purpose of the change

When drpc.authorizer.acl is set up with no values, like below,
```
-bash-4.2$ cat drpc-auth-acl.yaml
drpc.authorizer.acl:
```

DRPCSimpleACLAuthorizer will have NPE

## How was the change tested

Tested with different setup, including 

#### 1) drpc-auth-acl.yaml is empty. With or without code change, DRPC has the following exception (expected)
```
2021-04-22 15:31:32.746 o.a.s.t.ProcessFunction pool-9-thread-3 [ERROR] Internal error processing fetchRequest
java.lang.RuntimeException: Config file drpc-auth-acl.yaml doesn't have any valid storm configs
        at org.apache.storm.utils.Utils.findAndReadConfigFile(Utils.java:xxx) 
```
#### 2) drpc-auth-acl.yaml is 
```
drpc.authorizer.acl :
```
it worked well. 
If `drpc.authorizer.acl.strict` is set `true`, we will see
```
2021-04-22 15:27:27.871 o.a.s.s.a.a.DRPCSimpleACLAuthorizer pool-9-thread-1 [WARN] Requiring explicit ACL entries, but none given. Therefore, all operations will be denied.
```
#### 3)  drpc-auth-acl.yaml has values, like
```
-bash-4.2$ cat drpc-auth-acl.yaml

drpc.authorizer.acl:
  words:
    client.users:
      - "user1"
    invocation.user: "user1"
``` 
worked well.

Added unit tests