### PR TITLE
STORM-4008 - Implement timed GH actions to publish SNAPSHOTS

### DIFF
--- a/.github/workflows/snapshots.yaml
+++ b/.github/workflows/snapshots.yaml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Publish Storm to nightlies.apache.org
+
+on:
+  workflow_dispatch: { }
+  schedule:
+    # every day 5min after midnight, UTC.
+    - cron: "5 0 * * *"
+
+jobs:
+  upload_to_nightlies:
+    if: github.repository == 'apache/storm'
+    name: Publish Snapshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: snapshots-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            snapshots-maven-
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Set up Maven # We need to avoid default-http-blocker at the moment until we fix it ;-)
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.6.3
+      - id: extract_version
+        name: Extract project version
+        shell: bash
+        run: |
+          VERSION=$(mvn exec:exec -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive -q)
+          if [[ "$VERSION" == *"SNAPSHOT"* ]]; then
+             echo "snapshot=SNAPSHOT" >> $GITHUB_OUTPUT
+          fi
+      - name: Ensure a clean state without storm artifacts
+        if: steps.extract_version.outputs.snapshot == 'SNAPSHOT'
+        run: rm -rf ~/.m2/repository/org/apache/storm
+      - name: Set up project dependencies
+        if: steps.extract_version.outputs.snapshot == 'SNAPSHOT'
+        run: /bin/bash ./dev-tools/gitact/gitact-install.sh `pwd`
+      - name: Deploy Maven snapshots
+        if: steps.extract_version.outputs.snapshot == 'SNAPSHOT'
+        env:
+          ASF_USERNAME: ${{ secrets.NEXUS_USER }}
+          ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
+        run: |
+          echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
+          mvn --settings settings.xml -U -B -e -fae -ntp -DskipTests deploy

--- a/.github/workflows/snapshots.yaml
+++ b/.github/workflows/snapshots.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Publish Storm to nightlies.apache.org
+name: Publish Storm SNAPSHOTs
 
 on:
   workflow_dispatch: { }


### PR DESCRIPTION
## What is the purpose of the change

With STORM-4006 we are now publishing the tar.gz / zip files every day to https://nightlies.apache.org/storm/

In addition, we should publish SNAPSHOT artifacts to the nexus repository as well so people get a chance to test these SNAPSHOT builds.

Related INFRA ticket is open: https://issues.apache.org/jira/browse/INFRA-25234

After INFRA has added the secrets, we can move on with this PR.