### PR TITLE
DO NOT MERGE: change dist from trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   - MODULES=Integration-Test
   - MODULES=Check-Updated-License-Files
 
-dist: trusty
+dist: xenial
 sudo: required
 
 before_cache:


### PR DESCRIPTION
## What is the purpose of the change

Travis build keeps failing. Possibly due to the dist we are using. See if change to xenial (used by current 2.3.x-branch and master) can help

## How was the change tested

Let travis to run it