### PR TITLE
[STORM-3847] Fix various problems in the python PowerShell execution

### DIFF
--- a/bin/storm.ps1
+++ b/bin/storm.ps1
@@ -23,7 +23,7 @@ while((Get-Item $PRG).LinkType -eq "SymbolicLink") {
 }
 
 # Check for Python version
-$PythonVersion = (& python -V 2>&1)[0].ToString().Split(" ")[1];
+$PythonVersion = (& python -V 2>&1).Split(" ")[1];
 $PythonMajor = [int]$PythonVersion.Split(".")[0];
 $PythonMinor = [int]$PythonVersion.Split(".")[1];
 $PythonNumVersion = $PythonMajor * 10 + $PythonMinor;

--- a/bin/storm.ps1
+++ b/bin/storm.ps1
@@ -63,6 +63,7 @@ if(Test-Path $StormEnvPath) {
   . $StormEnvPath;
 }
 
-& ([io.path]::combine("$STORM_BIN_DIR", "storm.py")) $args;
+$ArgsForProcess = @(([io.path]::combine("$STORM_BIN_DIR", "storm.py"))) + $args
+Start-Process -FilePath python -ArgumentList $ArgsForProcess -Wait -NoNewWindow
 
 exit $LastExitCode

--- a/bin/storm.ps1
+++ b/bin/storm.ps1
@@ -28,7 +28,7 @@ $PythonMajor = [int]$PythonVersion.Split(".")[0];
 $PythonMinor = [int]$PythonVersion.Split(".")[1];
 $PythonNumVersion = $PythonMajor * 10 + $PythonMinor;
 if($PythonNumVersion -le 26) {
-  echo "Need python version > 2.6";
+  Write-Output "Need python version > 2.6";
   exit 1;
 }
 
@@ -40,14 +40,14 @@ if($args.Length -ge 1) {
   if("--config" -eq $args.get(0)) {
     $ConfFile = $args.get(1);
     if(-not (Test-Path $ConfFile)) {
-      echo ("Error: Path {0} does not exist" -f $ConfFile);
+      Write-Output ("Error: Path {0} does not exist" -f $ConfFile);
       exit 1;
     }
     if((Get-Item $ConfFile).PsIsContainer) {
       $ConfFile=[io.path]::combine($ConfFile, "storm.yaml");
     }
     if(-not (Test-Path $ConfFile)) {
-      echo ("Error: Path {0} does not exist" -f $ConfFile);
+      Write-Output ("Error: Path {0} does not exist" -f $ConfFile);
       exit 1;
     }
     $STORM_CONF_FILE = $ConfFile;
@@ -55,8 +55,8 @@ if($args.Length -ge 1) {
   } 
 }
 
-$env:STORM_CONF_DIR = if($STORM_CONF_DIR -ne $null) { $STORM_CONF_DIR; } else { [io.path]::combine($env:STORM_BASE_DIR, "conf"); }
-$env:STORM_CONF_FILE = if($STORM_CONF_FILE -ne $null) { $STORM_CONF_FILE; } else { [io.path]::combine($env:STORM_BASE_DIR, "conf", "storm.yaml"); }
+$env:STORM_CONF_DIR = if($null -ne $STORM_CONF_DIR) { $STORM_CONF_DIR; } else { [io.path]::combine($env:STORM_BASE_DIR, "conf"); }
+$env:STORM_CONF_FILE = if($null -ne $STORM_CONF_FILE) { $STORM_CONF_FILE; } else { [io.path]::combine($env:STORM_BASE_DIR, "conf", "storm.yaml"); }
 
 $StormEnvPath = [io.path]::combine($env:STORM_CONF_DIR, "storm-env.ps1");
 if(Test-Path $StormEnvPath) {

--- a/bin/storm.py
+++ b/bin/storm.py
@@ -255,8 +255,9 @@ def exec_storm_class(klass, storm_config_opts, jvmtype="-server", jvmopts=[],
     elif is_windows():
         # handling whitespaces in JAVA_CMD
         try:
-            ret = subprocess.check_output(all_args, stderr=subprocess.STDOUT)
-            print(ret)
+            process = subprocess.Popen(all_args, stderr=sys.stderr, stdout=sys.stdout)
+            process.wait()
+            sys.exit(process.returncode)
         except subprocess.CalledProcessError as e:
             print(e.output)
             sys.exit(e.returncode)


### PR DESCRIPTION
## What is the purpose of the change

Fixing the python version check in storm.ps1, that always fails due to wrong handling of a string.
Otherwise every windows user has to fix this file by themselves.

### Explanation
(& python -V 2>&1) already returns a string. Accessing it with `(& python -V 2>&1)[0]` returns a char. Therefore the script always fails with a NullPointerException at `[int]$PythonVersion.Split(".")[0]`.

## How was the change tested

I ran the script ([storm_python_check_test.zip](https://github.com/apache/storm/files/6776823/storm_python_check_test.zip)) and the modified storm.ps1 on my Windows 10 Pro Machine (With Python 3.9.1, OpenJDK 15).

When you execute the attached script you get the following console output:

> Original Version:
> 
> PythonVersion=
> error
> Es ist nicht möglich, eine Methode für einen Ausdruck aufzurufen, der den NULL hat.
> In <censored>\storm_python_check_test.ps1:11 Zeichen:3
> \+   $PythonMajor = [int]$PythonVersion.Split(".")[0];
> \+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>     \+ CategoryInfo          : InvalidOperation: (:) [], RuntimeException
>     \+ FullyQualifiedErrorId : InvokeMethodOnNull
> 
> Fixed Version:
> 
> PythonVersion=3.9.1
> PythonMajor=3
> PythonMinor=9
> PythonNumVersion=39

