### PR TITLE
STORM-4070 mTls support - fix LICENSE-binary

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -1017,9 +1017,9 @@ The license texts of these dependencies can be found in the licenses directory.
 
     Bouncy Castle Licence
 
-        * Bouncy Castle ASN.1 Extension and Utility APIs (org.bouncycastle:bcutil-jdk15on:1.70 - https://www.bouncycastle.org/java.html)
-        * Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (org.bouncycastle:bcpkix-jdk15on:1.70 - http://www.bouncycastle.org/java.html)
-        * Bouncy Castle Provider (org.bouncycastle:bcprov-jdk15on:1.70 - http://www.bouncycastle.org/java.html)
+        * Bouncy Castle ASN.1 Extension and Utility APIs (org.bouncycastle:bcutil-jdk15on:1.78.1 - https://www.bouncycastle.org/java.html)
+        * Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (org.bouncycastle:bcpkix-jdk15on:1.78.1 - http://www.bouncycastle.org/java.html)
+        * Bouncy Castle Provider (org.bouncycastle:bcprov-jdk15on:1.78.1 - http://www.bouncycastle.org/java.html)
 
     BSD 2-Clause license
 

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -921,6 +921,7 @@ The license texts of these dependencies can be found in the licenses directory.
         * Netty/Resolver/DNS/Native/MacOS (io.netty:netty-resolver-dns-native-macos:4.1.112.Final - https://netty.io/netty-resolver-dns-native-macos/)
         * Netty/Resolver/DNS (io.netty:netty-resolver-dns:4.1.112.Final - https://netty.io/netty-resolver-dns/)
         * Netty/Resolver (io.netty:netty-resolver:4.1.112.Final - https://netty.io/netty-resolver/)
+        * Netty/TomcatNative (io.netty:netty-tcnative:2.0.65.Final - https://github.com/netty/netty-tcnative)
         * Netty/TomcatNative [BoringSSL - Static] (io.netty:netty-tcnative-boringssl-static:jar:2.0.65.Final - https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/)
         * Netty/TomcatNative [BoringSSL - Static] (io.netty:netty-tcnative-boringssl-static:2.0.65.Final - https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/)
         * Netty/Transport/Classes/Epoll (io.netty:netty-transport-classes-epoll:4.1.112.Final - https://netty.io/netty-transport-classes-epoll/)
@@ -1017,9 +1018,9 @@ The license texts of these dependencies can be found in the licenses directory.
 
     Bouncy Castle Licence
 
-        * Bouncy Castle ASN.1 Extension and Utility APIs (org.bouncycastle:bcutil-jdk15on:1.78.1 - https://www.bouncycastle.org/java.html)
-        * Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (org.bouncycastle:bcpkix-jdk15on:1.78.1 - http://www.bouncycastle.org/java.html)
-        * Bouncy Castle Provider (org.bouncycastle:bcprov-jdk15on:1.78.1 - http://www.bouncycastle.org/java.html)
+        * Bouncy Castle ASN.1 Extension and Utility APIs (org.bouncycastle:bcutil-jdk18on:1.78.1 - https://www.bouncycastle.org/java.html)
+        * Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (org.bouncycastle:bcpkix-jdk18on:1.78.1 - http://www.bouncycastle.org/java.html)
+        * Bouncy Castle Provider (org.bouncycastle:bcprov-jdk18on:1.78.1 - http://www.bouncycastle.org/java.html)
 
     BSD 2-Clause license
 

--- a/external/storm-autocreds/pom.xml
+++ b/external/storm-autocreds/pom.xml
@@ -133,6 +133,10 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/external/storm-autocreds/pom.xml
+++ b/external/storm-autocreds/pom.xml
@@ -93,6 +93,10 @@
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/external/storm-hive/pom.xml
+++ b/external/storm-hive/pom.xml
@@ -112,6 +112,10 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <jgrapht.version>0.9.0</jgrapht.version>
         <guava.version>33.0.0-jre</guava.version>
         <auto-service.version>1.0-rc4</auto-service.version>
-        <netty-tcnative.version>2.0.61.Final</netty-tcnative.version>
+        <netty-tcnative.version>2.0.65.Final</netty-tcnative.version>
         <netty.version>4.1.112.Final</netty.version>
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
         <log4j.version>2.23.0</log4j.version>


### PR DESCRIPTION
Fix for

Dependencies missing from LICENSE-binary: 
```
io.netty:netty-tcnative:2.0.61.Final
org.bouncycastle:bcpkix-jdk18on:1.78.1
org.bouncycastle:bcprov-jdk18on:1.78.1
org.bouncycastle:bcutil-jdk18on:1.78.1
```