### PR TITLE
STORM-3897 Replace Travis with GitHub Actions

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Java CI with Maven
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  push:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        java: [ 8, 11 ]
+        # Ignore 'Integration-Test' atm as it is highly Travis specific
+        module: [ Client, Server, Core, External, Check-Updated-License-Files ]
+        experimental: [false]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+      - name: Set up Maven #We need to avoid default-http-blocker at the moment until we fix it ;-)
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.6.3
+      - name: Ensure a clean state without storm artifacts
+        run: rm -rf ~/.m2/repository/org/apache/storm
+      - name: Set up project dependencies
+        run: /bin/bash ./dev-tools/travis/travis-install.sh `pwd`
+      - name: Run build
+        run:  /bin/bash ./dev-tools/travis/travis-script.sh `pwd` ${{ matrix.module }};

--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -222,7 +222,6 @@ List of third-party dependencies grouped by their license type.
         * CloudWatch Metrics for AWS Java SDK (com.amazonaws:aws-java-sdk-cloudwatchmetrics:1.10.77 - https://aws.amazon.com/sdkforjava)
         * Codec (commons-codec:commons-codec:1.3 - http://jakarta.apache.org/commons/codec/)
         * com.papertrail:profiler (com.papertrail:profiler:1.0.2 - https://github.com/papertrail/profiler)
-        * Commons CLI (commons-cli:commons-cli:1.2 - http://commons.apache.org/cli/)
         * Commons Configuration (commons-configuration:commons-configuration:1.6 - http://commons.apache.org/${pom.artifactId.substring(8)}/)
         * Commons Daemon (commons-daemon:commons-daemon:1.0.13 - http://commons.apache.org/daemon/)
         * Commons DBCP (commons-dbcp:commons-dbcp:1.4 - http://commons.apache.org/dbcp/)

--- a/examples/storm-starter/pom.xml
+++ b/examples/storm-starter/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>7.7.0</version>
+      <version>6.8.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.7.0</version>
+            <version>6.8.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What is the purpose of the change

- Adds GitHub actions on the basis of the old travis script (and similar to them)
- Downgrades TestNG as it isn't compatible with Java 8
- Fixes license files

Note: `integration-tests` are failing as the related `.sh` is highly Travis specific and needs some rework. IMHO, we should fix it in a separate Jira. Wdyt?

It superseeds https://github.com/apache/storm/pull/3519

## How was the change tested

- GitHub Actions
