### PR TITLE
STORM-3801 add option for gauges to report values per reporter if sup…

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/metric/SystemBolt.java
+++ b/storm-client/src/jvm/org/apache/storm/metric/SystemBolt.java
@@ -18,9 +18,11 @@ import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.storm.Config;
 import org.apache.storm.metric.api.IMetric;
+import org.apache.storm.metrics2.PerReporterGauge;
 import org.apache.storm.metrics2.WorkerMetricRegistrant;
 import org.apache.storm.task.IBolt;
 import org.apache.storm.task.OutputCollector;
@@ -63,31 +65,44 @@ public class SystemBolt implements IBolt {
             }
         });
 
-        // newWorkerEvent: 1 when a worker is first started and 0 all other times.
-        // This can be used to tell when a worker has crashed and is restarted.
-        final IMetric newWorkerEvent = new IMetric() {
-            boolean doEvent = true;
 
-            @Override
-            public Object getValueAndReset() {
-                if (doEvent) {
-                    doEvent = false;
-                    return 1;
-                } else {
-                    return 0;
-                }
-            }
-        };
-        context.registerGauge("newWorkerEvent", new Gauge<Integer>() {
-            @Override
-            public Integer getValue() {
-                return (Integer) newWorkerEvent.getValueAndReset();
-            }
-        });
+        context.registerGauge("newWorkerEvent", new NewWorkerGauge());
 
         int bucketSize = ObjectReader.getInt(topoConf.get(Config.TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS));
         registerMetrics(context, (Map<String, String>) topoConf.get(Config.WORKER_METRICS), bucketSize, topoConf);
         registerMetrics(context, (Map<String, String>) topoConf.get(Config.TOPOLOGY_WORKER_METRICS), bucketSize, topoConf);
+    }
+
+    // newWorkerEvent: 1 when a worker is first started and 0 all other times.
+    // This can be used to tell when a worker has crashed and is restarted.
+    private class NewWorkerImetric implements IMetric {
+        boolean doEvent = true;
+
+        @Override
+        public Object getValueAndReset() {
+            if (doEvent) {
+                doEvent = false;
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+    }
+
+    // allow reporting new worker metric for multiple reporters if they support getValueForReporter().
+    private class NewWorkerGauge extends PerReporterGauge<Integer> {
+        private final NewWorkerImetric defaultValue = new NewWorkerImetric();
+        private final Map<Object, NewWorkerImetric> reporterValues = new HashMap<>();
+
+        @Override
+        public Integer getValue() {
+            return (Integer) defaultValue.getValueAndReset();
+        }
+
+        @Override
+        public Integer getValueForReporter(Object reporter) {
+            return (Integer) reporterValues.computeIfAbsent(reporter, (rep) -> new NewWorkerImetric()).getValueAndReset();
+        }
     }
 
     private void registerMetrics(TopologyContext context, Map<String, String> metrics, int bucketSize, Map<String, Object> conf) {

--- a/storm-client/src/jvm/org/apache/storm/metrics2/PerReporterGauge.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/PerReporterGauge.java
@@ -1,0 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.metrics2;
+
+import com.codahale.metrics.Gauge;
+
+public abstract class PerReporterGauge<T> implements Gauge<T> {
+
+    public abstract T getValueForReporter(Object reporter);
+}


### PR DESCRIPTION
…ported

## What is the purpose of the change

newWorkerEvent only works properly for the first reporter using it.  Added PerReporterGauge to allow reporters who want to support using it to add a reporter-specific version to get the value.  Other gauges can use this going forward.

## How was the change tested

Ran storm-client unit tests.  Ran topology and validated logging works for topology.