### PR TITLE
STORM-3804 Don't allow deleting blobs if they are required for an active topology

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -985,6 +985,37 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         return isTopologyActive(state, topoName) || state.activeStorms().contains(topoName);
     }
 
+    /**
+     * Returns the topology that is using this blob.
+     * @param state the cluster state
+     * @param topoCache the topology cache
+     * @param key the blob key
+     * @return null or id
+     */
+    private static String topologyUsingThisBlob(IStormClusterState state, TopoCache topoCache, String key) {
+        for (String topologyId : state.activeStorms()) {
+            Map<String, Object> topoConf = null;
+            try {
+                topoConf = readTopoConfAsNimbus(topologyId, topoCache);
+            } catch (KeyNotFoundException e) {
+                continue;
+            } catch (AuthorizationException e) {
+                continue;
+            } catch (IOException e) {
+                continue;
+            }
+            if (null == topoConf) {
+                continue;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Map<String, Object>> blobstoreMap = (Map<String, Map<String, Object>>) topoConf.get(Config.TOPOLOGY_BLOBSTORE_MAP);
+            if (null != blobstoreMap && blobstoreMap.containsKey(key)) {
+                return topologyId;
+            }
+        }
+        return null;
+    }
+
     private static Map<String, Object> tryReadTopoConf(String topoId, TopoCache tc)
         throws NotAliveException, AuthorizationException, IOException {
         try {
@@ -3906,6 +3937,12 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                     LOG.warn(message);
                     throw new WrappedIllegalStateException(message);
                 }
+            }
+            String topoId = topologyUsingThisBlob(stormClusterState, topoCache,  key);
+            if (null != topoId) {
+                String message = "Attempting to delete active blob " + key + " used by topology " + topoId;
+                LOG.warn(message);
+                throw new WrappedIllegalStateException(message);
             }
             blobStore.deleteBlob(key, getSubject());
             LOG.info("Deleted blob for key {} with {}", key, ReqContext.context());

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1005,7 +1005,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             }
             @SuppressWarnings("unchecked")
             Map<String, Map<String, Object>> blobstoreMap = (Map<String, Map<String, Object>>) topoConf.get(Config.TOPOLOGY_BLOBSTORE_MAP);
-            if (null != blobstoreMap && blobstoreMap.containsKey(key)) {
+            if (blobstoreMap != null && blobstoreMap.containsKey(key)) {
                 return topologyId;
             }
         }

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -986,7 +986,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     }
 
     /**
-     * Returns the topology that is using this blob.
+     * Returns the topologyId of the topology using this blob.
      * @param state the cluster state
      * @param topoCache the topology cache
      * @param key the blob key

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -997,11 +997,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             Map<String, Object> topoConf = null;
             try {
                 topoConf = readTopoConfAsNimbus(topologyId, topoCache);
-            } catch (KeyNotFoundException e) {
-                continue;
-            } catch (AuthorizationException e) {
-                continue;
-            } catch (IOException e) {
+            } catch (KeyNotFoundException | AuthorizationException | IOException e) {
                 continue;
             }
             if (null == topoConf) {
@@ -3939,7 +3935,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
                 }
             }
             String topoId = topologyUsingThisBlob(stormClusterState, topoCache,  key);
-            if (null != topoId) {
+            if (topoId != null) {
                 String message = "Attempting to delete active blob " + key + " used by topology " + topoId;
                 LOG.warn(message);
                 throw new WrappedIllegalStateException(message);

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1000,7 +1000,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             } catch (KeyNotFoundException | AuthorizationException | IOException e) {
                 continue;
             }
-            if (null == topoConf) {
+            if (topoConf == null) {
                 continue;
             }
             @SuppressWarnings("unchecked")


### PR DESCRIPTION

## What is the purpose of the change

Don't allow deleting blobs if they are required for an active topology

## How was the change tested
Tested on local cluster. Verified that it works as expected. Got the following error message:

"org.apache.storm.utils.WrappedIllegalStateException: Attempting to delete active blob test-delete16acbcb7-91f3-4497-a9bb-67dbfb786948.jar used by topology blob-3-1635454702"