### PR TITLE
[STORM-3925] Allow user resources (in WorkerTopologyContext) to be set by Worker Hooks

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/WorkerState.java
@@ -71,6 +71,7 @@ import org.apache.storm.serialization.KryoTupleSerializer;
 import org.apache.storm.shade.com.google.common.collect.ImmutableMap;
 import org.apache.storm.shade.com.google.common.collect.Sets;
 import org.apache.storm.task.WorkerTopologyContext;
+import org.apache.storm.task.WorkerUserContext;
 import org.apache.storm.tuple.AddressedTuple;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.ConfigUtils;
@@ -627,6 +628,19 @@ public class WorkerState {
         }
     }
 
+    public final WorkerUserContext getWorkerUserContext() {
+        try {
+            String codeDir = ConfigUtils.supervisorStormResourcesPath(ConfigUtils.supervisorStormDistRoot(conf, topologyId));
+            String pidDir = ConfigUtils.workerPidsRoot(conf, topologyId);
+            return new WorkerUserContext(systemTopology, topologyConf, taskToComponent, componentToSortedTasks,
+                    componentToStreamToFields, topologyId, codeDir, pidDir, port, localTaskIds,
+                    defaultSharedResources,
+                    userSharedResources, cachedTaskToNodePort, assignmentId, cachedNodeToHost);
+        } catch (IOException e) {
+            throw Utils.wrapInRuntime(e);
+        }
+    }
+
     private List<IWorkerHook> deserializeWorkerHooks() {
         List<IWorkerHook> myHookList = new ArrayList<>();
         if (topology.is_set_worker_hooks()) {
@@ -744,11 +758,6 @@ public class WorkerState {
     }
 
     private Map<String, Object> makeUserResources() {
-        /* TODO: need to invoke a hook provided by the topology, giving it a chance to create user resources.
-         * this would be part of the initialization hook
-         * need to separate workertopologycontext into WorkerContext and WorkerUserContext.
-         * actually just do it via interfaces. just need to make sure to hide setResource from tasks
-         */
         return new HashMap<>();
     }
 

--- a/storm-client/src/jvm/org/apache/storm/hooks/IWorkerHook.java
+++ b/storm-client/src/jvm/org/apache/storm/hooks/IWorkerHook.java
@@ -15,6 +15,7 @@ package org.apache.storm.hooks;
 import java.io.Serializable;
 import java.util.Map;
 import org.apache.storm.task.WorkerTopologyContext;
+import org.apache.storm.task.WorkerUserContext;
 
 /**
  * An IWorkerHook represents a topology component that can be executed when a worker starts, and when a worker shuts down. It can be useful
@@ -26,8 +27,24 @@ public interface IWorkerHook extends Serializable {
      *
      * @param topoConf The Storm configuration for this worker
      * @param context  This object can be used to get information about this worker's place within the topology
+     *
+     * @deprecated see {@link IWorkerHook#start(Map, WorkerUserContext)}
      */
-    void start(Map<String, Object> topoConf, WorkerTopologyContext context);
+    default void start(Map<String, Object> topoConf, WorkerTopologyContext context) {
+
+    }
+
+    /**
+     * This method is called when a worker is started and can be used to do necessary prep-processing and allow initialization of shared
+     * application state.
+     *
+     * @param topoConf The Storm configuration for this worker
+     * @param context  This object can be used to get information about this worker's place within the topology and exposes
+     * {@link WorkerUserContext#setResource(String, Object)} to set the shared application state.
+     */
+    default void start(Map<String, Object> topoConf, WorkerUserContext context) {
+        start(topoConf, context);
+    }
 
     /**
      * This method is called right before a worker shuts down.

--- a/storm-client/src/jvm/org/apache/storm/task/WorkerUserContext.java
+++ b/storm-client/src/jvm/org/apache/storm/task/WorkerUserContext.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.task;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.storm.generated.NodeInfo;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.tuple.Fields;
+
+public class WorkerUserContext extends WorkerTopologyContext {
+
+    public WorkerUserContext(
+        StormTopology topology,
+        Map<String, Object> topoConf, Map<Integer,
+        String> taskToComponent,
+        Map<String, List<Integer>> componentToSortedTasks,
+        Map<String, Map<String, Fields>> componentToStreamToFields,
+        String stormId,
+        String codeDir,
+        String pidDir,
+        Integer workerPort,
+        List<Integer> workerTasks,
+        Map<String, Object> defaultResources,
+        Map<String, Object> userResources,
+        AtomicReference<Map<Integer, NodeInfo>> taskToNodePort,
+        String assignmentId,
+        AtomicReference<Map<String, String>> nodeToHost) {
+        super(topology, topoConf, taskToComponent, componentToSortedTasks, componentToStreamToFields, stormId, codeDir, pidDir, workerPort,
+                workerTasks, defaultResources, userResources, taskToNodePort, assignmentId, nodeToHost);
+    }
+
+    public void setResource(String name, Object data) {
+        userResources.put(name, data);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The current implementation of WorkerTopologyContext in WorkerState will always lead to empty userResources as no interface exposes a way to allow user to set them. This change will allow a user to set application specific shared state in userResources via WorkerHooks to better manage application context.

## How was the change tested

Feature Tests: WIP
For regression: Git Actions build and test run as part of this pull request