### PR TITLE
  Fix corrupted record counter in SequenceFileReader.Offset.increment()

### DIFF
--- a/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
+++ b/external/storm-hdfs/src/main/java/org/apache/storm/hdfs/spout/SequenceFileReader.java
@@ -201,7 +201,7 @@ public class SequenceFileReader<KeyT extends Writable, ValueT extends Writable> 
             }
             ++currentRecord;
             prevRecordEndOffset = currRecordEndOffset;
-            currentRecord = newBytePosition;
+            currRecordEndOffset = newBytePosition;
         }
 
         @Override


### PR DESCRIPTION
In SequenceFileReader.Offset.increment(), line 204 overwrites `currentRecord` (a record counter) with `newBytePosition` (a byte offset), immediately after incrementing it on line 202:                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                              
```
  ++currentRecord;                        // line 202 — correct                                                                                                                                                                               
  prevRecordEndOffset = currRecordEndOffset; // line 203                                                                                                                                                                                      
  currentRecord = newBytePosition;         // line 204 — BUG: should be currRecordEndOffset
```
                                                                                                                                                                                                                                              
  This is a copy-paste error: `currentRecord` should be `currRecordEndOffset`.                                                                                                                                                                    
                                                                                                                                                                                                                                              
  **Impact**                                                                                                                                                                                                                                      
                                                            
  Every call to next() replaces the record counter with the reader's byte position. This corrupts:                                                                                                                                            
   
  - Offset equality/comparison — two offsets at the same record count compare as unequal if byte positions differ                                                                                                                             
  - Offset serialization (toString()) — the persisted record= field contains a byte offset, not a record number
  - Resume after restart — the HDFS spout uses the serialized offset to resume reading; a corrupted value causes records to be skipped or re-processed                                                                                        
  - prevRecordEndOffset tracking — since currRecordEndOffset is never updated, prevRecordEndOffset always copies a stale value, breaking sync point calculation  