### PR TITLE
[STORM-3922] Acker scheduling changes.

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/strategies/scheduling/BaseResourceAwareStrategy.java
@@ -527,7 +527,7 @@ public abstract class BaseResourceAwareStrategy implements IStrategy {
             if (execIndex == 0) {
                 break;
             } else {
-                searcherState.backtrack(execToComp, nodeForExec[execIndex - 1], workerSlotForExec[execIndex - 1]);
+                searcherState.backtrack(execToComp, nodeForExec, workerSlotForExec);
                 progressIdxForExec[execIndex] = -1;
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

*Acker executors are sorted in a specific order that backtracking needs to account for.*

## How was the change tested

*This code has been running for over a year on staging and production cluster at a contributing company*