### PR TITLE
[STORM-3912] Reference new clojar for carbonite version 1.6.0

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -14,6 +14,7 @@ List of third-party dependencies grouped by their license type.
 
     Apache License
 
+        * carbonite (org.clojars.bipinprasad:carbonite:1.6.0 - https://github.com/bipinprasad/carbonite)
         * HttpClient (commons-httpclient:commons-httpclient:3.1 - http://jakarta.apache.org/httpcomponents/httpclient-3.x/)
         * Log4j Implemented Over SLF4J (org.slf4j:log4j-over-slf4j:1.7.36 - http://www.slf4j.org)
 
@@ -215,9 +216,8 @@ List of third-party dependencies grouped by their license type.
         * Caffeine cache (com.github.ben-manes.caffeine:caffeine:2.3.5 - https://github.com/ben-manes/caffeine)
         * Calcite Core (org.apache.calcite:calcite-core:1.14.0 - https://calcite.apache.org/calcite-core)
         * Calcite Linq4j (org.apache.calcite:calcite-linq4j:1.14.0 - https://calcite.apache.org/calcite-linq4j)
-        * carbonite (com.twitter:carbonite:1.5.0 - no url defined)
         * CDI APIs (javax.enterprise:cdi-api:1.0 - http://www.seamframework.org/Weld/cdi-api)
-        * chill-java (com.twitter:chill-java:0.8.0 - https://github.com/twitter/chill)
+        * chill-java (com.twitter:chill-java:0.9.5 - https://github.com/twitter/chill)
         * ClassMate (com.fasterxml:classmate:1.3.1 - http://github.com/cowtowncoder/java-classmate)
         * CloudWatch Metrics for AWS Java SDK (com.amazonaws:aws-java-sdk-cloudwatchmetrics:1.10.77 - https://aws.amazon.com/sdkforjava)
         * Codec (commons-codec:commons-codec:1.3 - http://jakarta.apache.org/commons/codec/)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -645,6 +645,7 @@ The license texts of these dependencies can be found in the licenses directory.
 
     Apache License
 
+        * carbonite (org.clojars.bipinprasad:carbonite:1.6.0 - https://github.com/bipinprasad/carbonite)
         * HttpClient (commons-httpclient:commons-httpclient:3.1 - http://jakarta.apache.org/httpcomponents/httpclient-3.x/)
 
     Apache License, Version 2.0
@@ -773,8 +774,7 @@ The license texts of these dependencies can be found in the licenses directory.
         * BoneCP :: Core Library (com.jolbox:bonecp:0.8.0.RELEASE - http://jolbox.com/bonecp)
         * Calcite Core (org.apache.calcite:calcite-core:1.14.0 - https://calcite.apache.org/calcite-core)
         * Calcite Linq4j (org.apache.calcite:calcite-linq4j:1.14.0 - https://calcite.apache.org/calcite-linq4j)
-        * carbonite (com.twitter:carbonite:1.5.0 - no url defined)
-        * chill-java (com.twitter:chill-java:0.8.0 - https://github.com/twitter/chill)
+        * chill-java (com.twitter:chill-java:0.9.5 - https://github.com/twitter/chill)
         * ClassMate (com.fasterxml:classmate:1.3.1 - http://github.com/cowtowncoder/java-classmate)
         * com.papertrail:profiler (com.papertrail:profiler:1.0.2 - https://github.com/papertrail/profiler)
         * Commons Configuration (commons-configuration:commons-configuration:1.6 - http://commons.apache.org/${pom.artifactId.substring(8)}/)

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <json-simple.version>1.1</json-simple.version>
         <jetty.version>9.4.45.v20220203</jetty.version>
         <clojure.tools.logging.version>0.2.3</clojure.tools.logging.version>
-        <carbonite.version>1.5.0</carbonite.version>
+        <carbonite.version>1.6.0</carbonite.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <httpclient.version>4.5.13</httpclient.version>
         <jctools.version>2.0.1</jctools.version>
@@ -906,7 +906,7 @@
                 <version>${clojure.tools.logging.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.twitter</groupId>
+                <groupId>org.clojars.bipinprasad</groupId>
                 <artifactId>carbonite</artifactId>
                 <version>${carbonite.version}</version>
             </dependency>

--- a/storm-clojure/pom.xml
+++ b/storm-clojure/pom.xml
@@ -56,8 +56,9 @@
             <version>${kryo.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.twitter</groupId>
+            <groupId>org.clojars.bipinprasad</groupId>
             <artifactId>carbonite</artifactId>
+            <version>${carbonite.version}</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
## What is the purpose of the change

*Carbonite:1.5.0 jar hasn't been changed since 2012 and includes some very old dependencies and java version. Create a new carbonite jar with version 1.6.0, update compiler and dependencies. Then reference this new version 1.6.0 jar in storm*

## How was the change tested

*Build and run tests.*