### PR TITLE
STORM-3810: bumping log4j.version to 2.17.0 and disruptor.version to 3.4.4 (CVE-2021-44228, CVE-2021-45046)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,12 +241,12 @@
         <snakeyaml.version>1.11</snakeyaml.version>
         <httpclient.version>4.3.3</httpclient.version>
         <clojure.tools.cli.version>0.2.4</clojure.tools.cli.version>
-        <disruptor.version>3.3.11</disruptor.version>
+        <disruptor.version>3.4.4</disruptor.version>
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>16.0.1</guava.version>
         <netty.version>3.9.9.Final</netty.version>
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
-        <log4j.version>2.8.2</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <slf4j.version>1.7.21</slf4j.version>
         <metrics.version>3.1.0</metrics.version>
         <clojure.tools.nrepl.version>0.2.3</clojure.tools.nrepl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
         <guava.version>16.0.1</guava.version>
         <netty.version>3.9.9.Final</netty.version>
         <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <slf4j.version>1.7.21</slf4j.version>
         <metrics.version>3.1.0</metrics.version>
         <clojure.tools.nrepl.version>0.2.3</clojure.tools.nrepl.version>


### PR DESCRIPTION
## Fixing CVE-2021-44228 for 1.x-branch
Similarly to https://github.com/apache/storm/pull/3426, bumping log4j.version to 2.16.0 and consequently disruptor.version to 3.4.4 on 1.x-branch
