### PR TITLE
STORM-3835 log command that is failing

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/ShellUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ShellUtils.java
@@ -182,6 +182,7 @@ public abstract class ShellUtils {
             runCommand();
         } catch (IOException e) {
             numShellExceptions.mark();
+            LOG.info("Failed running command {}", getExecString(), e);
             throw e;
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

To be able to tell what commands are failing when the meter updates.

## How was the change tested

Built storm-client.  Validated logging on internal dev supervisor.