### PR TITLE
[STORM-4003] add missing jakarta.xml.bind dependency to storm-kafka-monitor

### DIFF
--- a/external/storm-kafka-monitor/pom.xml
+++ b/external/storm-kafka-monitor/pom.xml
@@ -62,6 +62,11 @@
            <groupId>commons-cli</groupId>
            <artifactId>commons-cli</artifactId>
        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <!-- version will be inherited -->
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## What is the purpose of the change

When running Storm UI with Java 17 runtime, the lag of Kafka consumers is not visible in the topology view for the topologies which are consuming Kafka topics. Based on exceptions found in ui.log, this is because storm-kakfa-monitor is missing JAXB API.

## How was the change tested

Using Storm 2.6.0 snapshot dated 2023/11/14, doing a copy of  jakarta.xml.bind-api-2.3.2.jar from lib-worker/ to lib-tools/storm-kafka-monitor/ then restarting Storm UI process solves the problem.

