### PR TITLE
[STORM-3910] Enhanced logging for rocksdb metrics store.

### DIFF
--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -60,6 +60,7 @@
         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
+            <version>${rocksdb-version}</version>
         </dependency>
 
         <!-- jline is included to make the zk shell work through the cli for debugging -->

--- a/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/RocksDbStore.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/RocksDbStore.java
@@ -75,7 +75,7 @@ public class RocksDbStore implements MetricStore, AutoCloseable {
             options.useCappedPrefixExtractor(RocksDbKey.KEY_SIZE);
 
             String path = getRocksDbAbsoluteDir(config);
-            LOG.info("Opening RocksDB from {}", path);
+            LOG.info("Opening RocksDB from {}, {}={}", path, DaemonConfig.STORM_ROCKSDB_CREATE_IF_MISSING, createIfMissing);
             db = RocksDB.open(options, path);
         } catch (RocksDBException e) {
             String message = "Error opening RockDB database";

--- a/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/StringMetadataCache.java
+++ b/storm-server/src/main/java/org/apache/storm/metricstore/rocksdb/StringMetadataCache.java
@@ -51,17 +51,17 @@ public class StringMetadataCache implements LruMap.CacheEvictionCallback<String,
     }
 
     /**
-     * Initializes the cache instance.
+     * Initializes the cache instance. Should be called only once in the JVM, subsequent calls
+     * will be ignored unless preceded by {@link #init(RocksDbMetricsWriter, int)}.
      *
      * @param dbWriter   the RocksDB writer instance to handle writing evicted cache data
      * @param capacity   the number of StringMetadata instances to hold in memory
-     * @throws MetricException   if creating multiple cache instances
      */
-    static void init(RocksDbMetricsWriter dbWriter, int capacity) throws MetricException {
+    static void init(RocksDbMetricsWriter dbWriter, int capacity) {
         if (instance == null) {
             instance = new StringMetadataCache(dbWriter, capacity);
         } else {
-            throw new MetricException("StringMetadataCache already created");
+            LOG.error("Ignoring call to init() since StringMetadataCache already created");
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*Rocksdb requires a platform specific JNI library. This library is included in the rocksdbjni jar but is not loaded unless the dynamic library is in a location specified by environment variable ROCKSDB_SHAREDLIB_DIR is set and points to directory where the native JNI library is extracted to.

## How was the change tested

*Run the code on Mac*