### PR TITLE
Handle InterruptedException in Supervisor close() method.

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Supervisor.java
@@ -508,7 +508,10 @@ public class Supervisor implements DaemonCommon, AutoCloseable {
             if (thriftServer != null) {
                 this.thriftServer.stop();
             }
-        } catch (Exception e) {
+        } catch (InterruptedException e) {
+            LOG.error("Error closing asyncLocalizer", e);
+        }
+        catch (Exception e) {
             LOG.error("Error Shutting down", e);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change
This PR addresses the handling of InterruptedException in the close() method of the Supervisor class. The changes include:

1. Adding a separate catch block for InterruptedException that is thrown by the close() method of the AsyncLocalizer class.
2. Logging the InterruptedException separately to ensure that the exception type and message are correctly recorded in the logs.

The motivation behind this change is to properly handle the scenario where the close() method of AsyncLocalizer is interrupted, which is a situation that was not specifically addressed in the original code. By catching and logging the InterruptedException separately, we can provide more specific information in the logs when such an event occurs.

## How was the change tested

Built storm-server. Validated logging on dev supervisor.