### PR TITLE
STORM-3862 HdfsBlobStoreImpl should check permission after mkdirs

### DIFF
--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreFile.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreFile.java
@@ -141,6 +141,11 @@ public class HdfsBlobStoreFile extends BlobStoreFile {
             if (!fileSystem.mkdirs(path.getParent(), dirperms)) {
                 LOG.warn("error creating parent dir: " + path.getParent());
             }
+            if (!fileSystem.getFileStatus(path.getParent()).getPermission().equals(dirperms)) {
+                LOG.warn("Directory {} created with unexpected permission {}.Set permission {} for this directory.",
+                    path.getParent(), fileSystem.getFileStatus(path.getParent()).getPermission(), dirperms);
+                fileSystem.setPermission(path.getParent(), dirperms);
+            }
             out = fileSystem.create(path, (short) this.getMetadata().get_replication_factor());
             fileSystem.setPermission(path, dirperms);
             fileSystem.setReplication(path, (short) this.getMetadata().get_replication_factor());

--- a/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImpl.java
+++ b/external/storm-hdfs-blobstore/src/main/java/org/apache/storm/hdfs/blobstore/HdfsBlobStoreImpl.java
@@ -143,6 +143,11 @@ public class HdfsBlobStoreImpl {
         if (!fileSystem.exists(fullPath)) {
             FsPermission perms = new FsPermission(BLOBSTORE_DIR_PERMISSION);
             boolean success = fileSystem.mkdirs(fullPath, perms);
+            if (!fileSystem.getFileStatus(fullPath).getPermission().equals(perms)) {
+                LOG.warn("Directory {} created with unexpected permission {}.Set permission {} for this directory.",
+                    fullPath, fileSystem.getFileStatus(fullPath).getPermission(), perms);
+                fileSystem.setPermission(fullPath, perms);
+            }
             if (!success) {
                 throw new IOException("Error creating blobstore directory: " + fullPath);
             }


### PR DESCRIPTION
STORM-3862 HdfsBlobStoreImpl should check permission after mkdirs
## What is the purpose of the change
HdfsBlobStoreImpl and HdfsBlobStoreFile will create directory with 700 permission, we need to check if permission is set as expected. Because of the influence of settings such as umask, we need to check whether the permissions are set as expected. If not, we should give them the correct permissions to ensure subsequent normal operation.
