### PR TITLE
[STORM-3911] fetch net.minidev:json-smart:2.3 artifact from maven repo before conjars.org repo is referenced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,6 +362,7 @@
         <jaxb-version>2.3.0</jaxb-version>
         <activation-version>1.1.1</activation-version>
         <rocksdb-version>6.27.3</rocksdb-version>
+        <json-smart.version>2.3</json-smart.version>
 
         <!-- see intellij profile below... This fixes an annoyance with intellij -->
         <provided.scope>provided</provided.scope>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -137,6 +137,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -227,6 +228,21 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <!--
+            This jar is pulled in as a transitive dependency from
+            org.apache.hadoop:hadoop-auth
+                -> com.nimbusds:nimbus-jose-jwt
+                -> com.github.stephenc.jcip:jcip-annotations
+            But is being downloaded from http://conjars.org/repo which is no longer active,
+
+            Download this directly from maven repository and avoid long build timeouts due to multiple failed attempts
+            to download from conjars.org
+            -->
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>${json-smart.version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION

## What is the purpose of the change

*Transitive dependency from hadoop-auth pulls in net.minidev:json-smart from http://conjars.org. conjars.org site is no longer active. And timeouts in the build process adds a very significant time to the build process. Adding json-smart as a dependency ensures that it is downloaded from the maven repo first, where the artifact exists.*

## How was the change tested

*Build the storm project*