### PR TITLE
fix(sec): upgrade org.yaml:snakeyaml to 2.0

### DIFF
--- a/external/storm-cassandra/pom.xml
+++ b/external/storm-cassandra/pom.xml
@@ -94,7 +94,7 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <!-- Override here as Cassandra version used isn't compatible with 2.0 -->
-            <version>1.33</version>
+            <version>2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.yaml:snakeyaml 1.33
- [CVE-2022-1471](https://www.oscs1024.com/hd/CVE-2022-1471)


### What did I do？
Upgrade org.yaml:snakeyaml from 1.33 to 2.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS