### PR TITLE
[STORM-3803] Format large integers with commas after three digits in Storm UI

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/component.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/component.html
@@ -264,7 +264,8 @@ $(document).ready(function() {
                         info: false,
                         searching: false,
                         columnDefs: [
-                          {type: "num", targets: [1, 2, 3, 4, 5]},
+                          {type: "num", targets: [1, 2, 4, 5], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                          {type: "num", targets: [3]},
                           {type: "time-str", targets: [0]}
                         ]
                     });
@@ -275,7 +276,8 @@ $(document).ready(function() {
                     //stream, emitted, transferred, compltete latency, acked, failed
                     dtAutoPage("#output-stats-table", {
                       columnDefs: [
-                        {type: "num", targets: [1, 2, 3, 4, 5]}
+                        {type: "num", targets: [1, 2, 4, 5], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [3]}
                       ]
                     });
                 });
@@ -287,7 +289,8 @@ $(document).ready(function() {
                       columnDefs: [
                         {render: renderSupervisorPageLink, searchable: true, targets: [2]},
                         {render: renderActionCheckbox, searchable: false, targets: [4]},
-                        {type: "num", targets: [5, 6, 7, 8, 9]},
+                        {type: "num", targets: [5, 6, 8, 9], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [7]},
                         {type: "time-str", targets: [1]},
                       ]
                     }).on("draw", function(e,s) {setWorkerActionCheckboxesClickCallback()});
@@ -298,7 +301,8 @@ $(document).ready(function() {
                     //window, emitted, transferred, execute latency, executed, process latency, acked, failed
                     dtAutoPage("#bolt-stats-table", {
                       columnDefs: [
-                        {type: "num", targets: [1, 2, 3, 4, 5, 6, 7]},
+                        {type: "num", targets: [1, 2, 4, 6, 7], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [3, 5]},
                         {type: "time-str", targets: [0]}
                       ]
                     });
@@ -309,7 +313,8 @@ $(document).ready(function() {
                     //component, stream, execute latency, executed, process latency, acked, failed
                     dtAutoPage("#bolt-input-stats-table", {
                       columnDefs: [
-                        {type: "num", targets: [2, 3, 4, 5, 6]}
+                        {type: "num", targets: [2, 4]},
+                        {type: "num", targets: [3, 5, 6], render: $.fn.dataTable.render.number( ',', '.', 0)}
                       ]
                     });
                 });
@@ -319,7 +324,7 @@ $(document).ready(function() {
                     //stream, emitted, transferred
                     dtAutoPage("#bolt-output-stats-table", {
                       columnDefs: [
-                        {type: "num", targets: [1, 2]}
+                        {type: "num", targets: [1, 2], render: $.fn.dataTable.render.number( ',', '.', 0)}
                       ]
                     });
                 });
@@ -331,7 +336,8 @@ $(document).ready(function() {
                       columnDefs: [
                         {render: renderSupervisorPageLink, searchable: true, targets: [2]},
                         {render: renderActionCheckbox, searchable: false, targets: [4]},
-                        {type: "num", targets: [5, 6, 7, 8, 9, 10, 11, 12]},
+                        {type: "num", targets: [5, 6, 9, 11, 12], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [7, 8, 10]},
                         {type: "time-str", targets: [1]},
                       ]
                     }).on("draw", function(e,s) {setWorkerActionCheckboxesClickCallback()});

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/component.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/component.html
@@ -264,7 +264,7 @@ $(document).ready(function() {
                         info: false,
                         searching: false,
                         columnDefs: [
-                          {type: "num", targets: [1, 2, 4, 5], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                          {type: "num", targets: [1, 2, 4, 5], render: $.fn.dataTable.render.number(',', '.', 0)},
                           {type: "num", targets: [3]},
                           {type: "time-str", targets: [0]}
                         ]
@@ -276,7 +276,7 @@ $(document).ready(function() {
                     //stream, emitted, transferred, compltete latency, acked, failed
                     dtAutoPage("#output-stats-table", {
                       columnDefs: [
-                        {type: "num", targets: [1, 2, 4, 5], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [1, 2, 4, 5], render: $.fn.dataTable.render.number(',', '.', 0)},
                         {type: "num", targets: [3]}
                       ]
                     });
@@ -289,7 +289,7 @@ $(document).ready(function() {
                       columnDefs: [
                         {render: renderSupervisorPageLink, searchable: true, targets: [2]},
                         {render: renderActionCheckbox, searchable: false, targets: [4]},
-                        {type: "num", targets: [5, 6, 8, 9], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [5, 6, 8, 9], render: $.fn.dataTable.render.number(',', '.', 0)},
                         {type: "num", targets: [7]},
                         {type: "time-str", targets: [1]},
                       ]
@@ -301,7 +301,7 @@ $(document).ready(function() {
                     //window, emitted, transferred, execute latency, executed, process latency, acked, failed
                     dtAutoPage("#bolt-stats-table", {
                       columnDefs: [
-                        {type: "num", targets: [1, 2, 4, 6, 7], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [1, 2, 4, 6, 7], render: $.fn.dataTable.render.number(',', '.', 0)},
                         {type: "num", targets: [3, 5]},
                         {type: "time-str", targets: [0]}
                       ]
@@ -314,7 +314,7 @@ $(document).ready(function() {
                     dtAutoPage("#bolt-input-stats-table", {
                       columnDefs: [
                         {type: "num", targets: [2, 4]},
-                        {type: "num", targets: [3, 5, 6], render: $.fn.dataTable.render.number( ',', '.', 0)}
+                        {type: "num", targets: [3, 5, 6], render: $.fn.dataTable.render.number(',', '.', 0)}
                       ]
                     });
                 });
@@ -324,7 +324,7 @@ $(document).ready(function() {
                     //stream, emitted, transferred
                     dtAutoPage("#bolt-output-stats-table", {
                       columnDefs: [
-                        {type: "num", targets: [1, 2], render: $.fn.dataTable.render.number( ',', '.', 0)}
+                        {type: "num", targets: [1, 2], render: $.fn.dataTable.render.number(',', '.', 0)}
                       ]
                     });
                 });
@@ -336,7 +336,7 @@ $(document).ready(function() {
                       columnDefs: [
                         {render: renderSupervisorPageLink, searchable: true, targets: [2]},
                         {render: renderActionCheckbox, searchable: false, targets: [4]},
-                        {type: "num", targets: [5, 6, 9, 11, 12], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [5, 6, 9, 11, 12], render: $.fn.dataTable.render.number(',', '.', 0)},
                         {type: "num", targets: [7, 8, 10]},
                         {type: "time-str", targets: [1]},
                       ]

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/index.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/index.html
@@ -199,7 +199,7 @@ $(document).ready(function() {
                     //name, owner, status, uptime, num workers, num executors, num tasks, replication count, assigned total mem, assigned total cpu, scheduler info
                     dtAutoPage("#topology-summary-table", {
                       columnDefs: [
-                        {type: "num", targets: [4, 5, 6, 7, 8, 9], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [4, 5, 6, 7, 8, 9], render: $.fn.dataTable.render.number(',', '.', 0)},
                         {type: "time-str", targets: [3]}
                       ]
                     });
@@ -214,7 +214,7 @@ $(document).ready(function() {
                     dtAutoPage("#supervisor-summary-table", {
                       columnDefs: [
                         {type: "num", targets: [3, 4]},
-                        {type: "num", targets: [6], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                        {type: "num", targets: [6], render: $.fn.dataTable.render.number(',', '.', 0)},
                         {type: "time-str", targets: [2]}
                       ]
                     });

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/index.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/index.html
@@ -199,7 +199,7 @@ $(document).ready(function() {
                     //name, owner, status, uptime, num workers, num executors, num tasks, replication count, assigned total mem, assigned total cpu, scheduler info
                     dtAutoPage("#topology-summary-table", {
                       columnDefs: [
-                        {type: "num", targets: [4, 5, 6, 7, 8, 9]},
+                        {type: "num", targets: [4, 5, 6, 7, 8, 9], render: $.fn.dataTable.render.number( ',', '.', 0)},
                         {type: "time-str", targets: [3]}
                       ]
                     });
@@ -210,10 +210,11 @@ $(document).ready(function() {
             $.getJSON("/api/v1/supervisor/summary",function(response,status,jqXHR) {
                 jsError(function() {
                     supervisorSummary.append(Mustache.render($(indexTemplate).filter("#supervisor-summary-template").html(),response));
-                    //id, host, uptime, slots, used slots
+                    //id, host, uptime, slots, used slots, avail slots, used mem, version, blacklisted
                     dtAutoPage("#supervisor-summary-table", {
                       columnDefs: [
                         {type: "num", targets: [3, 4]},
+                        {type: "num", targets: [6], render: $.fn.dataTable.render.number( ',', '.', 0)},
                         {type: "time-str", targets: [2]}
                       ]
                     });

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/owner.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/owner.html
@@ -192,7 +192,7 @@
                         columnDefs: [{
                             type: "num", targets: [4, 5, 6]
                         }, {
-                            type: "num", targets: [7], render: $.fn.dataTable.render.number( ',', '.', 0)
+                            type: "num", targets: [7], render: $.fn.dataTable.render.number(',', '.', 0)
                         }, {
                             type: "time-str", targets: [3]
                         }]

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/owner.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/owner.html
@@ -187,16 +187,31 @@
 
                     topologySummary.append(
                         Mustache.render($(template).filter("#owner-topology-summary-template").html(), response));
-                    //name, owner, status, uptime, num workers, num executors, num tasks, assigned total mem, assigned total cpu, scheduler info, topology version, storm version
-                    dtAutoPage("#owner-topology-summary-table", {
-                        columnDefs: [{
-                            type: "num", targets: [4, 5, 6]
-                        }, {
-                            type: "num", targets: [7], render: $.fn.dataTable.render.number(',', '.', 0)
-                        }, {
-                            type: "time-str", targets: [3]
-                        }]
-                    });
+                    if (displayResource) {
+                        // (0) name, (1) owner, (2) status, (3) uptime, (4) workersTotal, (5) executorsTotal, (6) tasksTotal,
+                        // (7) assignedTotalMem, [ (8) assignedCpu, ] (9), schedulerInfo, (10) topologyVersion, (11) stormVersion
+                        dtAutoPage("#owner-topology-summary-table", {
+                            columnDefs: [{
+                                type: "num", targets: [4, 5, 6]
+                            }, {
+                                type: "num", targets: [7, 8], render: $.fn.dataTable.render.number(',', '.', 0)
+                            }, {
+                                type: "time-str", targets: [3]
+                            }]
+                        });
+                    } else {
+                        // (0) name, (1) owner, (2) status, (3) uptime, (4) workersTotal, (5) executorsTotal, (6) tasksTotal,
+                        // (7) assignedTotalMem, (8), schedulerInfo, (9) topologyVersion, (10) stormVersion
+                        dtAutoPage("#owner-topology-summary-table", {
+                            columnDefs: [{
+                                type: "num", targets: [4, 5, 6]
+                            }, {
+                                type: "num", targets: [7], render: $.fn.dataTable.render.number(',', '.', 0)
+                            }, {
+                                type: "time-str", targets: [3]
+                            }]
+                        });
+                    }
                     $('#topology-summary [data-toggle="tooltip"]').tooltip();
 
                 });

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/owner.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/owner.html
@@ -187,14 +187,14 @@
 
                     topologySummary.append(
                         Mustache.render($(template).filter("#owner-topology-summary-template").html(), response));
-                    //name, owner, status, uptime, num workers, num executors, num tasks, assigned total mem, assigned total cpu, scheduler info
+                    //name, owner, status, uptime, num workers, num executors, num tasks, assigned total mem, assigned total cpu, scheduler info, topology version, storm version
                     dtAutoPage("#owner-topology-summary-table", {
                         columnDefs: [{
-                            type: "num",
-                            targets: [4, 5, 6, 7, 8]
+                            type: "num", targets: [4, 5, 6]
                         }, {
-                            type: "time-str",
-                            targets: [3]
+                            type: "num", targets: [7], render: $.fn.dataTable.render.number( ',', '.', 0)
+                        }, {
+                            type: "time-str", targets: [3]
                         }]
                     });
                     $('#topology-summary [data-toggle="tooltip"]').tooltip();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/supervisor.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/supervisor.html
@@ -121,10 +121,11 @@ $(document).ready(function() {
                 supervisorSummary.append(
                         Mustache.render($(template).filter("#supervisor-summary-template").html(),response));
                 
-                //id, host, uptime, slots, used slots
+                //host, supervisor id, uptime, slots, used slots, used mem, version, blacklisted
                 dtAutoPage("#supervisor-summary-table", {
                     columnDefs: [
                     {type: "num", targets: [3, 4]},
+                    {type: "num", targets: [5], render: $.fn.dataTable.render.number( ',', '.', 0)},
                     {type: "time-str", targets: [2]}
                     ]
                 });

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/supervisor.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/supervisor.html
@@ -120,15 +120,28 @@ $(document).ready(function() {
             jsError(function() {
                 supervisorSummary.append(
                         Mustache.render($(template).filter("#supervisor-summary-template").html(),response));
-                
-                //host, supervisor id, uptime, slots, used slots, used mem, version, blacklisted
-                dtAutoPage("#supervisor-summary-table", {
+                var displayResource = response["schedulerDisplayResource"];
+                if (displayResource){
+                  // (0) host, (1) supervisor id, (2) uptime, (3) slots, (4) used slots, (5) total mem (6) used mem,
+                  // (7) availMem (8) totalCpu (9) usedCpu (10) availCpu (11) totalGenericResources
+                  // (12) usedGenericResources (13) availGenericResources (14) version, (15) blacklisted
+                  dtAutoPage("#supervisor-summary-table", {
                     columnDefs: [
-                    {type: "num", targets: [3, 4]},
-                    {type: "num", targets: [5], render: $.fn.dataTable.render.number(',', '.', 0)},
-                    {type: "time-str", targets: [2]}
+                      {type: "num", targets: [3, 4]},
+                      {type: "num", targets: [5, 6, 7, 8, 9, 10, 11, 12, 13], render: $.fn.dataTable.render.number(',', '.', 0)},
+                      {type: "time-str", targets: [2]}
                     ]
-                });
+                  });
+                } else {
+                  // (0) host, (1) supervisor id, (2) uptime, (3) slots, (4) used slots, (5) used mem, (6) version, (7) blacklisted
+                  dtAutoPage("#supervisor-summary-table", {
+                    columnDefs: [
+                      {type: "num", targets: [3, 4]},
+                      {type: "num", targets: [5], render: $.fn.dataTable.render.number(',', '.', 0)},
+                      {type: "time-str", targets: [2]}
+                    ]
+                  });
+                }
 
                 $('#supervisor-summary-table [data-toggle="tooltip"]').tooltip();
                 workerStats.append(Mustache.render($(template).filter("#worker-stats-template").html(),response));

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/supervisor.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/supervisor.html
@@ -125,7 +125,7 @@ $(document).ready(function() {
                 dtAutoPage("#supervisor-summary-table", {
                     columnDefs: [
                     {type: "num", targets: [3, 4]},
-                    {type: "num", targets: [5], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                    {type: "num", targets: [5], render: $.fn.dataTable.render.number(',', '.', 0)},
                     {type: "time-str", targets: [2]}
                     ]
                 });

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
@@ -331,22 +331,27 @@ $(document).ready(function() {
               info: false,
               searching: false,
               columnDefs: [
-                {type: "num", targets: [1, 2, 3, 4, 5]},
+                {type: "num", targets: [1, 2, 4, 5], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                {type: "num", targets: [3]},
                 {type: "time-str", targets: [0]}
               ]
             });
 
             spoutStats.append(Mustache.render($(template).filter("#spout-stats-template").html(),response));
+            // id, executors, tasks, emitted, transferred, latency, acked, failed, error host, error port, last error, error time
             dtAutoPage("#spout-stats-table", {
               columnDefs: [
-                {type: "num", targets: 'table-num'}
+                {type: "num", targets: [1, 2, 5]},
+                {type: "num", targets: [3, 4, 6, 7], render: $.fn.dataTable.render.number( ',', '.', 0)}
               ]
             });
 
             boltStats.append(Mustache.render($(template).filter("#bolt-stats-template").html(),response));
+            // id, executors, tasks, emitted, transferred, capacity, exec latency, executed, process latency, acked, failed, error host, error port, last error, error time
             dtAutoPage("#bolt-stats-table", {
               columnDefs: [
-                {type: "num", targets: 'table-num'}
+                {type: "num", targets: [1, 2, 5, 6, 8, 12]},
+                {type: "num", targets: [3, 4, 7, 9, 10], render: $.fn.dataTable.render.number( ',', '.', 0)}
               ]
             });
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
@@ -338,22 +338,50 @@ $(document).ready(function() {
             });
 
             spoutStats.append(Mustache.render($(template).filter("#spout-stats-template").html(),response));
-            // id, executors, tasks, emitted, transferred, latency, acked, failed, error host, error port, last error, error time
-            dtAutoPage("#spout-stats-table", {
-              columnDefs: [
-                {type: "num", targets: [1, 2, 5]},
-                {type: "num", targets: [3, 4, 6, 7], render: $.fn.dataTable.render.number(',', '.', 0)}
-              ]
-            });
+            if (displayResource){
+              // (0) id, (1) executors, [(2) requestedMemOnHeap, (3) requestedMemOffHeap, (4) requestedCpu,
+              // (5) requestedGenericResourcesComp], (6) tasks, (7) emitted, (8) transferred, (9) latency, (10) acked,
+              // (11) failed, (12) error host, (13) error port, (14) last error, (15) error time
+              dtAutoPage("#spout-stats-table", {
+                columnDefs: [
+                  {type: "num", targets: [1, 6, 9]},
+                  {type: "num", targets: [2, 3, 4, 5, 7, 8, 10, 11], render: $.fn.dataTable.render.number(',', '.', 0)}
+                ]
+              });
+            } else {
+              // (0) id, (1) executors, (2) tasks, (3) emitted, (4) transferred, (5) latency, (6) acked, (7) failed,
+              // (8) error host, (9) error port, (10) last error, (11) error time
+              dtAutoPage("#spout-stats-table", {
+                columnDefs: [
+                  {type: "num", targets: [1, 2, 5]},
+                  {type: "num", targets: [3, 4, 6, 7], render: $.fn.dataTable.render.number(',', '.', 0)}
+                ]
+              });
+            }
 
             boltStats.append(Mustache.render($(template).filter("#bolt-stats-template").html(),response));
-            // id, executors, tasks, emitted, transferred, capacity, exec latency, executed, process latency, acked, failed, error host, error port, last error, error time
-            dtAutoPage("#bolt-stats-table", {
-              columnDefs: [
-                {type: "num", targets: [1, 2, 5, 6, 8, 12]},
-                {type: "num", targets: [3, 4, 7, 9, 10], render: $.fn.dataTable.render.number(',', '.', 0)}
-              ]
-            });
+            if (displayResource){
+              // (0) id, (1) executors, (2) tasks, [(3) requestedMemOnHeap, (4) requestedMemOffHeap, (5) requestedCpu,
+              // (6) requestedGenericResourcesComp], (7) emitted, (8) transferred, (9) capacity, (10) exec latency,
+              // (11) executed, (12) process latency, (13) acked, (14) failed, (15) error host, (16) error port,
+              // (17) last error, (18) error time
+              dtAutoPage("#bolt-stats-table", {
+                columnDefs: [
+                  {type: "num", targets: [1, 2, 9, 10, 12, 16]},
+                  {type: "num", targets: [3, 4, 5, 6, 7, 8, 11, 13, 14], render: $.fn.dataTable.render.number(',', '.', 0)}
+                ]
+              });
+            } else {
+              // (0) id, (1) executors, (2) tasks, (3) emitted, (4) transferred, (5) capacity, (6) exec latency,
+              // (7) executed, (8) process latency, (9) acked, (10) failed, (11) error host, (12) error port,
+              // (13) last error, (14) error time
+              dtAutoPage("#bolt-stats-table", {
+                columnDefs: [
+                  {type: "num", targets: [1, 2, 5, 6, 8, 12]},
+                  {type: "num", targets: [3, 4, 7, 9, 10], render: $.fn.dataTable.render.number(',', '.', 0)}
+                ]
+              });
+            }
 
           jsError(function() {
             workerStats.append(Mustache.render($(template).filter("#worker-stats-template").html(),response));

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
@@ -331,7 +331,7 @@ $(document).ready(function() {
               info: false,
               searching: false,
               columnDefs: [
-                {type: "num", targets: [1, 2, 4, 5], render: $.fn.dataTable.render.number( ',', '.', 0)},
+                {type: "num", targets: [1, 2, 4, 5], render: $.fn.dataTable.render.number(',', '.', 0)},
                 {type: "num", targets: [3]},
                 {type: "time-str", targets: [0]}
               ]
@@ -342,7 +342,7 @@ $(document).ready(function() {
             dtAutoPage("#spout-stats-table", {
               columnDefs: [
                 {type: "num", targets: [1, 2, 5]},
-                {type: "num", targets: [3, 4, 6, 7], render: $.fn.dataTable.render.number( ',', '.', 0)}
+                {type: "num", targets: [3, 4, 6, 7], render: $.fn.dataTable.render.number(',', '.', 0)}
               ]
             });
 
@@ -351,7 +351,7 @@ $(document).ready(function() {
             dtAutoPage("#bolt-stats-table", {
               columnDefs: [
                 {type: "num", targets: [1, 2, 5, 6, 8, 12]},
-                {type: "num", targets: [3, 4, 7, 9, 10], render: $.fn.dataTable.render.number( ',', '.', 0)}
+                {type: "num", targets: [3, 4, 7, 9, 10], render: $.fn.dataTable.render.number(',', '.', 0)}
               ]
             });
 


### PR DESCRIPTION

## What is the purpose of the change

*Large numbers for emitted, transferred, acked, failed, cpu, mem, etc are hard to read. Format the
integers with commas after three digits for readability.*

## How was the change tested

*Build code, deploy locally, and then view the changed pages in a web browser*

 - index.html
 - component.html
 - owner.html
 - supervisor.html
 - topology.html