### PR TITLE
[STORM-3903] Bump commons-fileupload from 1.3.3 to 1.5

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -48,7 +48,7 @@ List of third-party dependencies grouped by their license type.
         * Apache Commons Crypto (org.apache.commons:commons-crypto:1.0.0 - http://commons.apache.org/proper/commons-crypto/)
         * Apache Commons CSV (org.apache.commons:commons-csv:1.4 - http://commons.apache.org/proper/commons-csv/)
         * Apache Commons Exec (org.apache.commons:commons-exec:1.3 - http://commons.apache.org/proper/commons-exec/)
-        * Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.3.3 - http://commons.apache.org/proper/commons-fileupload/)
+        * Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.5 - http://commons.apache.org/proper/commons-fileupload/)
         * Apache Commons IO (commons-io:commons-io:2.11.0 - https://commons.apache.org/proper/commons-io/)
         * Apache Commons Lang (org.apache.commons:commons-lang3:3.2 - http://commons.apache.org/proper/commons-lang/)
         * Apache Commons Lang (org.apache.commons:commons-lang3:3.3 - http://commons.apache.org/proper/commons-lang/)

--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -9,6 +9,7 @@ List of third-party dependencies grouped by their license type.
 
     Apache-2.0
 
+        * Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.5 - https://commons.apache.org/proper/commons-fileupload/)
         * Gson (com.google.code.gson:gson:2.8.9 - https://github.com/google/gson/gson)
 
     Apache License
@@ -48,7 +49,6 @@ List of third-party dependencies grouped by their license type.
         * Apache Commons Crypto (org.apache.commons:commons-crypto:1.0.0 - http://commons.apache.org/proper/commons-crypto/)
         * Apache Commons CSV (org.apache.commons:commons-csv:1.4 - http://commons.apache.org/proper/commons-csv/)
         * Apache Commons Exec (org.apache.commons:commons-exec:1.3 - http://commons.apache.org/proper/commons-exec/)
-        * Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.5 - http://commons.apache.org/proper/commons-fileupload/)
         * Apache Commons IO (commons-io:commons-io:2.11.0 - https://commons.apache.org/proper/commons-io/)
         * Apache Commons Lang (org.apache.commons:commons-lang3:3.2 - http://commons.apache.org/proper/commons-lang/)
         * Apache Commons Lang (org.apache.commons:commons-lang3:3.3 - http://commons.apache.org/proper/commons-lang/)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -692,7 +692,7 @@ The license texts of these dependencies can be found in the licenses directory.
         * Apache Commons Crypto (org.apache.commons:commons-crypto:1.0.0 - http://commons.apache.org/proper/commons-crypto/)
         * Apache Commons CSV (org.apache.commons:commons-csv:1.4 - http://commons.apache.org/proper/commons-csv/)
         * Apache Commons Exec (org.apache.commons:commons-exec:1.3 - http://commons.apache.org/proper/commons-exec/)
-        * Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.5 - http://commons.apache.org/proper/commons-fileupload/)
+        * Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.5 - https://commons.apache.org/proper/commons-fileupload/)
         * Apache Commons IO (commons-io:commons-io:2.11.0 - http://commons.apache.org/proper/commons-io/)
         * Apache Commons Lang (org.apache.commons:commons-lang3:3.2 - http://commons.apache.org/proper/commons-lang/)
         * Apache Commons Lang (org.apache.commons:commons-lang3:3.6 - http://commons.apache.org/proper/commons-lang/)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -692,7 +692,7 @@ The license texts of these dependencies can be found in the licenses directory.
         * Apache Commons Crypto (org.apache.commons:commons-crypto:1.0.0 - http://commons.apache.org/proper/commons-crypto/)
         * Apache Commons CSV (org.apache.commons:commons-csv:1.4 - http://commons.apache.org/proper/commons-csv/)
         * Apache Commons Exec (org.apache.commons:commons-exec:1.3 - http://commons.apache.org/proper/commons-exec/)
-        * Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.3.3 - http://commons.apache.org/proper/commons-fileupload/)
+        * Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.5 - http://commons.apache.org/proper/commons-fileupload/)
         * Apache Commons IO (commons-io:commons-io:2.11.0 - http://commons.apache.org/proper/commons-io/)
         * Apache Commons Lang (org.apache.commons:commons-lang3:3.2 - http://commons.apache.org/proper/commons-lang/)
         * Apache Commons Lang (org.apache.commons:commons-lang3:3.6 - http://commons.apache.org/proper/commons-lang/)

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-exec.version>1.3</commons-exec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-fileupload.version>1.3.3</commons-fileupload.version>
+        <commons-fileupload.version>1.5</commons-fileupload.version>
         <commons-codec.version>1.11</commons-codec.version>
         <commons-cli.version>1.4</commons-cli.version>
         <curator.version>4.3.0</curator.version>


### PR DESCRIPTION
## What is the purpose of the change

*Based on dependabot PR that did not trigger a rebuild https://github.com/apache/storm/pull/3511 and add changes to license files*

## How was the change tested

*Trigger rebuild with this new PR*