### PR TITLE
[STORM-4053] Add Hadoop client API dependency back to storm-hdfs

### DIFF
--- a/external/storm-hdfs/pom.xml
+++ b/external/storm-hdfs/pom.xml
@@ -64,6 +64,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>


### PR DESCRIPTION
## What is the purpose of the change

Dependency was removed by mistake
See https://github.com/apache/incubator-stormcrawler/pull/1189

## How was the change tested

mvn clean test