### PR TITLE
STORM-3769 prevent topology blobs from being considered downloaded if…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
@@ -337,6 +337,12 @@ public class ConfigUtils {
         return (topologyId + "-stormconf.ser");
     }
 
+    /**
+     * Returns the topology ID belonging to a blob key if it exists.
+     *
+     * @param key the blob key
+     * @return the topology id belonging to the key if it can be inferred.  Returns null otherwise.
+     */
     public static String getIdFromBlobKey(String key) {
         if (key == null) {
             return null;

--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -630,14 +630,23 @@ public class AsyncLocalizer implements AutoCloseable {
             }
 
             toClean.addResources(topologyBlobs);
+            Set<String> topologiesWithDeletes = new HashSet<>();
             try (ClientBlobStore store = getClientBlobStore()) {
-                toClean.cleanup(store);
+                Set<LocallyCachedBlob> deletedBlobs = toClean.cleanup(store);
+                for (LocallyCachedBlob deletedBlob : deletedBlobs) {
+                    String topologyId = ConfigUtils.getIdFromBlobKey(deletedBlob.getKey());
+                    if (topologyId != null) {
+                        topologiesWithDeletes.add(topologyId);
+                    }
+                }
             }
 
             HashSet<String> safeTopologyIds = new HashSet<>();
             for (String blobKey : topologyBlobs.keySet()) {
                 safeTopologyIds.add(ConfigUtils.getIdFromBlobKey(blobKey));
             }
+            LOG.debug("Topologies {} can no longer be considered fully downloaded", topologiesWithDeletes);
+            safeTopologyIds.removeAll(topologiesWithDeletes);
 
             //Deleting this early does not hurt anything
             topologyBasicDownloaded.keySet().removeIf(topoId -> !safeTopologyIds.contains(topoId));


### PR DESCRIPTION
… any of their blobs was deleted

## What is the purpose of the change

Without this change it is possible to delete just 1 or 2 of the 3 topology blobs and still consider the topology as "safely downloaded" in safeTopologyIds.  This change properly removes them from the map after deletion.

## How was the change tested

Ran storm-server and storm-core unit tests.  Ran blob related integration tests on an internal test cluster.