### PR TITLE
[STORM-3954] Remove Logback pulled in by Zookeeper

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -680,11 +680,6 @@ List of third-party dependencies grouped by their license type.
         * spec.alpha (org.clojure:spec.alpha:0.2.176 - https://github.com/clojure/build.poms/spec.alpha)
         * tools.logging (org.clojure:tools.logging:0.2.3 - http://nexus.sonatype.org/oss-repository-hosting.html/pom.contrib/tools.logging)
 
-    Eclipse Public License, Version 1.0, GNU Lesser General Public License
-
-        * Logback Classic Module (ch.qos.logback:logback-classic:1.2.10 - http://logback.qos.ch/logback-classic)
-        * Logback Core Module (ch.qos.logback:logback-core:1.2.10 - http://logback.qos.ch/logback-core)
-
     Eclipse Public License, Version 2.0
 
         * grizzly-framework (org.glassfish.grizzly:grizzly-framework:2.4.4 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-framework)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -1043,11 +1043,6 @@ The license texts of these dependencies can be found in the licenses directory.
         * spec.alpha (org.clojure:spec.alpha:0.2.176 - https://github.com/clojure/build.poms/spec.alpha)
         * JGraphT (org.jgrapht:jgrapht-core:0.9.0 - https://jgrapht.org/)
 
-    Eclipse Public License, Version 1.0, GNU Lesser General Public License
-
-        * Logback Classic Module (ch.qos.logback:logback-classic:1.2.10 - http://logback.qos.ch/logback-classic)
-        * Logback Core Module (ch.qos.logback:logback-core:1.2.10 - http://logback.qos.ch/logback-core)
-
     Eclipse Public License, Version 2.0
     
         * jakarta.annotation API (jakarta.annotation:jakarta.annotation-api:1.3.4 - https://projects.eclipse.org/projects/ee4j.ca)

--- a/pom.xml
+++ b/pom.xml
@@ -828,6 +828,14 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-core</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/storm-shaded-deps/pom.xml
+++ b/storm-shaded-deps/pom.xml
@@ -76,6 +76,14 @@
                     <groupId>org.apache.yetus</groupId>
                     <artifactId>audience-annotations</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What is the purpose of the change

Zookeeper 3.9.0 pulls in logback. However, we are using slf4j + log4j2, so we can remove that dependency. 
Note: Some of our tests already complained about multiple logger bindings.

## How was the change tested

GH Actions