### PR TITLE
STORM-4024 Fix Bolt Input Stats are blank if topology.acker.executors…

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/stats/StatsUtil.java
+++ b/storm-server/src/main/java/org/apache/storm/stats/StatsUtil.java
@@ -150,13 +150,15 @@ public class StatsUtil {
                                                             Map<K, Double> id2procAvg,
                                                             Map<K, Long> id2numExec) {
         Map<K, Map> ret = new HashMap<>();
-        if (id2execAvg == null || id2procAvg == null || id2numExec == null) {
+        if (id2execAvg == null || id2numExec == null) {
             return ret;
         }
         for (K k : id2execAvg.keySet()) {
             Map<String, Object> subMap = new HashMap<>();
             subMap.put(EXEC_LAT_TOTAL, weightAvg(id2execAvg, id2numExec, k));
-            subMap.put(PROC_LAT_TOTAL, weightAvg(id2procAvg, id2numExec, k));
+            if (id2procAvg != null) {
+                subMap.put(PROC_LAT_TOTAL, weightAvg(id2procAvg, id2numExec, k));
+            }
             subMap.put(EXECUTED, id2numExec.get(k));
             ret.put(k, subMap);
         }


### PR DESCRIPTION
… is null or 0

## What is the purpose of the change
Fixes the bolt input stats not working if topology.acker.executors is null or 0 (https://issues.apache.org/jira/browse/STORM-4024)

*(Explain why we should have this change)*
The bolt input stats on StormUI and via API will be incorrect if ackers are not used

## How was the change tested
Ran a topology without any topology.acker.executors
Observed the Bolt Input Stats on StormUI

*(Explain what tests did you do to verify the code change)*
Manual testing with patched storm-server jar - see attachment with fix showing Bolt Input Stats now populated with ackers = 0
![image](https://github.com/apache/storm/assets/152920539/47fb61c9-5a1c-4954-a78d-071c1075adaf)
