### PR TITLE
[STORM-3889] Bump snakeyaml from 1.26 to 1.32

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -470,7 +470,7 @@ List of third-party dependencies grouped by their license type.
         * Sisu - Inject (Plexus bean support) (org.sonatype.sisu:sisu-inject-plexus:1.4.2 - http://sisu.sonatype.org/sisu-inject/guice-bean/guice-plexus/sisu-inject-plexus/)
         * slice (io.airlift:slice:0.29 - https://github.com/airlift/slice)
         * Slider Core (org.apache.slider:slider-core:0.90.2-incubating - http://slider.incubator.apache.org/slider-core/)
-        * SnakeYAML (org.yaml:snakeyaml:1.32 - http://www.snakeyaml.org)
+        * SnakeYAML (org.yaml:snakeyaml:1.32 - https://bitbucket.org/snakeyaml/snakeyaml)
         * Snappy for Java (org.xerial.snappy:snappy-java:1.0.5 - http://github.com/xerial/snappy-java/)
         * snappy-java (org.xerial.snappy:snappy-java:1.1.1.3 - https://github.comm/xerial/snappy-java)
         * snappy-java (org.xerial.snappy:snappy-java:1.1.2.6 - https://github.com/xerial/snappy-java)

--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -470,7 +470,7 @@ List of third-party dependencies grouped by their license type.
         * Sisu - Inject (Plexus bean support) (org.sonatype.sisu:sisu-inject-plexus:1.4.2 - http://sisu.sonatype.org/sisu-inject/guice-bean/guice-plexus/sisu-inject-plexus/)
         * slice (io.airlift:slice:0.29 - https://github.com/airlift/slice)
         * Slider Core (org.apache.slider:slider-core:0.90.2-incubating - http://slider.incubator.apache.org/slider-core/)
-        * SnakeYAML (org.yaml:snakeyaml:1.26 - http://www.snakeyaml.org)
+        * SnakeYAML (org.yaml:snakeyaml:1.32 - http://www.snakeyaml.org)
         * Snappy for Java (org.xerial.snappy:snappy-java:1.0.5 - http://github.com/xerial/snappy-java/)
         * snappy-java (org.xerial.snappy:snappy-java:1.1.1.3 - https://github.comm/xerial/snappy-java)
         * snappy-java (org.xerial.snappy:snappy-java:1.1.2.6 - https://github.com/xerial/snappy-java)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -909,7 +909,7 @@ The license texts of these dependencies can be found in the licenses directory.
         * oro (oro:oro:2.0.8 - no url defined)
         * slice (io.airlift:slice:0.29 - https://github.com/airlift/slice)
         * Slider Core (org.apache.slider:slider-core:0.90.2-incubating - http://slider.incubator.apache.org/slider-core/)
-        * SnakeYAML (org.yaml:snakeyaml:1.26 - http://www.snakeyaml.org)
+        * SnakeYAML (org.yaml:snakeyaml:1.32 - http://www.snakeyaml.org)
         * Snappy for Java (org.xerial.snappy:snappy-java:1.0.5 - http://github.com/xerial/snappy-java/)
         * snappy-java (org.xerial.snappy:snappy-java:1.1.2.6 - https://github.com/xerial/snappy-java)
         * StAX API (stax:stax-api:1.0.1 - http://stax.codehaus.org/)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -909,7 +909,7 @@ The license texts of these dependencies can be found in the licenses directory.
         * oro (oro:oro:2.0.8 - no url defined)
         * slice (io.airlift:slice:0.29 - https://github.com/airlift/slice)
         * Slider Core (org.apache.slider:slider-core:0.90.2-incubating - http://slider.incubator.apache.org/slider-core/)
-        * SnakeYAML (org.yaml:snakeyaml:1.32 - http://www.snakeyaml.org)
+        * SnakeYAML (org.yaml:snakeyaml:1.32 - https://bitbucket.org/snakeyaml/snakeyaml)
         * Snappy for Java (org.xerial.snappy:snappy-java:1.0.5 - http://github.com/xerial/snappy-java/)
         * snappy-java (org.xerial.snappy:snappy-java:1.1.2.6 - https://github.com/xerial/snappy-java)
         * StAX API (stax:stax-api:1.0.1 - http://stax.codehaus.org/)

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <jetty.version>9.4.45.v20220203</jetty.version>
         <clojure.tools.logging.version>0.2.3</clojure.tools.logging.version>
         <carbonite.version>1.5.0</carbonite.version>
-        <snakeyaml.version>1.26</snakeyaml.version>
+        <snakeyaml.version>1.32</snakeyaml.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jctools.version>2.0.1</jctools.version>
         <jgrapht.version>0.9.0</jgrapht.version>


### PR DESCRIPTION
## What is the purpose of the change

*Dependabot recommendation*

## How was the change tested

*Run unit and integration test*