### PR TITLE
STORM-3873: Remove junit4 dependency

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -660,7 +660,6 @@ List of third-party dependencies grouped by their license type.
         * Aether Utilities (org.eclipse.aether:aether-util:0.9.0.M2 - http://www.eclipse.org/aether/aether-util/)
         * clojure (org.clojure:clojure:1.10.0 - http://clojure.org/)
         * core.specs.alpha (org.clojure:core.specs.alpha:0.2.44 - https://github.com/clojure/build.poms/core.specs.alpha)
-        * JUnit (junit:junit:4.12 - http://junit.org)
         * org.eclipse.sisu.inject (org.eclipse.sisu:org.eclipse.sisu.inject:0.3.3 - http://www.eclipse.org/sisu/org.eclipse.sisu.inject/)
         * org.eclipse.sisu.plexus (org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.3 - http://www.eclipse.org/sisu/org.eclipse.sisu.plexus/)
         * spec.alpha (org.clojure:spec.alpha:0.2.176 - https://github.com/clojure/build.poms/spec.alpha)

--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -563,7 +563,6 @@ List of third-party dependencies grouped by their license type.
         * ASM Core (asm:asm:3.1 - http://asm.objectweb.org/asm/)
         * ASM Tree (asm:asm-tree:3.1 - http://asm.objectweb.org/asm-tree/)
         * Commons Compiler (org.codehaus.janino:commons-compiler:2.7.6 - http://docs.codehaus.org/display/JANINO/Home/commons-compiler)
-        * Hamcrest Core (org.hamcrest:hamcrest-core:1.3 - https://github.com/hamcrest/JavaHamcrest/hamcrest-core)
         * Janino (org.codehaus.janino:janino:2.7.6 - http://docs.codehaus.org/display/JANINO/Home/janino)
         * JPMML evaluator (org.jpmml:pmml-evaluator:1.0.22 - http://www.jpmml.org/pmml-evaluator)
         * JPMML manager (org.jpmml:pmml-manager:1.0.22 - http://www.jpmml.org/pmml-manager)
@@ -601,10 +600,6 @@ List of third-party dependencies grouped by their license type.
         * ParaNamer Core (com.thoughtworks.paranamer:paranamer:2.7 - http://paranamer.codehaus.org/paranamer)
         * Stax2 API (org.codehaus.woodstox:stax2-api:3.1.4 - http://wiki.fasterxml.com/WoodstoxStax2)
         * xmlenc Library (xmlenc:xmlenc:0.52 - http://xmlenc.sourceforge.net)
-
-    BSD style
-
-        * Hamcrest Core (org.hamcrest:hamcrest-core:1.1 - no url defined)
 
     CC0 1.0 Universal
 

--- a/external/storm-hdfs-blobstore/pom.xml
+++ b/external/storm-hdfs-blobstore/pom.xml
@@ -30,8 +30,6 @@
     <properties>
         <!-- Required downgrade by hadoop-hdfs 2.8.5 -->
         <guava.version>16.0.1</guava.version>
-        <!-- Required downgrade by hadoop-hdfs 2.8.5 (org.apache.hadoop.test.GenericTestUtils.getTestDir)-->
-        <junit.version>4.12</junit.version>
     </properties>
 
     <developers>
@@ -213,11 +211,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -30,8 +30,6 @@
     <properties>
         <!-- Required downgrade by hadoop-hdfs 2.8.5 -->
         <guava.version>16.0.1</guava.version>
-        <!-- Required downgrade by hadoop-hdfs 2.8.5 (org.apache.hadoop.test.GenericTestUtils.getTestDir)-->
-        <junit.version>4.12</junit.version>
     </properties>
 
     <developers>
@@ -236,11 +234,6 @@
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-autocreds</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/testing/MiniDFSClusterExtensionClassLevel.java
+++ b/external/storm-hdfs/src/test/java/org/apache/storm/hdfs/testing/MiniDFSClusterExtensionClassLevel.java
@@ -17,12 +17,15 @@
  */
 package org.apache.storm.hdfs.testing;
 
+import java.io.File;
 import java.util.function.Supplier;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static org.apache.storm.hdfs.testing.MiniDFSClusterExtension.getTestDir;
 
 public class MiniDFSClusterExtensionClassLevel implements BeforeAllCallback, AfterAllCallback {
 
@@ -52,6 +55,8 @@ public class MiniDFSClusterExtensionClassLevel implements BeforeAllCallback, Aft
     public void beforeAll(ExtensionContext arg0) throws Exception {
         System.setProperty(TEST_BUILD_DATA, "target/test/data");
         hadoopConf = hadoopConfSupplier.get();
+        String tempDir = getTestDir("dfs").getAbsolutePath() + File.separator;
+        hadoopConf.set("hdfs.minidfs.basedir", tempDir);
         dfscluster = new MiniDFSCluster.Builder(hadoopConf).numDataNodes(3).build();
         dfscluster.waitActive();
     }

--- a/storm-client/test/py/test_storm_cli.py
+++ b/storm-client/test/py/test_storm_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 from unittest import TestCase, main as test_main
-import mock
+from unittest import mock
 import sys
 import os
 


### PR DESCRIPTION
## What is the purpose of the change

Remove junit4 from storm-hdfs and storm-hdfs blobstore to completely remove junit4 from Storm.


## How was the change tested

built locally