### PR TITLE
STORM-3879: Add Kafka README files to distribution

### DIFF
--- a/storm-dist/source/src/main/assembly/source.xml
+++ b/storm-dist/source/src/main/assembly/source.xml
@@ -38,5 +38,20 @@
                 <exclude>**/.lien.*/**</exclude>
             </excludes>
         </fileSet>
+        <fileSet>
+            <directory>../../external/storm-kafka-migration</directory>
+            <outputDirectory>/external/storm-kafka-migration</outputDirectory>
+            <includes>
+                <include>README.md</include>
+            </includes>
+        </fileSet>
+
+        <fileSet>
+            <directory>../../external/storm-kafka-monitor</directory>
+            <outputDirectory>/external/storm-kafka-monitor</outputDirectory>
+            <includes>
+                <include>README.md</include>
+            </includes>
+        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
## What is the purpose of the change

This change ensures that the Kafka-related README files are included in the Storm distribution package.

Previously, the following README files were not part of the distribution:
- external/storm-kafka-migration/README.md
- external/storm-kafka-monitor/README.md

Including these files improves usability by providing necessary Kafka-related documentation directly within the distributed package.

## How was the change tested

- Verified that only `storm-dist/source/src/main/assembly/source.xml` is modified.
- Checked using `git diff upstream/master` to ensure no unrelated changes are included.
- Validated that the fileSet entries correctly reference the Kafka README paths.
- Ensured that the configuration will include these files during the distribution build.