### PR TITLE
[STORM-3851] Fix syntax errors and modify to run under python3

### DIFF
--- a/dev-tools/travis/print-errors-from-test-reports.py
+++ b/dev-tools/travis/print-errors-from-test-reports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -18,19 +18,20 @@ import glob
 import traceback
 from xml.etree.ElementTree import ElementTree
 
+
 def print_detail_information(testcase, fail_or_error):
-    print "-" * 50
-    print "classname: %s / testname: %s" % (testcase.get("classname"), testcase.get("name"))
-    print fail_or_error.text
+    print("-" * 50)
+    print("classname: %s / testname: %s" % (testcase.get("classname"), testcase.get("name")))
+    print(fail_or_error.text)
     stdout = testcase.find("system-out")
-    if stdout != None:
-        print "-" * 20, "system-out", "-"*20
-        print stdout.text
+    if stdout is not None:
+        print("-" * 20, "system-out", "-"*20)
+        print(stdout.text)
     stderr = testcase.find("system-err")
-    if stderr != None:
-        print "-" * 20, "system-err", "-"*20
-        print stderr.text
-    print "-" * 50
+    if stderr is not None:
+        print("-" * 20, "system-err", "-"*20)
+        print(stderr.text)
+    print("-" * 50)
 
 
 def print_error_reports_from_report_file(file_path):
@@ -38,11 +39,11 @@ def print_error_reports_from_report_file(file_path):
     try:
         tree.parse(file_path)
     except:
-        print "-" * 50
-        print "Error parsing %s"%file_path
-        f = open(file_path, "r");
-        print f.read();
-        print "-" * 50
+        print("-" * 50)
+        print("Error parsing %s"%file_path)
+        f = open(file_path, "r")
+        print(f.read())
+        print("-" * 50)
         return
 
     testcases = tree.findall(".//testcase")
@@ -64,17 +65,17 @@ def main(report_dir_path):
     for test_report in glob.iglob(report_dir_path + '/*.xml'):
         file_path = os.path.abspath(test_report)
         try:
-            print "Checking %s" % test_report
+            print("Checking %s" % test_report)
             print_error_reports_from_report_file(file_path)
-        except Exception, e:
-            print "Error while reading report file, %s" % file_path
-            print "Exception: %s" % e
+        except Exception as e:
+            print("Error while reading report file, %s" % file_path)
+            print("Exception: %s" % e)
             traceback.print_exc()
 
 
 if __name__ == "__main__":
-    if sys.argv < 2:
-        print "Usage: %s [report dir path]" % sys.argv[0]
+    if len(sys.argv) < 2:
+        print("Usage: %s [report dir path]" % sys.argv[0])
         sys.exit(1)
 
     main(sys.argv[1])


### PR DESCRIPTION
## What is the purpose of the change

*Errors in travis build are not always printed properly*

If errors are encountered in Travis build, then  script dev-tools/travis/print-errors-from-test-reports.py is used to examine the reports in target/test-reports and print the errors in test.

However, the script itself has syntax errors and therefore fails to load, especially under python3.

Fix the script so that it can properly parse and print.

## How was the change tested

*Ran this script against storm-core/target/test-reports.*

Old code gave an error:
```
(oath_tools) bprasad@C02XG0WLJGH8 storm-core % python3 ../dev-tools/travis/print-errors-from-test-reports.py target/test-reports
Traceback (most recent call last):
  File "/Users/bprasad/sources/community/bipinprasad/storm/storm-core/../dev-tools/travis/print-errors-from-test-reports.py", line 77, in <module>
    if sys.argv < 2:
TypeError: '<' not supported between instances of 'list' and 'int'

```

New code ran successfully and displayed error:

```
(oath_tools) bprasad@C02XG0WLJGH8 storm-core % python3 ../dev-tools/travis/print-errors-from-test-reports.py target/test-reports
Checking target/test-reports/org.apache.storm.cluster-test.xml
--------------------------------------------------
classname: org.apache.storm.cluster-test / testname: test-storm-cluster-state-errors
expected: (.contains (:error error) target)
  actual: false
      at: MultiFn.java:229
-------------------- system-out --------------------

5709 [main] INFO  o.a.s.z.Zookeeper - Starting inprocess zookeeper at port 2000 and dir /var/folders/ln/b66p649n02v3x6xyclwndw6w0000gn/T/d1fc7bb4-72d1-4082-a73c-9d126c4c2807
5713 [main] WARN  o.a.s.u.Time - AutoCloseable Simulated Time Starting...
5762 [main] INFO  o.a.s.z.ClientZookeeper - Starting ZK Curator
5895 [main] INFO  o.a.s.z.ClientZookeeper - Starting ZK Curator
IllegalArgumentException  =>  java.lang.RuntimeException
	at org.apache.storm.cluster_test$fn__636.invokeStatic(cluster_test.clj:274)
	at org.apache.storm.cluster_test$fn__636.invoke(cluster_test.clj:270)
	at clojure.test$test_var$fn__9707.invoke(test.clj:717)
	at clojure.test$test_var.invokeStatic(test.clj:717)
	at clojure.test$test_var.invoke(test.clj:708)
	at clojure.test$test_vars$fn__9733$fn__9738.invoke(test.clj:735)
	at clojure.test$default_fixture.invokeStatic(test.clj:687)
	at clojure.test$default_fixture.invoke(test.clj:683)
	at clojure.test$test_vars$fn__9733.invoke(test.clj:735)
	at clojure.test$default_fixture.invokeStatic(test.clj:687)
	at clojure.test$default_fixture.invoke(test.clj:683)
	at clojure.test$test_vars.invokeStatic(test.clj:731)
	at clojure.test$test_all_vars.invokeStatic(test.clj:737)
	at clojure.test$test_ns.invokeStatic(test.clj:758)
	at clojure.test$test_ns.invoke(test.clj:743)
	at clojure.core$map$fn__5851.invoke(core.clj:2755)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:51)
	at clojure.lang.Cons.next(Cons.java:39)
	at clojure.lang.RT.boundedLength(RT.java:1788)
	at clojure.lang.RestFn.applyTo(RestFn.java:130)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.test$run_tests.invokeStatic(test.clj:768)
	at clojure.test$run_tests.doInvoke(test.clj:768)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at org.apache.storm.testrunner$eval701$iter__702__706$fn__707$fn__708$fn__709.invoke(test_runner.clj:107)
	at org.apache.storm.testrunner$eval701$iter__702__706$fn__707$fn__708.invoke(test_runner.clj:53)
	at org.apache.storm.testrunner$eval701$iter__702__706$fn__707.invoke(test_runner.clj:52)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:51)
	at clojure.lang.RT.seq(RT.java:531)
	at clojure.core$seq__5387.invokeStatic(core.clj:137)
	at clojure.core$dorun.invokeStatic(core.clj:3133)
	at clojure.core$dorun.invoke(core.clj:3133)
	at org.apache.storm.testrunner$eval701.invokeStatic(test_runner.clj:52)
	at org.apache.storm.testrunner$eval701.invoke(test_runner.clj:47)
	at clojure.lang.Compiler.eval(Compiler.java:7176)
	at clojure.lang.Compiler.load(Compiler.java:7635)
	at clojure.lang.Compiler.loadFile(Compiler.java:7573)
	at clojure.main$load_script.invokeStatic(main.clj:452)
	at clojure.main$script_opt.invokeStatic(main.clj:512)
	at clojure.main$script_opt.invoke(main.clj:507)
	at clojure.main$main.invokeStatic(main.clj:598)
	at clojure.main$main.doInvoke(main.clj:561)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:37)

            
--------------------------------------------------

```