### PR TITLE
fix(sec): upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/examples/storm-solr-examples/pom.xml
+++ b/examples/storm-solr-examples/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <!-- Required downgrade by solr-core 5.5.5 -->
-        <guava.version>17.0</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <dependencies>

--- a/external/storm-solr/pom.xml
+++ b/external/storm-solr/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <solr.version>5.5.5</solr.version>
         <!-- Required downgrade by solr-core 5.5.5 -->
-        <guava.version>17.0</guava.version>
+        <guava.version>30.0-jre</guava.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.google.guava:guava 17.0
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)
- [CVE-2020-8908](https://www.oscs1024.com/hd/CVE-2020-8908)


### What did I do？
Upgrade com.google.guava:guava from 17.0 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS