### PR TITLE
[STORM-3909] Use python3 in metrics test

### DIFF
--- a/storm-core/test/clj/org/apache/storm/metrics_test.clj
+++ b/storm-core/test/clj/org/apache/storm/metrics_test.clj
@@ -194,7 +194,7 @@
                      {"2" (mk-shell-bolt-with-metrics-spec
                             {(Utils/getGlobalStreamId "1" nil)
                              (Thrift/prepareGlobalGrouping)}
-                            "python" "tester_bolt_metrics.py")})]
+                            "python3" "tester_bolt_metrics.py")})]
       (.submitTopology cluster "shell-metrics-tester" {} topology)
 
       (.feed feeder ["a"] 1)
@@ -226,7 +226,7 @@
                            "storm.zookeeper.session.timeout" 60000
                            })))]
     (let [topology (Thrift/buildTopology
-                     {"1" (mk-shell-spout-with-metrics-spec "python" "tester_spout_metrics.py")}
+                     {"1" (mk-shell-spout-with-metrics-spec "python3" "tester_spout_metrics.py")}
                      {"2" (Thrift/prepareBoltDetails
                             {(Utils/getGlobalStreamId "1" nil)
                              (Thrift/prepareAllGrouping)}


### PR DESCRIPTION
## What is the purpose of the change

*Ensure that python version 3 is used*

## How was the change tested

*Run test*