### PR TITLE
Use SHA for BLOB update instead of modification time

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/BlobStore.java
@@ -444,7 +444,7 @@ public abstract class BlobStore implements Shutdownable, AutoCloseable {
 
         @Override
         public long getVersion() throws IOException {
-            return part.getModTime();
+            return part.getVersion();
         }
 
         @Override

--- a/storm-client/src/jvm/org/apache/storm/blobstore/BlobStoreFile.java
+++ b/storm-client/src/jvm/org/apache/storm/blobstore/BlobStoreFile.java
@@ -42,6 +42,10 @@ public abstract class BlobStoreFile {
 
     public abstract long getModTime() throws IOException;
 
+    public long getVersion() throws IOException {
+        return getModTime();
+    }
+
     public abstract InputStream getInputStream() throws IOException;
 
     public abstract OutputStream getOutputStream() throws IOException;

--- a/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStore.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStore.java
@@ -291,7 +291,7 @@ public class LocalFsBlobStore extends BlobStore {
         rbm.set_settable(meta);
         try {
             LocalFsBlobStoreFile pf = fbs.read(DATA_PREFIX + key);
-            rbm.set_version(pf.getModTime());
+            rbm.set_version(pf.getVersion());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStoreFile.java
+++ b/storm-server/src/main/java/org/apache/storm/blobstore/LocalFsBlobStoreFile.java
@@ -20,8 +20,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import org.apache.storm.generated.SettableBlobMeta;
+import org.apache.storm.shade.org.apache.commons.codec.digest.DigestUtils;
 
 public class LocalFsBlobStoreFile extends BlobStoreFile {
 
@@ -70,6 +72,14 @@ public class LocalFsBlobStoreFile extends BlobStoreFile {
     @Override
     public String getKey() {
         return key;
+    }
+
+    @Override
+    public long getVersion() throws IOException {
+        try (FileInputStream fis = new FileInputStream(path)) {
+            byte[] bytes = DigestUtils.sha1(fis);
+            return Arrays.hashCode(bytes);
+        }
     }
 
     @Override

--- a/storm-server/src/test/java/org/apache/storm/blobstore/LocalFsBlobStoreFileTest.java
+++ b/storm-server/src/test/java/org/apache/storm/blobstore/LocalFsBlobStoreFileTest.java
@@ -1,0 +1,60 @@
+package org.apache.storm.blobstore;
+
+import org.apache.storm.shade.org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LocalFsBlobStoreFileTest {
+
+    private File tempFile;
+    private LocalFsBlobStoreFile blobStoreFile;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        tempFile = Files.createTempFile(null, ".tmp").toFile();
+        try (FileOutputStream fs = new FileOutputStream(tempFile)) {
+            fs.write("Content for SHA hash".getBytes());
+        }
+        blobStoreFile = new LocalFsBlobStoreFile(tempFile.getParentFile(), tempFile.getName());
+    }
+
+    @Test
+    void testGetVersion() throws IOException {
+        long expectedVersion = Arrays.hashCode(DigestUtils.sha1("Content for SHA hash"));
+        long actualVersion = blobStoreFile.getVersion();
+        assertEquals(expectedVersion, actualVersion, "The version should match the expected hash code.");
+    }
+
+    @Test
+    void testGetVersion_Mismatch() throws IOException {
+        long expectedVersion = Arrays.hashCode(DigestUtils.sha1("Different content"));
+        long actualVersion = blobStoreFile.getVersion();
+        assertNotEquals(expectedVersion, actualVersion, "The version shouldn't match the hash code of different content.");
+    }
+
+    @Test
+    void testGetVersion_FileNotFound() {
+        boolean deleted = tempFile.delete();
+        if (!deleted) {
+            throw new IllegalStateException("Failed to delete the temporary file.");
+        }
+        assertThrows(IOException.class, () -> blobStoreFile.getVersion(), "Should throw IOException if file is not found.");
+    }
+
+    @Test
+    void testGetModTime() throws IOException {
+        long expectedModTime = tempFile.lastModified();
+        long actualModTime = blobStoreFile.getModTime();
+        assertEquals(expectedModTime, actualModTime, "The modification time should match the expected value.");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Issue[[4077](https://issues.apache.org/jira/browse/STORM-4077)]

When deploying Nimbus or changing the leadership within a high availability Nimbus cluster, we've verified that the Topologies workers are killed due to different modification times.
By using the modTime as the version, we have found that, while using the LocalFsBlobStoreFile, every time the the Nimbus leader goes down the following occurs:

1. Nimbus (1) leader goes down and a new Nimbus (2) picks up the leadership.
2. If blobs in Nimbus (2) have a different modTime workers are restarted (even though they might be the same).
3. Nimbus (1) comes back up, syncs the blobs in the startup and updates the modTime, as it downloads the blobs again.
4. If Nimbus (2) leader goes down, all the workers will be restarted again as Nimbus (1) has new modTime again.
5. This can be repeated endless as the modTime will always be different in each Nimbus leader.

In this PR, we've introduced a new feature to use the SHA version of the file instead of the modification time. With this feature, when a nimbus loses the leadership, the workers will continue running because the version of the BLOB will continue the same as the BLOB is the same and also it's correspondent SHA.

## How was the change tested

Unit Tests
Test locally with specific jar on my local Storm, forced nimbus to change leadership and the workers on the topologies continued to work properly.