### PR TITLE
Storm 3872 Excluding some unused packages to enable compiling with maven versions >= 3.8.1 

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -443,7 +443,6 @@ List of third-party dependencies grouped by their license type.
         * Open JSON (com.tdunning:json:1.8 - https://github.com/tdunning/open-json)
         * ORC Core (org.apache.orc:orc-core:1.3.4 - http://orc.apache.org/orc-core)
         * oro (oro:oro:2.0.8 - no url defined)
-        * Pentaho Aggregate Designer Algorithm (org.pentaho:pentaho-aggdesigner-algorithm:5.1.5-jhyde - http://github.com/pentaho/mondrian/pentaho-aggdesigner-algorithm)
         * Plexus :: Component Annotations (org.codehaus.plexus:plexus-component-annotations:1.5.5 - http://plexus.codehaus.org/plexus-containers/plexus-component-annotations/)
         * Plexus :: Component Annotations (org.codehaus.plexus:plexus-component-annotations:1.7.1 - http://codehaus-plexus.github.io/plexus-containers/plexus-component-annotations/)
         * Plexus Cipher: encryption/decryption Component (org.sonatype.plexus:plexus-cipher:1.4 - http://spice.sonatype.org/plexus-cipher)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -907,7 +907,6 @@ The license texts of these dependencies can be found in the licenses directory.
         * Open JSON (com.tdunning:json:1.8 - https://github.com/tdunning/open-json)
         * ORC Core (org.apache.orc:orc-core:1.3.4 - http://orc.apache.org/orc-core)
         * oro (oro:oro:2.0.8 - no url defined)
-        * Pentaho Aggregate Designer Algorithm (org.pentaho:pentaho-aggdesigner-algorithm:5.1.5-jhyde - http://github.com/pentaho/mondrian/pentaho-aggdesigner-algorithm)
         * slice (io.airlift:slice:0.29 - https://github.com/airlift/slice)
         * Slider Core (org.apache.slider:slider-core:0.90.2-incubating - http://slider.incubator.apache.org/slider-core/)
         * SnakeYAML (org.yaml:snakeyaml:1.26 - http://www.snakeyaml.org)

--- a/external/storm-autocreds/pom.xml
+++ b/external/storm-autocreds/pom.xml
@@ -156,6 +156,10 @@
             <version>${hive.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -86,7 +86,7 @@
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
-	    	<exclusion>
+	    	    <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -73,6 +73,10 @@
       <version>${hive.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>

--- a/external/storm-solr/pom.xml
+++ b/external/storm-solr/pom.xml
@@ -82,6 +82,14 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
+                    <groupId>org.restlet.jee</groupId>
+                    <artifactId>org.restlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.restlet.jee</groupId>
+                    <artifactId>org.restlet.ext.servlet</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
@@ -98,6 +106,14 @@
             <version>${solr.version}</version>
             <scope>test</scope>
             <exclusions>
+                <exclusion>
+                    <groupId>org.restlet.jee</groupId>
+                    <artifactId>org.restlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.restlet.jee</groupId>
+                    <artifactId>org.restlet.ext.servlet</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

Excluding some unused packages to enable compiling with maven versions >= 3.8.1 

## How was the change tested

built locally.