### PR TITLE
[STORM-3913] Update rocksdb to version 8.1.1 that has Mac OSX JNI lib

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -541,7 +541,7 @@ List of third-party dependencies grouped by their license type.
 
     Apache License, Version 2.0, GNU General Public License, version 2
 
-        * RocksDB JNI (org.rocksdb:rocksdbjni:6.27.3 - https://rocksdb.org)
+        * RocksDB JNI (org.rocksdb:rocksdbjni:8.1.1 - https://rocksdb.org)
 
     Apache License, Version 2.0, GNU Lesser General Public License (LGPL), Version 2.1
 

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -936,7 +936,7 @@ The license texts of these dependencies can be found in the licenses directory.
         * JAX-RS provider for JSON content type (org.codehaus.jackson:jackson-jaxrs:1.9.13 - http://jackson.codehaus.org)
         * Xml Compatibility extensions for Jackson (org.codehaus.jackson:jackson-xc:1.9.13 - http://jackson.codehaus.org)
         * Javassist (org.javassist:javassist:3.24.1-GA - http://www.javassist.org/)
-        * RocksDB JNI (org.rocksdb:rocksdbjni:6.27.3 - https://rocksdb.org)
+        * RocksDB JNI (org.rocksdb:rocksdbjni:8.1.1 - https://rocksdb.org)
         * JCTools Core (org.jctools:jctools-core:2.0.1 - http://jctools.github.io/JCTools/)
         * Bean Validation API (javax.validation:validation-api:2.0.1.Final - http://beanvalidation.org)
         * jersey-container-grizzly2-http (org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.29 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-http)

--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
         <jakarta-activation-version>1.2.1</jakarta-activation-version>
         <jaxb-version>2.3.0</jaxb-version>
         <activation-version>1.1.1</activation-version>
-        <rocksdb-version>6.27.3</rocksdb-version>
+        <rocksdb-version>8.1.1</rocksdb-version>
 
         <!-- see intellij profile below... This fixes an annoyance with intellij -->
         <provided.scope>provided</provided.scope>

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -60,6 +60,7 @@
         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
+            <version>${rocksdb-version}</version>
         </dependency>
 
         <!-- jline is included to make the zk shell work through the cli for debugging -->

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -60,7 +60,6 @@
         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
-            <version>${rocksdb-version}</version>
         </dependency>
 
         <!-- jline is included to make the zk shell work through the cli for debugging -->


### PR DESCRIPTION
## What is the purpose of the change

*Version 6.27.3 does not have Mac OSX JNI Library. Some tests fail to load because of this missing dependency on Mac.*

## How was the change tested

*Run junit tests*