### PR TITLE
[STORM-3867] Bump activemq to 5.16.5 (highest for Jdk8) and undo guava downgrade

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -13,11 +13,11 @@ List of third-party dependencies grouped by their license type.
 
     Apache License, Version 2.0
 
-        * ActiveMQ :: Broker (org.apache.activemq:activemq-broker:5.15.15 - http://activemq.apache.org/activemq-broker)
-        * ActiveMQ :: Client (org.apache.activemq:activemq-client:5.15.15 - http://activemq.apache.org/activemq-client)
-        * ActiveMQ :: KahaDB Store (org.apache.activemq:activemq-kahadb-store:5.15.15 - http://activemq.apache.org/activemq-kahadb-store)
-        * ActiveMQ :: MQTT Protocol (org.apache.activemq:activemq-mqtt:5.15.15 - http://activemq.apache.org/activemq-mqtt)
-        * ActiveMQ :: Openwire Legacy Support (org.apache.activemq:activemq-openwire-legacy:5.15.15 - http://activemq.apache.org/activemq-openwire-legacy)
+        * ActiveMQ :: Broker (org.apache.activemq:activemq-broker:5.16.5 - http://activemq.apache.org/activemq-broker)
+        * ActiveMQ :: Client (org.apache.activemq:activemq-client:5.16.5 - http://activemq.apache.org/activemq-client)
+        * ActiveMQ :: KahaDB Store (org.apache.activemq:activemq-kahadb-store:5.16.5 - http://activemq.apache.org/activemq-kahadb-store)
+        * ActiveMQ :: MQTT Protocol (org.apache.activemq:activemq-mqtt:5.16.5 - http://activemq.apache.org/activemq-mqtt)
+        * ActiveMQ :: Openwire Legacy Support (org.apache.activemq:activemq-openwire-legacy:5.16.5 - http://activemq.apache.org/activemq-openwire-legacy)
         * ActiveMQ Protocol Buffers Implementation and Compiler (org.apache.activemq.protobuf:activemq-protobuf:1.1 - http://activemq.apache.org/activemq-protobuf)
         * Aether :: API (org.sonatype.aether:aether-api:1.7 - http://aether.sonatype.org/aether-api/)
         * Aether :: Implementation (org.sonatype.aether:aether-impl:1.7 - http://aether.sonatype.org/aether-impl/)

--- a/examples/storm-jms-examples/pom.xml
+++ b/examples/storm-jms-examples/pom.xml
@@ -72,6 +72,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
+            <version>${activemq.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/examples/storm-mqtt-examples/pom.xml
+++ b/examples/storm-mqtt-examples/pom.xml
@@ -30,11 +30,6 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
   
-  <properties>
-      <!-- Required downgrade by activemq-broker 5.15.3 -->
-      <guava.version>16.0.1</guava.version>
-  </properties>
-
   <dependencies>
    <dependency>
       <groupId>org.apache.storm</groupId>

--- a/external/storm-jms/pom.xml
+++ b/external/storm-jms/pom.xml
@@ -52,6 +52,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-all</artifactId>
+            <version>${activemq.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/external/storm-mqtt/pom.xml
+++ b/external/storm-mqtt/pom.xml
@@ -29,11 +29,6 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     
-    <properties>
-        <!-- Required downgrade by activemq-broker 5.15.3 -->
-        <guava.version>16.0.1</guava.version>
-    </properties>
-
     <repositories>
         <repository>
             <id>bintray</id>

--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
         <solr.version>5.2.1</solr.version>
         <jpmml.version>1.0.22</jpmml.version>
         <jedis.version>2.9.0</jedis.version>
-        <activemq.version>5.15.15</activemq.version>
+        <activemq.version>5.16.5</activemq.version>
         <rocketmq.version>4.2.0</rocketmq.version>
 
         <jackson.version>2.10.5</jackson.version>


### PR DESCRIPTION
## What is the purpose of the change

*Upgrade to ActiveMQ version 5.16.5 (highest for Jdk8) and undo com.google..guava version downgrade*

## How was the change tested

*Build, test, and check licenses*