### PR TITLE
STORM-3790 add meter to track getPassword failures

### DIFF
--- a/docs/ClusterMetrics.md
+++ b/docs/ClusterMetrics.md
@@ -218,6 +218,7 @@ Metrics associated with the supervisor, which launches the workers for a topolog
 | supervisor:worker-launch-duration | timer | Time taken for a worker to launch. |
 | supervisor:worker-per-call-clean-up-duration-ns | meter | how long it takes to cleanup a worker (ns). |
 | supervisor:worker-shutdown-duration-ns | meter | how long it takes to shutdown a worker (ns). |
+| supervisor:workerTokenAuthorizer-get-password-failures | meter | Failures getting password for user in WorkerTokenAuthorizer |
 
 
 ## UI Metrics


### PR DESCRIPTION
## What is the purpose of the change

Be able to alert based on repeated failures to getPassword for workers.

## How was the change tested

Ran storm-client/storm-server unit tests.  Launched a word count topology.  Validated new meter reports values on internal dev cluster.