### PR TITLE
[STORM-3885] fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
         <rocketmq.version>4.2.0</rocketmq.version>
 
         <jackson.version>2.10.5</jackson.version>
-        <jackson.databind.version>2.10.5.1</jackson.databind.version>
+        <jackson.databind.version>2.12.6.1</jackson.databind.version>
         
         <storm.kafka.client.version>0.11.0.3</storm.kafka.client.version>
 


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.10.5.1
- [CVE-2020-36518](https://www.oscs1024.com/hd/CVE-2020-36518)
- [MPS-2022-12500](https://www.oscs1024.com/hd/MPS-2022-12500)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.10.5.1 to 2.12.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS