### PR TITLE
STORM-4104 Fix Pacemaker server stability issues

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/Utils.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Utils.java
@@ -652,9 +652,11 @@ public class Utils {
             }
         }
 
-        if (allowedExceptions.contains(t.getClass())) {
-            LOG.info("Swallowing {} {}", t.getClass(), t);
-            return;
+        for (Class<?> classType : allowedExceptions) {
+            if (Utils.exceptionCauseIsInstanceOf(classType, t)) {
+                LOG.info("Swallowing {} {}", t.getClass(), t);
+                return;
+            }
         }
 
         if (worker && isAllowedWorkerException(t)) {


### PR DESCRIPTION
## What is the purpose of the change

Fixes STORM-4104 to improve the stability of Pacemaker server (and Netty Server in Workers) bringing it closer to the stability it had in Storm1. This is done by changing the behaviour of Utils.handleUncaughtException to also swallow exceptions derived from those in the supplied ALLOWED_EXCEPTIONS list instead of only the exact exceptions defined in there (i.e. instead of only 'swallowing' IOException, this change will allow SocketException (derived from IOException) to also be 'swallowed')

## How was the change tested

Before this change it is easy to see Pacemaker server shut down when simply killing a topology:
2024-11-06 15:21:13.251 [o.a.s.m.n.StormServerHandler] ERROR: server errors in handling the request from /10.44.19.106:59691
java.net.SocketException: Connection reset	at sun.nio.ch.SocketChannelImpl.throwConnectionReset(SocketChannelImpl.java:401) ~[?:?]
<...snip...>
2024-11-06 15:21:13.270 [o.a.s.m.n.StormServerHandler] INFO: Received error in netty thread.. terminating server...

With this fix the Pacemaker server now logs that a SocketException was received but that it is 'swallowing' it and pacemaker server continues to run:
2024-11-06 16:19:46.860 [o.a.s.u.Utils] INFO: Swallowing class java.net.SocketException java.net.SocketException: Connection reset

Also added unit tests for the new behaviour of  Utils.handleUncaughtException