### PR TITLE
STORM-3838 prevent topology from setting storm.workers.artifacts.dir

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1132,7 +1132,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
      * @param topoConf initial topology conf
      * @param topology  the Storm topology
      */
-    private static Map<String, Object> normalizeConf(Map<String, Object> conf, Map<String, Object> topoConf, StormTopology topology) {
+    static Map<String, Object> normalizeConf(Map<String, Object> conf, Map<String, Object> topoConf, StormTopology topology) {
 
         // clear any values from the topoConf that it should not be setting.
         topoConf.remove(Config.STORM_WORKERS_ARTIFACTS_DIR);

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -1133,6 +1133,10 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
      * @param topology  the Storm topology
      */
     private static Map<String, Object> normalizeConf(Map<String, Object> conf, Map<String, Object> topoConf, StormTopology topology) {
+
+        // clear any values from the topoConf that it should not be setting.
+        topoConf.remove(Config.STORM_WORKERS_ARTIFACTS_DIR);
+
         //ensure that serializations are same for all tasks no matter what's on
         // the supervisors. this also allows you to declare the serializations as a sequence
         List<Map<String, Object>> allConfs = new ArrayList<>();

--- a/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
@@ -88,4 +88,21 @@ public class NimbusTest {
 
         }
     }
+
+    @Test
+    public void validateNoTopoConfOverrides() {
+        StormTopology topology = new StormTopology();
+        topology.set_spouts(new HashMap<>());
+        topology.set_bolts(new HashMap<>());
+        topology.set_state_spouts(new HashMap<>());
+
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(Config.STORM_MESSAGING_NETTY_AUTHENTICATION, false);
+
+        conf.put(Config.STORM_WORKERS_ARTIFACTS_DIR, "a");
+        Map<String, Object> topoConf = new HashMap<>();
+        topoConf.put(Config.STORM_WORKERS_ARTIFACTS_DIR, "b");
+        Map<String, Object> normalized = Nimbus.normalizeConf(conf, topoConf, topology);
+        Assert.assertNull(normalized.get(Config.STORM_WORKERS_ARTIFACTS_DIR));
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

storm.workers.artifacts.dir is not a topology setting.  Users should not be allowed to set.

## How was the change tested

Built storm.  Validated user topology setting this does not make it to the topology conf on the UI on an internal dev cluster.