### PR TITLE
Adding IgnoreUnrecognizedVMOptions to make worker start with jdk-11

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -192,7 +192,7 @@ supervisor.thrift.socket.timeout.ms: 5000
 
 ### worker.* configs are for task workers
 worker.heap.memory.mb: 768
-worker.childopts: "-Xmx%HEAP-MEM%m -XX:+PrintGCDetails -Xloggc:artifacts/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"
+worker.childopts: "-Xmx%HEAP-MEM%m XX:+IgnoreUnrecognizedVMOptions -XX:+PrintGCDetails -Xloggc:artifacts/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"
 worker.gc.childopts: ""
 
 # Unlocking commercial features requires a special license from Oracle.

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -192,7 +192,7 @@ supervisor.thrift.socket.timeout.ms: 5000
 
 ### worker.* configs are for task workers
 worker.heap.memory.mb: 768
-worker.childopts: "-Xmx%HEAP-MEM%m XX:+IgnoreUnrecognizedVMOptions -XX:+PrintGCDetails -Xloggc:artifacts/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"
+worker.childopts: "-Xmx%HEAP-MEM%m -XX:+IgnoreUnrecognizedVMOptions -XX:+PrintGCDetails -Xloggc:artifacts/gc.log -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=artifacts/heapdump"
 worker.gc.childopts: ""
 
 # Unlocking commercial features requires a special license from Oracle.


### PR DESCRIPTION
Issue:

- Many of the default worker JVM parameters is no longer supported in java versions > 11. This will result in the worker process getting crashed. eg: https://github.com/31z4/storm-docker/issues/32
- The official storm docker hub (https://hub.docker.com/_/storm) now ships jdk-11 and worker process fails with Error: Could not create the Java Virtual Machine.

## What is the purpose of the change
To make storm workers run in jdk-11 and above

*(Explain why we should have this change)*
Storm workers are not able to start in jdk-11 and above

## How was the change tested
Tested by running " storm supervisor -c worker.childopts= .. " with open-jdk11 and see that the topology is working as expected and worker process is getting started.
*(Explain what tests did you do to verify the code change)*

before fix:

2022-12-07 17:38:27.653 o.a.s.d.s.BasicContainer SLOT_6700 [INFO] Launching worker with command: '/usr/local/openjdk-11/bin/java' '-cp' '/apache-storm-2.4.0/lib-worker/*:/apache-storm-2.4.0/extlib/*:/conf:/data/supervisor/stormdist/exclaimtopology-1-1670434694/stormjar.jar' '-Xmx64m' '-Dlogging.sensitivity=S3' '-Dlogfile.name=worker.log' '-Dstorm.home=/apache-storm-2.4.0' '-Dworkers.artifacts=/logs/workers-artifacts' '-Dstorm.id=exclaimtopology-1-1670434694' '-Dworker.id=f52f7411-c5dd-4a1f-941f-24a316d0e0fd' '-Dworker.port=6700' '-Dstorm.log.dir=/logs' '-DLog4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector' '-Dstorm.local.dir=/data' '-Dworker.memory_limit_mb=512' '-Dlog4j.configurationFile=/apache-storm-2.4.0/log4j2/worker.xml' 'org.apache.storm.LogWriter' '/usr/local/openjdk-11/bin/java' '-server' '-Dlogging.sensitivity=S3' '-Dlogfile.name=worker.log' '-Dstorm.home=/apache-storm-2.4.0' '-Dworkers.artifacts=/logs/workers-artifacts' '-Dstorm.id=exclaimtopology-1-1670434694' '-Dworker.id=f52f7411-c5dd-4a1f-941f-24a316d0e0fd' '-Dworker.port=6700' '-Dstorm.log.dir=/logs' '-DLog4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector' '-Dstorm.local.dir=/data' '-Dworker.memory_limit_mb=512' '-Dlog4j.configurationFile=/apache-storm-2.4.0/log4j2/worker.xml' '-Xmx512m' '-XX:+PrintGCDetails' '-Xloggc:artifacts/gc.log' '-XX:+PrintGCDateStamps' '-XX:+PrintGCTimeStamps' '-XX:+UseGCLogFileRotation' '-XX:NumberOfGCLogFiles=10' '-XX:GCLogFileSize=1M' '-XX:+HeapDumpOnOutOfMemoryError' '-XX:HeapDumpPath=artifacts/heapdump' '-Djava.library.path=/data/supervisor/stormdist/exclaimtopology-1-1670434694/resources/Linux-amd64:/data/supervisor/stormdist/exclaimtopology-1-1670434694/resources:/usr/local/lib:/opt/local/lib:/usr/lib:/usr/lib64' '-Dstorm.conf.file=' '-Dstorm.options=worker.childopts%3D-Xmx512m+-XX%3A%2BPrintGCDetails+-Xloggc%3Aartifacts%2Fgc.log+-XX%3A%2BPrintGCDateStamps+-XX%3A%2BPrintGCTimeStamps+-XX%3A%2BUseGCLogFileRotation+-XX%3ANumberOfGCLogFiles%3D10+-XX%3AGCLogFileSize%3D1M+-XX%3A%2BHeapDumpOnOutOfMemoryError+-XX%3AHeapDumpPath%3Dartifacts%2Fheapdump' '-Djava.io.tmpdir=/data/workers/f52f7411-c5dd-4a1f-941f-24a316d0e0fd/tmp' '-cp' '/apache-storm-2.4.0/lib-worker/*:/apache-storm-2.4.0/extlib/*:/conf:/data/supervisor/stormdist/exclaimtopology-1-1670434694/stormjar.jar' 'org.apache.storm.daemon.worker.Worker' 'exclaimtopology-1-1670434694' '21d4cb06-d0bc-44c6-bc73-b56078eadb82-172.17.0.4' '6628' '6700' 'f52f7411-c5dd-4a1f-941f-24a316d0e0fd'.
2022-12-07 17:38:27.679 o.a.s.d.s.Slot SLOT_6700 [INFO] STATE waiting-for-blob-localization msInState: 183 -> waiting-for-worker-start msInState: 0 topo:exclaimtopology-1-1670434694 worker:f52f7411-c5dd-4a1f-941f-24a316d0e0fd
2022-12-07 17:38:27.679 o.a.s.d.s.Slot SLOT_6700 [INFO] SLOT 6700: Changing current assignment from null to LocalAssignment(topology_id:exclaimtopology-1-1670434694, executors:[ExecutorInfo(task_start:4, task_end:4), ExecutorInfo(task_start:3, task_end:3), ExecutorInfo(task_start:2, task_end:2), ExecutorInfo(task_start:1, task_end:1)], resources:WorkerResources(mem_on_heap:512.0, mem_off_heap:0.0, cpu:40.0, shared_mem_on_heap:0.0, shared_mem_off_heap:0.0, resources:{offheap.memory.mb=0.0, onheap.memory.mb=512.0, cpu.pcore.percent=40.0}, shared_resources:{}), owner:storm)
**2022-12-07 17:38:29.077 o.a.s.d.s.BasicContainer Thread-7 [INFO] Worker Process f52f7411-c5dd-4a1f-941f-24a316d0e0fd exited with code: 1**


After:

2022-12-07 17:48:06.394 o.a.s.d.s.BasicContainer SLOT_6700 [INFO] Launching worker with command: '/usr/local/openjdk-11/bin/java' '-cp' '/apache-storm-2.4.0/lib-worker/*:/apache-storm-2.4.0/extlib/*:/conf:/data/supervisor/stormdist/exclaimtopology-1-1670434694/stormjar.jar' '-Xmx64m' '-Dlogging.sensitivity=S3' '-Dlogfile.name=worker.log' '-Dstorm.home=/apache-storm-2.4.0' '-Dworkers.artifacts=/logs/workers-artifacts' '-Dstorm.id=exclaimtopology-1-1670434694' '-Dworker.id=2a1f426e-dbf0-453b-a8bb-d1fe981b5ada' '-Dworker.port=6700' '-Dstorm.log.dir=/logs' '-DLog4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector' '-Dstorm.local.dir=/data' '-Dworker.memory_limit_mb=512' '-Dlog4j.configurationFile=/apache-storm-2.4.0/log4j2/worker.xml' 'org.apache.storm.LogWriter' '/usr/local/openjdk-11/bin/java' '-server' '-Dlogging.sensitivity=S3' '-Dlogfile.name=worker.log' '-Dstorm.home=/apache-storm-2.4.0' '-Dworkers.artifacts=/logs/workers-artifacts' '-Dstorm.id=exclaimtopology-1-1670434694' '-Dworker.id=2a1f426e-dbf0-453b-a8bb-d1fe981b5ada' '-Dworker.port=6700' '-Dstorm.log.dir=/logs' '-DLog4jContextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector' '-Dstorm.local.dir=/data' '-Dworker.memory_limit_mb=512' '-Dlog4j.configurationFile=/apache-storm-2.4.0/log4j2/worker.xml' '-Xmx512m' '-XX:+IgnoreUnrecognizedVMOptions' '-XX:+PrintGCDetails' '-Xloggc:artifacts/gc.log' '-XX:+PrintGCDateStamps' '-XX:+PrintGCTimeStamps' '-XX:+UseGCLogFileRotation' '-XX:NumberOfGCLogFiles=10' '-XX:GCLogFileSize=1M' '-XX:+HeapDumpOnOutOfMemoryError' '-XX:HeapDumpPath=artifacts/heapdump' '-Djava.library.path=/data/supervisor/stormdist/exclaimtopology-1-1670434694/resources/Linux-amd64:/data/supervisor/stormdist/exclaimtopology-1-1670434694/resources:/usr/local/lib:/opt/local/lib:/usr/lib:/usr/lib64' '-Dstorm.conf.file=' '-Dstorm.options=worker.childopts%3D-Xmx512m+-XX%3A%2BIgnoreUnrecognizedVMOptions+-XX%3A%2BPrintGCDetails+-Xloggc%3Aartifacts%2Fgc.log+-XX%3A%2BPrintGCDateStamps+-XX%3A%2BPrintGCTimeStamps+-XX%3A%2BUseGCLogFileRotation+-XX%3ANumberOfGCLogFiles%3D10+-XX%3AGCLogFileSize%3D1M+-XX%3A%2BHeapDumpOnOutOfMemoryError+-XX%3AHeapDumpPath%3Dartifacts%2Fheapdump' '-Djava.io.tmpdir=/data/workers/2a1f426e-dbf0-453b-a8bb-d1fe981b5ada/tmp' '-cp' '/apache-storm-2.4.0/lib-worker/*:/apache-storm-2.4.0/extlib/*:/conf:/data/supervisor/stormdist/exclaimtopology-1-1670434694/stormjar.jar' 'org.apache.storm.daemon.worker.Worker' 'exclaimtopology-1-1670434694' '832aed9c-a9ef-4100-b74b-0d28069b55e0-172.17.0.4' '6628' '6700' '2a1f426e-dbf0-453b-a8bb-d1fe981b5ada'.
2022-12-07 17:48:06.420 o.a.s.d.s.Slot SLOT_6700 [INFO] STATE waiting-for-blob-localization msInState: 224 -> waiting-for-worker-start msInState: 0 topo:exclaimtopology-1-1670434694 worker:2a1f426e-dbf0-453b-a8bb-d1fe981b5ada
2022-12-07 17:48:06.421 o.a.s.d.s.Slot SLOT_6700 [INFO] SLOT 6700: Changing current assignment from null to LocalAssignment(topology_id:exclaimtopology-1-1670434694, executors:[ExecutorInfo(task_start:4, task_end:4), ExecutorInfo(task_start:3, task_end:3), ExecutorInfo(task_start:2, task_end:2), ExecutorInfo(task_start:1, task_end:1)], resources:WorkerResources(mem_on_heap:512.0, mem_off_heap:0.0, cpu:40.0, shared_mem_on_heap:0.0, shared_mem_off_heap:0.0, resources:{offheap.memory.mb=0.0, onheap.memory.mb=512.0, cpu.pcore.percent=40.0}, shared_resources:{}), owner:storm)
**2022-12-07 17:48:11.440 o.a.s.d.s.Slot SLOT_6700 [INFO] STATE waiting-for-worker-start msInState: 5021 topo:exclaimtopology-1-1670434694 worker:2a1f426e-dbf0-453b-a8bb-d1fe981b5ada -> running msInState: 1 topo:exclaimtopology-1-1670434694 worker:2a1f426e-dbf0-453b-a8bb-d1fe981b5ada**