### PR TITLE
STORM-3815 add option to disable reporting of __send-iconnection metrics

### DIFF
--- a/docs/Metrics.md
+++ b/docs/Metrics.md
@@ -269,7 +269,7 @@ Be aware that the `__system` bolt is an actual bolt so regular bolt metrics desc
 ##### Send (Netty Client)
 
 The `__send-iconnection` metrics report information about all of the clients for this worker.  They are named __send-iconnection-METRIC_TYPE-HOST:PORT for a given Client that is
-connected to a worker with the given host/port.
+connected to a worker with the given host/port.  These metrics can be disabled by setting topology.enable.send.iconnection.metrics to false.
 
 The metric types reported for each client are:
 

--- a/storm-client/src/jvm/org/apache/storm/Config.java
+++ b/storm-client/src/jvm/org/apache/storm/Config.java
@@ -285,6 +285,12 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_V2_METRICS_TICK_INTERVAL_SECONDS = "topology.v2.metrics.tick.interval.seconds";
 
     /**
+     * This config allows a topology to enable/disable reporting of __send-iconnection metrics.
+     */
+    @IsBoolean
+    public static final String TOPOLOGY_ENABLE_SEND_ICONNECTION_METRICS = "topology.enable.send.iconnection.metrics";
+
+    /**
      * The class name of the {@link org.apache.storm.state.StateProvider} implementation. If not specified defaults to {@link
      * org.apache.storm.state.InMemoryKeyValueStateProvider}. This can be overridden at the component level.
      */

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/Client.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/Client.java
@@ -173,7 +173,10 @@ public class Client extends ConnectionWithStatus implements ISaslClient {
         this.metricRegistry = metricRegistry;
 
         // it's possible to be passed a null metric registry if users are using their own IContext implementation.
-        if (this.metricRegistry != null) {
+        boolean reportMetrics =  this.metricRegistry != null
+                && ObjectReader.getBoolean(topoConf.get(Config.TOPOLOGY_ENABLE_SEND_ICONNECTION_METRICS), true);
+
+        if (reportMetrics) {
             Gauge<Integer> reconnects = new Gauge<Integer>() {
                 @Override
                 public Integer getValue() {


### PR DESCRIPTION
## What is the purpose of the change

Add option to disable reporting of __send-iconnection metrics.

## How was the change tested

built storm code.