### PR TITLE
[STORM-3950] Modernize storm-jdbc

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -17,6 +17,7 @@ List of third-party dependencies grouped by their license type.
         * ActiveMQ :: MQTT Protocol (org.apache.activemq:activemq-mqtt:5.18.2 - http://activemq.apache.org/activemq-mqtt)
         * ActiveMQ :: Openwire Legacy Support (org.apache.activemq:activemq-openwire-legacy:5.18.2 - http://activemq.apache.org/activemq-openwire-legacy)
         * Apache Commons FileUpload (commons-fileupload:commons-fileupload:1.5 - https://commons.apache.org/proper/commons-fileupload/)
+        * Apache Commons Lang (org.apache.commons:commons-lang3:3.13.0 - https://commons.apache.org/proper/commons-lang/)
         * Gson (com.google.code.gson:gson:2.8.9 - https://github.com/google/gson/gson)
         * snappy-java (org.xerial.snappy:snappy-java:1.1.10.3 - https://github.com/xerial/snappy-java)
 
@@ -292,8 +293,8 @@ List of third-party dependencies grouped by their license type.
         * hawtdispatch-transport (org.fusesource.hawtdispatch:hawtdispatch-transport:1.22 - http://hawtdispatch.fusesource.org/hawtdispatch-transport/)
         * Hibernate Validator Engine (org.hibernate:hibernate-validator:5.4.3.Final - http://hibernate.org/validator/hibernate-validator)
         * Hibernate Validator Engine (org.hibernate.validator:hibernate-validator:6.0.17.Final - http://hibernate.org/validator/hibernate-validator)
-        * HikariCP (com.zaxxer:HikariCP:2.4.7 - https://github.com/brettwooldridge/HikariCP)
         * HikariCP (com.zaxxer:HikariCP:2.5.1 - https://github.com/brettwooldridge/HikariCP)
+        * HikariCP (com.zaxxer:HikariCP:5.0.1 - https://github.com/brettwooldridge/HikariCP)
         * HikariCP (com.zaxxer:HikariCP-java7:2.4.12 - https://github.com/brettwooldridge/HikariCP)
         * Hive CLI (org.apache.hive:hive-cli:2.3.9 - https://hive.apache.org/hive-cli)
         * Hive Common (org.apache.hive:hive-common:2.3.9 - https://hive.apache.org/hive-common)

--- a/external/storm-jdbc/pom.xml
+++ b/external/storm-jdbc/pom.xml
@@ -36,7 +36,7 @@
     </developers>
 
     <properties>
-        <hikari.version>2.4.7</hikari.version>
+        <hikari.version>5.0.1</hikari.version>
     </properties>
 
     <dependencies>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.3</version>
+            <version>3.13.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -64,12 +64,8 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.3.1</version>
+            <version>2.7.2</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/AbstractJdbcBolt.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/AbstractJdbcBolt.java
@@ -14,7 +14,7 @@ package org.apache.storm.jdbc.bolt;
 
 import java.sql.DriverManager;
 import java.util.Map;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.storm.Config;
 import org.apache.storm.jdbc.common.ConnectionProvider;
 import org.apache.storm.jdbc.common.JdbcClient;

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/JdbcInsertBolt.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/JdbcInsertBolt.java
@@ -15,8 +15,8 @@ package org.apache.storm.jdbc.bolt;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang.Validate;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.apache.storm.jdbc.common.Column;
 import org.apache.storm.jdbc.common.ConnectionProvider;
 import org.apache.storm.jdbc.mapper.JdbcMapper;
@@ -24,8 +24,6 @@ import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Tuple;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Basic bolt for writing to any Database table.
@@ -33,7 +31,6 @@ import org.slf4j.LoggerFactory;
  * Note: Each JdbcInsertBolt defined in a topology is tied to a specific table.
  */
 public class JdbcInsertBolt extends AbstractJdbcBolt {
-    private static final Logger LOG = LoggerFactory.getLogger(JdbcInsertBolt.class);
 
     private String tableName;
     private String insertQuery;

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/JdbcLookupBolt.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/bolt/JdbcLookupBolt.java
@@ -13,7 +13,7 @@
 package org.apache.storm.jdbc.bolt;
 
 import java.util.List;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.storm.jdbc.common.Column;
 import org.apache.storm.jdbc.common.ConnectionProvider;
 import org.apache.storm.jdbc.mapper.JdbcLookupMapper;

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/common/HikariCPConnectionProvider.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/common/HikariCPConnectionProvider.java
@@ -43,8 +43,8 @@ public class HikariCPConnectionProvider implements ConnectionProvider {
             } else if (config.getJdbcUrl() != null) {
                 LOG.info("JDBC Url: " + config.getJdbcUrl());
             }
+            config.setAutoCommit(false);
             this.dataSource = new HikariDataSource(config);
-            this.dataSource.setAutoCommit(false);
         }
     }
 

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/common/JdbcClient.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/common/JdbcClient.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/mapper/SimpleJdbcLookupMapper.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/mapper/SimpleJdbcLookupMapper.java
@@ -14,7 +14,7 @@ package org.apache.storm.jdbc.mapper;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.storm.jdbc.common.Column;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;

--- a/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/mapper/SimpleJdbcMapper.java
+++ b/external/storm-jdbc/src/main/java/org/apache/storm/jdbc/mapper/SimpleJdbcMapper.java
@@ -17,7 +17,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.storm.jdbc.common.Column;
 import org.apache.storm.jdbc.common.ConnectionProvider;
 import org.apache.storm.jdbc.common.JdbcClient;

--- a/external/storm-jdbc/src/test/java/org/apache/storm/jdbc/bolt/JdbcInsertBoltTest.java
+++ b/external/storm-jdbc/src/test/java/org/apache/storm/jdbc/bolt/JdbcInsertBoltTest.java
@@ -32,8 +32,8 @@ public class JdbcInsertBoltTest {
     public void testValidation() {
         ConnectionProvider provider = new HikariCPConnectionProvider(new HashMap<>());
         JdbcMapper mapper = new SimpleJdbcMapper(Lists.newArrayList(new Column<String>("test", 0)));
-        expectIllegalArgs(null, mapper);
-        expectIllegalArgs(provider, null);
+        expectNullPointerException(null, mapper);
+        expectNullPointerException(provider, null);
 
         assertThrows(IllegalArgumentException.class, () -> {
             JdbcInsertBolt bolt = new JdbcInsertBolt(provider, mapper);
@@ -48,8 +48,8 @@ public class JdbcInsertBoltTest {
         });
     }
 
-    private void expectIllegalArgs(ConnectionProvider provider, JdbcMapper mapper) {
-        assertThrows(IllegalArgumentException.class, () -> new JdbcInsertBolt(provider, mapper));
+    private void expectNullPointerException(ConnectionProvider provider, JdbcMapper mapper) {
+        assertThrows(NullPointerException.class, () -> new JdbcInsertBolt(provider, mapper));
     }
 
 }

--- a/external/storm-jdbc/src/test/java/org/apache/storm/jdbc/bolt/JdbcLookupBoltTest.java
+++ b/external/storm-jdbc/src/test/java/org/apache/storm/jdbc/bolt/JdbcLookupBoltTest.java
@@ -34,13 +34,13 @@ public class JdbcLookupBoltTest {
         ConnectionProvider provider = new HikariCPConnectionProvider(new HashMap<>());
         JdbcLookupMapper mapper = new SimpleJdbcLookupMapper(new Fields("test"), Lists.newArrayList(new Column<String>("test", 0)));
         String selectQuery = "select * from dual";
-        expectIllegalArgs(null, selectQuery, mapper);
-        expectIllegalArgs(provider, null, mapper);
-        expectIllegalArgs(provider, selectQuery, null);
+        expectNullPointerException(null, selectQuery, mapper);
+        expectNullPointerException(provider, null, mapper);
+        expectNullPointerException(provider, selectQuery, null);
     }
 
-    private void expectIllegalArgs(ConnectionProvider provider, String selectQuery, JdbcLookupMapper mapper) {
-        assertThrows(IllegalArgumentException.class, () -> new JdbcLookupBolt(provider, selectQuery, mapper));
+    private void expectNullPointerException(ConnectionProvider provider, String selectQuery, JdbcLookupMapper mapper) {
+        assertThrows(NullPointerException.class, () -> new JdbcLookupBolt(provider, selectQuery, mapper));
     }
 
 }


### PR DESCRIPTION
## What is the purpose of the change

- Modernize external module storm-jdbc with newer dependency versions

## How was the change tested

- Local test run with Maven
- GH actions

### Notes

Our dependency stack (mostly from hadoop / external) includes a lot of super old stuff. We also have some libraries multiple times in our dependency stack, so it would be a good thing to clean it up at some point.