### PR TITLE
STORM-4052 - Simplify/Remove double delete/lookup in heartbeat cleanup code.

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/VersionedStore.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/VersionedStore.java
@@ -128,15 +128,11 @@ public class VersionedStore {
     public void cleanup(int versionsToKeep) throws IOException {
         List<Long> versions = getAllVersions();
         if (versionsToKeep >= 0) {
-            versions = versions.subList(0, Math.min(versions.size(), versionsToKeep));
+            versions = versions.subList(Math.min(versions.size(), versionsToKeep), versions.size());
         }
-        HashSet<Long> keepers = new HashSet<Long>(versions);
 
-        for (String p : listDir(root)) {
-            Long v = parseVersion(p);
-            if (v != null && !keepers.contains(v)) {
-                deleteVersion(v);
-            }
+        for (Long v : versions) {
+            deleteVersion(v);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This changes slightly simplifies the heartbeat cleanup code so it no longer tries to delete the heartbeat files twice. It also removes an unneeded directory listing (and possible race) by truncating the versions list and using it for removal instead of for keeping.

Removing the double delete attempt is important because it removes a lookup for now non-existent files. Looking up non existent files, especially highly unique (like timestamped) ones can adversely affect many operating systems as these lookups are cached as negative dentries.
https://lwn.net/Articles/814535/

When cleanup runs, it iterates over the heartbeat directory that contains a token and version file for each heartbeat. It calls deleteVersion for each file in the directory which attempts to delete both files associated with the heartbeat. As deleteVersion already deletes both when it first iterates over the token file, the iteration for the version file has nothing to do.

Before removing, the deleteVersion code checks for the existence of these now non existent files. On linux (and other OSs) a lookup for a non-existent path will create a negative dentry in the operating system's cache. On some configurations this cache can grow effectively unbounded leading to performance issues. On newer systems this cache is better managed, but this will still dilute an otherwise useful OS cache with useless entries.

## How was the change tested

Ran tests.