### PR TITLE
[STORM-3785] Stop converting V2 rate metrics when adding to V1

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/executor/Executor.java
+++ b/storm-client/src/jvm/org/apache/storm/executor/Executor.java
@@ -414,27 +414,28 @@ public abstract class Executor implements Callable, JCQueue.Consumer {
     private void addMeteredDatapoints(String baseName, Metered metered, List<IMetricsConsumer.DataPoint> dataPoints) {
         IMetricsConsumer.DataPoint dataPoint = new IMetricsConsumer.DataPoint(baseName + ".count", metered.getCount());
         dataPoints.add(dataPoint);
-        addConvertedMetric(baseName, ".m1_rate", metered.getOneMinuteRate(), dataPoints);
-        addConvertedMetric(baseName, ".m5_rate", metered.getFiveMinuteRate(), dataPoints);
-        addConvertedMetric(baseName, ".m15_rate", metered.getFifteenMinuteRate(), dataPoints);
-        addConvertedMetric(baseName, ".mean_rate", metered.getMeanRate(), dataPoints);
+        addConvertedMetric(baseName, ".m1_rate", metered.getOneMinuteRate(), dataPoints, false);
+        addConvertedMetric(baseName, ".m5_rate", metered.getFiveMinuteRate(), dataPoints, false);
+        addConvertedMetric(baseName, ".m15_rate", metered.getFifteenMinuteRate(), dataPoints, false);
+        addConvertedMetric(baseName, ".mean_rate", metered.getMeanRate(), dataPoints, false);
     }
 
     private void addSnapshotDatapoints(String baseName, Snapshot snapshot, List<IMetricsConsumer.DataPoint> dataPoints) {
-        addConvertedMetric(baseName, ".max", snapshot.getMax(), dataPoints);
-        addConvertedMetric(baseName, ".mean", snapshot.getMean(), dataPoints);
-        addConvertedMetric(baseName, ".min", snapshot.getMin(), dataPoints);
-        addConvertedMetric(baseName, ".stddev", snapshot.getStdDev(), dataPoints);
-        addConvertedMetric(baseName, ".p50", snapshot.getMedian(), dataPoints);
-        addConvertedMetric(baseName, ".p75", snapshot.get75thPercentile(), dataPoints);
-        addConvertedMetric(baseName, ".p95", snapshot.get95thPercentile(), dataPoints);
-        addConvertedMetric(baseName, ".p98", snapshot.get98thPercentile(), dataPoints);
-        addConvertedMetric(baseName, ".p99", snapshot.get99thPercentile(), dataPoints);
-        addConvertedMetric(baseName, ".p999", snapshot.get999thPercentile(), dataPoints);
+        addConvertedMetric(baseName, ".max", snapshot.getMax(), dataPoints, true);
+        addConvertedMetric(baseName, ".mean", snapshot.getMean(), dataPoints, true);
+        addConvertedMetric(baseName, ".min", snapshot.getMin(), dataPoints, true);
+        addConvertedMetric(baseName, ".stddev", snapshot.getStdDev(), dataPoints, true);
+        addConvertedMetric(baseName, ".p50", snapshot.getMedian(), dataPoints, true);
+        addConvertedMetric(baseName, ".p75", snapshot.get75thPercentile(), dataPoints, true);
+        addConvertedMetric(baseName, ".p95", snapshot.get95thPercentile(), dataPoints, true);
+        addConvertedMetric(baseName, ".p98", snapshot.get98thPercentile(), dataPoints, true);
+        addConvertedMetric(baseName, ".p99", snapshot.get99thPercentile(), dataPoints, true);
+        addConvertedMetric(baseName, ".p999", snapshot.get999thPercentile(), dataPoints, true);
     }
 
-    private void addConvertedMetric(String baseName, String suffix, double value, List<IMetricsConsumer.DataPoint> dataPoints) {
-        IMetricsConsumer.DataPoint dataPoint = new IMetricsConsumer.DataPoint(baseName + suffix, convertDuration(value));
+    private void addConvertedMetric(String baseName, String suffix, double value, List<IMetricsConsumer.DataPoint> dataPoints, boolean needConversion) {
+        IMetricsConsumer.DataPoint dataPoint
+            = new IMetricsConsumer.DataPoint(baseName + suffix, needConversion ? convertDuration(value) : value);
         dataPoints.add(dataPoint);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Stop converting V2 rate metrics when adding to V1

## How was the change tested

Unit test