### PR TITLE
[STORM-3967] Specify generated sources directory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1464,6 +1464,7 @@
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
+                    <generatedSourcesDirectory>${project.build.directory}/generated-sources</generatedSourcesDirectory>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## What is the purpose of the change

*Specify the default location of generated sources. This allows IDEs like eclipse to generate, detect, and load generated classes*

## How was the change tested

*Loaded Storm into Eclipse as a maven project and very that storm-sql-core loads classes properly and org.apache.storm.sql.parser.impl.StomParserImpl is detected and loaded automatically*