### PR TITLE
[STORM-3849] Add maven-jxr-plugin to eliminate XREF build warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1527,6 +1527,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>


### PR DESCRIPTION
## What is the purpose of the change

*mvn build report WARNING for each submodule build*

```
[WARNING] Unable to locate Source XRef to link to - DISABLED
[WARNING] Unable to locate Source XRef to link to - DISABLED

```

## How was the change tested

*Rebuild project, capture output into file and then search for the WARNING to confirm the fix*