### PR TITLE
[STORM-3848] Add version for build-helper-maven-plugin.

### DIFF
--- a/storm-shaded-deps/pom.xml
+++ b/storm-shaded-deps/pom.xml
@@ -324,6 +324,7 @@
                 -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>workaround-makeItVisibleOnIntellij</id>


### PR DESCRIPTION
## What is the purpose of the change

*mvn build warns about missing version for build-helper-maven-plugin in storm-shaded-deps*

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.storm:storm-shaded-deps:jar:2.5.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 309, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

## How was the change tested

*Rebuild and confirm that this warning message goes away*