### PR TITLE
fix(sec): upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/examples/storm-hdfs-examples/pom.xml
+++ b/examples/storm-hdfs-examples/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- Required downgrade by hadoop-hdfs 2.6.1 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <dependencies>

--- a/examples/storm-hive-examples/pom.xml
+++ b/examples/storm-hive-examples/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- Required downgrade by hive-hcatalog-core 2.3.4 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <dependencies>

--- a/examples/storm-pmml-examples/pom.xml
+++ b/examples/storm-pmml-examples/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <!-- Required downgrade by pmml-evaluator 1.0.22 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <dependencies>

--- a/external/storm-blobstore-migration/pom.xml
+++ b/external/storm-blobstore-migration/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     
     <properties>
         <!-- Required downgrade by hadoop-hdfs 2.8.5 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
     
     <dependencies>

--- a/external/storm-cassandra/pom.xml
+++ b/external/storm-cassandra/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.slf4j.version>1.7.6</org.slf4j.version>
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <commons-lang3.version>3.3</commons-lang3.version>
         <cassandra.driver.core.version>3.1.2</cassandra.driver.core.version>
     </properties>

--- a/external/storm-hdfs-blobstore/pom.xml
+++ b/external/storm-hdfs-blobstore/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- Required downgrade by hadoop-hdfs 2.8.5 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <developers>

--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- Required downgrade by hadoop-hdfs 2.8.5 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <developers>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <!-- Required downgrade by hive-hcatalog-core 2.3.4 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
   <dependencies>

--- a/external/storm-pmml/pom.xml
+++ b/external/storm-pmml/pom.xml
@@ -33,7 +33,7 @@
     
     <properties>
         <!-- Required downgrade by pmml-evaluator 1.0.22 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <developers>

--- a/sql/storm-sql-core/pom.xml
+++ b/sql/storm-sql-core/pom.xml
@@ -37,7 +37,7 @@
     
     <properties>
         <!-- Required downgrade by calcite-core 1.14.0 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <dependencies>

--- a/sql/storm-sql-external/storm-sql-hdfs/pom.xml
+++ b/sql/storm-sql-external/storm-sql-hdfs/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- Required downgrade by calcite-core 1.14.0 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <developers>

--- a/sql/storm-sql-external/storm-sql-kafka/pom.xml
+++ b/sql/storm-sql-external/storm-sql-kafka/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- Required downgrade by calcite-core 1.15.0 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <developers>

--- a/sql/storm-sql-runtime/pom.xml
+++ b/sql/storm-sql-runtime/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- Required downgrade by calcite-core 1.15.0 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <developers>

--- a/storm-dist/binary/storm-sql-core-bin/pom.xml
+++ b/storm-dist/binary/storm-sql-core-bin/pom.xml
@@ -27,7 +27,7 @@
     
     <properties>
         <!-- Required downgrade by calcite-core 1.14.0 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
     
     <dependencies>

--- a/storm-dist/binary/storm-sql-runtime-bin/pom.xml
+++ b/storm-dist/binary/storm-sql-runtime-bin/pom.xml
@@ -27,7 +27,7 @@
     
     <properties>
         <!-- Required downgrade by calcite-core 1.14.0 -->
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
     
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.google.guava:guava 16.0.1
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)
- [CVE-2020-8908](https://www.oscs1024.com/hd/CVE-2020-8908)


### What did I do？
Upgrade com.google.guava:guava from 16.0.1 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS