### PR TITLE
[STORM-3939] Remove gitact build for JDK 8, set class format to JDK11 and allow introspection in test

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8, 11, 17 ]
+        java: [ 11, 17 ]
         module: [ Client, Server, Core, External, Check-Updated-License-Files, Integration-Test ]
         experimental: [false]
       fail-fast: false

--- a/external/storm-blobstore-migration/pom.xml
+++ b/external/storm-blobstore-migration/pom.xml
@@ -107,8 +107,8 @@ limitations under the License.
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/external/storm-cassandra/pom.xml
+++ b/external/storm-cassandra/pom.xml
@@ -36,31 +36,8 @@
         <guava.version>16.0.1</guava.version>
         <commons-lang3.version>3.3</commons-lang3.version>
         <cassandra.driver.core.version>3.1.2</cassandra.driver.core.version>
-        <storm-cassandra.test.introspection.argLine></storm-cassandra.test.introspection.argLine>
+        <storm-cassandra.test.introspection.argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED</storm-cassandra.test.introspection.argLine>
     </properties>
-
-    <profiles>
-        <profile>
-            <!-- if jdk17 or higher then allow introspection on specific packages -->
-            <id>java-17-or-higher</id>
-            <activation>
-                <jdk>[17,)</jdk> <!-- This activates the profile for JDK 17 and higher -->
-            </activation>
-            <properties>
-                <!-- note that java.lang reflection is currently used in storm-server test -->
-                <storm-cassandra.test.introspection.argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED</storm-cassandra.test.introspection.argLine>
-            </properties>
-        </profile>
-        <profile>
-            <id>java-11-to-below-17</id>
-            <activation>
-                <jdk>[11,17)</jdk>
-            </activation>
-            <properties>
-                <storm-cassandra.test.introspection.argLine>--illegal-access=warn</storm-cassandra.test.introspection.argLine>
-            </properties>
-        </profile>
-    </profiles>
 
     <developers>
         <developer>
@@ -187,11 +164,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <!-- remove this when Cassandra does not use reflection in
-                     at org.apache.cassandra.utils.FBUtilities.classForName(FBUtilities.java:454)
-                     that is called indirectly
-                     by org.apache.storm.cassandra.testtools.EmbeddedCassandraResource.getDataDirs(EmbeddedCassandraResource.java:138)
-                    -->
                     <argLine>${storm-cassandra.test.introspection.argLine} -Xmx3g -XX:+HeapDumpOnOutOfMemoryError</argLine>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <excludedGroups>IntegrationTest | ${java.unit.test.exclude.groups}</excludedGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
     </issueManagement>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>${maven.compiler.target}</maven.compiler.source>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <maven.javadoc.failOnWarnings>false</maven.javadoc.failOnWarnings>
@@ -1258,7 +1258,7 @@
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>3.16.0</version>
                     <configuration>
-                        <targetJdk>1.8</targetJdk>
+                        <targetJdk>${maven.compiler.target}</targetJdk>
                         <rulesets>
                             <ruleset>storm/pmd-ruleset.xml</ruleset>
                         </rulesets>
@@ -1431,8 +1431,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -29,29 +29,8 @@
     <artifactId>storm-server</artifactId>
 
     <properties>
-        <storm-server.test.introspection.argLine></storm-server.test.introspection.argLine>
+        <storm-server.test.introspection.argLine>--add-opens java.base/java.lang=ALL-UNNAMED</storm-server.test.introspection.argLine>
     </properties>
-
-    <profiles>
-        <profile>
-            <id>java-17-or-higher</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <properties>
-                <storm-server.test.introspection.argLine>--add-opens java.base/java.lang=ALL-UNNAMED</storm-server.test.introspection.argLine>
-            </properties>
-        </profile>
-        <profile>
-            <id>java-11-to-below-17</id>
-            <activation>
-                <jdk>[11,17)</jdk>
-            </activation>
-            <properties>
-                <storm-server.test.introspection.argLine>--illegal-access=warn</storm-server.test.introspection.argLine>
-            </properties>
-        </profile>
-    </profiles>
 
     <dependencies>
         <dependency>
@@ -194,7 +173,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <!-- remove this when ServerUtilsTest.getPidOfPosixProcess() returns p.pid() as allowed in JDK11 and above -->
                     <argLine>${storm-server.test.introspection.argLine} -Xmx3g -XX:+HeapDumpOnOutOfMemoryError</argLine>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## What is the purpose of the change

*Drop support for JDK8, set minimum JDK level to 11 - in order for new JDK and packaging features to be used*

## How was the change tested

*mvn test; also allow githun actions to run.*