### PR TITLE
STORM-3994 - LocalCluster init fails on Windows because of missing librocksdbjni-win64.dll

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -485,7 +485,7 @@ List of third-party dependencies grouped by their license type.
 
     Apache License, Version 2.0, GNU General Public License, version 2
 
-        * RocksDB JNI (org.rocksdb:rocksdbjni:8.1.1 - https://rocksdb.org)
+        * RocksDB JNI (org.rocksdb:rocksdbjni:8.5.4 - https://rocksdb.org)
 
     Apache License, Version 2.0, LGPL 2.1, MPL 1.1
 

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -1013,7 +1013,7 @@ The license texts of these dependencies can be found in the licenses directory.
 
     Apache License, Version 2.0, GNU General Public License, version 2
 
-        * RocksDB JNI (org.rocksdb:rocksdbjni:8.1.1 - https://rocksdb.org)
+        * RocksDB JNI (org.rocksdb:rocksdbjni:8.5.4 - https://rocksdb.org)
 
     Apache License, Version 2.0, LGPL 2.1, MPL 1.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <jakarta-activation-version>1.2.1</jakarta-activation-version>
         <jaxb-version>2.3.0</jaxb-version>
         <activation-version>1.1.1</activation-version>
-        <rocksdb-version>8.1.1</rocksdb-version>
+        <rocksdb-jni-version>8.5.4</rocksdb-jni-version>
         <json-smart.version>2.5.0</json-smart.version>
 
         <!-- see intellij profile below... This fixes an annoyance with intellij -->
@@ -914,7 +914,7 @@
             <dependency>
                 <groupId>org.rocksdb</groupId>
                 <artifactId>rocksdbjni</artifactId>
-                <version>${rocksdb-version}</version>
+                <version>${rocksdb-jni-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
-            <version>${rocksdb-version}</version>
+            <version>${rocksdb-jni-version}</version>
         </dependency>
 
         <!-- jline is included to make the zk shell work through the cli for debugging -->


### PR DESCRIPTION
## What is the purpose of the change

- Updates rocksdbjni as 8.1.1 is a broken release regarding Windows (cf. https://github.com/facebook/rocksdb/issues/11420)

## How was the change tested

- CI