### PR TITLE
STORM-4106 Fix Storm.ps1 stdout/stderr feedback in Powershell ISE

### DIFF
--- a/bin/storm.ps1
+++ b/bin/storm.ps1
@@ -64,6 +64,6 @@ if(Test-Path $StormEnvPath) {
 }
 
 $ArgsForProcess = @(([io.path]::combine("$STORM_BIN_DIR", "storm.py"))) + $args
-Start-Process -FilePath python3 -ArgumentList $ArgsForProcess -Wait -NoNewWindow
+& python3 $ArgsForProcess
 
 exit $LastExitCode


### PR DESCRIPTION
## What is the purpose of the change

Addresses STORM-4106. Stdout\Stderr feedback when launching Storm.ps1 in Powershell ISE now works with this change
Feedback from regular Powershell cmd prompt continues to work with this fix too.

## How was the change tested

Open Powershell ISE and run Storm.ps1 to run a command (e..g show usage with ./storm1.ps1 -h)
Before the fix the Powershell ISE returns nothing output from Storm.ps1
With this fix the output Storm.ps1 is seen in Powershell ISE command window (and continues to be seen in regular Powershell cmd prompt)

See attached screenshots from before and after fix for both Powershell ISE and regular Powershell command prompts

Before Fix
![STORM-4106-before-fix](https://github.com/user-attachments/assets/5267112d-b358-4c93-8f08-67885f75a556)

After Fix
![STORM-4106-after-fix](https://github.com/user-attachments/assets/cd7b46fd-f4e4-4024-83e3-99e610f39a6d)
