### PR TITLE
STORM-4057 - Validate user with the id cmd

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
+++ b/storm-server/src/main/java/org/apache/storm/utils/ServerUtils.java
@@ -1102,6 +1102,17 @@ public class ServerUtils {
         cmdArgs.add("-u");
         if (user != null && !user.isEmpty()) {
             cmdArgs.add(user);
+            int exitCode = 0;
+            try {
+                exitCode = new ProcessBuilder(cmdArgs).start().waitFor();
+            } catch (Exception e) {
+                // Ignore
+            } finally {
+                if (exitCode != 0) {
+                    LOG.debug("CMD: '{}' returned exit code of {}", String.join(" ", cmdArgs), exitCode);
+                    cmdArgs.remove(user);
+                }
+            }
         }
         LOG.debug("CMD: {}", String.join(" ", cmdArgs));
         ProcessBuilder pb = new ProcessBuilder(cmdArgs);


### PR DESCRIPTION
## What is the purpose of the change

Validate the user associated with the id command for scenarios where the user running Storm in a container is not listed in the /etc/passwd file when a Worker process is to be terminated, e.g. with a custom securityContext in Kubernetes:

      securityContext:
        runAsUser: 1000620005
        fsGroup: 1000620005
        supplementalGroups: [ 64000 ]

Without this change the Supervisor container itself dies rather than terminating the Worker process.

## How was the change tested

I have tested the change locally running a Kubernetes cluster with this fix in place.  The Worker process is successfully terminated and the Supervisor container does not die.