### PR TITLE
[STORM-3832] Remove python2 execution.

### DIFF
--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -273,25 +273,6 @@
                         <executions>
                             <execution>
                                 <configuration>
-                                    <executable>python2.7</executable>
-                                    <workingDirectory>test/py</workingDirectory>
-                                    <arguments>
-                                        <argument>test_storm_cli.py</argument>
-                                    </arguments>
-                                    <environmentVariables>
-                                        <PYTHONPATH>../../../bin:$PYTHONPATH</PYTHONPATH>
-                                        <PYTHONDONTWRITEBYTECODE>true</PYTHONDONTWRITEBYTECODE>
-                                    </environmentVariables>
-                                    <skip>${skipTests}</skip>
-                                </configuration>
-                                <id>python2.7-test</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <configuration>
                                     <executable>python3</executable>
                                     <workingDirectory>test/py</workingDirectory>
                                     <arguments>


### PR DESCRIPTION
## What is the purpose of the change

*Python version 2 has been EOL since January 1, 2020 (https://www.python.org/doc/sunset-python-2/).*

## How was the change tested

*mvn clean install with python2 removed*