### PR TITLE
STORM-3775 validate optional boolean fields in topology.blobstore.map

### DIFF
--- a/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
+++ b/storm-client/test/jvm/org/apache/storm/TestConfigValidate.java
@@ -136,7 +136,7 @@ public class TestConfigValidate {
     }
 
     @Test(expected = InvalidTopologyException.class)
-    public void testValidateTopologyBlobStoreMapWithNimbusBlobStore() throws InvalidTopologyException, AuthorizationException,
+    public void testValidateTopologyBlobStoreMissingKey() throws InvalidTopologyException, AuthorizationException,
         KeyNotFoundException {
         Map<String, Object> topoConf = new HashMap<>();
         Map<String, Map> topologyMap = new HashMap<>();
@@ -147,6 +147,40 @@ public class TestConfigValidate {
         NimbusBlobStore nimbusBlobStoreMock = mock(NimbusBlobStore.class);
         when(nimbusBlobStoreMock.getBlobMeta("key1")).thenReturn(null);
         when(nimbusBlobStoreMock.getBlobMeta("key2")).thenThrow(new KeyNotFoundException());
+
+        Utils.validateTopologyBlobStoreMap(topoConf, nimbusBlobStoreMock);
+    }
+
+    @Test
+    public void testValidateTopologyBlobStoreMap() throws InvalidTopologyException, AuthorizationException,
+            KeyNotFoundException {
+        Map<String, Object> topoConf = new HashMap<>();
+        Map<String, Map> topologyMap = new HashMap<>();
+        Map<String, Object> blobConf = new HashMap<>();
+        blobConf.put("uncompress", false);
+        topologyMap.put("key1", blobConf);
+        topologyMap.put("key2", blobConf);
+        topoConf.put(Config.TOPOLOGY_BLOBSTORE_MAP, topologyMap);
+
+        NimbusBlobStore nimbusBlobStoreMock = mock(NimbusBlobStore.class);
+        when(nimbusBlobStoreMock.getBlobMeta("key1")).thenReturn(null);
+        when(nimbusBlobStoreMock.getBlobMeta("key2")).thenReturn(null);
+
+        Utils.validateTopologyBlobStoreMap(topoConf, nimbusBlobStoreMock);
+    }
+
+    @Test(expected = InvalidTopologyException.class)
+    public void testValidateTopologyBlobStoreMapInvalidOption() throws InvalidTopologyException, AuthorizationException,
+            KeyNotFoundException {
+        Map<String, Object> topoConf = new HashMap<>();
+        Map<String, Map> topologyMap = new HashMap<>();
+        Map<String, Object> blobConf = new HashMap<>();
+        blobConf.put("uncompress", "false");
+        topologyMap.put("key1", blobConf);
+        topologyMap.put("key2", blobConf);
+        topoConf.put(Config.TOPOLOGY_BLOBSTORE_MAP, topologyMap);
+
+        NimbusBlobStore nimbusBlobStoreMock = mock(NimbusBlobStore.class);
 
         Utils.validateTopologyBlobStoreMap(topoConf, nimbusBlobStoreMock);
     }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/SupervisorUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/SupervisorUtils.java
@@ -120,7 +120,7 @@ public class SupervisorUtils {
     }
 
     /**
-     * Given the blob information returns the value of the uncompress field, handling it either being a string or a boolean value, or if
+     * Given the blob information returns the value of the uncompress field, handling it being a boolean value, or if
      * it's not specified then returns false.
      */
     public static boolean shouldUncompressBlob(Map<String, Object> blobInfo) {
@@ -128,7 +128,7 @@ public class SupervisorUtils {
     }
 
     /**
-     * Given the blob information returns the value of the workerRestart field, handling it either being a string or a boolean value, or if
+     * Given the blob information returns the value of the workerRestart field, handling it being a boolean value, or if
      * it's not specified then returns false.
      *
      * @param blobInfo the info for the blob.


### PR DESCRIPTION
## What is the purpose of the change

Prevent invalid blobstore map conf settings from restarting supervisors.

## How was the change tested

Ran new unit tests.  Validated submission of invalid boolean setting fails topology submission.  