### PR TITLE
[STORM-3968] Add missing groupId in storm-core/pom.xml for maven-dependency-plugin

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -361,6 +361,7 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION

## What is the purpose of the change

*Missing groupId for maven-dependency-plugin leads to errors in processing storm-core module in eclipse*

## How was the change tested

*Change pom.xml and refresh project in eclipse*