### PR TITLE
Fix ShellBolt log level

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/multilang/JsonSerializer.java
+++ b/storm-client/src/jvm/org/apache/storm/multilang/JsonSerializer.java
@@ -154,9 +154,9 @@ public class JsonSerializer implements ISerializer {
 
         if (command.equals("log")) {
             Object logLevelObj = msg.get("level");
-            if (logLevelObj != null && logLevelObj instanceof Long) {
-                long logLevel = (Long) logLevelObj;
-                shellMsg.setLogLevel((int) logLevel);
+            if (logLevelObj != null && logLevelObj instanceof Number) {
+                int logLevel = ((Number) logLevelObj).intValue();
+                shellMsg.setLogLevel(logLevel);
             }
         }
 


### PR DESCRIPTION
## What is the purpose of the change

ShellBolt log level is always INFO due to failed check against Long after deseralizing

## How was the change tested

I used the following minimal example:

```java
String json = "{\"command\": \"log\", \"msg\": \"Testing ...\", \"level\": 4}";

try {
    JSONObject msg = (JSONObject) JSONValue.parseWithException(json);

    ShellMsg shellMsg = new ShellMsg();
    String command = (String)msg.get("command");
    if (command.equals("log")) {
        Object logLevelObj = msg.get("level");
        if (logLevelObj != null && logLevelObj instanceof Number) {
            int logLevel = ((Number) logLevelObj).intValue();
            shellMsg.setLogLevel(logLevel);
        }
    }
} catch (ParseException e) {
    throw new RuntimeException(e);
}
```