### PR TITLE
STORM-3985 - Upgrade Metrics, Jetty, Dropwizard Integration + JakartaEE API

### DIFF
--- a/DEPENDENCY-LICENSES
+++ b/DEPENDENCY-LICENSES
@@ -9,6 +9,10 @@ List of third-party dependencies grouped by their license type.
         * Protocol Buffers [Core] (com.google.protobuf:protobuf-java:3.3.0 - https://developers.google.com/protocol-buffers/protobuf-java/)
         * ReflectASM (com.esotericsoftware:reflectasm:1.11.9 - https://github.com/EsotericSoftware/reflectasm)
 
+    AL 2.0, GPL v2, MPL 2.0
+
+        * RabbitMQ Java Client (com.rabbitmq:amqp-client:5.21.0 - https://www.rabbitmq.com)
+
     Apache License
 
         * carbonite (org.clojars.bipinprasad:carbonite:1.6.0 - https://github.com/bipinprasad/carbonite)
@@ -23,7 +27,7 @@ List of third-party dependencies grouped by their license type.
         * Aether :: Utilities (org.sonatype.aether:aether-util:1.7 - http://aether.sonatype.org/aether-util/)
         * Aggregate Designer Algorithm (net.hydromatic:aggdesigner-algorithm:6.0 - http://github.com/julianhyde/aggdesigner/aggdesigner-algorithm)
         * aircompressor (io.airlift:aircompressor:0.10 - http://github.com/airlift/aircompressor)
-        * Annotations for Metrics (io.dropwizard.metrics:metrics-annotation:4.1.16 - https://metrics.dropwizard.io/metrics-annotation)
+        * Annotations for Metrics (io.dropwizard.metrics:metrics-annotation:4.2.26 - https://metrics.dropwizard.io/metrics-annotation)
         * Apache Ant Core (org.apache.ant:ant:1.9.1 - http://ant.apache.org/)
         * Apache Ant Launcher (org.apache.ant:ant-launcher:1.9.1 - http://ant.apache.org/)
         * Apache Avro (org.apache.avro:avro:1.11.3 - https://avro.apache.org)
@@ -126,14 +130,14 @@ List of third-party dependencies grouped by their license type.
         * ASM based accessors helper used by json-smart (net.minidev:accessors-smart:2.5.1 - https://urielch.github.io/)
         * Auto Common Libraries (com.google.auto:auto-common:0.8 - https://github.com/google/auto/auto-common)
         * AutoService (com.google.auto.service:auto-service:1.0-rc4 - https://github.com/google/auto/auto-service)
-        * Bean Validation API (javax.validation:validation-api:1.1.0.Final - http://beanvalidation.org)
         * BoneCP :: Core Library (com.jolbox:bonecp:0.8.0.RELEASE - http://jolbox.com/bonecp)
+        * Caffeine cache (com.github.ben-manes.caffeine:caffeine:3.1.8 - https://github.com/ben-manes/caffeine)
         * Calcite Core (org.apache.calcite:calcite-core:1.16.0 - https://calcite.apache.org/calcite-core)
         * Calcite Druid (org.apache.calcite:calcite-druid:1.16.0 - https://calcite.apache.org/calcite-druid)
         * Calcite Linq4j (org.apache.calcite:calcite-linq4j:1.16.0 - https://calcite.apache.org/calcite-linq4j)
         * CDI APIs (javax.enterprise:cdi-api:1.0 - http://www.seamframework.org/Weld/cdi-api)
         * chill-java (com.twitter:chill-java:0.9.5 - https://github.com/twitter/chill)
-        * ClassMate (com.fasterxml:classmate:1.3.1 - http://github.com/cowtowncoder/java-classmate)
+        * ClassMate (com.fasterxml:classmate:1.7.0 - https://github.com/FasterXML/java-classmate)
         * com.helger:profiler (com.helger:profiler:1.1.1 - https://github.com/phax/profiler)
         * com.yahoo.datasketches:memory (com.yahoo.datasketches:memory:0.9.0 - https://datasketches.github.io/memory/)
         * com.yahoo.datasketches:sketches-core (com.yahoo.datasketches:sketches-core:0.9.0 - https://datasketches.github.io/sketches-core/)
@@ -149,19 +153,20 @@ List of third-party dependencies grouped by their license type.
         * DataNucleus Core (org.datanucleus:datanucleus-core:4.1.17 - http://www.datanucleus.org/#/datanucleus-core)
         * DataNucleus JDO API plugin (org.datanucleus:datanucleus-api-jdo:4.2.4 - http://www.datanucleus.org/#/datanucleus-api-jdo)
         * DataNucleus RDBMS plugin (org.datanucleus:datanucleus-rdbms:4.1.19 - http://www.datanucleus.org/#/datanucleus-rdbms)
-        * Dropwizard (io.dropwizard:dropwizard-core:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-core)
-        * Dropwizard Asset Bundle (io.dropwizard:dropwizard-assets:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-assets)
-        * Dropwizard Configuration Support (io.dropwizard:dropwizard-configuration:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-configuration)
-        * Dropwizard Jackson Support (io.dropwizard:dropwizard-jackson:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-jackson)
-        * Dropwizard Jersey Support (io.dropwizard:dropwizard-jersey:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-jersey)
-        * Dropwizard Jetty Support (io.dropwizard:dropwizard-jetty:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-jetty)
-        * Dropwizard Lifecycle Support (io.dropwizard:dropwizard-lifecycle:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-lifecycle)
-        * Dropwizard Logging Support (io.dropwizard:dropwizard-logging:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-logging)
-        * Dropwizard Metrics Support (io.dropwizard:dropwizard-metrics:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-metrics)
-        * Dropwizard Request Logging Support (io.dropwizard:dropwizard-request-logging:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-request-logging)
-        * Dropwizard Servlet Support (io.dropwizard:dropwizard-servlets:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-servlets)
-        * Dropwizard Utility Classes (io.dropwizard:dropwizard-util:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-util)
-        * Dropwizard Validation Support (io.dropwizard:dropwizard-validation:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-validation)
+        * Dropwizard (io.dropwizard:dropwizard-core:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-core)
+        * Dropwizard Asset Bundle (io.dropwizard:dropwizard-assets:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-assets)
+        * Dropwizard Configuration Support (io.dropwizard:dropwizard-configuration:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-configuration)
+        * Dropwizard Health Checking Support (io.dropwizard:dropwizard-health:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-health)
+        * Dropwizard Jackson Support (io.dropwizard:dropwizard-jackson:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-jackson)
+        * Dropwizard Jersey Support (io.dropwizard:dropwizard-jersey:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-jersey)
+        * Dropwizard Jetty Support (io.dropwizard:dropwizard-jetty:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-jetty)
+        * Dropwizard Lifecycle Support (io.dropwizard:dropwizard-lifecycle:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-lifecycle)
+        * Dropwizard Logging Support (io.dropwizard:dropwizard-logging:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-logging)
+        * Dropwizard Metrics Support (io.dropwizard:dropwizard-metrics:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-metrics)
+        * Dropwizard Request Logging Support (io.dropwizard:dropwizard-request-logging:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-request-logging)
+        * Dropwizard Servlet Support (io.dropwizard:dropwizard-servlets:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-servlets)
+        * Dropwizard Utility Classes (io.dropwizard:dropwizard-util:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-util)
+        * Dropwizard Validation Support (io.dropwizard:dropwizard-validation:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-validation)
         * Ehcache (org.ehcache:ehcache:3.3.1 - http://ehcache.org)
         * error-prone annotations (com.google.errorprone:error_prone_annotations:2.25.0 - https://errorprone.info/error_prone_annotations)
         * Esri Geometry API for Java (com.esri.geometry:esri-geometry-api:2.0.0 - https://github.com/Esri/geometry-api-java)
@@ -175,7 +180,7 @@ List of third-party dependencies grouped by their license type.
         * Google Guice - Core Library (com.google.inject:guice:4.2.3 - https://github.com/google/guice/guice)
         * Google Guice - Extensions - AssistedInject (com.google.inject.extensions:guice-assistedinject:3.0 - http://code.google.com/p/google-guice/extensions-parent/guice-assistedinject/)
         * Google Guice - Extensions - Servlet (com.google.inject.extensions:guice-servlet:4.2.3 - https://github.com/google/guice/extensions-parent/guice-servlet)
-        * Graphite Integration for Metrics (io.dropwizard.metrics:metrics-graphite:3.2.6 - http://metrics.dropwizard.io/metrics-graphite/)
+        * Graphite Integration for Metrics (io.dropwizard.metrics:metrics-graphite:4.2.26 - https://metrics.dropwizard.io/metrics-graphite)
         * Gson (com.google.code.gson:gson:2.10.1 - https://github.com/google/gson/gson)
         * Guava: Google Core Libraries for Java (com.google.guava:guava:19.0 - https://github.com/google/guava/guava)
         * Guava: Google Core Libraries for Java (com.google.guava:guava:33.0.0-jre - https://github.com/google/guava)
@@ -183,8 +188,7 @@ List of third-party dependencies grouped by their license type.
         * Guava ListenableFuture only (com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava - https://github.com/google/guava/listenablefuture)
         * Hadoop Metrics2 Reporter for Dropwizard Metrics (com.github.joshelser:dropwizard-metrics-hadoop-metrics2-reporter:0.1.2 - https://github.com/joshelser/dropwizard-hadoop-metrics2)
         * hawtbuf (org.fusesource.hawtbuf:hawtbuf:1.11 - http://hawtbuf.fusesource.org/hawtbuf)
-        * Hibernate Validator Engine (org.hibernate:hibernate-validator:5.4.3.Final - http://hibernate.org/validator/hibernate-validator)
-        * Hibernate Validator Engine (org.hibernate.validator:hibernate-validator:6.2.5.Final - http://hibernate.org/validator/hibernate-validator)
+        * Hibernate Validator Engine (org.hibernate.validator:hibernate-validator:7.0.5.Final - http://hibernate.org/validator/hibernate-validator)
         * HikariCP (com.zaxxer:HikariCP:2.6.1 - https://github.com/brettwooldridge/HikariCP)
         * HikariCP (com.zaxxer:HikariCP:5.0.1 - https://github.com/brettwooldridge/HikariCP)
         * Hive Classifications (org.apache.hive:hive-classification:3.1.3 - https://hive.apache.org/hive-classification)
@@ -220,19 +224,21 @@ List of third-party dependencies grouped by their license type.
         * Jackson-dataformat-YAML (com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.1 - https://github.com/FasterXML/jackson-dataformats-text)
         * Jackson datatype: Guava (com.fasterxml.jackson.datatype:jackson-datatype-guava:2.16.1 - https://github.com/FasterXML/jackson-datatypes-collections)
         * Jackson datatype: jdk8 (com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.1 - https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
-        * Jackson datatype: Joda (com.fasterxml.jackson.datatype:jackson-datatype-joda:2.16.1 - https://github.com/FasterXML/jackson-datatype-joda)
         * Jackson datatype: JSR310 (com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.1 - https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
-        * Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:3.1.0 - http://metrics.codahale.com/metrics-json/)
-        * Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:4.1.16 - https://metrics.dropwizard.io/metrics-json)
+        * Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:4.2.26 - https://metrics.dropwizard.io/metrics-json)
+        * Jackson Jakarta-RS: base (com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:2.16.1 - https://github.com/FasterXML/jackson-jakarta-rs-providers/jackson-jakarta-rs-base)
+        * Jackson Jakarta-RS: JSON (com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.16.1 - https://github.com/FasterXML/jackson-jakarta-rs-providers/jackson-jakarta-rs-json-provider)
         * Jackson-JAXRS: base (com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.16.1 - https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-base)
         * Jackson-JAXRS: JSON (com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.16.1 - https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-json-provider)
-        * Jackson module: Afterburner (com.fasterxml.jackson.module:jackson-module-afterburner:2.16.1 - https://github.com/FasterXML/jackson-modules-base)
+        * Jackson module: Blackbird (com.fasterxml.jackson.module:jackson-module-blackbird:2.16.1 - https://github.com/FasterXML/jackson-modules-base)
+        * Jackson module: Jakarta XML Bind Annotations (jakarta.xml.bind) (com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.16.1 - https://github.com/FasterXML/jackson-modules-base)
         * Jackson module: Old JAXB Annotations (javax.xml.bind) (com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.16.1 - https://github.com/FasterXML/jackson-modules-base)
         * Jackson-module-parameter-names (com.fasterxml.jackson.module:jackson-module-parameter-names:2.16.1 - https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
-        * Jakarta Bean Validation API (jakarta.validation:jakarta.validation-api:2.0.2 - https://beanvalidation.org)
+        * Jakarta Bean Validation API (jakarta.validation:jakarta.validation-api:3.0.2 - https://beanvalidation.org)
+        * Jakarta Dependency Injection (jakarta.inject:jakarta.inject-api:2.0.1.MR - https://github.com/eclipse-ee4j/injection-api)
         * Java Concurrency Tools Core Library (org.jctools:jctools-core:2.0.1 - https://github.com/JCTools)
         * javax.inject (javax.inject:javax.inject:1 - http://code.google.com/p/atinject/)
-        * JBoss Logging 3 (org.jboss.logging:jboss-logging:3.3.0.Final - http://www.jboss.org)
+        * JBoss Logging 3 (org.jboss.logging:jboss-logging:3.5.3.Final - http://www.jboss.org)
         * JCIP Annotations under Apache License (com.github.stephenc.jcip:jcip-annotations:1.0-1 - http://stephenc.github.com/jcip-annotations)
         * JCL 1.2 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.36 - http://www.slf4j.org)
         * jdependency (org.vafer:jdependency:1.2 - http://github.com/tcurdt/jdependency)
@@ -243,7 +249,7 @@ List of third-party dependencies grouped by their license type.
         * JPam (net.sf.jpam:jpam:1.1 - http://jpam.sf.net)
         * jsonschema2pojo-core (org.jsonschema2pojo:jsonschema2pojo-core:1.0.2 - https://github.com/joelittlejohn/jsonschema2pojo/jsonschema2pojo-core)
         * JSON Small and Fast Parser (net.minidev:json-smart:2.5.1 - https://urielch.github.io/)
-        * JVM Integration for Metrics (io.dropwizard.metrics:metrics-jvm:3.2.6 - http://metrics.dropwizard.io/metrics-jvm/)
+        * JVM Integration for Metrics (io.dropwizard.metrics:metrics-jvm:4.2.26 - https://metrics.dropwizard.io/metrics-jvm)
         * Kerb Simple Kdc (org.apache.kerby:kerb-simplekdc:2.0.3 - https://directory.apache.org/kerby/kerby-kerb/kerb-simplekdc)
         * Kerby ASN1 Project (org.apache.kerby:kerby-asn1:2.0.3 - https://directory.apache.org/kerby/kerby-common/kerby-asn1)
         * Kerby Config (org.apache.kerby:kerby-config:2.0.3 - https://directory.apache.org/kerby/kerby-common/kerby-config)
@@ -310,13 +316,13 @@ List of third-party dependencies grouped by their license type.
         * Maven Settings (org.apache.maven:maven-settings:3.8.1 - https://maven.apache.org/ref/3.8.1/maven-settings/)
         * Maven Settings Builder (org.apache.maven:maven-settings-builder:3.0 - http://maven.apache.org/maven-settings-builder/)
         * Maven Settings Builder (org.apache.maven:maven-settings-builder:3.8.1 - https://maven.apache.org/ref/3.8.1/maven-settings-builder/)
-        * Metrics Core (io.dropwizard.metrics:metrics-core:3.2.6 - http://metrics.dropwizard.io/metrics-core/)
-        * Metrics Health Checks (io.dropwizard.metrics:metrics-healthchecks:4.1.16 - https://metrics.dropwizard.io/metrics-healthchecks)
-        * Metrics Integration for Jersey 2.x (io.dropwizard.metrics:metrics-jersey2:4.1.16 - https://metrics.dropwizard.io/metrics-jersey2)
-        * Metrics Integration for Jetty 9.3 and higher (io.dropwizard.metrics:metrics-jetty9:4.1.16 - https://metrics.dropwizard.io/metrics-jetty9)
-        * Metrics Integration for Logback (io.dropwizard.metrics:metrics-logback:4.1.16 - https://metrics.dropwizard.io/metrics-logback)
-        * Metrics Integration with JMX (io.dropwizard.metrics:metrics-jmx:4.1.16 - https://metrics.dropwizard.io/metrics-jmx)
-        * Metrics Utility Servlets (io.dropwizard.metrics:metrics-servlets:4.1.16 - https://metrics.dropwizard.io/metrics-servlets)
+        * Metrics Core (io.dropwizard.metrics:metrics-core:4.2.26 - https://metrics.dropwizard.io/metrics-core)
+        * Metrics Health Checks (io.dropwizard.metrics:metrics-healthchecks:4.2.26 - https://metrics.dropwizard.io/metrics-healthchecks)
+        * Metrics Integration for Jersey 3.x (io.dropwizard.metrics:metrics-jersey3:4.2.26 - https://metrics.dropwizard.io/metrics-jersey3)
+        * Metrics Integration for Jetty 11.x and higher (io.dropwizard.metrics:metrics-jetty11:4.2.26 - https://metrics.dropwizard.io/metrics-jetty11)
+        * Metrics Integration for Logback (io.dropwizard.metrics:metrics-logback:4.2.26 - https://metrics.dropwizard.io/metrics-logback)
+        * Metrics Integration with JMX (io.dropwizard.metrics:metrics-jmx:4.2.26 - https://metrics.dropwizard.io/metrics-jmx)
+        * Metrics Utility Jakarta Servlets (io.dropwizard.metrics:metrics-jakarta-servlets:4.2.26 - https://metrics.dropwizard.io/metrics-jakarta-servlets)
         * Netty/All-in-One (io.netty:netty-all:4.1.107.Final - https://netty.io/netty-all/)
         * Netty/Buffer (io.netty:netty-buffer:4.1.107.Final - https://netty.io/netty-buffer/)
         * Netty/Codec/DNS (io.netty:netty-codec-dns:4.1.107.Final - https://netty.io/netty-codec-dns/)
@@ -403,45 +409,46 @@ List of third-party dependencies grouped by their license type.
         * Tephra API (co.cask.tephra:tephra-api:0.6.0 - https://github.com/caskdata/tephra/tephra-api)
         * Tephra Core (co.cask.tephra:tephra-core:0.6.0 - https://github.com/caskdata/tephra/tephra-core)
         * Tephra HBase 1.0 Compatibility (co.cask.tephra:tephra-hbase-compat-1.0:0.6.0 - https://github.com/caskdata/tephra/tephra-hbase-compat-1.0)
+        * Throttling Appender (io.dropwizard.logback:logback-throttling-appender:1.4.2 - https://github.com/dropwizard/logback-throttling-appender/)
         * Token provider (org.apache.kerby:token-provider:2.0.3 - https://directory.apache.org/kerby/kerby-provider/token-provider)
         * Woodstox (com.fasterxml.woodstox:woodstox-core:5.4.0 - https://github.com/FasterXML/woodstox)
 
     Apache License, Version 2.0, BSD 2-Clause, Eclipse Distribution License, Version 1.0, Eclipse Public License, Version 2.0, jQuery license, MIT License, Modified BSD, Public Domain, The GNU General Public License (GPL), Version 2, With Classpath Exception, W3C license
 
-        * jersey-container-grizzly2-http (org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-http)
-        * jersey-container-grizzly2-servlet (org.glassfish.jersey.containers:jersey-container-grizzly2-servlet:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-servlet)
-        * jersey-container-servlet (org.glassfish.jersey.containers:jersey-container-servlet:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet)
-        * jersey-container-servlet-core (org.glassfish.jersey.containers:jersey-container-servlet-core:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet-core)
-        * jersey-core-client (org.glassfish.jersey.core:jersey-client:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-client)
-        * jersey-ext-bean-validation (org.glassfish.jersey.ext:jersey-bean-validation:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-bean-validation)
-        * jersey-ext-metainf-services (org.glassfish.jersey.ext:jersey-metainf-services:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-metainf-services)
-        * jersey-inject-hk2 (org.glassfish.jersey.inject:jersey-hk2:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-hk2)
+        * jersey-container-grizzly2-http (org.glassfish.jersey.containers:jersey-container-grizzly2-http:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-http)
+        * jersey-container-grizzly2-servlet (org.glassfish.jersey.containers:jersey-container-grizzly2-servlet:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-servlet)
+        * jersey-container-servlet (org.glassfish.jersey.containers:jersey-container-servlet:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet)
+        * jersey-container-servlet-core (org.glassfish.jersey.containers:jersey-container-servlet-core:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet-core)
+        * jersey-core-client (org.glassfish.jersey.core:jersey-client:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-client)
+        * jersey-ext-bean-validation (org.glassfish.jersey.ext:jersey-bean-validation:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-bean-validation)
+        * jersey-ext-metainf-services (org.glassfish.jersey.ext:jersey-metainf-services:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-metainf-services)
+        * jersey-inject-hk2 (org.glassfish.jersey.inject:jersey-hk2:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-hk2)
 
     Apache License, Version 2.0, Eclipse Public License, Version 2.0, Modified BSD, The GNU General Public License (GPL), Version 2, With Classpath Exception
 
-        * jersey-core-server (org.glassfish.jersey.core:jersey-server:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-server)
+        * jersey-core-server (org.glassfish.jersey.core:jersey-server:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-server)
 
     Apache License, Version 2.0, Eclipse Public License, Version 2.0, Public Domain, The GNU General Public License (GPL), Version 2, With Classpath Exception
 
-        * jersey-core-common (org.glassfish.jersey.core:jersey-common:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-common)
+        * jersey-core-common (org.glassfish.jersey.core:jersey-common:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-common)
 
     Apache License, Version 2.0, Eclipse Public License - Version 1.0
 
-        * Jetty :: Continuation (org.eclipse.jetty:jetty-continuation:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-continuation)
-        * Jetty :: Http Utility (org.eclipse.jetty:jetty-http:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-http)
-        * Jetty :: IO Utility (org.eclipse.jetty:jetty-io:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-io)
-        * Jetty :: Security (org.eclipse.jetty:jetty-security:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-security)
-        * Jetty :: Server Core (org.eclipse.jetty:jetty-server:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-server)
-        * Jetty :: Servlet Handling (org.eclipse.jetty:jetty-servlet:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-servlet)
+        * Jetty :: Jakarta Servlet API and Schemas for JPMS and OSGi (org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2 - https://eclipse.org/jetty/jetty-jakarta-servlet-api)
         * Jetty :: SetUID Java (org.eclipse.jetty.toolchain.setuid:jetty-setuid-java:1.0.4 - https://eclipse.org/jetty/jetty-setuid-parent/jetty-setuid-java)
-        * Jetty :: Utilities :: Ajax(JSON) (org.eclipse.jetty:jetty-util-ajax:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-util-ajax)
-        * Jetty :: Utilities (org.eclipse.jetty:jetty-util:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-util)
-        * Jetty :: Utility Servlets and Filters (org.eclipse.jetty:jetty-servlets:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-servlets)
-        * Jetty :: Webapp Application Support (org.eclipse.jetty:jetty-webapp:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-webapp)
         * Jetty :: Websocket :: API (org.eclipse.jetty.websocket:websocket-api:9.4.53.v20231009 - https://eclipse.org/jetty/websocket-parent/websocket-api)
         * Jetty :: Websocket :: Client (org.eclipse.jetty.websocket:websocket-client:9.4.53.v20231009 - https://eclipse.org/jetty/websocket-parent/websocket-client)
         * Jetty :: Websocket :: Common (org.eclipse.jetty.websocket:websocket-common:9.4.53.v20231009 - https://eclipse.org/jetty/websocket-parent/websocket-common)
-        * Jetty :: XML utilities (org.eclipse.jetty:jetty-xml:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-xml)
+
+    Apache License, Version 2.0, Eclipse Public License - Version 2.0
+
+        * Jetty :: Http Utility (org.eclipse.jetty:jetty-http:11.0.21 - https://eclipse.dev/jetty/jetty-http)
+        * Jetty :: IO Utility (org.eclipse.jetty:jetty-io:11.0.21 - https://eclipse.dev/jetty/jetty-io)
+        * Jetty :: Security (org.eclipse.jetty:jetty-security:11.0.21 - https://eclipse.dev/jetty/jetty-security)
+        * Jetty :: Server Core (org.eclipse.jetty:jetty-server:11.0.21 - https://eclipse.dev/jetty/jetty-server)
+        * Jetty :: Servlet Handling (org.eclipse.jetty:jetty-servlet:11.0.21 - https://eclipse.dev/jetty/jetty-servlet)
+        * Jetty :: Utilities (org.eclipse.jetty:jetty-util:11.0.21 - https://eclipse.dev/jetty/jetty-util)
+        * Jetty :: Utility Servlets and Filters (org.eclipse.jetty:jetty-servlets:11.0.21 - https://eclipse.dev/jetty/jetty-servlets)
 
     Apache License, Version 2.0, GNU General Public License, version 2
 
@@ -449,7 +456,7 @@ List of third-party dependencies grouped by their license type.
 
     Apache License, Version 2.0, LGPL 2.1, MPL 1.1
 
-        * Javassist (org.javassist:javassist:3.29.2-GA - http://www.javassist.org/)
+        * Javassist (org.javassist:javassist:3.30.2-GA - https://www.javassist.org/)
 
     Apache License, Version 2.0, LGPL-2.1-or-later
 
@@ -514,7 +521,6 @@ List of third-party dependencies grouped by their license type.
 
     Common Development and Distribution License
 
-        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b12 - http://uel.java.net)
         * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
         * javax.annotation API (javax.annotation:javax.annotation-api:1.3.2 - http://jcp.org/en/jsr/detail?id=250)
 
@@ -556,26 +562,25 @@ List of third-party dependencies grouped by their license type.
 
     Eclipse Public License, Version 2.0
 
-        * grizzly-framework (org.glassfish.grizzly:grizzly-framework:2.4.4 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-framework)
-        * grizzly-http (org.glassfish.grizzly:grizzly-http:2.4.4 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http)
-        * grizzly-http-server (org.glassfish.grizzly:grizzly-http-server:2.4.4 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-server)
-        * grizzly-http-servlet (org.glassfish.grizzly:grizzly-http-servlet:2.4.4 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-servlet)
+        * grizzly-framework (org.glassfish.grizzly:grizzly-framework:4.0.2 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-framework)
+        * grizzly-http (org.glassfish.grizzly:grizzly-http:4.0.2 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http)
+        * grizzly-http-server (org.glassfish.grizzly:grizzly-http-server:4.0.2 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-server)
+        * grizzly-http-servlet (org.glassfish.grizzly:grizzly-http-servlet:4.0.2 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-servlet)
+
+    Eclipse Public License, Version 2.0, GPL-2.0-with-classpath-exception
+
+        * Jakarta RESTful WS API (jakarta.ws.rs:jakarta.ws.rs-api:3.1.0 - https://github.com/eclipse-ee4j/jaxrs-api)
 
     Eclipse Public License, Version 2.0, The GNU General Public License (GPL), Version 2, With Classpath Exception
 
-        * aopalliance version 1.0 repackaged as a module (org.glassfish.hk2.external:aopalliance-repackaged:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/external/aopalliance-repackaged)
-        * HK2 API module (org.glassfish.hk2:hk2-api:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-api)
-        * HK2 Implementation Utilities (org.glassfish.hk2:hk2-utils:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-utils)
-        * jakarta.ws.rs-api (jakarta.ws.rs:jakarta.ws.rs-api:2.1.6 - https://github.com/eclipse-ee4j/jaxrs-api)
-        * Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:1.3.5 - https://projects.eclipse.org/projects/ee4j.ca)
+        * aopalliance version 1.0 repackaged as a module (org.glassfish.hk2.external:aopalliance-repackaged:3.0.6 - https://github.com/eclipse-ee4j/glassfish-hk2/external/aopalliance-repackaged)
+        * HK2 API module (org.glassfish.hk2:hk2-api:3.0.6 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-api)
+        * HK2 Implementation Utilities (org.glassfish.hk2:hk2-utils:3.0.6 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-utils)
+        * Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:2.0.0 - https://projects.eclipse.org/projects/ee4j.ca)
         * Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:2.1.1 - https://projects.eclipse.org/projects/ee4j.ca)
-        * Jakarta Expression Language 3.0 (org.glassfish:jakarta.el:3.0.4 - https://projects.eclipse.org/projects/ee4j.el)
-        * Jakarta Expression Language 3.0 API (jakarta.el:jakarta.el-api:3.0.3 - https://projects.eclipse.org/projects/ee4j.el)
-        * Jakarta Servlet (jakarta.servlet:jakarta.servlet-api:4.0.4 - https://projects.eclipse.org/projects/ee4j.servlet)
         * Jakarta Servlet (jakarta.servlet:jakarta.servlet-api:5.0.0 - https://projects.eclipse.org/projects/ee4j.servlet)
-        * javax.inject:1 as OSGi bundle (org.glassfish.hk2.external:jakarta.inject:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/external/jakarta.inject)
         * OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
-        * ServiceLocator Default Implementation (org.glassfish.hk2:hk2-locator:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-locator)
+        * ServiceLocator Default Implementation (org.glassfish.hk2:hk2-locator:3.0.6 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-locator)
 
     Eclipse Public License (EPL) 1.0, GNU Lesser General Public License Version 2.1, February 1999
 
@@ -587,6 +592,9 @@ List of third-party dependencies grouped by their license type.
 
     Eclipse Public License v. 2.0, GNU General Public License, version 2 with the GNU Classpath Exception
 
+        * Eclipse Expressly (org.glassfish.expressly:expressly:5.0.0 - https://projects.eclipse.org/projects/ee4j.expressly)
+        * Jakarta Expression Language API (jakarta.el:jakarta.el-api:4.0.0 - https://projects.eclipse.org/projects/ee4j.el)
+        * Jakarta Expression Language Implementation (org.glassfish:jakarta.el:4.0.2 - https://projects.eclipse.org/projects/ee4j.el)
         * jms (jakarta.jms:jakarta.jms-api:2.0.2 - https://projects.eclipse.org/projects/ee4j.jms)
 
     Elastic License 2.0
@@ -611,7 +619,7 @@ List of third-party dependencies grouped by their license type.
 
     MIT License
 
-        * argparse4j (net.sourceforge.argparse4j:argparse4j:0.8.1 - http://argparse4j.github.io)
+        * argparse4j (net.sourceforge.argparse4j:argparse4j:0.9.0 - https://argparse4j.github.io)
         * Checker Qual (org.checkerframework:checker-qual:3.42.0 - https://checkerframework.org/)
         * JCodings (org.jruby.jcodings:jcodings:1.0.55 - http://nexus.sonatype.org/oss-repository-hosting.html/jcodings)
         * Jedis (redis.clients:jedis:5.1.0 - https://github.com/redis/jedis)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -840,7 +840,6 @@ The license texts of these dependencies can be found in the licenses directory.
         * Jackson datatype: Guava (com.fasterxml.jackson.datatype:jackson-datatype-guava:2.16.1 - https://github.com/FasterXML/jackson-datatypes-collections)
         * Jackson datatype: jdk8 (com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.1 - https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
         * Jackson datatype: JSR310 (com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.1 - https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
-        * Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:3.1.0 - http://metrics.codahale.com/metrics-json/)
         * Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:4.2.26 - https://metrics.dropwizard.io/metrics-json)
         * Jackson Jakarta-RS: base (com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:2.16.1 - https://github.com/FasterXML/jackson-jakarta-rs-providers/jackson-jakarta-rs-base)
         * Jackson Jakarta-RS: JSON (com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.16.1 - https://github.com/FasterXML/jackson-jakarta-rs-providers/jackson-jakarta-rs-json-provider)

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -658,6 +658,10 @@ The license texts of these dependencies can be found in the licenses directory.
         * Apache Commons Text (org.apache.commons:commons-text:1.11.0 - https://commons.apache.org/proper/commons-text)
         * snappy-java (org.xerial.snappy:snappy-java:1.1.10.4 - https://github.com/xerial/snappy-java)
 
+    AL 2.0, GPL v2, MPL 2.0
+
+        * RabbitMQ Java Client (com.rabbitmq:amqp-client:5.21.0 - https://www.rabbitmq.com)
+
     Apache License
 
         * carbonite (org.clojars.bipinprasad:carbonite:1.6.0 - https://github.com/bipinprasad/carbonite)
@@ -666,8 +670,8 @@ The license texts of these dependencies can be found in the licenses directory.
     Apache License, Version 2.0
 
         * Aggregate Designer Algorithm (net.hydromatic:aggdesigner-algorithm:6.0 - http://github.com/julianhyde/aggdesigner/aggdesigner-algorithm)
+        * Annotations for Metrics (io.dropwizard.metrics:metrics-annotation:4.2.26 - https://metrics.dropwizard.io/metrics-annotation)
         * aircompressor (io.airlift:aircompressor:0.10 - http://github.com/airlift/aircompressor)
-        * Annotations for Metrics (io.dropwizard.metrics:metrics-annotation:4.1.16 - https://metrics.dropwizard.io/metrics-annotation)
         * Apache Ant Core (org.apache.ant:ant:1.9.1 - http://ant.apache.org/)
         * Apache Ant Launcher (org.apache.ant:ant-launcher:1.9.1 - http://ant.apache.org/)
         * Apache Calcite Avatica (org.apache.calcite.avatica:avatica-core:1.11.0 - https://calcite.apache.org/avatica/avatica-core)
@@ -750,13 +754,13 @@ The license texts of these dependencies can be found in the licenses directory.
         * Arrow Memory (org.apache.arrow:arrow-memory:0.8.0 - http://arrow.apache.org/arrow-memory/)
         * Arrow Vectors (org.apache.arrow:arrow-vector:0.8.0 - http://arrow.apache.org/arrow-vector/)
         * ASM based accessors helper used by json-smart (net.minidev:accessors-smart:2.5.1 - https://urielch.github.io/)
-        * Bean Validation API (javax.validation:validation-api:1.1.0.Final - http://beanvalidation.org)
         * BoneCP :: Core Library (com.jolbox:bonecp:0.8.0.RELEASE - http://jolbox.com/bonecp)
+        * Caffeine cache (com.github.ben-manes.caffeine:caffeine:3.1.8 - https://github.com/ben-manes/caffeine)
         * Calcite Core (org.apache.calcite:calcite-core:1.16.0 - https://calcite.apache.org/calcite-core)
         * Calcite Druid (org.apache.calcite:calcite-druid:1.16.0 - https://calcite.apache.org/calcite-druid)
         * Calcite Linq4j (org.apache.calcite:calcite-linq4j:1.16.0 - https://calcite.apache.org/calcite-linq4j)
         * chill-java (com.twitter:chill-java:0.9.5 - https://github.com/twitter/chill)
-        * ClassMate (com.fasterxml:classmate:1.3.1 - http://github.com/cowtowncoder/java-classmate)
+        * ClassMate (com.fasterxml:classmate:1.7.0 - https://github.com/FasterXML/java-classmate)
         * com.helger:profiler (com.helger:profiler:1.1.1 - https://github.com/phax/profiler)
         * com.yahoo.datasketches:memory (com.yahoo.datasketches:memory:0.9.0 - https://datasketches.github.io/memory/)
         * com.yahoo.datasketches:sketches-core (com.yahoo.datasketches:sketches-core:0.9.0 - https://datasketches.github.io/sketches-core/)
@@ -772,19 +776,20 @@ The license texts of these dependencies can be found in the licenses directory.
         * DataNucleus Core (org.datanucleus:datanucleus-core:4.1.17 - http://www.datanucleus.org/#/datanucleus-core)
         * DataNucleus JDO API plugin (org.datanucleus:datanucleus-api-jdo:4.2.4 - http://www.datanucleus.org/#/datanucleus-api-jdo)
         * DataNucleus RDBMS plugin (org.datanucleus:datanucleus-rdbms:4.1.19 - http://www.datanucleus.org/#/datanucleus-rdbms)
-        * Dropwizard (io.dropwizard:dropwizard-core:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-core)
-        * Dropwizard Asset Bundle (io.dropwizard:dropwizard-assets:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-assets)
-        * Dropwizard Configuration Support (io.dropwizard:dropwizard-configuration:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-configuration)
-        * Dropwizard Jackson Support (io.dropwizard:dropwizard-jackson:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-jackson)
-        * Dropwizard Jersey Support (io.dropwizard:dropwizard-jersey:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-jersey)
-        * Dropwizard Jetty Support (io.dropwizard:dropwizard-jetty:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-jetty)
-        * Dropwizard Lifecycle Support (io.dropwizard:dropwizard-lifecycle:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-lifecycle)
-        * Dropwizard Logging Support (io.dropwizard:dropwizard-logging:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-logging)
-        * Dropwizard Metrics Support (io.dropwizard:dropwizard-metrics:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-metrics)
-        * Dropwizard Request Logging Support (io.dropwizard:dropwizard-request-logging:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-request-logging)
-        * Dropwizard Servlet Support (io.dropwizard:dropwizard-servlets:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-servlets)
-        * Dropwizard Utility Classes (io.dropwizard:dropwizard-util:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-util)
-        * Dropwizard Validation Support (io.dropwizard:dropwizard-validation:1.3.29 - http://www.dropwizard.io/1.3.29/dropwizard-validation)
+        * Dropwizard (io.dropwizard:dropwizard-core:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-core)
+        * Dropwizard Asset Bundle (io.dropwizard:dropwizard-assets:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-assets)
+        * Dropwizard Configuration Support (io.dropwizard:dropwizard-configuration:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-configuration)
+        * Dropwizard Health Checking Support (io.dropwizard:dropwizard-health:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-health)
+        * Dropwizard Jackson Support (io.dropwizard:dropwizard-jackson:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-jackson)
+        * Dropwizard Jersey Support (io.dropwizard:dropwizard-jersey:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-jersey)
+        * Dropwizard Jetty Support (io.dropwizard:dropwizard-jetty:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-jetty)
+        * Dropwizard Lifecycle Support (io.dropwizard:dropwizard-lifecycle:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-lifecycle)
+        * Dropwizard Logging Support (io.dropwizard:dropwizard-logging:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-logging)
+        * Dropwizard Metrics Support (io.dropwizard:dropwizard-metrics:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-metrics)
+        * Dropwizard Request Logging Support (io.dropwizard:dropwizard-request-logging:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-request-logging)
+        * Dropwizard Servlet Support (io.dropwizard:dropwizard-servlets:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-servlets)
+        * Dropwizard Utility Classes (io.dropwizard:dropwizard-util:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-util)
+        * Dropwizard Validation Support (io.dropwizard:dropwizard-validation:4.0.7 - http://www.dropwizard.io/4.0.7/dropwizard-bom/dropwizard-dependencies/dropwizard-parent/dropwizard-validation)
         * Ehcache (org.ehcache:ehcache:3.3.1 - http://ehcache.org)
         * error-prone annotations (com.google.errorprone:error_prone_annotations:2.25.0 - https://errorprone.info/error_prone_annotations)
         * Esri Geometry API for Java (com.esri.geometry:esri-geometry-api:2.0.0 - https://github.com/Esri/geometry-api-java)
@@ -795,15 +800,14 @@ The license texts of these dependencies can be found in the licenses directory.
         * Google Guice - Core Library (com.google.inject:guice:4.2.3 - https://github.com/google/guice/guice)
         * Google Guice - Extensions - AssistedInject (com.google.inject.extensions:guice-assistedinject:3.0 - http://code.google.com/p/google-guice/extensions-parent/guice-assistedinject/)
         * Google Guice - Extensions - Servlet (com.google.inject.extensions:guice-servlet:4.2.3 - https://github.com/google/guice/extensions-parent/guice-servlet)
-        * Graphite Integration for Metrics (io.dropwizard.metrics:metrics-graphite:3.2.6 - http://metrics.dropwizard.io/metrics-graphite/)
+        * Graphite Integration for Metrics (io.dropwizard.metrics:metrics-graphite:4.2.26 - https://metrics.dropwizard.io/metrics-graphite)
         * Gson (com.google.code.gson:gson:2.10.1 - https://github.com/google/gson/gson)
         * Guava: Google Core Libraries for Java (com.google.guava:guava:19.0 - http://code.google.com/p/guava-libraries/guava)
         * Guava: Google Core Libraries for Java (com.google.guava:guava:33.0.0-jre - https://github.com/google/guava)
         * Guava InternalFutureFailureAccess and InternalFutures (com.google.guava:failureaccess:1.0.2 - https://github.com/google/guava/failureaccess)
         * Guava ListenableFuture only (com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava - https://github.com/google/guava/listenablefuture)
         * Hadoop Metrics2 Reporter for Dropwizard Metrics (com.github.joshelser:dropwizard-metrics-hadoop-metrics2-reporter:0.1.2 - https://github.com/joshelser/dropwizard-hadoop-metrics2)
-        * Hibernate Validator Engine (org.hibernate:hibernate-validator:5.4.3.Final - http://hibernate.org/validator/hibernate-validator)
-        * Hibernate Validator Engine (org.hibernate.validator:hibernate-validator:6.2.5.Final - http://hibernate.org/validator/hibernate-validator)
+        * Hibernate Validator Engine (org.hibernate.validator:hibernate-validator:7.0.5.Final - http://hibernate.org/validator/hibernate-validator)
         * HikariCP (com.zaxxer:HikariCP:2.6.1 - https://github.com/brettwooldridge/HikariCP)
         * Hive Classifications (org.apache.hive:hive-classification:3.1.3 - https://hive.apache.org/hive-classification)
         * Hive Common (org.apache.hive:hive-common:3.1.3 - https://hive.apache.org/hive-common)
@@ -835,19 +839,22 @@ The license texts of these dependencies can be found in the licenses directory.
         * Jackson-dataformat-YAML (com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.1 - https://github.com/FasterXML/jackson-dataformats-text)
         * Jackson datatype: Guava (com.fasterxml.jackson.datatype:jackson-datatype-guava:2.16.1 - https://github.com/FasterXML/jackson-datatypes-collections)
         * Jackson datatype: jdk8 (com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.1 - https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
-        * Jackson datatype: Joda (com.fasterxml.jackson.datatype:jackson-datatype-joda:2.16.1 - https://github.com/FasterXML/jackson-datatype-joda)
         * Jackson datatype: JSR310 (com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.1 - https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310)
         * Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:3.1.0 - http://metrics.codahale.com/metrics-json/)
-        * Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:4.1.16 - https://metrics.dropwizard.io/metrics-json)
+        * Jackson Integration for Metrics (io.dropwizard.metrics:metrics-json:4.2.26 - https://metrics.dropwizard.io/metrics-json)
+        * Jackson Jakarta-RS: base (com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base:2.16.1 - https://github.com/FasterXML/jackson-jakarta-rs-providers/jackson-jakarta-rs-base)
+        * Jackson Jakarta-RS: JSON (com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider:2.16.1 - https://github.com/FasterXML/jackson-jakarta-rs-providers/jackson-jakarta-rs-json-provider)
         * Jackson-JAXRS: base (com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.16.1 - https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-base)
         * Jackson-JAXRS: JSON (com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.16.1 - https://github.com/FasterXML/jackson-jaxrs-providers/jackson-jaxrs-json-provider)
-        * Jackson module: Afterburner (com.fasterxml.jackson.module:jackson-module-afterburner:2.16.1 - https://github.com/FasterXML/jackson-modules-base)
+        * Jackson module: Blackbird (com.fasterxml.jackson.module:jackson-module-blackbird:2.16.1 - https://github.com/FasterXML/jackson-modules-base)
+        * Jackson module: Jakarta XML Bind Annotations (jakarta.xml.bind) (com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations:2.16.1 - https://github.com/FasterXML/jackson-modules-base)
         * Jackson module: Old JAXB Annotations (javax.xml.bind) (com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.16.1 - https://github.com/FasterXML/jackson-modules-base)
         * Jackson-module-parameter-names (com.fasterxml.jackson.module:jackson-module-parameter-names:2.16.1 - https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
-        * Jakarta Bean Validation API (jakarta.validation:jakarta.validation-api:2.0.2 - https://beanvalidation.org)
+        * Jakarta Bean Validation API (jakarta.validation:jakarta.validation-api:3.0.2 - https://beanvalidation.org)
+        * Jakarta Dependency Injection (jakarta.inject:jakarta.inject-api:2.0.1.MR - https://github.com/eclipse-ee4j/injection-api)
         * Java Concurrency Tools Core Library (org.jctools:jctools-core:2.0.1 - https://github.com/JCTools)
         * javax.inject (javax.inject:javax.inject:1 - http://code.google.com/p/atinject/)
-        * JBoss Logging 3 (org.jboss.logging:jboss-logging:3.3.0.Final - http://www.jboss.org)
+        * JBoss Logging 3 (org.jboss.logging:jboss-logging:3.5.3.Final - http://www.jboss.org)
         * JCIP Annotations under Apache License (com.github.stephenc.jcip:jcip-annotations:1.0-1 - http://stephenc.github.com/jcip-annotations)
         * JCL 1.2 implemented over SLF4J (org.slf4j:jcl-over-slf4j:1.7.36 - http://www.slf4j.org)
         * JDO API (javax.jdo:jdo-api:3.0.1 - http://db.apache.org/jdo)
@@ -857,7 +864,7 @@ The license texts of these dependencies can be found in the licenses directory.
         * jsonschema2pojo-core (org.jsonschema2pojo:jsonschema2pojo-core:1.0.2 - https://github.com/joelittlejohn/jsonschema2pojo/jsonschema2pojo-core)
         * JPam (net.sf.jpam:jpam:1.1 - http://jpam.sf.net)
         * JSON Small and Fast Parser (net.minidev:json-smart:2.5.1 - https://urielch.github.io/)
-        * JVM Integration for Metrics (io.dropwizard.metrics:metrics-jvm:3.2.6 - http://metrics.dropwizard.io/metrics-jvm/)
+        * JVM Integration for Metrics (io.dropwizard.metrics:metrics-jvm:4.2.26 - https://metrics.dropwizard.io/metrics-jvm)
         * Kerb Simple Kdc (org.apache.kerby:kerb-simplekdc:2.0.3 - http://directory.apache.org/kerby/kerby-kerb/kerb-simplekdc)
         * Kerby ASN1 Project (org.apache.kerby:kerby-asn1:2.0.3 - http://directory.apache.org/kerby/kerby-common/kerby-asn1)
         * Kerby Config (org.apache.kerby:kerby-config:2.0.3 - http://directory.apache.org/kerby/kerby-common/kerby-config)
@@ -886,13 +893,13 @@ The license texts of these dependencies can be found in the licenses directory.
         * Maven Model (org.apache.maven:maven-model:3.6.0 - https://maven.apache.org/ref/3.6.0/maven-model/)
         * Maven Model Builder (org.apache.maven:maven-model-builder:3.6.0 - https://maven.apache.org/ref/3.6.0/maven-model-builder/)
         * Maven Repository Metadata Model (org.apache.maven:maven-repository-metadata:3.6.0 - https://maven.apache.org/ref/3.6.0/maven-repository-metadata/)
-        * Metrics Core (io.dropwizard.metrics:metrics-core:3.2.6 - http://metrics.dropwizard.io/metrics-core/)
-        * Metrics Health Checks (io.dropwizard.metrics:metrics-healthchecks:4.1.16 - https://metrics.dropwizard.io/metrics-healthchecks)
-        * Metrics Integration for Jersey 2.x (io.dropwizard.metrics:metrics-jersey2:4.1.16 - https://metrics.dropwizard.io/metrics-jersey2)
-        * Metrics Integration for Jetty 9.3 and higher (io.dropwizard.metrics:metrics-jetty9:4.1.16 - https://metrics.dropwizard.io/metrics-jetty9)
-        * Metrics Integration for Logback (io.dropwizard.metrics:metrics-logback:4.1.16 - https://metrics.dropwizard.io/metrics-logback)
-        * Metrics Integration with JMX (io.dropwizard.metrics:metrics-jmx:4.1.16 - https://metrics.dropwizard.io/metrics-jmx)
-        * Metrics Utility Servlets (io.dropwizard.metrics:metrics-servlets:4.1.16 - https://metrics.dropwizard.io/metrics-servlets)
+        * Metrics Core (io.dropwizard.metrics:metrics-core:4.2.26 - https://metrics.dropwizard.io/metrics-core)
+        * Metrics Health Checks (io.dropwizard.metrics:metrics-healthchecks:4.2.26 - https://metrics.dropwizard.io/metrics-healthchecks)
+        * Metrics Integration for Jersey 3.x (io.dropwizard.metrics:metrics-jersey3:4.2.26 - https://metrics.dropwizard.io/metrics-jersey3)
+        * Metrics Integration for Jetty 11.x and higher (io.dropwizard.metrics:metrics-jetty11:4.2.26 - https://metrics.dropwizard.io/metrics-jetty11)
+        * Metrics Integration for Logback (io.dropwizard.metrics:metrics-logback:4.2.26 - https://metrics.dropwizard.io/metrics-logback)
+        * Metrics Integration with JMX (io.dropwizard.metrics:metrics-jmx:4.2.26 - https://metrics.dropwizard.io/metrics-jmx)
+        * Metrics Utility Jakarta Servlets (io.dropwizard.metrics:metrics-jakarta-servlets:4.2.26 - https://metrics.dropwizard.io/metrics-jakarta-servlets)
         * Netty/All-in-One (io.netty:netty-all:4.1.107.Final - https://netty.io/netty-all/)
         * Netty/Buffer (io.netty:netty-buffer:4.1.107.Final - https://netty.io/netty-buffer/)
         * Netty/Codec/DNS (io.netty:netty-codec-dns:4.1.107.Final - https://netty.io/netty-codec-dns/)
@@ -956,45 +963,46 @@ The license texts of these dependencies can be found in the licenses directory.
         * Tephra API (co.cask.tephra:tephra-api:0.6.0 - https://github.com/caskdata/tephra/tephra-api)
         * Tephra Core (co.cask.tephra:tephra-core:0.6.0 - https://github.com/caskdata/tephra/tephra-core)
         * Tephra HBase 1.0 Compatibility (co.cask.tephra:tephra-hbase-compat-1.0:0.6.0 - https://github.com/caskdata/tephra/tephra-hbase-compat-1.0)
+        * Throttling Appender (io.dropwizard.logback:logback-throttling-appender:1.4.2 - https://github.com/dropwizard/logback-throttling-appender/)
         * Token provider (org.apache.kerby:token-provider:2.0.3 - http://directory.apache.org/kerby/kerby-provider/token-provider)
         * Woodstox (com.fasterxml.woodstox:woodstox-core:5.4.0 - https://github.com/FasterXML/woodstox)
 
     Apache License, Version 2.0, BSD 2-Clause, Eclipse Distribution License, Version 1.0, Eclipse Public License, Version 2.0, jQuery license, MIT License, Modified BSD, Public Domain, The GNU General Public License (GPL), Version 2, With Classpath Exception, W3C license
 
-        * jersey-container-grizzly2-http (org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-http)
-        * jersey-container-grizzly2-servlet (org.glassfish.jersey.containers:jersey-container-grizzly2-servlet:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-servlet)
-        * jersey-container-servlet (org.glassfish.jersey.containers:jersey-container-servlet:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet)
-        * jersey-container-servlet-core (org.glassfish.jersey.containers:jersey-container-servlet-core:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet-core)
-        * jersey-core-client (org.glassfish.jersey.core:jersey-client:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-client)
-        * jersey-ext-bean-validation (org.glassfish.jersey.ext:jersey-bean-validation:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-bean-validation)
-        * jersey-ext-metainf-services (org.glassfish.jersey.ext:jersey-metainf-services:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-metainf-services)
-        * jersey-inject-hk2 (org.glassfish.jersey.inject:jersey-hk2:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-hk2)
+        * jersey-container-grizzly2-http (org.glassfish.jersey.containers:jersey-container-grizzly2-http:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-http)
+        * jersey-container-grizzly2-servlet (org.glassfish.jersey.containers:jersey-container-grizzly2-servlet:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-grizzly2-servlet)
+        * jersey-container-servlet (org.glassfish.jersey.containers:jersey-container-servlet:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet)
+        * jersey-container-servlet-core (org.glassfish.jersey.containers:jersey-container-servlet-core:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-container-servlet-core)
+        * jersey-core-client (org.glassfish.jersey.core:jersey-client:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-client)
+        * jersey-ext-bean-validation (org.glassfish.jersey.ext:jersey-bean-validation:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-bean-validation)
+        * jersey-ext-metainf-services (org.glassfish.jersey.ext:jersey-metainf-services:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-metainf-services)
+        * jersey-inject-hk2 (org.glassfish.jersey.inject:jersey-hk2:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/project/jersey-hk2)
 
     Apache License, Version 2.0, Eclipse Public License, Version 2.0, Modified BSD, The GNU General Public License (GPL), Version 2, With Classpath Exception
 
-        * jersey-core-server (org.glassfish.jersey.core:jersey-server:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-server)
+        * jersey-core-server (org.glassfish.jersey.core:jersey-server:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-server)
 
     Apache License, Version 2.0, Eclipse Public License, Version 2.0, Public Domain, The GNU General Public License (GPL), Version 2, With Classpath Exception
 
-        * jersey-core-common (org.glassfish.jersey.core:jersey-common:2.40 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-common)
+        * jersey-core-common (org.glassfish.jersey.core:jersey-common:3.1.7 - https://projects.eclipse.org/projects/ee4j.jersey/jersey-common)
 
     Apache License, Version 2.0, Eclipse Public License - Version 1.0
 
-        * Jetty :: Continuation (org.eclipse.jetty:jetty-continuation:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-continuation)
-        * Jetty :: Http Utility (org.eclipse.jetty:jetty-http:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-http)
-        * Jetty :: IO Utility (org.eclipse.jetty:jetty-io:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-io)
-        * Jetty :: Security (org.eclipse.jetty:jetty-security:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-security)
-        * Jetty :: Server Core (org.eclipse.jetty:jetty-server:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-server)
-        * Jetty :: Servlet Handling (org.eclipse.jetty:jetty-servlet:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-servlet)
+        * Jetty :: Jakarta Servlet API and Schemas for JPMS and OSGi (org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2 - https://eclipse.org/jetty/jetty-jakarta-servlet-api)
         * Jetty :: SetUID Java (org.eclipse.jetty.toolchain.setuid:jetty-setuid-java:1.0.4 - https://eclipse.org/jetty/jetty-setuid-parent/jetty-setuid-java)
-        * Jetty :: Utilities :: Ajax(JSON) (org.eclipse.jetty:jetty-util-ajax:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-util-ajax)
-        * Jetty :: Utilities (org.eclipse.jetty:jetty-util:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-util)
-        * Jetty :: Utility Servlets and Filters (org.eclipse.jetty:jetty-servlets:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-servlets)
-        * Jetty :: Webapp Application Support (org.eclipse.jetty:jetty-webapp:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-webapp)
         * Jetty :: Websocket :: API (org.eclipse.jetty.websocket:websocket-api:9.4.53.v20231009 - https://eclipse.org/jetty/websocket-parent/websocket-api)
         * Jetty :: Websocket :: Client (org.eclipse.jetty.websocket:websocket-client:9.4.53.v20231009 - https://eclipse.org/jetty/websocket-parent/websocket-client)
         * Jetty :: Websocket :: Common (org.eclipse.jetty.websocket:websocket-common:9.4.53.v20231009 - https://eclipse.org/jetty/websocket-parent/websocket-common)
-        * Jetty :: XML utilities (org.eclipse.jetty:jetty-xml:9.4.53.v20231009 - https://eclipse.org/jetty/jetty-xml)
+
+    Apache License, Version 2.0, Eclipse Public License - Version 2.0
+
+        * Jetty :: Http Utility (org.eclipse.jetty:jetty-http:11.0.21 - https://eclipse.dev/jetty/jetty-http)
+        * Jetty :: IO Utility (org.eclipse.jetty:jetty-io:11.0.21 - https://eclipse.dev/jetty/jetty-io)
+        * Jetty :: Security (org.eclipse.jetty:jetty-security:11.0.21 - https://eclipse.dev/jetty/jetty-security)
+        * Jetty :: Server Core (org.eclipse.jetty:jetty-server:11.0.21 - https://eclipse.dev/jetty/jetty-server)
+        * Jetty :: Servlet Handling (org.eclipse.jetty:jetty-servlet:11.0.21 - https://eclipse.dev/jetty/jetty-servlet)
+        * Jetty :: Utilities (org.eclipse.jetty:jetty-util:11.0.21 - https://eclipse.dev/jetty/jetty-util)
+        * Jetty :: Utility Servlets and Filters (org.eclipse.jetty:jetty-servlets:11.0.21 - https://eclipse.dev/jetty/jetty-servlets)
 
     Apache License, Version 2.0, GNU General Public License, version 2
 
@@ -1002,7 +1010,7 @@ The license texts of these dependencies can be found in the licenses directory.
 
     Apache License, Version 2.0, LGPL 2.1, MPL 1.1
 
-        * Javassist (org.javassist:javassist:3.29.2-GA - http://www.javassist.org/)
+        * Javassist (org.javassist:javassist:3.30.2-GA - https://www.javassist.org/)
 
     Apache License (v2.0)
 
@@ -1053,7 +1061,6 @@ The license texts of these dependencies can be found in the licenses directory.
 
     Common Development and Distribution License
 
-        * Expression Language 3.0 (org.glassfish:javax.el:3.0.1-b12 - http://uel.java.net)
         * Java Servlet API (javax.servlet:javax.servlet-api:3.1.0 - http://servlet-spec.java.net)
         * javax.annotation API (javax.annotation:javax.annotation-api:1.3.2 - http://jcp.org/en/jsr/detail?id=250)
 
@@ -1092,38 +1099,40 @@ The license texts of these dependencies can be found in the licenses directory.
 
     Eclipse Public License, Version 2.0
 
-        * grizzly-framework (org.glassfish.grizzly:grizzly-framework:2.4.4 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-framework)
-        * grizzly-http (org.glassfish.grizzly:grizzly-http:2.4.4 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http)
-        * grizzly-http-server (org.glassfish.grizzly:grizzly-http-server:2.4.4 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-server)
-        * grizzly-http-servlet (org.glassfish.grizzly:grizzly-http-servlet:2.4.4 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-servlet)
+        * grizzly-framework (org.glassfish.grizzly:grizzly-framework:4.0.2 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-framework)
+        * grizzly-http (org.glassfish.grizzly:grizzly-http:4.0.2 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http)
+        * grizzly-http-server (org.glassfish.grizzly:grizzly-http-server:4.0.2 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-server)
+        * grizzly-http-servlet (org.glassfish.grizzly:grizzly-http-servlet:4.0.2 - https://projects.eclipse.org/projects/ee4j.grizzly/grizzly-http-servlet)
+
+    Eclipse Public License, Version 2.0, GPL-2.0-with-classpath-exception
+
+        * Jakarta RESTful WS API (jakarta.ws.rs:jakarta.ws.rs-api:3.1.0 - https://github.com/eclipse-ee4j/jaxrs-api)
+
+    Eclipse Public License, Version 2.0, The GNU General Public License (GPL), Version 2, With Classpath Exception
+
+        * aopalliance version 1.0 repackaged as a module (org.glassfish.hk2.external:aopalliance-repackaged:3.0.6 - https://github.com/eclipse-ee4j/glassfish-hk2/external/aopalliance-repackaged)
+        * HK2 API module (org.glassfish.hk2:hk2-api:3.0.6 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-api)
+        * HK2 Implementation Utilities (org.glassfish.hk2:hk2-utils:3.0.6 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-utils)
+        * Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:2.0.0 - https://projects.eclipse.org/projects/ee4j.ca)
+        * Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:2.1.1 - https://projects.eclipse.org/projects/ee4j.ca)
+        * Jakarta Servlet (jakarta.servlet:jakarta.servlet-api:5.0.0 - https://projects.eclipse.org/projects/ee4j.servlet)
+        * OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
+        * ServiceLocator Default Implementation (org.glassfish.hk2:hk2-locator:3.0.6 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-locator)
 
     Eclipse Public License (EPL) 1.0, GNU Lesser General Public License Version 2.1, February 1999
 
         * JGraphT - Core (org.jgrapht:jgrapht-core:0.9.0 - http://www.jgrapht.org/jgrapht-core)
 
-    Eclipse Public License, Version 2.0, The GNU General Public License (GPL), Version 2, With Classpath Exception
-
-        * aopalliance version 1.0 repackaged as a module (org.glassfish.hk2.external:aopalliance-repackaged:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/external/aopalliance-repackaged)
-        * HK2 API module (org.glassfish.hk2:hk2-api:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-api)
-        * HK2 Implementation Utilities (org.glassfish.hk2:hk2-utils:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-utils)
-        * jakarta.ws.rs-api (jakarta.ws.rs:jakarta.ws.rs-api:2.1.6 - https://github.com/eclipse-ee4j/jaxrs-api)
-        * Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:1.3.5 - https://projects.eclipse.org/projects/ee4j.ca)
-        * Jakarta Annotations API (jakarta.annotation:jakarta.annotation-api:2.1.1 - https://projects.eclipse.org/projects/ee4j.ca)
-        * Jakarta Expression Language 3.0 (org.glassfish:jakarta.el:3.0.4 - https://projects.eclipse.org/projects/ee4j.el)
-        * Jakarta Expression Language 3.0 API (jakarta.el:jakarta.el-api:3.0.3 - https://projects.eclipse.org/projects/ee4j.el)
-        * Jakarta Servlet (jakarta.servlet:jakarta.servlet-api:4.0.4 - https://projects.eclipse.org/projects/ee4j.servlet)
-        * Jakarta Servlet (jakarta.servlet:jakarta.servlet-api:5.0.0 - https://projects.eclipse.org/projects/ee4j.servlet)
-        * javax.inject:1 as OSGi bundle (org.glassfish.hk2.external:jakarta.inject:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/external/jakarta.inject)
-        * OSGi resource locator (org.glassfish.hk2:osgi-resource-locator:1.0.3 - https://projects.eclipse.org/projects/ee4j/osgi-resource-locator)
-        * ServiceLocator Default Implementation (org.glassfish.hk2:hk2-locator:2.6.1 - https://github.com/eclipse-ee4j/glassfish-hk2/hk2-locator)
-
     Eclipse Public License v. 2.0, GNU General Public License, version 2 with the GNU Classpath Exception
 
+        * Eclipse Expressly (org.glassfish.expressly:expressly:5.0.0 - https://projects.eclipse.org/projects/ee4j.expressly)
+        * Jakarta Expression Language API (jakarta.el:jakarta.el-api:4.0.0 - https://projects.eclipse.org/projects/ee4j.el)
+        * Jakarta Expression Language Implementation (org.glassfish:jakarta.el:4.0.2 - https://projects.eclipse.org/projects/ee4j.el)
         * jms (jakarta.jms:jakarta.jms-api:2.0.2 - https://projects.eclipse.org/projects/ee4j.jms)
 
     MIT License
 
-        * argparse4j (net.sourceforge.argparse4j:argparse4j:0.8.1 - http://argparse4j.github.io)
+        * argparse4j (net.sourceforge.argparse4j:argparse4j:0.9.0 - https://argparse4j.github.io)
         * Checker Qual (org.checkerframework:checker-qual:3.42.0 - https://checkerframework.org/)
         * JCodings (org.jruby.jcodings:jcodings:1.0.55 - http://nexus.sonatype.org/oss-repository-hosting.html/jcodings)
         * Joni (org.jruby.joni:joni:2.1.31 - http://nexus.sonatype.org/oss-repository-hosting.html/joni)

--- a/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/HttpForwardingMetricsServer.java
+++ b/examples/storm-loadgen/src/main/java/org/apache/storm/loadgen/HttpForwardingMetricsServer.java
@@ -19,16 +19,16 @@
 package org.apache.storm.loadgen;
 
 import com.esotericsoftware.kryo.io.Input;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.apache.storm.metric.api.IMetricsConsumer.DataPoint;
 import org.apache.storm.metric.api.IMetricsConsumer.TaskInfo;
 import org.apache.storm.serialization.KryoValuesDeserializer;

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
         <log4j.version>2.23.0</log4j.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <metrics.version>3.2.6</metrics.version>
+        <metrics.version>4.2.26</metrics.version>
         <mockito.version>4.11.0</mockito.version>
         <zookeeper.version>3.9.2</zookeeper.version>
         <snappy.version>1.1.10.4</snappy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <commons-text.version>1.11.0</commons-text.version>
         <commons-cli.version>1.4</commons-cli.version>
         <curator.version>5.7.0</curator.version>
-        <jetty.version>9.4.53.v20231009</jetty.version>
+        <jetty.version>11.0.21</jetty.version>
         <clojure.tools.logging.version>0.2.3</clojure.tools.logging.version>
         <carbonite.version>1.6.0</carbonite.version>
         <snakeyaml.version>2.2</snakeyaml.version>
@@ -118,7 +118,7 @@
         <hdfs.version>${hadoop.version}</hdfs.version>
         <hbase.version>2.5.6-hadoop3</hbase.version>
         <kryo.version>5.6.0</kryo.version>
-        <servlet.version>3.1.0</servlet.version>
+        <jakarta.servlet.version>5.0.0</jakarta.servlet.version>
         <joda-time.version>2.12.5</joda-time.version>
         <thrift.version>0.19.0</thrift.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
@@ -145,13 +145,13 @@
         <maven-resolver.version>1.3.3</maven-resolver.version>
         <maven.version>3.6.0</maven.version>
         <azure-eventhubs.version>0.13.1</azure-eventhubs.version>
-        <!-- Jersey 3.x is jakarta.* namespace. We have too many javax.* dependencies atm-->
-        <jersey.version>2.40</jersey.version>
-        <dropwizard.version>1.3.29</dropwizard.version>
+        <jersey.version>3.1.7</jersey.version>
+        <dropwizard.version>4.0.7</dropwizard.version>
         <j2html.version>1.6.0</j2html.version>
         <caffeine.version>3.1.8</caffeine.version>
         <jakarta-jaxb-version>2.3.2</jakarta-jaxb-version>
         <jakarta-activation-version>1.2.1</jakarta-activation-version>
+        <jakarta-jaxws-version>3.1.0</jakarta-jaxws-version>
         <jaxb-version>2.3.0</jaxb-version>
         <activation-version>1.1.1</activation-version>
         <rocksdb-jni-version>8.10.0</rocksdb-jni-version>
@@ -558,11 +558,6 @@
                 <version>${jaxb-version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>${activation-version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.hdrhistogram</groupId>
                 <artifactId>HdrHistogram</artifactId>
                 <version>${hdrhistogram.version}</version>
@@ -678,14 +673,19 @@
                 <version>${snappy.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${servlet.version}</version>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>${jakarta-el.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${jakarta-jaxws-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -846,6 +846,46 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-jvm</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jmx</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-annotation</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-json</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-healthchecks</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jersey3</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jetty11</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-logback</artifactId>
+                <version>${metrics.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jakarta-servlets</artifactId>
                 <version>${metrics.version}</version>
             </dependency>
             <dependency>

--- a/storm-client/pom.xml
+++ b/storm-client/pom.xml
@@ -104,6 +104,10 @@
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+        </dependency>
 
         <!-- end of transitive dependency management -->
 

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ConsoleStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ConsoleStormReporter.java
@@ -15,16 +15,15 @@ package org.apache.storm.metrics2.reporters;
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
+
+import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.apache.storm.Config;
 import org.apache.storm.daemon.metrics.ClientMetricsUtils;
 import org.apache.storm.metrics2.DimensionalReporter;
 import org.apache.storm.metrics2.MetricRegistryProvider;
-import org.apache.storm.metrics2.StormMetricRegistry;
 import org.apache.storm.metrics2.filters.StormMetricsFilter;
-import org.apache.storm.utils.ObjectReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,5 +101,10 @@ public class ConsoleStormReporter extends ScheduledStormReporter implements Dime
         for (Map.Entry<String, String> entry : dimensions.entrySet()) {
             System.out.println(entry.getKey() + " : " + entry.getValue());
         }
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/CsvStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/CsvStormReporter.java
@@ -14,7 +14,9 @@ package org.apache.storm.metrics2.reporters;
 
 import com.codahale.metrics.CsvReporter;
 import com.codahale.metrics.MetricRegistry;
+
 import java.io.File;
+import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -85,5 +87,10 @@ public class CsvStormReporter extends ScheduledStormReporter {
 
         File csvMetricsDir = getCsvLogDir(topoConf, reporterConf);
         reporter = builder.build(csvMetricsDir);
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/GraphiteStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/GraphiteStormReporter.java
@@ -17,6 +17,8 @@ import com.codahale.metrics.graphite.Graphite;
 import com.codahale.metrics.graphite.GraphiteReporter;
 import com.codahale.metrics.graphite.GraphiteSender;
 import com.codahale.metrics.graphite.GraphiteUDP;
+
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.storm.daemon.metrics.ClientMetricsUtils;
@@ -91,5 +93,10 @@ public class GraphiteStormReporter extends ScheduledStormReporter {
             sender = new Graphite(host, port);
         }
         reporter = builder.build(sender);
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/JmxStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/JmxStormReporter.java
@@ -12,8 +12,10 @@
 
 package org.apache.storm.metrics2.reporters;
 
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
+
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.storm.daemon.metrics.ClientMetricsUtils;
@@ -81,6 +83,13 @@ public class JmxStormReporter implements StormReporter {
             reporter.stop();
         } else {
             throw new IllegalStateException("Attempt to stop without preparing " + getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (reporter != null) {
+            reporter.close();
         }
     }
 }

--- a/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ScheduledStormReporter.java
+++ b/storm-client/src/jvm/org/apache/storm/metrics2/reporters/ScheduledStormReporter.java
@@ -13,6 +13,8 @@
 package org.apache.storm.metrics2.reporters;
 
 import com.codahale.metrics.ScheduledReporter;
+
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.storm.daemon.metrics.ClientMetricsUtils;
@@ -71,6 +73,13 @@ public abstract class ScheduledStormReporter implements StormReporter {
             reporter.stop();
         } else {
             throw new IllegalStateException("Attempt to stop without preparing " + getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (reporter != null) {
+            reporter.close();
         }
     }
 }

--- a/storm-server/pom.xml
+++ b/storm-server/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>metrics-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
         </dependency>
@@ -75,8 +79,8 @@
 
         <!-- servlet -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <!-- test -->

--- a/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
+++ b/storm-server/src/main/java/org/apache/storm/DaemonConfig.java
@@ -522,13 +522,13 @@ public class DaemonConfig implements Validated {
     public static final String LOGVIEWER_APPENDER_NAME = "logviewer.appender.name";
 
     /**
-     * A class implementing javax.servlet.Filter for authenticating/filtering Logviewer requests.
+     * A class implementing jakarta.servlet.Filter for authenticating/filtering Logviewer requests.
      */
     @IsString
     public static final String LOGVIEWER_FILTER = "logviewer.filter";
 
     /**
-     * Initialization parameters for the javax.servlet.Filter for Logviewer.
+     * Initialization parameters for the jakarta.servlet.Filter for Logviewer.
      */
     @IsMapEntryType(keyType = String.class, valueType = String.class)
     public static final String LOGVIEWER_FILTER_PARAMS = "logviewer.filter.params";
@@ -540,13 +540,13 @@ public class DaemonConfig implements Validated {
     public static final String UI_CHILDOPTS = "ui.childopts";
 
     /**
-     * A class implementing javax.servlet.Filter for authenticating/filtering UI requests.
+     * A class implementing jakarta.servlet.Filter for authenticating/filtering UI requests.
      */
     @IsString
     public static final String UI_FILTER = "ui.filter";
 
     /**
-     * Initialization parameters for the javax.servlet.Filter for UI.
+     * Initialization parameters for the jakarta.servlet.Filter for UI.
      */
     @IsMapEntryType(keyType = String.class, valueType = String.class)
     public static final String UI_FILTER_PARAMS = "ui.filter.params";
@@ -838,13 +838,13 @@ public class DaemonConfig implements Validated {
     public static final String NIMBUS_SLOTS_PER_TOPOLOGY = "nimbus.slots.perTopology";
 
     /**
-     * A class implementing javax.servlet.Filter for DRPC HTTP requests.
+     * A class implementing jakarta.servlet.Filter for DRPC HTTP requests.
      */
     @IsString
     public static final String DRPC_HTTP_FILTER = "drpc.http.filter";
 
     /**
-     * Initialization parameters for the javax.servlet.Filter of the DRPC HTTP service.
+     * Initialization parameters for the jakarta.servlet.Filter of the DRPC HTTP service.
      */
     @IsMapEntryType(keyType = String.class, valueType = String.class)
     public static final String DRPC_HTTP_FILTER_PARAMS = "drpc.http.filter.params";

--- a/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/JmxPreparableReporter.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/metrics/reporters/JmxPreparableReporter.java
@@ -12,12 +12,12 @@
 
 package org.apache.storm.daemon.metrics.reporters;
 
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
+
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.storm.DaemonConfig;
-import org.apache.storm.daemon.metrics.ClientMetricsUtils;
 import org.apache.storm.daemon.metrics.MetricsUtils;
 import org.apache.storm.utils.ObjectReader;
 import org.slf4j.Logger;

--- a/storm-server/src/main/java/org/apache/storm/logging/filters/AccessLoggingFilter.java
+++ b/storm-server/src/main/java/org/apache/storm/logging/filters/AccessLoggingFilter.java
@@ -12,15 +12,17 @@
 
 package org.apache.storm.logging.filters;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/storm-server/src/main/java/org/apache/storm/security/auth/DefaultHttpCredentialsPlugin.java
+++ b/storm-server/src/main/java/org/apache/storm/security/auth/DefaultHttpCredentialsPlugin.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.security.auth.Subject;
-import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,14 +34,8 @@ public class DefaultHttpCredentialsPlugin implements IHttpCredentialsPlugin {
         // Do nothing.
     }
 
-    /**
-     * Gets the user name from the request principal.
-     *
-     * @param req the servlet request
-     * @return the authenticated user, or null if none is authenticated
-     */
     @Override
-    public String getUserName(HttpServletRequest req) {
+    public String getUserName(jakarta.servlet.http.HttpServletRequest req) {
         String ret = null;
         if (req != null) {
             Principal princ = req.getUserPrincipal();
@@ -62,16 +55,8 @@ public class DefaultHttpCredentialsPlugin implements IHttpCredentialsPlugin {
         return ret;
     }
 
-    /**
-     * Populates a given context with a new Subject derived from the credentials in a servlet request.
-     *
-     * @param context the context to be populated
-     * @param req     the servlet request
-     * @return the context
-     */
     @Override
-    public ReqContext populateContext(ReqContext context,
-                                      HttpServletRequest req) {
+    public ReqContext populateContext(ReqContext context, jakarta.servlet.http.HttpServletRequest req) {
         String userName = getUserName(req);
 
         String doAsUser = req.getHeader("doAsUser");

--- a/storm-server/src/main/java/org/apache/storm/security/auth/IHttpCredentialsPlugin.java
+++ b/storm-server/src/main/java/org/apache/storm/security/auth/IHttpCredentialsPlugin.java
@@ -19,7 +19,6 @@
 package org.apache.storm.security.auth;
 
 import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Interface for handling credentials in an HttpServletRequest.
@@ -39,7 +38,7 @@ public interface IHttpCredentialsPlugin {
      * @param req the servlet request
      * @return the authenticated user, or null if none is authenticated.
      */
-    String getUserName(HttpServletRequest req);
+    String getUserName(jakarta.servlet.http.HttpServletRequest req);
 
     /**
      * Populates a given context with credentials information from an HTTP request.
@@ -47,5 +46,6 @@ public interface IHttpCredentialsPlugin {
      * @param req the servlet request
      * @return the context
      */
-    ReqContext populateContext(ReqContext context, HttpServletRequest req);
+    ReqContext populateContext(ReqContext context, jakarta.servlet.http.HttpServletRequest req);
+
 }

--- a/storm-server/src/test/java/org/apache/storm/security/auth/DefaultHttpCredentialsPluginTest.java
+++ b/storm-server/src/test/java/org/apache/storm/security/auth/DefaultHttpCredentialsPluginTest.java
@@ -16,7 +16,7 @@ import java.security.Principal;
 import java.util.HashMap;
 import java.util.HashSet;
 import javax.security.auth.Subject;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.storm.shade.com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -32,7 +32,7 @@ public class DefaultHttpCredentialsPluginTest {
         DefaultHttpCredentialsPlugin handler = new DefaultHttpCredentialsPlugin();
         handler.prepare(new HashMap<>());
 
-        assertNull(handler.getUserName(null), "Should return null when request is null");
+        assertNull(handler.getUserName((HttpServletRequest) null), "Should return null when request is null");
 
         assertNull(handler.getUserName(Mockito.mock(HttpServletRequest.class)), "Should return null when user principal is null");
 

--- a/storm-server/src/test/java/org/apache/storm/security/auth/ServerAuthUtilsTest.java
+++ b/storm-server/src/test/java/org/apache/storm/security/auth/ServerAuthUtilsTest.java
@@ -21,7 +21,6 @@ package org.apache.storm.security.auth;
 import org.apache.storm.DaemonConfig;
 import org.junit.jupiter.api.Test;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,12 +36,12 @@ public class ServerAuthUtilsTest {
         }
 
         @Override
-        public String getUserName(HttpServletRequest req) {
+        public String getUserName(jakarta.servlet.http.HttpServletRequest req) {
             return null;
         }
 
         @Override
-        public ReqContext populateContext(ReqContext context, HttpServletRequest req) {
+        public ReqContext populateContext(ReqContext context, jakarta.servlet.http.HttpServletRequest req) {
             return null;
         }
     }

--- a/storm-webapp/pom.xml
+++ b/storm-webapp/pom.xml
@@ -110,7 +110,20 @@
             <version>${dropwizard.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
         <!-- UI -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
@@ -124,21 +137,6 @@
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-grizzly2-servlet</artifactId>
         </dependency>
-        <!-- Extra Java 11 jars for Jersey. Jersey's dependency tree only includes these on Java 11,
-            so we need to include them manually to ensure that Java 8 builds work on Java 11. -->
-        <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
-        <!-- End extra Jersey Java 11 jars -->
     </dependencies>
     <build>
         <resources>

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/AuthorizationExceptionMapper.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/AuthorizationExceptionMapper.java
@@ -20,11 +20,11 @@ package org.apache.storm.daemon.common;
 
 import static org.apache.storm.daemon.ui.exceptionmappers.ExceptionMapperUtils.getResponse;
 
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 import org.apache.storm.generated.AuthorizationException;
 
@@ -32,7 +32,7 @@ import org.apache.storm.generated.AuthorizationException;
 public class AuthorizationExceptionMapper implements ExceptionMapper<AuthorizationException> {
 
     @Inject
-    public javax.inject.Provider<HttpServletRequest> request;
+    public jakarta.inject.Provider<HttpServletRequest> request;
 
     @Override
     public Response toResponse(AuthorizationException ex) {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/JsonResponseBuilder.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/JsonResponseBuilder.java
@@ -18,9 +18,10 @@
 
 package org.apache.storm.daemon.common;
 
+import jakarta.ws.rs.core.Response;
+
 import java.util.Collections;
 import java.util.Map;
-import javax.ws.rs.core.Response;
 
 import org.apache.storm.daemon.ui.UIHelpers;
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/common/ReloadableSslContextFactory.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/common/ReloadableSslContextFactory.java
@@ -25,7 +25,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReloadableSslContextFactory extends SslContextFactory {
+public class ReloadableSslContextFactory extends SslContextFactory.Server {
 
     private static final Logger LOG = LoggerFactory.getLogger(ReloadableSslContextFactory.class);
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/DRPCServer.java
@@ -20,11 +20,11 @@ package org.apache.storm.daemon.drpc;
 
 import com.codahale.metrics.Meter;
 import com.google.common.annotations.VisibleForTesting;
+import jakarta.servlet.DispatcherType;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.DispatcherType;
 import org.apache.storm.Config;
 import org.apache.storm.DaemonConfig;
 import org.apache.storm.daemon.drpc.webapp.DRPCApplication;
@@ -119,7 +119,7 @@ public class DRPCServer implements AutoCloseable {
 
             ServletHolder jerseyServlet = context.addServlet(ServletContainer.class, "/*");
             jerseyServlet.setInitOrder(1);
-            jerseyServlet.setInitParameter("javax.ws.rs.Application", DRPCApplication.class.getName());
+            jerseyServlet.setInitParameter("jakarta.ws.rs.Application", DRPCApplication.class.getName());
             
             UIHelpers.configFilters(context, filterConfigurations);
             addRequestContextFilter(context, DaemonConfig.DRPC_HTTP_CREDS_PLUGIN, conf);

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCApplication.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCApplication.java
@@ -18,11 +18,11 @@
 
 package org.apache.storm.daemon.drpc.webapp;
 
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
 
 import org.apache.storm.daemon.common.AuthorizationExceptionMapper;
 import org.apache.storm.daemon.drpc.DRPC;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCExceptionMapper.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCExceptionMapper.java
@@ -18,13 +18,13 @@
 
 package org.apache.storm.daemon.drpc.webapp;
 
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.ResponseBuilder;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
 
 import net.minidev.json.JSONValue;
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/DRPCResource.java
@@ -21,12 +21,12 @@ package org.apache.storm.daemon.drpc.webapp;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.Context;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Context;
 
 import org.apache.storm.daemon.drpc.DRPC;
 import org.apache.storm.metric.StormMetricsRegistry;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/ReqContextFilter.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/drpc/webapp/ReqContextFilter.java
@@ -18,18 +18,18 @@
 
 package org.apache.storm.daemon.drpc.webapp;
 
-import java.io.IOException;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.ext.Provider;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.container.PreMatching;
-import javax.ws.rs.ext.Provider;
+import java.io.IOException;
 
 import org.apache.storm.security.auth.IHttpCredentialsPlugin;
 import org.apache.storm.security.auth.ReqContext;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/LogviewerServer.java
@@ -111,7 +111,7 @@ public class LogviewerServer implements AutoCloseable {
 
             ServletHolder jerseyServlet = context.addServlet(ServletContainer.class, "/api/v1/*");
             jerseyServlet.setInitOrder(2);
-            jerseyServlet.setInitParameter("javax.ws.rs.Application", LogviewerApplication.class.getName());
+            jerseyServlet.setInitParameter("jakarta.ws.rs.Application", LogviewerApplication.class.getName());
 
             UIHelpers.configFilters(context, filterConfigurations);
         }

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogDownloadHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogDownloadHandler.java
@@ -18,8 +18,9 @@
 
 package org.apache.storm.daemon.logviewer.handler;
 
+import jakarta.ws.rs.core.Response;
+
 import java.io.IOException;
-import javax.ws.rs.core.Response;
 
 import org.apache.storm.daemon.logviewer.utils.LogFileDownloader;
 import org.apache.storm.daemon.logviewer.utils.ResourceAuthorizer;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandler.java
@@ -41,6 +41,8 @@ import com.codahale.metrics.Meter;
 import j2html.attributes.Attr;
 import j2html.tags.DomContent;
 
+import jakarta.ws.rs.core.Response;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -62,8 +64,6 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
-
-import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.storm.daemon.logviewer.LogviewerConstant;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandler.java
@@ -32,6 +32,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 
+import jakarta.ws.rs.core.Response;
+
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,8 +55,6 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
-
-import javax.ws.rs.core.Response;
 
 import net.minidev.json.JSONAware;
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandler.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandler.java
@@ -31,12 +31,13 @@ import static java.util.stream.Collectors.toList;
 import com.codahale.metrics.Meter;
 import j2html.tags.DomContent;
 
+import jakarta.ws.rs.core.Response;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.storm.daemon.logviewer.utils.DirectoryCleaner;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogFileDownloader.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogFileDownloader.java
@@ -21,11 +21,11 @@ package org.apache.storm.daemon.logviewer.utils;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 
+import jakarta.ws.rs.core.Response;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import javax.ws.rs.core.Response;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.storm.metric.StormMetricsRegistry;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogviewerResponseBuilder.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogviewerResponseBuilder.java
@@ -20,12 +20,14 @@ package org.apache.storm.daemon.logviewer.utils;
 
 import static j2html.TagCreator.body;
 import static j2html.TagCreator.h2;
-import static javax.ws.rs.core.Response.Status.FORBIDDEN;
-import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
 
 import com.codahale.metrics.Meter;
 import com.google.common.io.ByteStreams;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -35,10 +37,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
 
 import org.apache.storm.daemon.common.JsonResponseBuilder;
 import org.apache.storm.daemon.ui.UIHelpers;
@@ -54,7 +52,7 @@ public class LogviewerResponseBuilder {
      * @param content HTML entity content, String type
      */
     public static Response buildSuccessHtmlResponse(String content) {
-        return Response.status(OK).entity(content)
+        return Response.status(jakarta.ws.rs.core.Response.Status.OK).entity(content)
                 .type(MediaType.TEXT_HTML_TYPE).build();
     }
 
@@ -81,7 +79,7 @@ public class LogviewerResponseBuilder {
         try {
             // do not close this InputStream in method: it will be used from jetty server
             InputStream is = Files.newInputStream(file.toPath());
-            return Response.status(OK)
+            return Response.status(jakarta.ws.rs.core.Response.Status.OK)
                     .entity(wrapWithStreamingOutput(is))
                     .type(MediaType.APPLICATION_OCTET_STREAM_TYPE)
                     .header("Content-Disposition", "attachment; filename=\"" + contentDispositionName + "\"")
@@ -99,7 +97,7 @@ public class LogviewerResponseBuilder {
      */
     public static Response buildResponseUnauthorizedUser(String user) {
         String entity = buildUnauthorizedUserHtml(user);
-        return Response.status(FORBIDDEN)
+        return Response.status(jakarta.ws.rs.core.Response.Status.FORBIDDEN)
                 .entity(entity)
                 .type(MediaType.TEXT_HTML_TYPE)
                 .build();

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerApplication.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerApplication.java
@@ -20,14 +20,14 @@ package org.apache.storm.daemon.logviewer.webapp;
 
 import static org.apache.storm.DaemonConfig.LOGVIEWER_APPENDER_NAME;
 
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/webapp/LogviewerResource.java
@@ -21,16 +21,15 @@ package org.apache.storm.daemon.logviewer.webapp;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.Map;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Map;
 
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/TestingFilter.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/TestingFilter.java
@@ -18,16 +18,16 @@
 
 package org.apache.storm.daemon.ui;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import java.io.IOException;
 import java.security.Principal;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -21,6 +21,10 @@ package org.apache.storm.daemon.ui;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Servlet;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -40,10 +44,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import javax.servlet.DispatcherType;
-import javax.servlet.Servlet;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
 import net.minidev.json.JSONValue;
 import org.apache.storm.Config;
 import org.apache.storm.Constants;
@@ -233,7 +233,7 @@ public class UIHelpers {
                                                   String tsPassword, String tsType,
                                                   Boolean needClientAuth, Boolean wantClientAuth,
                                                   Integer headerBufferSize, boolean enableSslReload) {
-        SslContextFactory factory = new ReloadableSslContextFactory(enableSslReload);
+        SslContextFactory.Server factory = new ReloadableSslContextFactory(enableSslReload);
         factory.setExcludeCipherSuites("SSL_RSA_WITH_RC4_128_MD5", "SSL_RSA_WITH_RC4_128_SHA");
         factory.setExcludeProtocols("SSLv3");
         factory.setRenegotiationAllowed(false);

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIServer.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIServer.java
@@ -21,13 +21,15 @@ package org.apache.storm.daemon.ui;
 import static org.apache.storm.utils.ConfigUtils.FILE_SEPARATOR;
 import static org.apache.storm.utils.ConfigUtils.STORM_HOME;
 
+import jakarta.servlet.DispatcherType;
+
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import javax.servlet.DispatcherType;
+
 import org.apache.storm.DaemonConfig;
 import org.apache.storm.daemon.drpc.webapp.ReqContextFilter;
 import org.apache.storm.daemon.ui.exceptionmappers.AuthorizationExceptionMapper;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/AuthorizationExceptionMapper.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/AuthorizationExceptionMapper.java
@@ -20,18 +20,18 @@ package org.apache.storm.daemon.ui.exceptionmappers;
 
 import static org.apache.storm.daemon.ui.exceptionmappers.ExceptionMapperUtils.getResponse;
 
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import org.apache.storm.generated.AuthorizationException;
 
 @Provider
 public class AuthorizationExceptionMapper implements ExceptionMapper<AuthorizationException> {
 
     @Inject
-    public javax.inject.Provider<HttpServletRequest> request;
+    public jakarta.inject.Provider<HttpServletRequest> request;
 
     @Override
     public Response toResponse(AuthorizationException e) {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/DefaultExceptionMapper.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/DefaultExceptionMapper.java
@@ -20,17 +20,17 @@ package org.apache.storm.daemon.ui.exceptionmappers;
 
 import static org.apache.storm.daemon.ui.exceptionmappers.ExceptionMapperUtils.getResponse;
 
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class DefaultExceptionMapper implements ExceptionMapper<Throwable> {
 
     @Inject
-    public javax.inject.Provider<HttpServletRequest> request;
+    public jakarta.inject.Provider<HttpServletRequest> request;
 
     /**
      * toResponse.

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/ExceptionMapperUtils.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/ExceptionMapperUtils.java
@@ -18,9 +18,9 @@
 
 package org.apache.storm.daemon.ui.exceptionmappers;
 
-import javax.inject.Provider;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Provider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.storm.daemon.common.JsonResponseBuilder;
 import org.apache.storm.daemon.ui.UIHelpers;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/NotAliveExceptionMapper.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/exceptionmappers/NotAliveExceptionMapper.java
@@ -20,11 +20,11 @@ package org.apache.storm.daemon.ui.exceptionmappers;
 
 import static org.apache.storm.daemon.ui.exceptionmappers.ExceptionMapperUtils.getResponse;
 
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import org.apache.storm.generated.NotAliveException;
 
 
@@ -32,7 +32,7 @@ import org.apache.storm.generated.NotAliveException;
 public class NotAliveExceptionMapper implements ExceptionMapper<NotAliveException> {
 
     @Inject
-    public javax.inject.Provider<HttpServletRequest> request;
+    public jakarta.inject.Provider<HttpServletRequest> request;
 
     @Override
     public Response toResponse(NotAliveException ex) {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/AuthorizedUserFilter.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/AuthorizedUserFilter.java
@@ -18,18 +18,18 @@
 
 package org.apache.storm.daemon.ui.filters;
 
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.security.Principal;
 import java.util.Map;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ResourceInfo;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.Provider;
 import net.minidev.json.JSONValue;
 import org.apache.commons.codec.Charsets;
 import org.apache.commons.io.IOUtils;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/HeaderResponseFilter.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/HeaderResponseFilter.java
@@ -19,12 +19,12 @@
 package org.apache.storm.daemon.ui.filters;
 
 import com.codahale.metrics.Meter;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
-import javax.inject.Inject;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.ext.Provider;
 import org.apache.storm.metric.StormMetricsRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/HeaderResponseServletFilter.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/filters/HeaderResponseServletFilter.java
@@ -19,15 +19,15 @@
 package org.apache.storm.daemon.ui.filters;
 
 import com.codahale.metrics.Meter;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.apache.storm.metric.StormMetricsRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/resources/StormApiResource.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/resources/StormApiResource.java
@@ -19,24 +19,21 @@
 package org.apache.storm.daemon.ui.resources;
 
 import com.codahale.metrics.Meter;
-import java.io.UnsupportedEncodingException;
+import jakarta.inject.Inject;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 import java.util.Map;
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
-
 import net.minidev.json.JSONValue;
-
 import org.apache.storm.daemon.ui.UIHelpers;
 import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.thrift.TException;
@@ -45,7 +42,6 @@ import org.apache.storm.utils.NimbusClient;
 import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * Root resource (exposed at "storm" path).

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogDownloadHandlerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogDownloadHandlerTest.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import org.apache.storm.daemon.logviewer.utils.ResourceAuthorizer;
 import org.apache.storm.daemon.logviewer.utils.WorkerLogs;
 import org.apache.storm.metric.StormMetricsRegistry;

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandlerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogPageHandlerTest.java
@@ -33,7 +33,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.storm.daemon.logviewer.utils.LogviewerResponseBuilder;
 import org.apache.storm.daemon.logviewer.utils.ResourceAuthorizer;
@@ -41,7 +41,6 @@ import org.apache.storm.daemon.logviewer.utils.WorkerLogs;
 import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.testing.TmpPath;
 import org.apache.storm.utils.Utils;
-import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
 public class LogviewerLogPageHandlerTest {
@@ -70,19 +69,19 @@ public class LogviewerLogPageHandlerTest {
                 new WorkerLogs(stormConf, Paths.get(rootPath), metricsRegistry), new ResourceAuthorizer(stormConf), metricsRegistry);
 
         final Response expectedAll = LogviewerResponseBuilder.buildSuccessJsonResponse(
-                Lists.newArrayList("topoA/port1/worker.log", "topoA/port2/worker.log", "topoB/port1/worker.log"),
+                List.of("topoA/port1/worker.log", "topoA/port2/worker.log", "topoB/port1/worker.log"),
                 null,
                 origin
         );
 
         final Response expectedFilterPort = LogviewerResponseBuilder.buildSuccessJsonResponse(
-                Lists.newArrayList("topoA/port1/worker.log", "topoB/port1/worker.log"),
+                List.of("topoA/port1/worker.log", "topoB/port1/worker.log"),
                 null,
                 origin
         );
 
         final Response expectedFilterTopoId = LogviewerResponseBuilder.buildSuccessJsonResponse(
-                Lists.newArrayList("topoB/port1/worker.log"),
+                List.of("topoB/port1/worker.log"),
                 null,
                 origin
         );
@@ -116,7 +115,7 @@ public class LogviewerLogPageHandlerTest {
 
             //The response should be empty, since you should not be able to list files outside the worker log root.
             final Response expected = LogviewerResponseBuilder.buildSuccessJsonResponse(
-                Lists.newArrayList(),
+                List.of(),
                 null,
                 origin
             );

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandlerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerLogSearchHandlerTest.java
@@ -56,15 +56,14 @@ import org.apache.storm.streams.tuple.Tuple3;
 import org.apache.storm.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
-@RunWith(Enclosed.class)
 public class LogviewerLogSearchHandlerTest {
 
-    public static class SearchViaRestApi {
+    @Nested
+    public class SearchViaRestApi {
 
         private final String pattern = "needle";
         private final String expectedHost = "dev.null.invalid";

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandlerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/handler/LogviewerProfileHandlerTest.java
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import org.apache.storm.daemon.logviewer.utils.ResourceAuthorizer;
 import org.apache.storm.metric.StormMetricsRegistry;
 import org.apache.storm.testing.TmpPath;


### PR DESCRIPTION
## What is the purpose of the change

- Follows up on https://github.com/apache/storm/pull/3654 -> https://issues.apache.org/jira/projects/STORM/issues/STORM-4065
- Moves to Jakarta Namespace -> https://issues.apache.org/jira/projects/STORM/issues/STORM-3985
- Upgrades Jetty, etc. -> https://issues.apache.org/jira/projects/STORM/issues/STORM-4066 + https://issues.apache.org/jira/projects/STORM/issues/STORM-4067
- Upgrades Dropwizard Metrics -> https://issues.apache.org/jira/projects/STORM/issues/STORM-4065

## How was the change tested

- Full CI build

## Notes

- This PR modernizes quite a lot of legacy out of date (unmaintained) 3rd party dependencies. The upgrade of metrics required the Jakarta upgrade as well, but user topologies shouldn't be affected by this change.
- Nevertheless, I would propose, that we go for 2.7.0 as a next version because javax -> jakarta can be considered as a breaking change.