### PR TITLE
Fix NPE in getSupervisorPageInfo for unknown hostnames

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -4643,6 +4643,9 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             } else {
                 supervisorIds = Arrays.asList(superId);
             }
+            if (supervisorIds == null) {
+                supervisorIds = Collections.emptyList();
+            }
             SupervisorPageInfo pageInfo = new SupervisorPageInfo();
             Map<String, Assignment> topoToAssignment = state.assignmentsInfo();
             for (String sid : supervisorIds) {


### PR DESCRIPTION
## Summary

  Fix a `NullPointerException` in `Nimbus.getSupervisorPageInfo()` when querying by a hostname with no supervisor registered in the cluster.                                                                                                  
  
  ## Bug                                                                                                                                                                                                                                      
                                                            
  `getSupervisorPageInfo` is called by the Storm UI's `/api/v1/supervisor` endpoint. When `superId` is null (query by hostname), `hostToSuperId.get(host)` returns `null` for unknown hosts. The subsequent for-each loop dereferences it:    
  
  ```java                                                                                                                                                                                                                                     
  supervisorIds = hostToSuperId.get(host);  // null if host not in cluster
  // ...
  for (String sid : supervisorIds) {        // NPE
```
                                                                                                                                                                                                                                        
  This is easily triggered by bookmarked URLs for decommissioned supervisors or hostname typos.                                                                                                                                               
                                                                                                                                                                                                                                              
 ##  Fix                                                                                                                                                                                                                                         
                                                            
  Guard against null with Collections.emptyList(), returning an empty SupervisorPageInfo instead of crashing

  🤖 Generated with Claude Code           