### PR TITLE
Enable s390x builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
 arch:
   - amd64
   - arm64
+  - s390x
 
 env:
   - MODULES=Client
@@ -38,11 +39,10 @@ jdk:
   - openjdk11
   
 matrix:
-  include:
-    - arch: s390x
-      jdk: openjdk11
   exclude:
     - arch: arm64
+      jdk: openjdk8
+    - arch: s390x
       jdk: openjdk8
 
 before_install:
@@ -61,9 +61,7 @@ before_install:
 
 install: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
 script:
-  - if [[ $(uname -m) != 's390x' ]]; then 
-      /bin/bash ./dev-tools/travis/travis-script.sh `pwd` $MODULES;
-    fi
+  - /bin/bash ./dev-tools/travis/travis-script.sh `pwd` $MODULES
 cache:
   directories:
     - "$HOME/.m2/repository"

--- a/integration-test/run-it.sh
+++ b/integration-test/run-it.sh
@@ -36,7 +36,7 @@ then
   chmod o+rx /home/travis
 fi
 list_storm_processes || true
-if [ "$(uname -m)" != aarch64 ]; then
+if [ "$(uname -m)" != aarch64 ] && [ "$(uname -m)" != s390x ]; then
   # increasing swap space so we can run lots of workers
   sudo dd if=/dev/zero of=/swapfile.img bs=4096 count=1M
   sudo mkswap /swapfile.img


### PR DESCRIPTION
Signed-off-by: Shahid Shaikh <shahid@us.ibm.com>

## What is the purpose of the change

Enable s390x builds on Travis.

## How was the change tested

Changes are tested by running Travis [builds](https://app.travis-ci.com/github/linux-on-ibm-z/storm/builds/255643186).