### PR TITLE
STORM-4079: Add SSL setup documentation

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -195,6 +195,14 @@ If users want to setup 2-way auth
 
 Storm now supports mutual TLS (mTLS) for internal Thrift RPC communication among Nimbus, Supervisors, and workers. Unlike one-way TLS, mTLS requires both parties to present and verify each other's certificates. This ensures full two-way certificate authentication and encryption.
 
+### Overview of TLS Configuration
+
+Storm provides TLS support for securing internal communication between Nimbus, Supervisors, and workers. This is achieved using existing configuration properties for Thrift-based RPC communication and Netty-based messaging.
+
+The TLS setup requires configuring keystore and truststore paths along with enabling TLS flags for each component. Nimbus and Supervisors use Thrift TLS settings, while workers use Netty TLS settings.
+
+The following sections provide example configurations for each component.
+
 ### Example TLS Configuration
 
 ### 1. Nimbus Settings


### PR DESCRIPTION
## What is the purpose of the change

This PR adds documentation explaining how to configure SSL in Apache Storm.

It provides clear guidance for users who want to secure their Storm cluster communication. 
The documentation explains the process of enabling SSL and configuring the required 
security components.

The documentation includes:
- Steps to generate keystore and truststore
- Configuration required in storm.yaml
- Instructions for enabling HTTPS for Storm UI

## How was the change tested

The documentation was reviewed to ensure the configuration steps and commands are accurate 
and consistent with the current Apache Storm configuration options. Since this change only 
adds documentation and does not modify runtime code, no additional functional tests were required.