### PR TITLE
[STORM-4022] Do not log Exception when getting heartbeat timeout for dead topologies

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -2673,6 +2673,9 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
         try {
             Map<String, Object> topoConf = tryReadTopoConf(topoId, topoCache);
             return getTopologyHeartbeatTimeoutSecs(topoConf);
+        } catch (NotAliveException e) {
+            // no log here to avoid flooding nimbus logs
+            return ObjectReader.getInt(conf.get(DaemonConfig.NIMBUS_TASK_TIMEOUT_SECS));
         } catch (Exception e) {
             // contain any exception
             LOG.warn("Exception when getting heartbeat timeout", e);


### PR DESCRIPTION

## What is the purpose of the change

*In AWS EKS environment, the nimbus log seems to be flooded with heartbeat time exception messages for dead topologies*

## How was the change tested

*Test run as part of this Pull Request*