### PR TITLE
STORM-3958: Capacity to set Storm UI's title in conf/storm.yaml

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -87,6 +87,7 @@ nimbus.topology.blobstore.deletion.delay.ms: 300000
 ### ui.* configs are for the master
 ui.host: 0.0.0.0
 ui.port: 8080
+ui.title: "Storm UI"
 ui.childopts: "-Xmx768m"
 ui.actions.enabled: true
 ui.filter: null

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -339,6 +339,12 @@ public class DaemonConfig implements Validated {
     @IsInteger
     @IsPositiveNumber
     public static final String UI_PORT = "ui.port";
+    
+    /**
+     * Storm UI's title.
+     */
+    @IsString
+    public static final String UI_TITLE = "ui.title";
 
     /**
      * This controls wheather Storm UI should bind to http port even if ui.port is > 0.

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/component.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/component.html
@@ -37,9 +37,7 @@
 <body>
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-11">
-      <h1><a href="/">Storm UI</a></h1>
-    </div>
+    <div id="ui-title" class="col-md-11"></div>
     <div id="ui-user" class="col-md-1"></div>
   </div>
   <div class="row">
@@ -153,6 +151,8 @@ $(document).ready(function() {
     });
 
     $.getJSON("/api/v1/cluster/configuration",function(response,status,jqXHR) {
+        var uiTitle = $("#ui-title");
+        setStormUITitle(uiTitle, response);				
         $.extend( $.fn.dataTable.defaults, {
           stateSave: true,
           stateSaveCallback: function (oSettings, oData) {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/index.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/index.html
@@ -37,9 +37,7 @@
 <body>
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-9">
-      <h1><a href="/">Storm UI</a></h1>
-    </div>
+    <div id="ui-title" class="col-md-9"></div>
     <div id="ui-user" class="col-md-2"></div>
   </div>
   <div class="row">
@@ -128,6 +126,7 @@ $(document).ready(function() {
         });
 
         var uiUser = $("#ui-user");
+        var uiTitle = $("#ui-title");
         var clusterSummary = $("#cluster-summary");
         var clusterResources = $("#cluster-resources");
         var nimbusSummary = $("#nimbus-summary");
@@ -135,6 +134,8 @@ $(document).ready(function() {
         var topologySummary = $("#topology-summary");
         var supervisorSummary = $("#supervisor-summary");
         var config = $("#nimbus-configuration");
+				
+        setStormUITitle(uiTitle, responseClusterConfig);
 
         getStatic("/templates/index-page-template.html", function(indexTemplate) {
             $.getJSON("/api/v1/cluster/summary",function(response,status,jqXHR) {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/script.js
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/script.js
@@ -614,3 +614,13 @@ var makeOwnerSummaryTable = function(response, elId, parentId) {
 function getPageRenderedTimestamp(eId) {
     document.getElementById(eId).innerHTML = "Page rendered at: " + Date();
 };
+
+function setStormUITitle(uiTitle, clusterConfig) { 
+    title = clusterConfig["ui.title"]; 
+    $(document).prop('title', title); 
+    getStatic("/templates/title-template.html", function(template) { 
+        jsError(function() { 
+            uiTitle.append(Mustache.render($(template).filter("#title-template").html(),{title:title})); 
+        }); 
+    }); 
+};

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/owner.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/owner.html
@@ -44,9 +44,7 @@
   <div class="warning" id="ras-warning-top-buffer"></div>
   <div class="container-fluid">
     <div class="row">
-        <div class="col-md-11">
-            <h1><a href="/">Storm UI</a></h1>
-        </div>
+        <div id="ui-title" class="col-md-11"></div>
         <div id="ui-user" class="col-md-1"></div>
     </div>
     <div class="row">
@@ -123,6 +121,11 @@
                     $("#json-response-error").append(Mustache.render($(template).filter("#json-error-template").html(), errorJson));
                 });
             }
+        });
+
+        $.getJSON("/api/v1/cluster/configuration",function(response,status,jqXHR) {
+            var uiTitle = $("#ui-title");
+            setStormUITitle(uiTitle, response);				
         });
 
         function jsError(other) {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/supervisor.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/supervisor.html
@@ -39,9 +39,7 @@
 <body>
 <div class="supervisor-page container-fluid">
   <div class="row">
-    <div class="col-md-11">
-      <h1><a href="/">Storm UI</a></h1>
-    </div>
+    <div id="ui-title" class="col-md-11"></div>
     <div id="ui-user" class="col-md-1"></div>
   </div>
   <div class="row">
@@ -114,6 +112,11 @@ $(document).ready(function() {
             });
         }
     });
+
+    $.getJSON("/api/v1/cluster/configuration",function(response,status,jqXHR) {
+        var uiTitle = $("#ui-title");
+        setStormUITitle(uiTitle, response);				
+    };
 
     $.getJSON(url,function(response,status,jqXHR) {
         getStatic("/templates/supervisor-page-template.html", function(template) {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/templates/title-template.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/templates/title-template.html
@@ -1,0 +1,21 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<script id="title-template" type="text/html">
+ <div class="ui-title">
+     <h1><a href="/">{{ui.title}}</a></h1>
+ </div>
+</script>

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/topology.html
@@ -39,9 +39,7 @@
 <body>
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-11">
-      <h1><a href="/">Storm UI</a></h1>
-    </div>
+    <div id="ui-title" class="col-md-11"></div>
     <div id="ui-user" class="col-md-1"></div>
   </div>
   <div class="row">
@@ -275,6 +273,8 @@ $(document).ready(function() {
     });
 
     $.getJSON("/api/v1/cluster/configuration",function(response,status,jqXHR) {
+        var uiTitle = $("#ui-title");
+        setStormUITitle(uiTitle, response);	
         $.extend( $.fn.dataTable.defaults, {
           stateSave: true,
           stateSaveCallback: function (oSettings, oData) {


### PR DESCRIPTION
## What is the purpose of the change

Currently, the string "Storm UI" is hard-coded in Storm's UI pages. 
When one is managing different Storm deployments, say for example for pre-production vs. production purposes, it's hard to tell which Storm UI is for which deployment just looking at brower's tabs names.

The change allows defining a replacement value for "Storm UI" in conf/storm.yaml with "ui.title" property.
The default value of this property remains "Storm UI", for compatibility purposes.

## How was the change tested

I tested this change by first patching an already deployed Storm cluster with my changes, with and without setting "storm.ui" property in storm.yaml (having to restart storm and storm-ui for the changes to be taken into account).

I ran 'mvn' commands to have compilation / checkstyle stuff to be applied to my changes.