### PR TITLE
CVE-2021-44832: bumping log4j version to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>16.0.1</guava.version>
         <netty.version>3.9.9.Final</netty.version>
-        <\-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
+        <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
         <log4j.version>2.17.1</log4j.version>
         <slf4j.version>1.7.21</slf4j.version>
         <metrics.version>3.1.0</metrics.version>

--- a/pom.xml
+++ b/pom.xml
@@ -245,8 +245,8 @@
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>16.0.1</guava.version>
         <netty.version>3.9.9.Final</netty.version>
-        <log4j-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
-        <log4j.version>2.17.0</log4j.version>
+        <\-over-slf4j.version>1.6.6</log4j-over-slf4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <slf4j.version>1.7.21</slf4j.version>
         <metrics.version>3.1.0</metrics.version>
         <clojure.tools.nrepl.version>0.2.3</clojure.tools.nrepl.version>


### PR DESCRIPTION
https://logging.apache.org/log4j/2.x/security.html

## What is the purpose of the change

Mitigation of https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832

## How was the change tested

*(Explain what tests did you do to verify the code change)*