### PR TITLE
STORM-3822 fix visualization when streamId contains colon

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -1748,15 +1748,12 @@ public class UIHelpers {
     /**
      * Sanitizes streamName for use as an identifier in the visualization.  Replaces all characters except A-Z, a-z,
      * '.', '-', and '_' with '_'.  If streamName does not start with A-Z or a-z, adds '_s' prefix.
-     * @param streamName non-null, non-empty streamName
+     * @param streamName non-null streamName
      * @return sanitized stream name
      */
     public static String sanitizeStreamName(String streamName) {
-        if (streamName == null || streamName.isEmpty()) {
-            throw new IllegalArgumentException("streamName: " + streamName == null ? "null" : "empty");
-        }
         Matcher problemCharacterMatcher = Pattern.compile("(?![A-Za-z_\\-\\.]).").matcher(streamName);
-        if (Character.isLetter(streamName.charAt(0))) {
+        if (streamName.length() > 0 && Character.isLetter(streamName.charAt(0))) {
             return problemCharacterMatcher.replaceAll("_");
         } else {
             return "_s" + problemCharacterMatcher.replaceAll("_");

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -1748,24 +1748,19 @@ public class UIHelpers {
     /**
      * Sanitizes streamName for use as an identifier in the visualization.  Replaces all characters except A-Z, a-z,
      * '.', '-', and '_' with '_'.  If streamName does not start with A-Z or a-z, adds '_s' prefix.
-     * @param streamName streamName
+     * @param streamName non-null, non-empty streamName
      * @return sanitized stream name
      */
     public static String sanitizeStreamName(String streamName) {
-        Pattern startsWithLetterPattern = Pattern.compile("^[A-Za-z]");
-        Pattern problemCharacterPattern = Pattern.compile("(?![A-Za-z_\\-\\.]).");
-
-        Matcher startsWithLetterMatcher = startsWithLetterPattern.matcher(streamName);
-        Matcher problemCharacterMatcher;
-        if (startsWithLetterMatcher.find()) {
-            problemCharacterMatcher = problemCharacterPattern.matcher(streamName);
-        } else {
-            // if the streamName starts with non-letter character, prepend "\s".  The backslash will then
-            // get replaced by an underscore, resulting in the prefix of "_s" in the final sanitized name
-            problemCharacterMatcher = problemCharacterPattern.matcher("\\s" + streamName);
+        if (streamName == null || streamName.isEmpty()) {
+            throw new IllegalArgumentException("streamName: " + streamName == null ? "null" : "empty");
         }
-        // replace all characters not preceded by (A-Z, a-z, underscore, dash, colon, or dot) with underscore
-        return problemCharacterMatcher.replaceAll("_");
+        Matcher problemCharacterMatcher = Pattern.compile("(?![A-Za-z_\\-\\.]).").matcher(streamName);
+        if (Character.isLetter(streamName.charAt(0))) {
+            return problemCharacterMatcher.replaceAll("_");
+        } else {
+            return "_s" + problemCharacterMatcher.replaceAll("_");
+        }
     }
 
     /**

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -1746,19 +1746,26 @@ public class UIHelpers {
     }
 
     /**
-     * sanitizeStreamName.
+     * Sanitizes streamName for use as an identifier in the visualization.  Replaces all characters except A-Z, a-z,
+     * '.', '-', and '_' with '_'.  If streamName does not start with A-Z or a-z, adds '_s' prefix.
      * @param streamName streamName
-     * @return sanitizeStreamName
+     * @return sanitized stream name
      */
     public static String sanitizeStreamName(String streamName) {
-        Pattern pattern = Pattern.compile("(?![A-Za-z_\\-:\\.]).");
-        Pattern pattern2 = Pattern.compile("^[A-Za-z]");
-        Matcher matcher = pattern2.matcher(streamName);
-        Matcher matcher2 = pattern.matcher("\\s" + streamName);
-        if (matcher.find()) {
-            matcher2 = pattern.matcher(streamName);
+        Pattern startsWithLetterPattern = Pattern.compile("^[A-Za-z]");
+        Pattern problemCharacterPattern = Pattern.compile("(?![A-Za-z_\\-\\.]).");
+
+        Matcher startsWithLetterMatcher = startsWithLetterPattern.matcher(streamName);
+        Matcher problemCharacterMatcher;
+        if (startsWithLetterMatcher.find()) {
+            problemCharacterMatcher = problemCharacterPattern.matcher(streamName);
+        } else {
+            // if the streamName starts with non-letter character, prepend "\s".  The backslash will then
+            // get replaced by an underscore, resulting in the prefix of "_s" in the final sanitized name
+            problemCharacterMatcher = problemCharacterPattern.matcher("\\s" + streamName);
         }
-        return matcher2.replaceAll("_");
+        // replace all characters not preceded by (A-Z, a-z, underscore, dash, colon, or dot) with underscore
+        return problemCharacterMatcher.replaceAll("_");
     }
 
     /**

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/ui/UIHelpersTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/ui/UIHelpersTest.java
@@ -496,6 +496,9 @@ class UIHelpersTest {
 
         // has the expected effect when streamName begins with a non-alpha character
         assertEquals("_s_foo", UIHelpers.sanitizeStreamName("3foo"));
+
+        // handles empty string, though that's not an expected stream name
+        assertEquals("_s", UIHelpers.sanitizeStreamName(""));
     }
 
     /**

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/ui/UIHelpersTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/ui/UIHelpersTest.java
@@ -486,6 +486,19 @@ class UIHelpersTest {
     }
 
     /**
+     * Tests that santizeStreamName() does the expected manipulations
+     */
+    @Test
+    public void testSanitizeStreamName() {
+        // replaces the expected characters with underscores (everything except A-Z, a-z, dot, dash, and underscore)
+        assertEquals("my-stream_with.all_characterClasses____",
+                UIHelpers.sanitizeStreamName("my-stream:with.all_characterClasses1/\\2"));
+
+        // has the expected effect when streamName begins with a non-alpha character
+        assertEquals("_s_foo", UIHelpers.sanitizeStreamName("3foo"));
+    }
+
+    /**
      * Add an AggregateStats entry to the TopologyPageInfo instance.
      * @param boltId Id of the bolt to add the entry for.
      * @param aggregateStats Defines the entry.


### PR DESCRIPTION
## What is the purpose of the change

This fixes [STORM-3822](https://issues.apache.org/jira/browse/STORM-3822), making the Topology Visualization UI render correctly when a streamId contains a colon character.

## How was the change tested

I have tested with a modified version of WordCountTopology where I used a custom streamId ("my:stream") containing a colon and verified the UI loads successfully.  I have also tested with some of my team's real topologies that utilize streamIds containing colons.

Further, I have added a unit test for the function of the sanitizeStreamName() method modified in this PR.

## Notes

The sanitizeStreamName() method body was a bit cryptic and hard to follow.  I refactored it in an attempt to make it more readable.  I could have gone a little further.  In the initial version in the PR I have just added comments, renamed variables, and created an if/else block where previously there was a default assignment followed by a reassignment in an if condition.

The real change I made was simply to remove ':' as one of the allowed (not replaced) characters such that it would be replaced by '_' like other classes of characters that aren't allowed.

I have also done a couple of other things discussed in [STORM-3817](https://issues.apache.org/jira/browse/STORM-3817):
* removed yetus dependency exclusion that was causing me local build failures
* cherry-picked 1988a47f2b82ec103fffb02fc323aab0de3b09c6 so hopefully travis will build successfully

These last two items can be removed from this PR before merge, assuming they get incorporated elsewhere.