### PR TITLE
Uplift netty to 4.1.112

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>33.0.0-jre</guava.version>
         <auto-service.version>1.0-rc4</auto-service.version>
-        <netty.version>4.1.107.Final</netty.version>
+        <netty.version>4.1.112.Final</netty.version>
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
         <log4j.version>2.23.0</log4j.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
## What is the purpose of the change

We have detected a CVE ([CVE-2024-29025](https://nvd.nist.gov/vuln/detail/CVE-2024-29025)) in our code and have tracked it down to the version of netty included with storm-shaded-deps. This will need to be fixed in a storm 2.6.4 release so that we can resolve this CVE by uplifting to that version.

## How was the change tested

Small dependency bump. No tests performed.