### PR TITLE
feat: Ensure that DownloadOrUpdate exception is caught

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/AsyncLocalizer.java
@@ -197,7 +197,7 @@ public class AsyncLocalizer implements AutoCloseable {
             throw new AssertionError("All user archives require a user present");
         }
         ConcurrentMap<String, LocalizedResource> keyToResource = userArchives.computeIfAbsent(user, (u) -> new ConcurrentHashMap<>());
-        return keyToResource.computeIfAbsent(key, 
+        return keyToResource.computeIfAbsent(key,
             (k) -> new LocalizedResource(key, localBaseDir, true, fsOps, conf, user, metricsRegistry));
     }
 
@@ -206,7 +206,7 @@ public class AsyncLocalizer implements AutoCloseable {
             throw new AssertionError("All user archives require a user present");
         }
         ConcurrentMap<String, LocalizedResource> keyToResource = userFiles.computeIfAbsent(user, (u) -> new ConcurrentHashMap<>());
-        return keyToResource.computeIfAbsent(key, 
+        return keyToResource.computeIfAbsent(key,
             (k) -> new LocalizedResource(key, localBaseDir, false, fsOps, conf, user, metricsRegistry));
     }
 
@@ -335,13 +335,11 @@ public class AsyncLocalizer implements AutoCloseable {
                 }
             }
             for (CompletableFuture<?> f : futures) {
-                try {
-                    f.get();
-                } catch (Exception e) {
-                    updateBlobExceptions.mark();
-                    LOG.warn("Could not update blob ({}), will retry again later." , e.getClass().getName());
-                }
+                f.get();
             }
+        } catch (Exception e) {
+            updateBlobExceptions.mark();
+            LOG.warn("Could not update blob ({}), will retry again later.", e.getClass().getName());
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The AsyncLocalizer class contains a scheduler that continuously performs downloadOrUpdate operations on blobs. Currently, if an exception occurs during this update process, the exception is not properly handled, causing the thread to terminate.
As a result, workers are unable to update blobs because the threads have been killed. The only way to recover from this is by restarting the supervisor.

This fix ensures that exceptions are properly handled, preventing workers from getting stuck while updating blobs.

## How was the change tested

After a few leadership changes, the worker threads for updating blobs are killed.  On my tests, I forced leadership changes and ensure that the threads are not being killed due to exceptions.