### PR TITLE
[STORM-3807] Topology Stats columns show NaN

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -1577,9 +1577,8 @@ public class UIHelpers {
             temp.put("emitted", emittedStatDisplayMap.get(window));
             temp.put("transferred", transferred.get(window));
             temp.put("completeLatency", StatsUtil.floatStr(completeLatency.get(getWindowHint(window))));
-            temp.put("acked", acked.get(window));
-            temp.put("failed", failed.get(window));
-
+            temp.put("acked", acked.getOrDefault(window, 0L));
+            temp.put("failed", failed.getOrDefault(window, 0L));
 
             result.add(temp);
         }


### PR DESCRIPTION
## What is the purpose of the change

*Acked and Fixed columns in topology page of Storm UI display NaN.*

## How was the change tested

*Compiled and run locally. Submit a new wordcount topology. Navigate to topology page and view "Topology Stats" section*