### PR TITLE
[STORM-3965] Allow reflection access to java.nio for protobuf in JDK11 and above

### DIFF
--- a/sql/storm-sql-core/pom.xml
+++ b/sql/storm-sql-core/pom.xml
@@ -27,6 +27,18 @@
 
     <artifactId>storm-sql-core</artifactId>
 
+    <properties>
+        <!--
+            +- org.apache.calcite:calcite-core:jar:1.16.0:compile
+             |  +- org.apache.calcite.avatica:avatica-core:jar:1.11.0:compile
+             |  |  \- com.google.protobuf:protobuf-java:jar:3.3.0:compile
+
+             to fix Illegal reflective access by com.google.protobuf.UnsafeUtil
+             (com.google.protobuf:protobuf-java:3.3.0) to field java.nio.Buffer.address add
+             "add-opens java.base/java.nio=ALL-UNNAMED"
+        -->
+        <storm-sql-core.test.introspection.argLine>--add-opens java.base/java.nio=ALL-UNNAMED</storm-sql-core.test.introspection.argLine>
+    </properties>
     <developers>
         <developer>
             <id>haohui</id>
@@ -35,11 +47,6 @@
         </developer>
     </developers>
     
-    <properties>
-        <!-- Required downgrade by calcite-core 1.14.0 -->
-        <guava.version>16.0.1</guava.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.storm</groupId>
@@ -127,11 +134,6 @@
             <version>4.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>src/jvm</sourceDirectory>
@@ -199,7 +201,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>${storm-sql-core.test.introspection.argLine} -Xmx3g -XX:+HeapDumpOnOutOfMemoryError</argLine>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <excludedGroups>IntegrationTest | ${java.unit.test.exclude.groups}</excludedGroups>
+                    <trimStackTrace>false</trimStackTrace>
                     <forkCount>1.0C</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <systemPropertyVariables>
+                        <storm.home>${project.basedir}/target/testhome</storm.home>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
@@ -216,7 +226,6 @@
                      it under ${project.build.directory} where all freemarker templates are. -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
                 <executions>
                     <execution>
                         <id>unpack-parser-template</id>


### PR DESCRIPTION
## What is the purpose of the change

*Allow explicit reflection permission for use in JDK11 and above*

## How was the change tested

*Run mvn test; activate github actions*