### PR TITLE
Missing dependency prevents Storm from being built, fixes #3940

### DIFF
--- a/external/storm-autocreds/pom.xml
+++ b/external/storm-autocreds/pom.xml
@@ -195,6 +195,10 @@
             <version>${hive.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -105,6 +105,10 @@
       <version>${hive.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
@@ -158,6 +162,10 @@
         <exclusion>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
## What is the purpose of the change

Storm can't be built because the dependency pentaho-aggdesigner-algorithm is not available. 

This dependency is excluded in some places of the poms but not systematically, excluding it everywhere allows the code to be built.

## How was the change tested

`mvn clean install -DskipTests`