### PR TITLE
[STORM-3956] Fix cli monitor component's argument type

### DIFF
--- a/bin/storm.py
+++ b/bin/storm.py
@@ -1061,7 +1061,7 @@ def initialize_monitor_subcommand(subparsers):
         "-i", "--interval", type=check_positive, default=None,
         help="""By default, poll-interval is 4 seconds"""
     )
-    sub_parser.add_argument("-m", "--component", type=check_positive, default=None)
+    sub_parser.add_argument("-m", "--component", default=None)
     sub_parser.add_argument("-s", "--stream", default=None)
     sub_parser.add_argument("-w", "--watch", default=None)
     sub_parser.set_defaults(func=monitor)


### PR DESCRIPTION
## What is the purpose of the change

The `component` value is a string, not a number, see [Monitor.java](https://github.com/apache/storm/blob/master/storm-core/src/jvm/org/apache/storm/utils/Monitor.java#L156).

Attempting to use a number throws a stacktrace like such:

```
~/apache-storm-2.3.0/bin/storm monitor -m wordGenerator production-topology
topology	component	parallelism	stream	time-diff ms	emitted	throughput (Kt/s)
Available components for production-topology :
------------------
__acker
wordGenerator
intermediateRanker
counter
finalRanker
------------------
Exception in thread "main" java.lang.IllegalArgumentException: component: wordGeneratotor not found
	at org.apache.storm.utils.Monitor.metrics(Monitor.java:128)
	at org.apache.storm.utils.Monitor.metrics(Monitor.java:83)
	at org.apache.storm.command.Monitor$1.run(Monitor.java:53)
	at org.apache.storm.utils.NimbusClient.withConfiguredClient(NimbusClient.java:128)
	at org.apache.storm.utils.NimbusClient.withConfiguredClient(NimbusClient.java:117)
	at org.apache.storm.command.Monitor.main(Monitor.java:50)
```

## How was the change tested

The monitor command now works.