### PR TITLE
[STORM-3930] Change the source code control URI 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,9 +267,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://gitbox.apache.org/repos/asf/storm.git</connection>
-        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/storm.git</developerConnection>
-        <url>https://gitbox.apache.org/repos/asf/storm</url>
+        <connection>scm:git:git@github.com:apache/storm.git</connection>
+        <developerConnection>scm:git:git@github.com:apache/storm.git</developerConnection>
+        <url>https://github.com/apache/storm</url>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
## What is the purpose of the change

*While doing "mvn release:perform", the checkout times out at the end when using the https connection. Also the url is old. Use the new url (change from gitbox to github) that is the target of redirect.*

## How was the change tested

*Pull Request checks (github actions)*