### PR TITLE
Fix infinite loop when no files are left to remove

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/DirectoryCleaner.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/DirectoryCleaner.java
@@ -173,6 +173,7 @@ public class DirectoryCleaner {
                 LOG.warn("No more files eligible to be deleted this round, but {} is over {} quota by {} MB",
                         forPerDir ? "worker directory: " + dirs.get(0).toAbsolutePath().normalize() : "log root directory",
                         forPerDir ? "per-worker" : "global", toDeleteSize * 1e-6);
+                break; // No entries left to delete
             }
         }
         return new DeletionMeta(deletedSize, deletedFiles);


### PR DESCRIPTION
## What is the purpose of the change
An infinite loop can occur when the worker directory takes too much space, but no files are found to remove.

## How was the change tested
I have not independently tested this change. 
