### PR TITLE
fix(sec): upgrade org.elasticsearch:elasticsearch to 6.8.17

### DIFF
--- a/examples/storm-elasticsearch-examples/pom.xml
+++ b/examples/storm-elasticsearch-examples/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>storm-elasticsearch-examples</artifactId>
     <properties>
-        <elasticsearch.test.version>2.4.4</elasticsearch.test.version>
+        <elasticsearch.test.version>6.8.17</elasticsearch.test.version>
     </properties>
 
     <dependencies>

--- a/external/storm-elasticsearch/pom.xml
+++ b/external/storm-elasticsearch/pom.xml
@@ -41,7 +41,7 @@
     </developers>
 
     <properties>
-        <elasticsearch.test.version>2.4.4</elasticsearch.test.version>
+        <elasticsearch.test.version>6.8.17</elasticsearch.test.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 6 security vulnerabilities found in org.elasticsearch:elasticsearch 2.4.4
- [CVE-2020-7020](https://www.oscs1024.com/hd/CVE-2020-7020)
- [CVE-2021-22144](https://www.oscs1024.com/hd/CVE-2021-22144)
- [CVE-2020-7021](https://www.oscs1024.com/hd/CVE-2020-7021)
- [CVE-2021-22137](https://www.oscs1024.com/hd/CVE-2021-22137)
- [CVE-2021-22135](https://www.oscs1024.com/hd/CVE-2021-22135)
- [CVE-2019-7614](https://www.oscs1024.com/hd/CVE-2019-7614)


### What did I do？
Upgrade org.elasticsearch:elasticsearch from 2.4.4 to 6.8.17 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS