### PR TITLE
[STORM-3948] Hive 2.3.9 declares an offline / unmaintained maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1179,6 +1179,17 @@
             <id>clojars</id>
             <url>https://clojars.org/repo/</url>
         </repository>
+        <!--
+            STORM-3948: This repository is declared by hive-2.3.9 (parent pom). As of today (08/14/23) this Maven Repository isn't available anymore.
+            hive-2.3.10 already removed it, so we only need to wait for a 2.3.10 release here. As long is that didn't happen,
+            we work around by overriding the repository with the same id targeting to maven central.
+            TODO: Remove this repository declaration after hive-2.3.10 is available.
+         -->
+        <repository>
+            <id>conjars</id>
+            <name>STORM-3948-Workaround-Offline-Conjars-Repo</name>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
## What is the purpose of the change

Hive 2.3.9 declares an offline repository in its parent pom.  Leading to timeouts resolving that repository during a local build. We can work around by re-declaring this repository until 2.3.10 is hopefully released (which removed that repo on their side).

## How was the change tested

* Local Build