### PR TITLE
fix flaky tests testTopologyIsolation and testDefaultResourceAwareStrategySharedMemory

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/resource/RasNode.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/resource/RasNode.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -103,7 +104,7 @@ public class RasNode implements Comparable<RasNode> {
                 freeById.removeAll(assignment.keySet());
             }
         }
-        originallyFreeSlots = new HashSet<>();
+        originallyFreeSlots = new LinkedHashSet<>();
         for (WorkerSlot slot : slots.values()) {
             if (freeById.contains(slot.getId())) {
                 originallyFreeSlots.add(slot);


### PR DESCRIPTION
## What is the purpose of the change
The following test cases
https://github.com/apache/storm/blob/c0d7b475da99c28043b137e892d58aedde4eb840/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestRoundRobinNodeSorterHostIsolation.java#L155 
https://github.com/apache/storm/blob/c0d7b475da99c28043b137e892d58aedde4eb840/storm-server/src/test/java/org/apache/storm/scheduler/resource/strategies/scheduling/TestDefaultResourceAwareStrategy.java#L309

fail due to the non-deterministic behavior of the line  

https://github.com/apache/storm/blob/c0d7b475da99c28043b137e892d58aedde4eb840/storm-server/src/main/java/org/apache/storm/scheduler/resource/RasNode.java#L106

as hashset does not guarantee the ordering of elements in the class object.

I found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

## How was the change tested

The following command can be used to reproduce assertion failures and verify the fix:
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl storm-server -Dtest='org.apache.storm.scheduler.resource.strategies.scheduling.TestDefaultResourceAwareStrategy#testDefaultResourceAwareStrategySharedMemory'
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl storm-server -Dtest='org.apache.storm.scheduler.resource.strategies.scheduling.TestRoundRobinNodeSorterHostIsolation#testTopologyIsolation'
```