### PR TITLE
[STORM-3927] Change python to python3 in examples

### DIFF
--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/BlobStoreAPIWordCountTopology.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/BlobStoreAPIWordCountTopology.java
@@ -247,7 +247,7 @@ public class BlobStoreAPIWordCountTopology {
     public static class SplitSentence extends ShellBolt implements IRichBolt {
 
         public SplitSentence() {
-            super("python", "splitsentence.py");
+            super("python3", "splitsentence.py");
         }
 
         @Override

--- a/examples/storm-starter/src/jvm/org/apache/storm/starter/WordCountTopology.java
+++ b/examples/storm-starter/src/jvm/org/apache/storm/starter/WordCountTopology.java
@@ -61,7 +61,7 @@ public class WordCountTopology extends ConfigurableTopology {
     public static class SplitSentence extends ShellBolt implements IRichBolt {
 
         public SplitSentence() {
-            super("python", "splitsentence.py");
+            super("python3", "splitsentence.py");
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

*Python2 has been deprecated. However many systems still activate python2 when only using python. Change it to python3 to ensure Python version 3 is used.*

## How was the change tested

*Run the example python scripts through Python 3 syntax checks*