### PR TITLE
[STORM-3914] Several External Modules as not being tested for JDK 11

### DIFF
--- a/dev-tools/gitact/gitact-script.sh
+++ b/dev-tools/gitact/gitact-script.sh
@@ -41,12 +41,7 @@ then
     TEST_MODULES=storm-core
 elif [ "$2" == "External" ]
 then
-    if [ "$JDK_VERSION" == "11" ]
-    then
-        TEST_MODULES='!storm-client,!storm-server,!storm-core,!storm-webapp,!storm-shaded-deps,!external/storm-cassandra,!external/storm-hive,!external/storm-hdfs,!external/storm-hbase,!sql/storm-sql-external/storm-sql-hdfs,!external/storm-hdfs-blobstore'
-    else
-        TEST_MODULES='!storm-client,!storm-server,!storm-core,!storm-webapp,!storm-shaded-deps'
-    fi
+    TEST_MODULES='!storm-client,!storm-server,!storm-core,!storm-webapp,!storm-shaded-deps'
 fi
 # We should be concerned that Travis CI could be very slow because it uses VM
 export STORM_TEST_TIMEOUT_MS=150000


### PR DESCRIPTION
## What is the purpose of the change

- We are testing everything for Java 17, so we should also test everything with Java 11

## How was the change tested

- Run GH actions