### PR TITLE
[STORM-3928] Use python3 in flux test, examples and wrappers

### DIFF
--- a/flux/README.md
+++ b/flux/README.md
@@ -44,7 +44,7 @@ The easiest way to use Flux, is to add it as a Maven dependency in you project a
 If you would like to build Flux from source and run the unit/integration tests, you will need the following installed
 on your system:
 
-* Python 2.6.x or later
+* Python 3.0.x or later
 * Node.js 0.10.x or later
 
 #### Building with unit tests enabled:
@@ -640,7 +640,7 @@ bolts:
     className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
     constructorArgs:
       # command line
-      - ["python", "splitsentence.py"]
+      - ["python3", "splitsentence.py"]
       # output fields
       - ["word"]
     parallelism: 1
@@ -787,7 +787,7 @@ bolts:
     className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
     constructorArgs:
       # command line
-      - ["python", "splitsentence.py"]
+      - ["python3", "splitsentence.py"]
       # output fields
       - ["word"]
     parallelism: 1

--- a/flux/flux-core/src/test/resources/configs/bad_shell_test.yaml
+++ b/flux/flux-core/src/test/resources/configs/bad_shell_test.yaml
@@ -69,7 +69,7 @@ bolts:
     className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
     constructorArgs:
       # command line
-      - ["python", "splitsentence.py"]
+      - ["python3", "splitsentence.py"]
       # output fields
       - ["word"]
     configMethods:

--- a/flux/flux-core/src/test/resources/configs/kafka_test.yaml
+++ b/flux/flux-core/src/test/resources/configs/kafka_test.yaml
@@ -71,7 +71,7 @@ bolts:
     className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
     constructorArgs:
       # command line
-      - ["python", "splitsentence.py"]
+      - ["python3", "splitsentence.py"]
       # output fields
       - ["word"]
     parallelism: 1

--- a/flux/flux-core/src/test/resources/configs/shell_test.yaml
+++ b/flux/flux-core/src/test/resources/configs/shell_test.yaml
@@ -69,7 +69,7 @@ bolts:
     className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
     constructorArgs:
       # command line
-      - ["python", "splitsentence.py"]
+      - ["python3", "splitsentence.py"]
       # output fields
       - ["word"]
     configMethods:

--- a/flux/flux-core/src/test/resources/configs/substitution-test.yaml
+++ b/flux/flux-core/src/test/resources/configs/substitution-test.yaml
@@ -67,7 +67,7 @@ bolts:
     className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
     constructorArgs:
       # command line
-      - ["python", "splitsentence.py"]
+      - ["python3", "splitsentence.py"]
       # output fields
       - ["word"]
     parallelism: 1

--- a/flux/flux-examples/src/main/resources/kafka_spout.yaml
+++ b/flux/flux-examples/src/main/resources/kafka_spout.yaml
@@ -71,7 +71,7 @@ bolts:
     className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
     constructorArgs:
       # command line
-      - ["python", "splitsentence.py"]
+      - ["python3", "splitsentence.py"]
       # output fields
       - ["word"]
     parallelism: 1

--- a/flux/flux-examples/src/main/resources/multilang.yaml
+++ b/flux/flux-examples/src/main/resources/multilang.yaml
@@ -47,7 +47,7 @@ bolts:
     className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
     constructorArgs:
       # command line
-      - ["python", "splitsentence.py"]
+      - ["python3", "splitsentence.py"]
       # output fields
       - ["word"]
     parallelism: 1

--- a/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/bolts/FluxShellBolt.java
+++ b/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/bolts/FluxShellBolt.java
@@ -65,7 +65,7 @@ public class FluxShellBolt extends ShellBolt implements IRichBolt {
      * className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
      * constructorArgs:
      * # command line
-     * - ["python", "splitsentence.py"]
+     * - ["python3", "splitsentence.py"]
      * # output fields
      * - ["word"]
      * configMethods:
@@ -90,7 +90,7 @@ public class FluxShellBolt extends ShellBolt implements IRichBolt {
      * className: "org.apache.storm.flux.wrappers.bolts.FluxShellBolt"
      * constructorArgs:
      * # command line
-     * - ["python", "splitsentence.py"]
+     * - ["python3", "splitsentence.py"]
      * # output fields
      * - ["word"]
      * configMethods:
@@ -118,7 +118,7 @@ public class FluxShellBolt extends ShellBolt implements IRichBolt {
      * - className: org.apache.storm.flux.wrappers.bolts.FluxShellBolt
      *   id: my_bolt
      *   constructorArgs:
-     *   - [python, my_bolt.py]
+     *   - [python3, my_bolt.py]
      *   configMethods:
      *   - name: setDefaultStream
      *     args:
@@ -139,7 +139,7 @@ public class FluxShellBolt extends ShellBolt implements IRichBolt {
      * - className: org.apache.storm.flux.wrappers.bolts.FluxShellBolt
      *   id: my_bolt
      *   constructorArgs:
-     *   - [python, my_bolt.py]
+     *   - [python3, my_bolt.py]
      *   configMethods:
      *   - name: setNamedStream
      *     args:

--- a/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/spouts/FluxShellSpout.java
+++ b/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/spouts/FluxShellSpout.java
@@ -67,7 +67,7 @@ public class FluxShellSpout extends ShellSpout implements IRichSpout {
      * className: "org.apache.storm.flux.wrappers.bolts.FluxShellSpout"
      * constructorArgs:
      * # command line
-     * - ["python", "splitsentence.py"]
+     * - ["python3", "splitsentence.py"]
      * # output fields
      * - ["word"]
      * configMethods:
@@ -92,7 +92,7 @@ public class FluxShellSpout extends ShellSpout implements IRichSpout {
      * className: "org.apache.storm.flux.wrappers.bolts.FluxShellSpout"
      * constructorArgs:
      * # command line
-     * - ["python", "splitsentence.py"]
+     * - ["python3", "splitsentence.py"]
      * # output fields
      * - ["word"]
      * configMethods:
@@ -120,7 +120,7 @@ public class FluxShellSpout extends ShellSpout implements IRichSpout {
      * - className: org.apache.storm.flux.wrappers.bolts.FluxShellSpout
      *   id: my_spout
      *   constructorArgs:
-     *   - [python, my_spout.py]
+     *   - [python3, my_spout.py]
      *   configMethods:
      *   - name: setDefaultStream
      *     args:
@@ -141,7 +141,7 @@ public class FluxShellSpout extends ShellSpout implements IRichSpout {
      * - className: org.apache.storm.flux.wrappers.bolts.FluxShellSpout
      *   id: my_spout
      *   constructorArgs:
-     *   - [python, my_spout.py]
+     *   - [python3, my_spout.py]
      *   configMethods:
      *   - name: setNamedStream
      *     args:


### PR DESCRIPTION
## What is the purpose of the change

*Python2 has been deprecated. However many systems still activate python2 when only using python. Change it to python3 to ensure Python version 3 is used.*

## How was the change tested

*Run the example python scripts through Python 3 syntax checks*