### PR TITLE
STORM-4076 KafkaTridentSpoutEmitters can poll all partitions at once instead of one at a time

### DIFF
--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentOpaqueSpoutEmitter.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentOpaqueSpoutEmitter.java
@@ -19,6 +19,8 @@ package org.apache.storm.kafka.spout.trident;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.spout.IOpaquePartitionedTridentSpout;
 import org.apache.storm.trident.topology.TransactionAttempt;
@@ -37,10 +39,12 @@ public class KafkaTridentOpaqueSpoutEmitter<K, V> implements IOpaquePartitionedT
     }
 
     @Override
-    public Map<String, Object> emitPartitionBatch(TransactionAttempt tx, TridentCollector collector,
-        KafkaTridentSpoutTopicPartition partition, Map<String, Object> lastPartitionMeta) {
-        return emitter.emitPartitionBatchNew(tx, collector, partition, lastPartitionMeta);
+    public Map<KafkaTridentSpoutTopicPartition, Map<String, Object>> emitPartitionBatch(TransactionAttempt tx,
+        TridentCollector collector, Set<KafkaTridentSpoutTopicPartition> partitions, Map<KafkaTridentSpoutTopicPartition,
+        Map<String, Object>> lastPartitionMetaMap) {
+        return emitter.emitPartitionBatchNew(tx, collector, partitions, lastPartitionMetaMap);
     }
+
 
     @Override
     public void refreshPartitions(List<KafkaTridentSpoutTopicPartition> partitionResponsibilities) {

--- a/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentTransactionalSpoutEmitter.java
+++ b/external/storm-kafka-client/src/main/java/org/apache/storm/kafka/spout/trident/KafkaTridentTransactionalSpoutEmitter.java
@@ -19,6 +19,8 @@ package org.apache.storm.kafka.spout.trident;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.spout.IPartitionedTridentSpout;
 import org.apache.storm.trident.topology.TransactionAttempt;
@@ -45,6 +47,13 @@ public class KafkaTridentTransactionalSpoutEmitter<K, V> implements IPartitioned
     public Map<String, Object> emitPartitionBatchNew(TransactionAttempt tx, TridentCollector collector,
         KafkaTridentSpoutTopicPartition partition, Map<String, Object> lastPartitionMeta) {
         return emitter.emitPartitionBatchNew(tx, collector, partition, lastPartitionMeta);
+    }
+
+    @Override
+    public Map<KafkaTridentSpoutTopicPartition, Map<String, Object>> emitPartitionBatchNew(TransactionAttempt tx,
+        TridentCollector collector, Set<KafkaTridentSpoutTopicPartition> partitions,
+        Map<KafkaTridentSpoutTopicPartition, Map<String, Object>> lastPartitionMetaMap) {
+        return emitter.emitPartitionBatchNew(tx, collector, partitions, lastPartitionMetaMap);
     }
 
     @Override

--- a/storm-client/src/jvm/org/apache/storm/trident/spout/IOpaquePartitionedTridentSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/spout/IOpaquePartitionedTridentSpout.java
@@ -15,6 +15,8 @@ package org.apache.storm.trident.spout;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.topology.TransactionAttempt;
@@ -67,12 +69,13 @@ public interface IOpaquePartitionedTridentSpout<PartitionsT, PartitionT extends 
 
     interface Emitter<PartitionsT, PartitionT extends ISpoutPartition, M> {
         /**
-         * Emit a batch of tuples for a partition/transaction.
+         * Emit a batch of tuples for a list of partitions/transactions.
          *
          * <p>Return the metadata describing this batch that will be used as lastPartitionMeta for defining the
-         * parameters of the next batch.
+         * parameters of the next batch for each partition.
          */
-        M emitPartitionBatch(TransactionAttempt tx, TridentCollector collector, PartitionT partition, M lastPartitionMeta);
+        Map<PartitionT, M> emitPartitionBatch(TransactionAttempt tx, TridentCollector collector,
+            Set<PartitionT> partitions, Map<PartitionT, M> lastPartitionMetaMap);
 
         /**
          * This method is called when this task is responsible for a new set of partitions. Should be used to manage things like connections

--- a/storm-client/src/jvm/org/apache/storm/trident/spout/IPartitionedTridentSpout.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/spout/IPartitionedTridentSpout.java
@@ -15,6 +15,7 @@ package org.apache.storm.trident.spout;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.storm.task.TopologyContext;
 import org.apache.storm.trident.operation.TridentCollector;
 import org.apache.storm.trident.topology.TransactionAttempt;
@@ -61,6 +62,9 @@ public interface IPartitionedTridentSpout<PartitionsT, PartitionT extends ISpout
          * reconstruct this partition/batch in the future.
          */
         X emitPartitionBatchNew(TransactionAttempt tx, TridentCollector collector, PartitionT partition, X lastPartitionMeta);
+
+        Map<PartitionT, X> emitPartitionBatchNew(TransactionAttempt tx, TridentCollector collector, Set<PartitionT> partitions,
+                                                 Map<PartitionT, X> lastPartitionMetaMap);
 
         /**
          * This method is called when this task is responsible for a new set of partitions. Should be used to manage things like connections


### PR DESCRIPTION
## What is the purpose of the change

Currently 'KafkaTridentTransactionalSpoutEmitter' and 'KafkaTridentOpaqueEmitter' polls every partition assigned to the spout one by one while emitting new batches. 

But this can be improved by leveraging Kafka Consumer's usual polling strategy. That is Kafka Broker will take care of choosing the right partition.

Advantages of this are
1. If a spout is assigned multiple Topic Partitions, the consumer doesn't have to waste time on polling partitions with no data.
2. This change will give better control over the Trident batch size, by adjusting Kafka Consumer properties.

Note: This change will affect only when the batch is emitted for the first time.

## How was the change tested

Tested by running a Kafka Trident topology locally.