### PR TITLE
CVE-2021-44832: Bumping log4j version to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
         <auto-service.version>1.0-rc4</auto-service.version>
         <netty.version>4.1.30.Final</netty.version>
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <slf4j.version>1.7.26</slf4j.version>
         <metrics.version>3.2.6</metrics.version>
         <mockito.version>3.0.0</mockito.version>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832

## What is the purpose of the change

Mitigation of https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832

As recommended in https://logging.apache.org/log4j/2.x/security.html

## How was the change tested

*(Explain what tests did you do to verify the code change)*