### PR TITLE
[STORM-3854] Fix maven-pmd-plugin errors

### DIFF
--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/AnchoredWordCount.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/AnchoredWordCount.java
@@ -32,6 +32,7 @@ import org.apache.storm.utils.Utils;
 
 public class AnchoredWordCount extends ConfigurableTopology {
 
+    @Override
     protected int run(String[] args) throws Exception {
         TopologyBuilder builder = new TopologyBuilder();
 

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/ExclamationTopology.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/ExclamationTopology.java
@@ -33,6 +33,7 @@ public class ExclamationTopology extends ConfigurableTopology {
         ConfigurableTopology.start(new ExclamationTopology(), args);
     }
 
+    @Override
     protected int run(String[] args) {
         TopologyBuilder builder = new TopologyBuilder();
 

--- a/external/storm-hdfs-oci/src/main/java/org/apache/storm/container/oci/HdfsOciResourcesLocalizer.java
+++ b/external/storm-hdfs-oci/src/main/java/org/apache/storm/container/oci/HdfsOciResourcesLocalizer.java
@@ -47,6 +47,7 @@ public class HdfsOciResourcesLocalizer implements OciResourcesLocalizerInterface
      * @param conf the storm conf.
      * @throws IOException on I/O exception
      */
+    @Override
     public void init(Map<String, Object> conf) throws IOException {
         //login to hdfs
         HadoopLoginUtil.loginHadoop(conf);
@@ -66,6 +67,7 @@ public class HdfsOciResourcesLocalizer implements OciResourcesLocalizerInterface
      * @return the destination of the oci resource
      * @throws IOException on I/O exception
      */
+    @Override
     public synchronized String localize(OciResource ociResource) throws IOException {
         if (ociResource == null) {
             return null;

--- a/pom.xml
+++ b/pom.xml
@@ -1265,6 +1265,7 @@
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>3.12.0</version>
                     <configuration>
+                        <targetJdk>1.8</targetJdk>
                         <rulesets>
                             <ruleset>storm/pmd-ruleset.xml</ruleset>
                         </rulesets>

--- a/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/StormClusterStateImpl.java
@@ -95,6 +95,7 @@ public class StormClusterStateImpl implements IStormClusterState {
 
         stateId = this.stateStorage.register(new ZKStateChangedCallback() {
 
+            @Override
             public void changed(Watcher.Event.EventType type, String path) {
                 List<String> toks = tokenizePath(path);
                 int size = toks.size();
@@ -762,6 +763,7 @@ public class StormClusterStateImpl implements IStormClusterState {
         List<String> childrens = stateStorage.get_children(path, false);
 
         Collections.sort(childrens, new Comparator<String>() {
+            @Override
             public int compare(String arg0, String arg1) {
                 return Long.compare(Long.parseLong(arg0.substring(1)), Long.parseLong(arg1.substring(1)));
             }
@@ -797,6 +799,7 @@ public class StormClusterStateImpl implements IStormClusterState {
             }
         }
         Collections.sort(errorInfos, new Comparator<ErrorInfo>() {
+            @Override
             public int compare(ErrorInfo arg0, ErrorInfo arg1) {
                 return Integer.compare(arg1.get_error_time_secs(), arg0.get_error_time_secs());
             }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/StormMetricRegistry.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/StormMetricRegistry.java
@@ -349,10 +349,12 @@ public class StormMetricRegistry implements MetricRegistryProvider {
         return RATE_COUNTER_UPDATE_INTERVAL_SECONDS;
     }
 
+    @Override
     public MetricRegistry getRegistry() {
         return registry;
     }
 
+    @Override
     public Map<TaskMetricDimensions, TaskMetricRepo> getTaskMetrics() {
         return taskMetrics;
     }

--- a/storm-client/src/jvm/org/apache/storm/streams/PairStream.java
+++ b/storm-client/src/jvm/org/apache/storm/streams/PairStream.java
@@ -168,6 +168,7 @@ public class PairStream<K, V> extends Stream<Pair<K, V>> {
     /**
      * {@inheritDoc}
      */
+    @Override
     public PairStream<K, V> filter(Predicate<? super Pair<K, V>> predicate) {
         return toPairStream(super.filter(predicate));
     }

--- a/storm-client/src/jvm/org/apache/storm/topology/BaseConfigurationDeclarer.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/BaseConfigurationDeclarer.java
@@ -89,6 +89,7 @@ public abstract class BaseConfigurationDeclarer<T extends ComponentConfiguration
     }
 
     @SuppressWarnings("unchecked")
+    @Override
     public T addResource(String resourceName, Number resourceValue) {
         Map<String, Double> resourcesMap = (Map<String, Double>) getComponentConfiguration()
                 .computeIfAbsent(Config.TOPOLOGY_COMPONENT_RESOURCES_MAP,

--- a/storm-client/src/jvm/org/apache/storm/topology/TopologyBuilder.java
+++ b/storm-client/src/jvm/org/apache/storm/topology/TopologyBuilder.java
@@ -653,58 +653,72 @@ public class TopologyBuilder {
             this.boltId = boltId;
         }
 
+        @Override
         public BoltDeclarer fieldsGrouping(String componentId, Fields fields) {
             return fieldsGrouping(componentId, Utils.DEFAULT_STREAM_ID, fields);
         }
 
+        @Override
         public BoltDeclarer fieldsGrouping(String componentId, String streamId, Fields fields) {
             return grouping(componentId, streamId, Grouping.fields(fields.toList()));
         }
 
+        @Override
         public BoltDeclarer globalGrouping(String componentId) {
             return globalGrouping(componentId, Utils.DEFAULT_STREAM_ID);
         }
 
+        @Override
         public BoltDeclarer globalGrouping(String componentId, String streamId) {
             return grouping(componentId, streamId, Grouping.fields(new ArrayList<String>()));
         }
 
+        @Override
         public BoltDeclarer shuffleGrouping(String componentId) {
             return shuffleGrouping(componentId, Utils.DEFAULT_STREAM_ID);
         }
 
+        @Override
         public BoltDeclarer shuffleGrouping(String componentId, String streamId) {
             return grouping(componentId, streamId, Grouping.shuffle(new NullStruct()));
         }
 
+        @Override
         public BoltDeclarer localOrShuffleGrouping(String componentId) {
             return localOrShuffleGrouping(componentId, Utils.DEFAULT_STREAM_ID);
         }
 
+        @Override
         public BoltDeclarer localOrShuffleGrouping(String componentId, String streamId) {
             return grouping(componentId, streamId, Grouping.local_or_shuffle(new NullStruct()));
         }
 
+        @Override
         public BoltDeclarer noneGrouping(String componentId) {
             return noneGrouping(componentId, Utils.DEFAULT_STREAM_ID);
         }
 
+        @Override
         public BoltDeclarer noneGrouping(String componentId, String streamId) {
             return grouping(componentId, streamId, Grouping.none(new NullStruct()));
         }
 
+        @Override
         public BoltDeclarer allGrouping(String componentId) {
             return allGrouping(componentId, Utils.DEFAULT_STREAM_ID);
         }
 
+        @Override
         public BoltDeclarer allGrouping(String componentId, String streamId) {
             return grouping(componentId, streamId, Grouping.all(new NullStruct()));
         }
 
+        @Override
         public BoltDeclarer directGrouping(String componentId) {
             return directGrouping(componentId, Utils.DEFAULT_STREAM_ID);
         }
 
+        @Override
         public BoltDeclarer directGrouping(String componentId, String streamId) {
             return grouping(componentId, streamId, Grouping.direct(new NullStruct()));
         }

--- a/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/ConfigUtils.java
@@ -80,6 +80,7 @@ public class ConfigUtils {
 
     public static Map<String, Object> maskPasswords(final Map<String, Object> conf) {
         Maps.EntryTransformer<String, Object, Object> maskPasswords = new Maps.EntryTransformer<String, Object, Object>() {
+            @Override
             public Object transformEntry(String key, Object value) {
                 return passwordConfigKeys.contains(key) ? "*****" : value;
             }

--- a/storm-client/src/jvm/org/apache/storm/utils/JCQueue.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/JCQueue.java
@@ -254,6 +254,7 @@ public class JCQueue implements Closeable {
     }
 
     public interface Consumer extends MessagePassingQueue.Consumer<Object> {
+        @Override
         void accept(Object event);
 
         void flush() throws InterruptedException;

--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -386,6 +386,7 @@ public class Utils {
                                         int priority, final boolean isFactory, boolean startImmediately,
                                         String threadName) {
         SmartThread thread = new SmartThread(new Runnable() {
+            @Override
             public void run() {
                 try {
                     final Callable<Long> fn = isFactory ? (Callable<Long>) afn.call() : afn;
@@ -416,6 +417,7 @@ public class Utils {
             thread.setUncaughtExceptionHandler(eh);
         } else {
             thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                @Override
                 public void uncaughtException(Thread t, Throwable e) {
                     LOG.error("Async loop died!", e);
                     Utils.exitProcess(1, "Async loop died!");

--- a/storm-client/src/jvm/org/apache/storm/windowing/persistence/SimpleWindowPartitionCache.java
+++ b/storm-client/src/jvm/org/apache/storm/windowing/persistence/SimpleWindowPartitionCache.java
@@ -180,16 +180,19 @@ public class SimpleWindowPartitionCache<K, V> implements WindowPartitionCache<K,
         private long maximumSize;
         private RemovalListener<K, V> removalListener;
 
+        @Override
         public SimpleWindowPartitionCacheBuilder<K, V> maximumSize(long size) {
             maximumSize = size;
             return this;
         }
 
+        @Override
         public SimpleWindowPartitionCacheBuilder<K, V> removalListener(RemovalListener<K, V> listener) {
             removalListener = listener;
             return this;
         }
 
+        @Override
         public SimpleWindowPartitionCache<K, V> build(CacheLoader<K, V> loader) {
             return new SimpleWindowPartitionCache<>(maximumSize, removalListener, loader);
         }

--- a/storm-server/src/main/java/org/apache/storm/LocalCluster.java
+++ b/storm-server/src/main/java/org/apache/storm/LocalCluster.java
@@ -1055,6 +1055,7 @@ public class LocalCluster implements ILocalClusterTrackedTopologyAware, Iface {
 
     }
 
+    @Override
     public void processWorkerMetrics(WorkerMetrics metrics) throws TException {
         getNimbus().processWorkerMetrics(metrics);
     }

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
@@ -1185,6 +1185,7 @@ public class Slot extends Thread implements AutoCloseable, BlobChangingCallback 
             this.slotMetrics = slotMetrics;
         }
 
+        @Override
         public String toString() {
             StringBuffer sb = new StringBuffer();
             sb.append(state);

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/ExecSorterByConnectionCount.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/ExecSorterByConnectionCount.java
@@ -50,6 +50,7 @@ public class ExecSorterByConnectionCount implements IExecSorter {
      * @param unassignedExecutors an unmodifiable set of executors that need to be scheduled.
      * @return a list of executors in sorted order for scheduling.
      */
+    @Override
     public List<ExecutorDetails> sortExecutors(Set<ExecutorDetails> unassignedExecutors) {
         Map<String, Component> componentMap = topologyDetails.getUserTopolgyComponents(); // excludes system components
         LinkedHashSet<ExecutorDetails> orderedExecutorSet = new LinkedHashSet<>(); // in insert order

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/ExecSorterByProximity.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/ExecSorterByProximity.java
@@ -54,6 +54,7 @@ public class ExecSorterByProximity implements IExecSorter {
      * @param unassignedExecutors an unmodifiable set of executors that need to be scheduled.
      * @return a list of executors in sorted order for scheduling.
      */
+    @Override
     public List<ExecutorDetails> sortExecutors(Set<ExecutorDetails> unassignedExecutors) {
         Map<String, Component> componentMap = topologyDetails.getUserTopolgyComponents(); // excludes system components
         LinkedHashSet<ExecutorDetails> orderedExecutorSet = new LinkedHashSet<>(); // in insert order

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/NodeSorter.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/NodeSorter.java
@@ -587,6 +587,7 @@ public class NodeSorter implements INodeSorter {
      *
      * @return a sorted list of racks
      */
+    @Override
     public List<ObjectResourcesItem> getSortedRacks() {
 
         final ObjectResourcesSummary clusterResourcesSummary = createClusterSummarizedResources();

--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/NodeSorterHostProximity.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/sorter/NodeSorterHostProximity.java
@@ -674,6 +674,7 @@ public class NodeSorterHostProximity implements INodeSorter {
      *
      * @return an iterable of sorted racks
      */
+    @Override
     public Iterable<ObjectResourcesItem> getSortedRacks() {
 
         final ObjectResourcesSummary clusterResourcesSummary = createClusterSummarizedResources();

--- a/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestConstraintSolverStrategy.java
@@ -352,6 +352,7 @@ public class TestConstraintSolverStrategy {
         }
 
         ConstraintSolverStrategy cs = new ConstraintSolverStrategy() {
+            @Override
             protected void prepareForScheduling(Cluster cluster, TopologyDetails topologyDetails) {
                 super.prepareForScheduling(cluster, topologyDetails);
 


### PR DESCRIPTION
## What is the purpose of the change

When running a build of storm project, say with "mvn compile" or "mvn clean install",
a very large number of PMDExceptions are thrown and a large number of files are not parsed.

This can also be duplicated by running "mvn pmd:pmd".

 Remove PMD Exceptions - because they are too numerous, annoying, and mask other warnings and errors.

## How was the change tested

*run "mvn pmd:pmd" and also "mvn pmd:check" to capture files unparsed before*