### PR TITLE
[STORM-3762] Set a default character set in InputStreamReader to solv…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/metric/cgroup/CGroupCpu.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/cgroup/CGroupCpu.java
@@ -15,6 +15,7 @@ package org.apache.storm.metric.cgroup;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.storm.container.cgroup.SubSystemType;
@@ -39,7 +40,7 @@ public class CGroupCpu extends CGroupMetricsBase<Map<String, Long>> {
         if (userHz < 0) {
             ProcessBuilder pb = new ProcessBuilder("getconf", "CLK_TCK");
             Process p = pb.start();
-            BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8));
             String line = in.readLine().trim();
             userHz = Integer.valueOf(line);
         }

--- a/storm-client/src/jvm/org/apache/storm/utils/ShellUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ShellUtils.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -227,11 +228,13 @@ public abstract class ShellUtils {
             timeOutTimer.schedule(timeoutTimerTask, timeOutInterval);
         }
         final BufferedReader errReader =
-            new BufferedReader(new InputStreamReader(process
-                                                         .getErrorStream()));
+            new BufferedReader(
+                new InputStreamReader(
+                    process.getErrorStream(), StandardCharsets.UTF_8));
         BufferedReader inReader =
-            new BufferedReader(new InputStreamReader(process
-                                                         .getInputStream()));
+            new BufferedReader(
+                new InputStreamReader(
+                    process.getInputStream(), StandardCharsets.UTF_8));
         final StringBuffer errMsg = new StringBuffer();
 
         // read error and input streams as this would free up the buffers

--- a/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
@@ -33,6 +33,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -808,7 +809,7 @@ public class ServerUtils {
         LOG.debug("CMD: tasklist /fo list /fi \"pid eq {}\" /v", pid);
         ProcessBuilder pb = new ProcessBuilder("tasklist", "/fo", "list", "/fi", "pid eq " + pid, "/v");
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream()))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream(), StandardCharsets.UTF_8))) {
             int lineNo = 0;
             String line;
             while ((line = in.readLine()) != null) {
@@ -842,7 +843,7 @@ public class ServerUtils {
         LOG.debug("CMD: ps -o user -p {}", pid);
         ProcessBuilder pb = new ProcessBuilder("ps", "-o", "user", "-p", String.valueOf(pid));
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream()))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream(), StandardCharsets.UTF_8))) {
             int lineNo = 1;
             String line = in.readLine();
             LOG.debug("CMD-LINE#{}: {}", lineNo, line);
@@ -928,7 +929,7 @@ public class ServerUtils {
         ProcessBuilder pb = new ProcessBuilder(cmdArgs);
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
         List<String> unexpectedUsers = new ArrayList<>();
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream()))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream(), StandardCharsets.UTF_8))) {
             int lineNo = 0;
             String line;
             while ((line = in.readLine()) != null) {
@@ -993,7 +994,7 @@ public class ServerUtils {
         ProcessBuilder pb = new ProcessBuilder("ps", "-o", "user", "-p", pidParams);
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
         List<String> unexpectedUsers = new ArrayList<>();
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream()))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream(), StandardCharsets.UTF_8))) {
             int lineNo = 1;
             String line = in.readLine();
             LOG.debug("CMD-LINE#{}: {}", lineNo, line);
@@ -1037,7 +1038,7 @@ public class ServerUtils {
         ProcessBuilder pb = new ProcessBuilder("ps", "-o", "uid", "-p", pidParams);
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
         List<String> unexpectedUsers = new ArrayList<>();
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream()))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream(), StandardCharsets.UTF_8))) {
             int lineNo = 1;
             String line = in.readLine();
             LOG.debug("CMD-LINE#{}: {}", lineNo, line);
@@ -1091,7 +1092,7 @@ public class ServerUtils {
         LOG.debug("CMD: {}", String.join(" ", cmdArgs));
         ProcessBuilder pb = new ProcessBuilder(cmdArgs);
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream()))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream(), StandardCharsets.UTF_8))) {
             String line = in.readLine();
             LOG.debug("CMD-LINE#1: {}", line);
             try {
@@ -1125,7 +1126,7 @@ public class ServerUtils {
         LOG.debug("CMD: ls -dn {}", fpath);
         ProcessBuilder pb = new ProcessBuilder("ls", "-dn", fpath);
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream()))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(pb.start().getInputStream(), StandardCharsets.UTF_8))) {
             String line = in.readLine();
             LOG.debug("CMD-OUTLINE: {}", line);
             line = line.trim();


### PR DESCRIPTION
…e potential garbled problems

When a InputStreamReader is used, the parameter setting of a default character set is recommended to solve potential garbled problem.