### PR TITLE
[storm-client] Add missing logging to TridentBoltExecutor on tuple count mismatch failures

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/trident/topology/TridentBoltExecutor.java
+++ b/storm-client/src/jvm/org/apache/storm/trident/topology/TridentBoltExecutor.java
@@ -40,9 +40,13 @@ import org.apache.storm.tuple.Values;
 import org.apache.storm.utils.RotatingMap;
 import org.apache.storm.utils.TupleUtils;
 import org.apache.storm.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TridentBoltExecutor implements IRichBolt {
     public static final String COORD_STREAM_PREFIX = "$coord-";
+    private static final Logger LOG = LoggerFactory.getLogger(TridentBoltExecutor.class);
+
     Map<GlobalStreamId, String> batchGroupIds;
     Map<String, CoordSpec> coordSpecs;
     Map<String, CoordCondition> coordConditions;
@@ -160,7 +164,8 @@ public class TridentBoltExecutor implements IRichBolt {
             if (tracked.receivedTuples == tracked.expectedTupleCount) {
                 finishBatch(tracked, tuple);
             } else {
-                //TODO: add logging that not all tuples were received
+                LOG.warn("Failing batch {}: expected {} tuples but only received {}", 
+                         tracked.info.batchId, tracked.expectedTupleCount, tracked.receivedTuples);
                 failBatch(tracked);
                 collector.fail(tuple);
                 failed = true;


### PR DESCRIPTION
Addresses Issue #3 from static analysis.

When verifying if a Trident batch finish condition is met, the executor checks if the number of received tuples matches the number of actual tuple counts. If there is a mismatch, the executor invokes failBatch(tracked) and rejects the tuple, but without any logging indicating the mismatch.

This PR adds an SLF4J `LOG.warn` explaining the mismatch so that operators can correctly diagnose data loss or malformed batches.