### PR TITLE
STORM-3802 allow adding system metrics reporters to all topologies

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -1216,6 +1216,12 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_METRICS_REPORTERS = "topology.metrics.reporters";
 
     /**
+     * A list of system metrics reporters that will get added to each topology.
+     */
+    @IsListEntryCustom(entryValidatorClasses = { MetricReportersValidator.class })
+    public static final String STORM_TOPOLOGY_METRICS_SYSTEM_REPORTERS = "storm.topology.metrics.system.reporters";
+
+    /**
      * Configure the topology metrics reporters to be used on workers.
      * @deprecated Use {@link Config#TOPOLOGY_METRICS_REPORTERS} instead.
      */

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1152,6 +1152,15 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             ret.put(Config.TOPOLOGY_METRICS_REPORTERS, mergedConf.get(Config.STORM_METRICS_REPORTERS));
         }
 
+        // add any system metrics reporters to the topology metrics reporters
+        if (conf.containsKey(Config.STORM_TOPOLOGY_METRICS_SYSTEM_REPORTERS)) {
+            List<Map<String, Object>> reporters = (List<Map<String, Object>>)
+                    ret.computeIfAbsent(Config.TOPOLOGY_METRICS_REPORTERS, (key) -> new ArrayList<>());
+            List<Map<String, Object>> systemReporters = (List<Map<String, Object>>)
+                    conf.get(Config.STORM_TOPOLOGY_METRICS_SYSTEM_REPORTERS);
+            reporters.addAll(systemReporters);
+        }
+
         // Don't allow topoConf to override various cluster-specific properties.
         // Specifically adding the cluster settings to the topoConf here will make sure these settings
         // also override the subsequently generated conf picked up locally on the classpath.


### PR DESCRIPTION
## What is the purpose of the change

Allow adding the same metrics reporters to all topologies regardless of what user requests.

## How was the change tested

Built storm code.  Ran storm-server unit tests.  Tested on internal clusters for topologies with and without metrics reporters and validated system reporters were added.