### PR TITLE
STORM-4017 Fix for isAnyWindowsProcessAlive with multiple pids

### DIFF
--- a/storm-server/src/test/java/org/apache/storm/utils/ServerUtilsTest.java
+++ b/storm-server/src/test/java/org/apache/storm/utils/ServerUtilsTest.java
@@ -106,17 +106,24 @@ public class ServerUtilsTest {
     private Collection<Long> getRunningProcessIds(String user) throws IOException {
         // get list of few running processes
         Collection<Long> pids = new ArrayList<>();
-        String cmd = ServerUtils.IS_ON_WINDOWS ? "tasklist" : (user == null) ? "ps -e" : "ps -U " + user ;
+        int pidIndex = 0;
+        String cmd;
+        if (ServerUtils.IS_ON_WINDOWS) {
+            cmd = "tasklist";
+            pidIndex = 1;
+        } else {
+            cmd = (user == null) ? "ps -e" : "ps -U " + user;
+        }
         Process p = Runtime.getRuntime().exec(cmd);
         try (BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
             String line;
             while ((line = input.readLine()) != null) {
                 line = line.trim();
-                if (line.isEmpty() || line.startsWith("PID")) {
+                if (line.isEmpty()) {
                     continue;
                 }
                 try {
-                    String pidStr = line.split("\\s")[0];
+                    String pidStr = line.split("\\s+")[pidIndex];
                     if (pidStr.equalsIgnoreCase("pid")) {
                         continue; // header line
                     }


### PR DESCRIPTION
## What is the purpose of the change

Fixes STORM-4017 I raised recently so that isAnyWindowsProcessAlive works correctly in Windows.
What prompted this was that we are evaluating Storm 2.5.0 under Windows and noticed that when workers are restarted the child processes are left running.
We noticed logs reporting that "None of the processes , , are alive" when they were in fact still running.
Further investigation showed why this was happening, hence raised STORM-4017
How was the change tested

## How was the change tested

Existing unit test 'testIsAnyProcessAlive' in ServerUtilsTest.java did not work under Windows but now does with this fix.

We have confirmed that we only now see the "None of the processes ... are alive" when the processes are genuinely not running

See attached unit test run before and after fix
![STORM-4017-not-fixed-2](https://github.com/apache/storm/assets/152920539/4b905714-cf31-45c5-9316-29bae229fdf4)
![STORM-4017-fixed-2](https://github.com/apache/storm/assets/152920539/de9a3315-5a6f-46d4-816e-419e25d1e7d4)
