### PR TITLE
[STORM-3906] Remove org.mockito.internal.util.reflection.FieldSetter and set mockito.version to 3.11.2

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -440,7 +440,7 @@ List of third-party dependencies grouped by their license type.
         * Nimbus JOSE+JWT (com.nimbusds:nimbus-jose-jwt:7.9 - https://bitbucket.org/connect2id/nimbus-jose-jwt)
         * Noggit (org.noggit:noggit:0.6 - http://github.com/yonik/noggit)
         * Objenesis (org.objenesis:objenesis:2.5.1 - http://objenesis.org)
-        * Objenesis (org.objenesis:objenesis:2.6 - http://objenesis.org)
+        * Objenesis (org.objenesis:objenesis:3.2 - http://objenesis.org/objenesis)
         * OkHttp (com.squareup.okhttp:okhttp:2.7.5 - https://github.com/square/okhttp/okhttp)
         * Okio (com.squareup.okio:okio:1.6.0 - https://github.com/square/okio/okio)
         * opencsv (net.sf.opencsv:opencsv:2.3 - http://opencsv.sf.net)

--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
         <log4j.version>2.17.1</log4j.version>
         <slf4j.version>1.7.36</slf4j.version>
         <metrics.version>3.2.6</metrics.version>
-        <mockito.version>3.0.0</mockito.version>
+        <mockito.version>3.11.2</mockito.version>
         <zookeeper.version>3.5.9</zookeeper.version>
         <jline.version>0.9.94</jline.version>
         <hive.version>2.3.9</hive.version>


### PR DESCRIPTION
## What is the purpose of the change

*FieldSetter class has been deprecated in minor version of Mockito, replace with reflection API*

## How was the change tested

*Build and test*