### PR TITLE
[STORM-3821] upgrade commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
 
         <!-- dependency versions -->
         <clojure.version>1.10.0</clojure.version>
-        <commons-compress.version>1.18</commons-compress.version>
+        <commons-compress.version>1.21</commons-compress.version>
         <commons-io.version>2.6</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-exec.version>1.3</commons-exec.version>


### PR DESCRIPTION
## What is the purpose of the change

Due to vulnerabilities - see https://mvnrepository.com/artifact/org.apache.commons/commons-compress/1.18

## How was the change tested

Ran build and unit tests