### PR TITLE
[STORM-3917] Remove explicit worker heap size in ThroughputVsLatency

### DIFF
--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/ThroughputVsLatency.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/ThroughputVsLatency.java
@@ -261,7 +261,6 @@ public class ThroughputVsLatency {
         }
         conf.put(Config.TOPOLOGY_WORKER_METRICS, workerMetrics);
         conf.put(Config.TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS, 10);
-        conf.put(Config.TOPOLOGY_WORKER_CHILDOPTS, "-Xmx2g");
 
         TopologyBuilder builder = new TopologyBuilder();
 


### PR DESCRIPTION
Allow users to change worker heap size in ThroughputVsLatency example topo.

## What is the purpose of the change

ThroughputVsLatency adds an explicit 2GB worker heapsize overriding the RAS / user settings

## How was the change tested

Worker JVM options were observed to have both automatic heap and this explicit setting. No further testing was performed. 