### PR TITLE
[STORM-3982] Updates README, POM.xml and DOAP file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,58 +1,55 @@
 Master Branch:  
 [![Java CI with Maven](https://github.com/apache/storm/actions/workflows/maven.yaml/badge.svg)](https://github.com/apache/storm/actions/workflows/maven.yaml)
-[![Maven Version](https://maven-badges.herokuapp.com/maven-central/org.apache.storm/storm-core/badge.svg)](http://search.maven.org/#search|gav|1|g:"org.apache.storm"%20AND%20a:"storm-core")
+[![Maven Version](https://maven-badges.herokuapp.com/maven-central/org.apache.storm/storm-core/badge.svg)](https://search.maven.org/#search|gav|1|g:"org.apache.storm"%20AND%20a:"storm-core")
  
-Storm is a distributed realtime computation system. Similar to how Hadoop provides a set of general primitives for doing batch processing, Storm provides a set of general primitives for doing realtime computation. Storm is simple, can be used with any programming language, [is used by many companies](http://storm.apache.org/Powered-By.html), and is a lot of fun to use!
+Storm is a distributed realtime computation system. Similar to how Hadoop provides a set of general primitives for doing batch processing, Storm provides a set of general primitives for doing realtime computation. Storm is simple, can be used with any programming language, [is used by many companies](https://storm.apache.org/Powered-By.html), and is a lot of fun to use!
 
-The [Rationale page](http://storm.apache.org/documentation/Rationale.html) explains what Storm is and why it was built. [This presentation](http://vimeo.com/40972420) is also a good introduction to the project.
+The [Rationale page](https://storm.apache.org/documentation/Rationale.html) explains what Storm is and why it was built. [This presentation](https://vimeo.com/40972420) is also a good introduction to the project.
 
-Storm has a website at [storm.apache.org](http://storm.apache.org). Follow [@stormprocessor](https://twitter.com/stormprocessor) on Twitter for updates on the project.
+Storm has a website at [storm.apache.org](https://storm.apache.org). 
 
 ## Documentation
 
-Documentation and tutorials can be found on the [Storm website](http://storm.apache.org/documentation/Home.html).
+Documentation and tutorials can be found on the [Storm website](https://storm.apache.org/documentation/Home.html).
 
 Developers and contributors should also take a look at our [Developer documentation](DEVELOPER.md).
  
 
 ## Getting help
 
-__NOTE:__ The google groups account storm-user@googlegroups.com is now officially deprecated in favor of the Apache-hosted user/dev mailing lists.
-
 ### Storm Users
 Storm users should send messages and subscribe to [user@storm.apache.org](mailto:user@storm.apache.org).
 
 You can subscribe to this list by sending an email to [user-subscribe@storm.apache.org](mailto:user-subscribe@storm.apache.org). Likewise, you can cancel a subscription by sending an email to [user-unsubscribe@storm.apache.org](mailto:user-unsubscribe@storm.apache.org).
 
-You can also [browse the archives of the storm-user mailing list](http://mail-archives.apache.org/mod_mbox/storm-user/).
+You can also [browse the archives of the storm-user mailing list](https://mail-archives.apache.org/mod_mbox/storm-user/).
 
 ### Storm Developers
 Storm developers should send messages and subscribe to [dev@storm.apache.org](mailto:dev@storm.apache.org).
 
 You can subscribe to this list by sending an email to [dev-subscribe@storm.apache.org](mailto:dev-subscribe@storm.apache.org). Likewise, you can cancel a subscription by sending an email to [dev-unsubscribe@storm.apache.org](mailto:dev-unsubscribe@storm.apache.org).
 
-You can also [browse the archives of the storm-dev mailing list](http://mail-archives.apache.org/mod_mbox/storm-dev/).
+You can also [browse the archives of the storm-dev mailing list](https://mail-archives.apache.org/mod_mbox/storm-dev/).
 
 Storm developers who would want to track the JIRA issues should subscribe to [issues@storm.apache.org](mailto:issues@storm.apache.org).
 
 You can subscribe to this list by sending an email to [issues-subscribe@storm.apache.org](mailto:issues-subscribe@storm.apache.org). Likewise, you can cancel a subscription by sending an email to [issues-unsubscribe@storm.apache.org](mailto:issues-unsubscribe@storm.apache.org).
 
-You can view the archives of the mailing list [here](http://mail-archives.apache.org/mod_mbox/storm-issues/).
+You can view the archives of the mailing list [here](https://mail-archives.apache.org/mod_mbox/storm-issues/).
 
 ### Issue tracker
-In case you want to raise a bug/feature or propose an idea, please use [Apache Jira](https://issues.apache.org/jira/projects/STORM)
+In case you want to raise a bug/feature or propose an idea, please use [Apache Jira](https://issues.apache.org/jira/projects/STORM).
+If you do not have an account, you need to create one.
 
 ### Which list should I send/subscribe to?
-If you are using a pre-built binary distribution of Storm, then chances are you should send questions, comments, storm-related announcements, etc. to [user@storm.apache.org](mailto:user@storm.apache.org).
+If you are using a pre-built binary distribution of Storm, then you should send questions, comments, storm-related announcements, etc. to [user@storm.apache.org](mailto:user@storm.apache.org).
 
 If you are building storm from source, developing new features, or otherwise hacking storm source code, then [dev@storm.apache.org](mailto:dev@storm.apache.org) is more appropriate.
 
 If you are committers and/or PMCs, or contributors looking for following up and participating development of Storm, then you would want to also subscribe [issues@storm.apache.org](issues@storm.apache.org) in addition to [dev@storm.apache.org](dev@storm.apache.org).
 
-### What will happen with storm-user@googlegroups.com?
+### What happened with storm-user@googlegroups.com?
 All existing messages will remain archived there, and can be accessed/searched [here](https://groups.google.com/forum/#!forum/storm-user).
-
-New messages sent to storm-user@googlegroups.com will either be rejected/bounced or replied to with a message to direct the email to the appropriate Apache-hosted group.
 
 ## License
 
@@ -64,7 +61,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
@@ -75,49 +72,6 @@ under the License.
 
 The LICENSE and NOTICE files cover the source distributions. The LICENSE-binary and NOTICE-binary files cover the binary distributions. The DEPENDENCY-LICENSES file lists the licenses of all dependencies of Storm, including those not packaged in the source or binary distributions, such as dependencies of optional connector modules.
 
-
-## Project lead
-
-* Nathan Marz ([@nathanmarz](http://twitter.com/nathanmarz))
-
-## Committers
-
-* James Xu ([@xumingming](https://github.com/xumingming))
-* Jason Jackson ([@jason_j](http://twitter.com/jason_j))
-* Andy Feng ([@anfeng](https://github.com/anfeng))
-* Flip Kromer ([@mrflip](https://github.com/mrflip))
-* David Lao ([@davidlao2k](https://github.com/davidlao2k))
-* P. Taylor Goetz ([@ptgoetz](https://github.com/ptgoetz))
-* Derek Dagit ([@d2r](https://github.com/d2r))
-* Robert Evans ([@revans2](https://github.com/revans2))
-* Michael G. Noll ([@miguno](https://github.com/miguno))
-* Kishor Patil ([@kishorvpatil](https://github.com/kishorvpatil))
-* Sriharsha Chintalapani([@harshach](https://github.com/harshach))
-* Sean Zhong ([@clockfly](http://github.com/clockfly))
-* Kyle Nusbaum ([@knusbaum](https://github.com/knusbaum))
-* Parth Brahmbhatt ([@Parth-Brahmbhatt](https://github.com/Parth-Brahmbhatt))
-* Jungtaek Lim ([@HeartSaVioR](https://github.com/HeartSaVioR))
-* Aaron Dossett ([@dossett](https://github.com/dossett))
-* Matthias J. Sax ([@mjsax](https://github.com/mjsax))
-* Arun Mahadevan ([@arunmahadevan](https://github.com/arunmahadevan))
-* Boyang Jerry Peng ([@jerrypeng](https://github.com/jerrypeng))
-* Zhuo Liu ([@zhuoliu](https://github.com/zhuoliu))
-* Haohui Mai ([@haohui](https://github.com/haohui))
-* Sanket Chintapalli ([@redsanket](https://github.com/redsanket))
-* Longda Feng ([@longda](https://github.com/longdafeng))
-* John Fang ([@hustfxj](https://github.com/hustfxj))
-* Abhishek Agarwal ([@abhishekagarwal87](https://github.com/abhishekagarwal87))
-* Satish Duggana ([@satishd](https://github.com/satishd))
-* Xin Wang ([@vesense](https://github.com/vesense))
-* Hugo da Cruz Louro ([@hmcl](https://github.com/hmcl))
-* Stig Rohde Døssing ([@srdo](https://github.com/srdo/))
-* Roshan Naik ([@roshannaik](http://github.com/roshannaik))
-* Ethan Li ([@Ethanlm](https://github.com/Ethanlm))
-* Govind Menon ([@govind](https://github.com/govind-menon))
-* Aaron Gresch ([@agresch](https://github.com/agresch))
-* Rui Li ([@ruili](https://github.com/RuiLi8080))
-* Bipin Prasad ([@bipinprasad](https://github.com/bipinprasad))
-
 ## Acknowledgements
 
-YourKit is kindly supporting open source projects with its full-featured Java Profiler. YourKit, LLC is the creator of innovative and intelligent tools for profiling Java and .NET applications. Take a look at YourKit's leading software products: [YourKit Java Profiler](http://www.yourkit.com/java/profiler/index.jsp) and [YourKit .NET Profiler](http://www.yourkit.com/.net/profiler/index.jsp).
+YourKit is kindly supporting open source projects with its full-featured Java Profiler. YourKit, LLC is the creator of innovative and intelligent tools for profiling Java and .NET applications. Take a look at YourKit's leading software products: [YourKit Java Profiler](https://www.yourkit.com/java/profiler/index.jsp) and [YourKit .NET Profiler](https://www.yourkit.com/.net/profiler/index.jsp).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -117,7 +117,8 @@ Thanks!
 
 ## Releasing if the vote succeeds
 
-0. Announce the results. Use the following template.
+0. Announce the results. Use the following template:
+
 ```agsl
 Subject: [VOTE][RESULT] Storm [VERSION] Release Candidate [N]
 
@@ -133,6 +134,7 @@ Thanks to everyone who contributed to this release.
 
 [RELEASE MANAGER NAME]
 ```
+
 1. `svn mv https://dist.apache.org/repos/dist/dev/storm/apache-storm-x.x.x-rcx https://dist.apache.org/repos/dist/release/storm/apache-storm-x.x.x`. This will make the release artifacts available on dist.apache.org and the artifacts will start replicating to mirrors.
 
 2. Go to http://repository.apache.org and release the staging repository
@@ -140,16 +142,19 @@ Thanks to everyone who contributed to this release.
 3. Wait at least 24 hrs. for the mirrors to catch up.
 
 4. Check out the [storm-site](https://github.com/apache/storm-site) repository, and follow the README to generate release specific documentation for 
-the site. Compose a new blog post announcement for the new release. Update the downloads page. Finally commit and push 
+the site. Compose a new blog post announcement for the new release. Update the downloads page. Finally, commit and push 
 the site as described in the storm-site README to publish the site.
 
-5. Announce the new release to dev@storm.apache.org, user@storm.apache.org, and announce@apache.org. You will need to use your @apache.org email to do this.
+5. Update `doap_Storm.rdf` with the new release version.
 
-6. Delete any outdated releases from the https://dist.apache.org/repos/dist/release/storm/ repository. See [when to archive](http://www.apache.org/legal/release-policy.html#when-to-archive). 
+6. Announce the new release to dev@storm.apache.org, user@storm.apache.org, and announce@apache.org. You will need to use your @apache.org email to do this.
 
-7. Delete any outdated releases from the storm-site releases directory, and republish the site.
+7. Delete any outdated releases from the https://dist.apache.org/repos/dist/release/storm/ repository. See [when to archive](http://www.apache.org/legal/release-policy.html#when-to-archive). 
 
-8. Tweet, promote, celebrate. ;) Annoucement email can be sent to announce@apache.org using the following template:
+8. Delete any outdated releases from the storm-site releases directory, and republish the site.
+
+9. Tweet, promote, celebrate. ;) Annoucement email can be sent to announce@apache.org using the following template:
+
 ```agsl
 Subject: [ANNOUNCE] Apache Storm [VERSION] Released
 
@@ -179,7 +184,7 @@ groupId: org.apache.storm
 artifactId: storm-{component}
 version: [VERSION]
 
-The full list of changes is available here[1]. Please let us know [2] if
+The full list of changes is available here [1]. Please let us know [2] if
 you encounter any problems.
 
 Regards,
@@ -191,15 +196,16 @@ The Apache Storm Team
 
 ## Cleaning up if the vote fails
 
-0. Sent email to dev@storm.apache.org 
+1. Sent email to dev@storm.apache.org 
 
-1. Go to http://repository.apache.org and drop the staging repository.
+2. Go to http://repository.apache.org and drop the staging repository.
 
-2. Delete the staged distribution files from https://dist.apache.org/repos/dist/dev/storm/
+3. Delete the staged distribution files from https://dist.apache.org/repos/dist/dev/storm/
 
-3. Delete the git tag.
+4. Delete the git tag.
 
-4. Send a [VOTE][CANCELED] message using the following format:
+5. Send a [VOTE][CANCELED] message using the following format:
+
 ```agsl
 Subject: [VOTE][CANCELED] Storm [VERSION] Release Candidate [N]
 

--- a/doap_Storm.rdf
+++ b/doap_Storm.rdf
@@ -36,9 +36,9 @@
     <category rdf:resource="http://projects.apache.org/category/big-data" />
     <release>
       <Version>
-        <name>Apache Storm 0.9.5</name>
-        <created>2015-06-03</created>
-        <revision>0.9.5</revision>
+        <name>Apache Storm 2.5.0</name>
+        <created>2023-08-04</created>
+        <revision>2.5.0</revision>
       </Version>
     </release>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -55,223 +56,12 @@
         </mailingList>
     </mailingLists>
 
-    <developers>
-        <developer>
-            <id>nathanmarz</id>
-            <name>Nathan Marz</name>
-            <email>nathan@nathanmarz.com</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-8</timezone>
-        </developer>
-        <developer>
-            <id>ptgoetz</id>
-            <name>P. Taylor Goetz</name>
-            <email>ptgoetz@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-5</timezone>
-        </developer>
-        <developer>
-            <id>xumingming</id>
-            <name>James Xu</name>
-            <email>xumingming@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone />
-        </developer>
-        <developer>
-            <id>afeng</id>
-            <name>Andy Feng</name>
-            <email>afeng@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-8</timezone>
-        </developer>
-        <developer>
-            <id>davidlao</id>
-            <name>David Lao</name>
-            <email>davidlao@microsoft.com</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-8</timezone>
-        </developer>
-        <developer>
-            <id>mrflip</id>
-            <name>Flip Kromer</name>
-            <email>mrflip@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone />
-        </developer>
-        <developer>
-            <id>jjackson</id>
-            <name>Jason Jackson</name>
-            <email>jasonjckn@gmail.com</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-8</timezone>
-        </developer>
-        <developer>
-            <id>bobby</id>
-            <name>Robert Evans</name>
-            <email>evans@yahoo-inc.com</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-6</timezone>
-        </developer>
-        <developer>
-            <id>dagit</id>
-            <name>Derek Dagit</name>
-            <email>derekd@yahoo-inc.com</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-6</timezone>
-        </developer>
-        <developer>
-            <id>miguno</id>
-            <name>Michael G. Noll</name>
-            <email>michael@michael-noll.com</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>+1</timezone>
-        </developer>
-        <developer>
-            <id>dossett</id>
-            <name>Aaron Dossett</name>
-            <email>dossett@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-6</timezone>
-        </developer>
-        <developer>
-            <id>jerrypeng</id>
-            <name>Boyang Jerry Peng</name>
-            <email>jerrypeng@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-6</timezone>
-        </developer>
-        <developer>
-            <id>longda</id>
-            <name>Longda Feng</name>
-            <email>longda@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>+8</timezone>
-        </developer>
-        <developer>
-            <id>abhishek</id>
-            <name>Abhishek Agarwal</name>
-            <email>abhishek@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>+5.5</timezone>
-        </developer>
-        <developer>
-            <id>satishd</id>
-            <name>Satish Duggana</name>
-            <email>satishd@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>+5.5</timezone>
-        </developer>
-        <developer>
-            <id>vesense</id>
-            <name>Xin Wang</name>
-            <email>xinwang@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>+8</timezone>
-        </developer>
-        <developer>
-            <id>hmclouro</id>
-            <name>Hugo da Cruz Louro</name>
-            <email>hmclouro@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-8</timezone>
-        </developer>
-        <developer>
-            <id>roshannaik</id>
-            <name>Roshan Naik</name>
-            <email>roshannaik@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-8</timezone>
-        </developer>
-        <developer>
-            <id>Ethanlm</id>
-            <name>Ethan Li</name>
-            <email>ethanli@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-6</timezone>
-        </developer>
-        <developer>
-            <id>govind-menon</id>
-            <name>Govind Menon</name>
-            <email>govind@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-6</timezone>
-        </developer>
-        <developer>
-            <id>agresch</id>
-            <name>Aaron Gresch</name>
-            <email>agresch@gmail.com</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-6</timezone>
-        </developer>
-        <developer>
-            <id>ruili</id>
-            <name>Rui Li</name>
-            <email>ruili@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-6</timezone>
-        </developer>
-        <developer>
-            <id>bipinprasad</id>
-            <name>Bipin Prasad</name>
-            <email>bipinprasad@apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-            <timezone>-6</timezone>
-        </developer>
-
-    </developers>
-
     <scm>
         <connection>git@github.com:apache/storm.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/storm.git</developerConnection>
         <url>https://github.com/apache/storm</url>
-      <tag>v2.5.0</tag>
-  </scm>
+        <tag>v2.5.0</tag>
+    </scm>
 
     <issueManagement>
         <system>jira</system>
@@ -348,7 +138,7 @@
 
         <jackson.version>2.15.2</jackson.version>
         <jackson.databind.version>2.15.2</jackson.databind.version>
-        
+
         <storm.kafka.client.version>0.11.0.3</storm.kafka.client.version>
 
         <!-- Java and clojure build lifecycle test properties are defined here to avoid having to create a default profile -->
@@ -473,30 +263,71 @@
                                 <exclude>install.txt</exclude>
                                 <exclude>storm-shaded-deps/install-shade.txt</exclude>
                                 <!-- the following are in the LICENSE file -->
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery.dataTables.1.10.4.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/jquery.dataTables.1.10.4.min.css</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/images/*</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/bootstrap-3.3.1.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/bootstrap-3.3.1.min.css</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/dataTables.bootstrap.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/dataTables.bootstrap.css</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jsonFormatter.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/jsonFormatter.min.css</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery-3.5.1.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery.cookies.2.2.0.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/moment.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery.blockUI.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/url.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery.mustache.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/typeahead.jquery.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/cytoscape-dagre.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/dagre.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/esprima.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/js-yaml.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/vis.min.js</exclude>
-                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/vis.min.css</exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery.dataTables.1.10.4.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/jquery.dataTables.1.10.4.min.css
+                                </exclude>
+                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/images/*
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/bootstrap-3.3.1.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/bootstrap-3.3.1.min.css
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/dataTables.bootstrap.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/dataTables.bootstrap.css
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jsonFormatter.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/jsonFormatter.min.css
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery-3.5.1.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery.cookies.2.2.0.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/moment.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery.blockUI.min.js
+                                </exclude>
+                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/url.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/jquery.mustache.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/typeahead.jquery.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/cytoscape-dagre.js
+                                </exclude>
+                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/dagre.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/esprima.min.js
+                                </exclude>
+                                <exclude>
+                                    **/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/js-yaml.min.js
+                                </exclude>
+                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/js/vis.min.js
+                                </exclude>
+                                <exclude>**/src/main/java/org/apache/storm/daemon/ui/WEB-INF/css/vis.min.css
+                                </exclude>
                                 <exclude>**/src/main/resources/Audit.50.csv</exclude>
-                                <exclude>**/src/main/resources/KNIME_PMML_4.1_Examples_single_audit_logreg.xml</exclude>
+                                <exclude>
+                                    **/src/main/resources/KNIME_PMML_4.1_Examples_single_audit_logreg.xml
+                                </exclude>
                                 <exclude>**/src/main/sampledata/**</exclude>
 
                                 <!-- generated by shade plugin -->
@@ -512,7 +343,8 @@
                                 <exclude>**/src/test/resources/test-3072.log.test</exclude>
                                 <exclude>**/src/test/resources/small-worker.log.test</exclude>
                                 <exclude>**/src/test/resources/test-worker.log.test</exclude>
-                                <exclude>**/src/test/resources/logviewer-search-context-tests.log.test</exclude>
+                                <exclude>**/src/test/resources/logviewer-search-context-tests.log.test
+                                </exclude>
 
                                 <!-- StormSQL -->
                                 <exclude>**/src/codegen/config.fmpp</exclude>
@@ -623,7 +455,7 @@
                 <!-- add perf tests back in -->
                 <java.unit.test.exclude.groups>nothing</java.unit.test.exclude.groups>
             </properties>
-        </profile> 
+        </profile>
         <profile>
             <id>integration-tests-only</id>
             <properties>
@@ -1108,78 +940,78 @@
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-kahadb-store</artifactId>
                 <version>${activemq.version}</version>
-           </dependency>
-           <dependency>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-all</artifactId>
                 <version>${activemq.version}</version>
                 <exclusions>
-                   <exclusion>
-                       <groupId>org.slf4j</groupId>
-                       <artifactId>slf4j-api</artifactId>
-                   </exclusion>
-                   <exclusion>
-                       <groupId>log4j</groupId>
-                       <artifactId>log4j</artifactId>
-                   </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
                 </exclusions>
-           </dependency>
-           <!-- Hadoop dependencies. Specified here so HDFS/HBase don't import older versions of these jars in their projects-->
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-auth</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-hdfs</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-common</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-annotations</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-mapreduce-client-core</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-yarn-common</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-yarn-server-applicationhistoryservice</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-yarn-server-web-proxy</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-yarn-registry</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
-           <dependency>
-               <groupId>org.apache.hadoop</groupId>
-               <artifactId>hadoop-archives</artifactId>
-               <version>${hadoop.version}</version>
-           </dependency>
+            </dependency>
+            <!-- Hadoop dependencies. Specified here so HDFS/HBase don't import older versions of these jars in their projects-->
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-auth</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-hdfs</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-common</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-annotations</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-mapreduce-client-core</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-common</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-server-applicationhistoryservice</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-server-web-proxy</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-yarn-registry</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-archives</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
@@ -1377,7 +1209,8 @@
                         <useMissingFile>true</useMissingFile>
                         <failOnMissing>true</failOnMissing>
                         <includeTransitiveDependencies>true</includeTransitiveDependencies>
-                        <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByMultiLicense.ftl</fileTemplate>
+                        <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByMultiLicense.ftl
+                        </fileTemplate>
                         <excludedScopes>system,test</excludedScopes>
                         <excludedGroups>${project.groupId}</excludedGroups>
                         <licenseMerges>
@@ -1400,7 +1233,7 @@
                                 The Apache Software License, Version 2.0
                             </licenseMerge>
                             <licenseMerge>
-                                Apache License | 
+                                Apache License |
                                 Apache Software Licenses
                             </licenseMerge>
                             <licenseMerge>
@@ -1423,13 +1256,13 @@
                                 CDDL 1.0
                             </licenseMerge>
                             <licenseMerge>
-                                Common Development and Distribution License (CDDL) v1.1 | 
+                                Common Development and Distribution License (CDDL) v1.1 |
                                 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 |
                                 CDDL 1.1 |
                                 Common Development and Distribution License (CDDL), Version 1.1
                             </licenseMerge>
                             <licenseMerge>
-                                Common Development and Distribution License | 
+                                Common Development and Distribution License |
                                 <!-- Multilicense, choosing CDDL -->
                                 CDDL+GPL |
                                 CDDL+GPL License |
@@ -1485,7 +1318,8 @@
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
-                    <generatedSourcesDirectory>${project.build.directory}/generated-sources</generatedSourcesDirectory>
+                    <generatedSourcesDirectory>${project.build.directory}/generated-sources
+                    </generatedSourcesDirectory>
                 </configuration>
             </plugin>
             <plugin>
@@ -1525,7 +1359,7 @@
                                         <exclude>jdk.tools:jdk.tools:*</exclude>
                                     </excludes>
                                 </bannedDependencies>
-                            </rules>    
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>
@@ -1536,7 +1370,8 @@
                 <inherited>false</inherited>
                 <configuration>
                     <missingFile>${project.basedir}/THIRD-PARTY.properties</missingFile>
-                    <aggregateMissingLicensesFile>${project.basedir}/THIRD-PARTY.properties</aggregateMissingLicensesFile>
+                    <aggregateMissingLicensesFile>${project.basedir}/THIRD-PARTY.properties
+                    </aggregateMissingLicensesFile>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## What is the purpose of the change

- Removes outdated developer information from README. Project's roster can be found on Storm's website
- Removes the `developer` section in the ROOT Pom for the same reason.
- Updates DOAP file with latest release
- Move links to HTTPS
- POM formatting