### PR TITLE
Run all the tests in multiple forked VM

### DIFF
--- a/external/storm-hdfs-blobstore/pom.xml
+++ b/external/storm-hdfs-blobstore/pom.xml
@@ -225,7 +225,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <reuseForks>false</reuseForks>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/external/storm-hdfs-oci/pom.xml
+++ b/external/storm-hdfs-oci/pom.xml
@@ -95,7 +95,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <reuseForks>false</reuseForks>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -248,7 +248,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <reuseForks>false</reuseForks>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -219,7 +219,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <reuseForks>true</reuseForks>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
         </configuration>
       </plugin>
       <plugin>

--- a/external/storm-kafka-client/pom.xml
+++ b/external/storm-kafka-client/pom.xml
@@ -158,7 +158,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <reuseForks>true</reuseForks>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -119,7 +119,7 @@
                         </property>
                     </properties>
                     <reuseForks>true</reuseForks>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <systemPropertyVariables>
                         <regression.downloadWorkerLogs>${regression.downloadWorkerLogs}</regression.downloadWorkerLogs>
                     </systemPropertyVariables>

--- a/sql/storm-sql-core/pom.xml
+++ b/sql/storm-sql-core/pom.xml
@@ -199,7 +199,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -167,7 +167,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
