### PR TITLE
Port Clojure tests to Java: scheduler_test and multitenant_scheduler_…

### DIFF
--- a/storm-server/src/test/java/org/apache/storm/scheduler/SchedulerModelTest.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/SchedulerModelTest.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.scheduler;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.storm.Config;
+import org.apache.storm.daemon.nimbus.Nimbus.StandaloneINimbus;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SchedulerModelTest {
+
+    @Test
+    public void testSupervisorDetails() {
+        Map<ExecutorDetails, WorkerSlot> executorToSlot = new HashMap<>();
+        executorToSlot.put(new ExecutorDetails(1, 5), new WorkerSlot("supervisor1", 1));
+        executorToSlot.put(new ExecutorDetails(6, 10), new WorkerSlot("supervisor2", 2));
+
+        String topologyId = "topology1";
+        SchedulerAssignmentImpl assignment = new SchedulerAssignmentImpl(topologyId, executorToSlot, null, null);
+
+        // test assign
+        assignment.assign(new WorkerSlot("supervisor1", 1),
+                Arrays.asList(new ExecutorDetails(11, 15), new ExecutorDetails(16, 20)));
+
+        Map<ExecutorDetails, WorkerSlot> result = assignment.getExecutorToSlot();
+        assertEquals(new WorkerSlot("supervisor1", 1), result.get(new ExecutorDetails(1, 5)));
+        assertEquals(new WorkerSlot("supervisor2", 2), result.get(new ExecutorDetails(6, 10)));
+        assertEquals(new WorkerSlot("supervisor1", 1), result.get(new ExecutorDetails(11, 15)));
+        assertEquals(new WorkerSlot("supervisor1", 1), result.get(new ExecutorDetails(16, 20)));
+        assertEquals(4, result.size());
+
+        // test isSlotOccupied
+        assertTrue(assignment.isSlotOccupied(new WorkerSlot("supervisor2", 2)));
+        assertTrue(assignment.isSlotOccupied(new WorkerSlot("supervisor1", 1)));
+
+        // test isExecutorAssigned
+        assertTrue(assignment.isExecutorAssigned(new ExecutorDetails(1, 5)));
+        assertFalse(assignment.isExecutorAssigned(new ExecutorDetails(21, 25)));
+
+        // test unassignBySlot
+        assignment.unassignBySlot(new WorkerSlot("supervisor1", 1));
+        Map<ExecutorDetails, WorkerSlot> afterUnassign = assignment.getExecutorToSlot();
+        assertEquals(1, afterUnassign.size());
+        assertEquals(new WorkerSlot("supervisor2", 2), afterUnassign.get(new ExecutorDetails(6, 10)));
+    }
+
+    @Test
+    public void testTopologies() {
+        ExecutorDetails executor1 = new ExecutorDetails(1, 5);
+        ExecutorDetails executor2 = new ExecutorDetails(6, 10);
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+
+        Map<ExecutorDetails, String> executorToComponent1 = new HashMap<>();
+        executorToComponent1.put(executor1, "spout1");
+        executorToComponent1.put(executor2, "bolt1");
+
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 1,
+                executorToComponent1, "user");
+
+        // test topology.selectExecutorToComponent
+        Map<ExecutorDetails, String> selected = topology1.selectExecutorToComponent(Arrays.asList(executor1));
+        assertEquals(1, selected.size());
+        assertEquals("spout1", selected.get(executor1));
+
+        // test topologies.getById
+        Map<String, Object> conf2 = new HashMap<>();
+        conf2.put(Config.TOPOLOGY_NAME, "topology-name-2");
+
+        TopologyDetails topology2 = new TopologyDetails("topology2", conf2, new StormTopology(), 1,
+                new HashMap<>(), "user");
+
+        Map<String, TopologyDetails> topoMap = new HashMap<>();
+        topoMap.put("topology1", topology1);
+        topoMap.put("topology2", topology2);
+        Topologies topologies = new Topologies(topoMap);
+
+        assertEquals("topology1", topologies.getById("topology1").getId());
+
+        // test topologies.getByName
+        assertEquals("topology2", topologies.getByName("topology-name-2").getId());
+    }
+
+    @Test
+    public void testCluster() {
+        SupervisorDetails supervisor1 = new SupervisorDetails("supervisor1", "192.168.0.1",
+                Collections.emptyList(), Arrays.asList(1, 3, 5, 7, 9));
+        SupervisorDetails supervisor2 = new SupervisorDetails("supervisor2", "192.168.0.2",
+                Collections.emptyList(), Arrays.asList(2, 4, 6, 8, 10));
+
+        ExecutorDetails executor1 = new ExecutorDetails(1, 5);
+        ExecutorDetails executor2 = new ExecutorDetails(6, 10);
+        ExecutorDetails executor3 = new ExecutorDetails(11, 15);
+        ExecutorDetails executor11 = new ExecutorDetails(100, 105);
+        ExecutorDetails executor12 = new ExecutorDetails(106, 110);
+        ExecutorDetails executor21 = new ExecutorDetails(201, 205);
+        ExecutorDetails executor22 = new ExecutorDetails(206, 210);
+
+        // topology1 needs scheduling: executor3 is NOT assigned a slot.
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        Map<ExecutorDetails, String> exec2comp1 = new HashMap<>();
+        exec2comp1.put(executor1, "spout1");
+        exec2comp1.put(executor2, "bolt1");
+        exec2comp1.put(executor3, "bolt2");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 2,
+                exec2comp1, "user");
+
+        // topology2 is fully scheduled
+        Map<String, Object> conf2 = new HashMap<>();
+        conf2.put(Config.TOPOLOGY_NAME, "topology-name-2");
+        Map<ExecutorDetails, String> exec2comp2 = new HashMap<>();
+        exec2comp2.put(executor11, "spout11");
+        exec2comp2.put(executor12, "bolt12");
+        TopologyDetails topology2 = new TopologyDetails("topology2", conf2, new StormTopology(), 2,
+                exec2comp2, "user");
+
+        // topology3 needs scheduling, since the assignment is squeezed
+        Map<String, Object> conf3 = new HashMap<>();
+        conf3.put(Config.TOPOLOGY_NAME, "topology-name-3");
+        Map<ExecutorDetails, String> exec2comp3 = new HashMap<>();
+        exec2comp3.put(executor21, "spout21");
+        exec2comp3.put(executor22, "bolt22");
+        TopologyDetails topology3 = new TopologyDetails("topology3", conf3, new StormTopology(), 2,
+                exec2comp3, "user");
+
+        Map<String, TopologyDetails> topoMap = new HashMap<>();
+        topoMap.put("topology1", topology1);
+        topoMap.put("topology2", topology2);
+        topoMap.put("topology3", topology3);
+        Topologies topologies = new Topologies(topoMap);
+
+        Map<ExecutorDetails, WorkerSlot> executorToSlot1 = new HashMap<>();
+        executorToSlot1.put(executor1, new WorkerSlot("supervisor1", 1));
+        executorToSlot1.put(executor2, new WorkerSlot("supervisor2", 2));
+
+        Map<ExecutorDetails, WorkerSlot> executorToSlot2 = new HashMap<>();
+        executorToSlot2.put(executor11, new WorkerSlot("supervisor1", 3));
+        executorToSlot2.put(executor12, new WorkerSlot("supervisor2", 4));
+
+        Map<ExecutorDetails, WorkerSlot> executorToSlot3 = new HashMap<>();
+        executorToSlot3.put(executor21, new WorkerSlot("supervisor1", 5));
+        executorToSlot3.put(executor22, new WorkerSlot("supervisor1", 5));
+
+        SchedulerAssignmentImpl assignment1 = new SchedulerAssignmentImpl("topology1", executorToSlot1, null, null);
+        SchedulerAssignmentImpl assignment2 = new SchedulerAssignmentImpl("topology2", executorToSlot2, null, null);
+        SchedulerAssignmentImpl assignment3 = new SchedulerAssignmentImpl("topology3", executorToSlot3, null, null);
+
+        Map<String, SupervisorDetails> supervisors = new HashMap<>();
+        supervisors.put("supervisor1", supervisor1);
+        supervisors.put("supervisor2", supervisor2);
+
+        Map<String, SchedulerAssignmentImpl> assignments = new HashMap<>();
+        assignments.put("topology1", assignment1);
+        assignments.put("topology2", assignment2);
+        assignments.put("topology3", assignment3);
+
+        Cluster cluster = new Cluster(new StandaloneINimbus(),
+                new ResourceMetrics(new StormMetricsRegistry()),
+                supervisors, assignments, topologies, new HashMap<>());
+
+        // test Cluster constructor
+        assertEquals(new HashSet<>(Arrays.asList("supervisor1", "supervisor2")),
+                cluster.getSupervisors().keySet());
+        assertEquals(new HashSet<>(Arrays.asList("topology1", "topology2", "topology3")),
+                cluster.getAssignments().keySet());
+
+        // test Cluster.getUnassignedExecutors
+        assertEquals(new HashSet<>(Arrays.asList(executor3)),
+                new HashSet<>(cluster.getUnassignedExecutors(topology1)));
+        assertTrue(cluster.getUnassignedExecutors(topology2).isEmpty());
+
+        // test Cluster.needsScheduling
+        assertTrue(cluster.needsScheduling(topology1));
+        assertFalse(cluster.needsScheduling(topology2));
+        assertTrue(cluster.needsScheduling(topology3));
+
+        // test Cluster.needsSchedulingTopologies
+        Set<String> needsSchedulingIds = cluster.needsSchedulingTopologies().stream()
+                .map(TopologyDetails::getId)
+                .collect(Collectors.toSet());
+        assertEquals(new HashSet<>(Arrays.asList("topology1", "topology3")), needsSchedulingIds);
+
+        // test Cluster.getNeedsSchedulingExecutorToComponents
+        Map<ExecutorDetails, String> needsSched1 = cluster.getNeedsSchedulingExecutorToComponents(topology1);
+        assertEquals(1, needsSched1.size());
+        assertEquals("bolt2", needsSched1.get(executor3));
+        assertTrue(cluster.getNeedsSchedulingExecutorToComponents(topology2).isEmpty());
+        assertTrue(cluster.getNeedsSchedulingExecutorToComponents(topology3).isEmpty());
+
+        // test Cluster.getNeedsSchedulingComponentToExecutors
+        Map<String, List<ExecutorDetails>> needsSchedComp1 =
+                cluster.getNeedsSchedulingComponentToExecutors(topology1);
+        assertEquals(1, needsSchedComp1.size());
+        assertEquals(new HashSet<>(Arrays.asList(executor3)),
+                new HashSet<>(needsSchedComp1.get("bolt2")));
+        assertTrue(cluster.getNeedsSchedulingComponentToExecutors(topology2).isEmpty());
+        assertTrue(cluster.getNeedsSchedulingComponentToExecutors(topology3).isEmpty());
+
+        // test Cluster.getUsedPorts
+        assertEquals(new HashSet<>(Arrays.asList(1, 3, 5)),
+                new HashSet<>(cluster.getUsedPorts(supervisor1)));
+        assertEquals(new HashSet<>(Arrays.asList(2, 4)),
+                new HashSet<>(cluster.getUsedPorts(supervisor2)));
+
+        // test Cluster.getAvailablePorts
+        assertEquals(new HashSet<>(Arrays.asList(7, 9)),
+                new HashSet<>(cluster.getAvailablePorts(supervisor1)));
+        assertEquals(new HashSet<>(Arrays.asList(6, 8, 10)),
+                new HashSet<>(cluster.getAvailablePorts(supervisor2)));
+
+        // test Cluster.getAvailableSlots (per supervisor)
+        Set<String> availSlots1 = cluster.getAvailableSlots(supervisor1).stream()
+                .map(s -> s.getNodeId() + ":" + s.getPort())
+                .collect(Collectors.toSet());
+        assertEquals(new HashSet<>(Arrays.asList("supervisor1:7", "supervisor1:9")), availSlots1);
+
+        Set<String> availSlots2 = cluster.getAvailableSlots(supervisor2).stream()
+                .map(s -> s.getNodeId() + ":" + s.getPort())
+                .collect(Collectors.toSet());
+        assertEquals(new HashSet<>(Arrays.asList("supervisor2:6", "supervisor2:8", "supervisor2:10")), availSlots2);
+
+        // test Cluster.getAvailableSlots (all)
+        Set<String> allAvailSlots = cluster.getAvailableSlots().stream()
+                .map(s -> s.getNodeId() + ":" + s.getPort())
+                .collect(Collectors.toSet());
+        assertEquals(new HashSet<>(Arrays.asList(
+                "supervisor1:7", "supervisor1:9",
+                "supervisor2:6", "supervisor2:8", "supervisor2:10")),
+                allAvailSlots);
+
+        // test Cluster.getAssignedNumWorkers
+        assertEquals(2, cluster.getAssignedNumWorkers(topology1));
+        assertEquals(2, cluster.getAssignedNumWorkers(topology2));
+        assertEquals(1, cluster.getAssignedNumWorkers(topology3));
+
+        // test Cluster.isSlotOccupied
+        assertTrue(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 1)));
+        assertTrue(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 3)));
+        assertTrue(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 5)));
+        assertFalse(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 7)));
+        assertFalse(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 9)));
+        assertTrue(cluster.isSlotOccupied(new WorkerSlot("supervisor2", 2)));
+        assertTrue(cluster.isSlotOccupied(new WorkerSlot("supervisor2", 4)));
+        assertFalse(cluster.isSlotOccupied(new WorkerSlot("supervisor2", 6)));
+        assertFalse(cluster.isSlotOccupied(new WorkerSlot("supervisor2", 8)));
+        assertFalse(cluster.isSlotOccupied(new WorkerSlot("supervisor2", 10)));
+
+        // test Cluster.getAssignmentById
+        assertTrue(assignment1.equalsIgnoreResources(cluster.getAssignmentById("topology1")));
+        assertTrue(assignment2.equalsIgnoreResources(cluster.getAssignmentById("topology2")));
+        assertTrue(assignment3.equalsIgnoreResources(cluster.getAssignmentById("topology3")));
+
+        // test Cluster.getSupervisorById
+        assertEquals(supervisor1, cluster.getSupervisorById("supervisor1"));
+        assertEquals(supervisor2, cluster.getSupervisorById("supervisor2"));
+
+        // test Cluster.getSupervisorsByHost
+        assertEquals(new HashSet<>(Arrays.asList(supervisor1)),
+                new HashSet<>(cluster.getSupervisorsByHost("192.168.0.1")));
+        assertEquals(new HashSet<>(Arrays.asList(supervisor2)),
+                new HashSet<>(cluster.getSupervisorsByHost("192.168.0.2")));
+
+        // ==== the following tests will change the state of the cluster ====
+
+        // test Cluster.assign
+        cluster.assign(new WorkerSlot("supervisor1", 7), "topology1", Arrays.asList(executor3));
+        assertFalse(cluster.needsScheduling(topology1));
+        assertTrue(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 7)));
+
+        // revert the change
+        cluster.freeSlot(new WorkerSlot("supervisor1", 7));
+
+        // test Cluster.assign: if an executor is already assigned, there will be an exception
+        assertThrows(Exception.class,
+                () -> cluster.assign(new WorkerSlot("supervisor1", 9), "topology1", Arrays.asList(executor1)));
+
+        // test Cluster.assign: if a slot is occupied, there will be an exception
+        assertThrows(Exception.class,
+                () -> cluster.assign(new WorkerSlot("supervisor2", 4), "topology1", Arrays.asList(executor3)));
+
+        // test Cluster.freeSlot
+        cluster.freeSlot(new WorkerSlot("supervisor1", 7));
+        assertFalse(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 7)));
+
+        // test Cluster.freeSlots
+        assertTrue(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 1)));
+        assertTrue(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 3)));
+        assertTrue(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 5)));
+        cluster.freeSlots(Arrays.asList(
+                new WorkerSlot("supervisor1", 1),
+                new WorkerSlot("supervisor1", 3),
+                new WorkerSlot("supervisor1", 5)));
+        assertFalse(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 1)));
+        assertFalse(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 3)));
+        assertFalse(cluster.isSlotOccupied(new WorkerSlot("supervisor1", 5)));
+    }
+
+    @Test
+    public void testSortSlots() {
+        // test supervisor2 has more free slots
+        List<WorkerSlot> sorted1 = EvenScheduler.sortSlots(Arrays.asList(
+                new WorkerSlot("supervisor1", 6700), new WorkerSlot("supervisor1", 6701),
+                new WorkerSlot("supervisor2", 6700), new WorkerSlot("supervisor2", 6701),
+                new WorkerSlot("supervisor2", 6702)));
+
+        List<WorkerSlot> expected1 = Arrays.asList(
+                new WorkerSlot("supervisor2", 6700), new WorkerSlot("supervisor1", 6700),
+                new WorkerSlot("supervisor2", 6701), new WorkerSlot("supervisor1", 6701),
+                new WorkerSlot("supervisor2", 6702));
+        assertEquals(expected1, sorted1);
+
+        // test supervisor3 has more free slots
+        List<WorkerSlot> sorted2 = EvenScheduler.sortSlots(Arrays.asList(
+                new WorkerSlot("supervisor1", 6700), new WorkerSlot("supervisor1", 6701),
+                new WorkerSlot("supervisor2", 6700), new WorkerSlot("supervisor2", 6701),
+                new WorkerSlot("supervisor2", 6702),
+                new WorkerSlot("supervisor3", 6700), new WorkerSlot("supervisor3", 6703),
+                new WorkerSlot("supervisor3", 6702), new WorkerSlot("supervisor3", 6701)));
+
+        List<WorkerSlot> expected2 = Arrays.asList(
+                new WorkerSlot("supervisor3", 6700), new WorkerSlot("supervisor2", 6700),
+                new WorkerSlot("supervisor1", 6700),
+                new WorkerSlot("supervisor3", 6701), new WorkerSlot("supervisor2", 6701),
+                new WorkerSlot("supervisor1", 6701),
+                new WorkerSlot("supervisor3", 6702), new WorkerSlot("supervisor2", 6702),
+                new WorkerSlot("supervisor3", 6703));
+        assertEquals(expected2, sorted2);
+    }
+}

--- a/storm-server/src/test/java/org/apache/storm/scheduler/multitenant/MultitenantSchedulerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/multitenant/MultitenantSchedulerTest.java
@@ -1,0 +1,1082 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.scheduler.multitenant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.storm.Config;
+import org.apache.storm.DaemonConfig;
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.daemon.nimbus.Nimbus.StandaloneINimbus;
+import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.scheduler.Cluster;
+import org.apache.storm.scheduler.ExecutorDetails;
+import org.apache.storm.scheduler.SchedulerAssignment;
+import org.apache.storm.scheduler.SchedulerAssignmentImpl;
+import org.apache.storm.scheduler.SupervisorDetails;
+import org.apache.storm.scheduler.Topologies;
+import org.apache.storm.scheduler.TopologyDetails;
+import org.apache.storm.scheduler.WorkerSlot;
+import org.apache.storm.scheduler.resource.normalization.ResourceMetrics;
+import org.junit.jupiter.api.Test;
+
+public class MultitenantSchedulerTest {
+
+    private static ExecutorDetails ed(int id) {
+        return new ExecutorDetails(id, id);
+    }
+
+    private static Map<String, SupervisorDetails> genSupervisors(int count) {
+        Map<String, SupervisorDetails> supervisors = new LinkedHashMap<>();
+        for (int id = 0; id < count; id++) {
+            SupervisorDetails supervisor = new SupervisorDetails(
+                "super" + id, "host" + id, Collections.emptyList(), Arrays.asList(1, 2, 3, 4));
+            supervisors.put(supervisor.getId(), supervisor);
+        }
+        return supervisors;
+    }
+
+    private static Map<String, TopologyDetails> toTopMap(TopologyDetails... topologies) {
+        Map<String, TopologyDetails> map = new HashMap<>();
+        for (TopologyDetails top : topologies) {
+            map.put(top.getId(), top);
+        }
+        return map;
+    }
+
+    private static Map<ExecutorDetails, String> mkEdMap(Object[]... args) {
+        Map<ExecutorDetails, String> map = new HashMap<>();
+        for (Object[] entry : args) {
+            String name = (String) entry[0];
+            int start = (int) entry[1];
+            int end = (int) entry[2];
+            for (int at = start; at < end; at++) {
+                map.put(ed(at), name);
+            }
+        }
+        return map;
+    }
+
+    private static Set<String> getNodeIds(Set<WorkerSlot> slots) {
+        Set<String> nodeIds = new HashSet<>();
+        for (WorkerSlot slot : slots) {
+            nodeIds.add(slot.getNodeId());
+        }
+        return nodeIds;
+    }
+
+    private static ResourceMetrics newResourceMetrics() {
+        return new ResourceMetrics(new StormMetricsRegistry());
+    }
+
+    @Test
+    public void testNode() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+        TopologyDetails topology1 = new TopologyDetails("topology1", new HashMap<>(), null, 1, "user");
+        TopologyDetails topology2 = new TopologyDetails("topology2", new HashMap<>(), null, 1, "user");
+        Map<String, TopologyDetails> topMap = new HashMap<>();
+        topMap.put("topology1", topology1);
+        topMap.put("topology2", topology2);
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            new Topologies(topMap), new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        assertEquals(5, nodeMap.size());
+
+        Node node = nodeMap.get("super0");
+        assertEquals("super0", node.getId());
+        assertTrue(node.isAlive());
+        assertEquals(0, node.getRunningTopologies().size());
+        assertTrue(node.isTotallyFree());
+        assertEquals(4, node.totalSlotsFree());
+        assertEquals(0, node.totalSlotsUsed());
+        assertEquals(4, node.totalSlots());
+
+        node.assign("topology1", Arrays.asList(new ExecutorDetails(1, 1)), cluster);
+        assertEquals(1, node.getRunningTopologies().size());
+        assertFalse(node.isTotallyFree());
+        assertEquals(3, node.totalSlotsFree());
+        assertEquals(1, node.totalSlotsUsed());
+        assertEquals(4, node.totalSlots());
+
+        node.assign("topology1", Arrays.asList(new ExecutorDetails(2, 2)), cluster);
+        assertEquals(1, node.getRunningTopologies().size());
+        assertFalse(node.isTotallyFree());
+        assertEquals(2, node.totalSlotsFree());
+        assertEquals(2, node.totalSlotsUsed());
+        assertEquals(4, node.totalSlots());
+
+        node.assign("topology2", Arrays.asList(new ExecutorDetails(1, 1)), cluster);
+        assertEquals(2, node.getRunningTopologies().size());
+        assertFalse(node.isTotallyFree());
+        assertEquals(1, node.totalSlotsFree());
+        assertEquals(3, node.totalSlotsUsed());
+        assertEquals(4, node.totalSlots());
+
+        node.assign("topology2", Arrays.asList(new ExecutorDetails(2, 2)), cluster);
+        assertEquals(2, node.getRunningTopologies().size());
+        assertFalse(node.isTotallyFree());
+        assertEquals(0, node.totalSlotsFree());
+        assertEquals(4, node.totalSlotsUsed());
+        assertEquals(4, node.totalSlots());
+
+        node.freeAllSlots(cluster);
+        assertEquals(0, node.getRunningTopologies().size());
+        assertTrue(node.isTotallyFree());
+        assertEquals(4, node.totalSlotsFree());
+        assertEquals(0, node.totalSlotsUsed());
+        assertEquals(4, node.totalSlots());
+    }
+
+    @Test
+    public void testFreePool() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+        TopologyDetails topology1 = new TopologyDetails("topology1", new HashMap<>(), null, 1, "user");
+        Map<String, TopologyDetails> topMap = new HashMap<>();
+        topMap.put("topology1", topology1);
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            new Topologies(topMap), new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+        FreePool freePool = new FreePool();
+
+        // assign one node so it is not in the pool
+        nodeMap.get("super0").assign("topology1", Arrays.asList(new ExecutorDetails(1, 1)), cluster);
+        freePool.init(cluster, nodeMap);
+
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+
+        NodePool.NodeAndSlotCounts nsCount1 = freePool.getNodeAndSlotCountIfSlotsWereTaken(1);
+        NodePool.NodeAndSlotCounts nsCount3 = freePool.getNodeAndSlotCountIfSlotsWereTaken(3);
+        NodePool.NodeAndSlotCounts nsCount4 = freePool.getNodeAndSlotCountIfSlotsWereTaken(4);
+        NodePool.NodeAndSlotCounts nsCount5 = freePool.getNodeAndSlotCountIfSlotsWereTaken(5);
+
+        assertEquals(1, nsCount1.nodes);
+        assertEquals(4, nsCount1.slots);
+        assertEquals(1, nsCount3.nodes);
+        assertEquals(4, nsCount3.slots);
+        assertEquals(1, nsCount4.nodes);
+        assertEquals(4, nsCount4.slots);
+        assertEquals(2, nsCount5.nodes);
+        assertEquals(8, nsCount5.slots);
+
+        Collection<Node> nodes = freePool.takeNodesBySlots(5);
+        assertEquals(2, nodes.size());
+        assertEquals(8, Node.countFreeSlotsAlive(nodes));
+        assertEquals(8, Node.countTotalSlotsAlive(nodes));
+        assertEquals(2, freePool.nodesAvailable());
+        assertEquals(2 * 4, freePool.slotsAvailable());
+
+        Collection<Node> nodes2 = freePool.takeNodes(3); // Only 2 should be left
+        assertEquals(2, nodes2.size());
+        assertEquals(8, Node.countFreeSlotsAlive(nodes2));
+        assertEquals(8, Node.countTotalSlotsAlive(nodes2));
+        assertEquals(0, freePool.nodesAvailable());
+        assertEquals(0, freePool.slotsAvailable());
+    }
+
+    @Test
+    public void testDefaultPoolSimple() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+        FreePool freePool = new FreePool();
+        DefaultPool defaultPool = new DefaultPool();
+        ExecutorDetails executor1 = ed(1);
+        ExecutorDetails executor2 = ed(2);
+        ExecutorDetails executor3 = ed(3);
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        Map<ExecutorDetails, String> execMap1 = new HashMap<>();
+        execMap1.put(executor1, "spout1");
+        execMap1.put(executor2, "bolt1");
+        execMap1.put(executor3, "bolt2");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 2, execMap1, "user");
+        Topologies topologies = new Topologies(toTopMap(topology1));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            topologies, new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        // assign one node so it is not in the pool
+        nodeMap.get("super0").assign("topology1", Arrays.asList(executor1), cluster);
+        freePool.init(cluster, nodeMap);
+        defaultPool.init(cluster, nodeMap);
+
+        assertTrue(defaultPool.canAdd(topology1));
+        defaultPool.addTopology(topology1);
+
+        // Only 1 node is in the default-pool because only one node was scheduled already
+        assertEquals(4, defaultPool.slotsAvailable());
+        assertEquals(1, defaultPool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(1, cluster.getAssignmentById("topology1").getSlots().size());
+
+        defaultPool.scheduleAsNeeded(new NodePool[]{freePool});
+        assertEquals(4, defaultPool.slotsAvailable());
+        assertEquals(1, defaultPool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(2, cluster.getAssignmentById("topology1").getSlots().size());
+        assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology1"));
+    }
+
+    @Test
+    public void testDefaultPoolBigRequest() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+        FreePool freePool = new FreePool();
+        DefaultPool defaultPool = new DefaultPool();
+        ExecutorDetails executor1 = ed(1);
+        ExecutorDetails executor2 = ed(2);
+        ExecutorDetails executor3 = ed(3);
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        Map<ExecutorDetails, String> execMap1 = new HashMap<>();
+        execMap1.put(executor1, "spout1");
+        execMap1.put(executor2, "bolt1");
+        execMap1.put(executor3, "bolt2");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 5, execMap1, "user");
+        Topologies topologies = new Topologies(toTopMap(topology1));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            topologies, new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        // assign one node so it is not in the pool
+        nodeMap.get("super0").assign("topology1", Arrays.asList(executor1), cluster);
+        freePool.init(cluster, nodeMap);
+        defaultPool.init(cluster, nodeMap);
+
+        assertTrue(defaultPool.canAdd(topology1));
+        defaultPool.addTopology(topology1);
+
+        assertEquals(4, defaultPool.slotsAvailable());
+        assertEquals(1, defaultPool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(1, cluster.getAssignmentById("topology1").getSlots().size());
+
+        defaultPool.scheduleAsNeeded(new NodePool[]{freePool});
+        assertEquals(4, defaultPool.slotsAvailable());
+        assertEquals(1, defaultPool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(3, cluster.getAssignmentById("topology1").getSlots().size());
+        assertEquals("Fully Scheduled (requested 5 slots, but could only use 3)",
+            cluster.getStatusMap().get("topology1"));
+    }
+
+    @Test
+    public void testDefaultPoolBigRequest2() {
+        Map<String, SupervisorDetails> supers = genSupervisors(1);
+        FreePool freePool = new FreePool();
+        DefaultPool defaultPool = new DefaultPool();
+        ExecutorDetails executor1 = ed(1);
+        ExecutorDetails executor2 = ed(2);
+        ExecutorDetails executor3 = ed(3);
+        ExecutorDetails executor4 = ed(4);
+        ExecutorDetails executor5 = ed(5);
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        Map<ExecutorDetails, String> execMap1 = new HashMap<>();
+        execMap1.put(executor1, "spout1");
+        execMap1.put(executor2, "bolt1");
+        execMap1.put(executor3, "bolt1");
+        execMap1.put(executor4, "bolt1");
+        execMap1.put(executor5, "bolt2");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 5, execMap1, "user");
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            new Topologies(toTopMap(topology1)), new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        // assign one node so it is not in the pool
+        nodeMap.get("super0").assign("topology1", Arrays.asList(executor1), cluster);
+        freePool.init(cluster, nodeMap);
+        defaultPool.init(cluster, nodeMap);
+
+        assertTrue(defaultPool.canAdd(topology1));
+        defaultPool.addTopology(topology1);
+
+        assertEquals(4, defaultPool.slotsAvailable());
+        assertEquals(1, defaultPool.nodesAvailable());
+        assertEquals(0, freePool.slotsAvailable());
+        assertEquals(0, freePool.nodesAvailable());
+        assertEquals(1, cluster.getAssignmentById("topology1").getSlots().size());
+
+        defaultPool.scheduleAsNeeded(new NodePool[]{freePool});
+        assertEquals(4, defaultPool.slotsAvailable());
+        assertEquals(1, defaultPool.nodesAvailable());
+        assertEquals(0, freePool.slotsAvailable());
+        assertEquals(0, freePool.nodesAvailable());
+        assertEquals(4, cluster.getAssignmentById("topology1").getSlots().size());
+        assertEquals("Running with fewer slots than requested (4/5)",
+            cluster.getStatusMap().get("topology1"));
+    }
+
+    @Test
+    public void testDefaultPoolFull() {
+        Map<String, SupervisorDetails> supers = genSupervisors(2);
+        // make 2 supervisors but only schedule with one of them
+        Map.Entry<String, SupervisorDetails> firstEntry = supers.entrySet().iterator().next();
+        Map<String, SupervisorDetails> singleSuper = new HashMap<>();
+        singleSuper.put(firstEntry.getKey(), firstEntry.getValue());
+
+        ExecutorDetails executor1 = ed(1);
+        ExecutorDetails executor2 = ed(2);
+        ExecutorDetails executor3 = ed(3);
+        ExecutorDetails executor4 = ed(4);
+        ExecutorDetails executor5 = ed(5);
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        Map<ExecutorDetails, String> execMap1 = new HashMap<>();
+        execMap1.put(executor1, "spout1");
+        execMap1.put(executor2, "bolt1");
+        execMap1.put(executor3, "bolt2");
+        execMap1.put(executor4, "bolt3");
+        execMap1.put(executor5, "bolt4");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 5, execMap1, "user");
+        Topologies topologies = new Topologies(toTopMap(topology1));
+        Cluster singleCluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), singleSuper,
+            new HashMap<>(), topologies, new HashMap<>());
+
+        {
+            Map<String, Node> nodeMap = Node.getAllNodesFrom(singleCluster);
+            FreePool freePool = new FreePool();
+            DefaultPool defaultPool = new DefaultPool();
+            freePool.init(singleCluster, nodeMap);
+            defaultPool.init(singleCluster, nodeMap);
+            defaultPool.addTopology(topology1);
+            defaultPool.scheduleAsNeeded(new NodePool[]{freePool});
+            // The cluster should be full and have 4 slots used, but the topology would like 1 more
+            assertEquals(4, singleCluster.getUsedSlots().size());
+            assertEquals("Running with fewer slots than requested (4/5)",
+                singleCluster.getStatusMap().get("topology1"));
+        }
+
+        {
+            Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers,
+                singleCluster.getAssignments(), topologies, new HashMap<>());
+            Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+            FreePool freePool = new FreePool();
+            DefaultPool defaultPool = new DefaultPool();
+            freePool.init(cluster, nodeMap);
+            defaultPool.init(cluster, nodeMap);
+            defaultPool.addTopology(topology1);
+            defaultPool.scheduleAsNeeded(new NodePool[]{freePool});
+            // The cluster should now have 5 slots used
+            assertEquals(5, cluster.getUsedSlots().size());
+            assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology1"));
+        }
+    }
+
+    @Test
+    public void testDefaultPoolComplex() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+        FreePool freePool = new FreePool();
+        DefaultPool defaultPool = new DefaultPool();
+        ExecutorDetails executor1 = ed(1);
+        ExecutorDetails executor2 = ed(2);
+        ExecutorDetails executor3 = ed(3);
+        ExecutorDetails executor11 = ed(11);
+        ExecutorDetails executor12 = ed(12);
+        ExecutorDetails executor13 = ed(13);
+        ExecutorDetails executor14 = ed(14);
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        Map<ExecutorDetails, String> execMap1 = new HashMap<>();
+        execMap1.put(executor1, "spout1");
+        execMap1.put(executor2, "bolt1");
+        execMap1.put(executor3, "bolt2");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 2, execMap1, "user");
+
+        Map<String, Object> conf2 = new HashMap<>();
+        conf2.put(Config.TOPOLOGY_NAME, "topology-name-2");
+        Map<ExecutorDetails, String> execMap2 = new HashMap<>();
+        execMap2.put(executor11, "spout11");
+        execMap2.put(executor12, "bolt12");
+        execMap2.put(executor13, "bolt13");
+        execMap2.put(executor14, "bolt14");
+        TopologyDetails topology2 = new TopologyDetails("topology2", conf2, new StormTopology(), 4, execMap2, "user");
+
+        Topologies topologies = new Topologies(toTopMap(topology1, topology2));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            topologies, new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        // assign one node so it is not in the pool
+        nodeMap.get("super0").assign("topology1", Arrays.asList(executor1), cluster);
+        freePool.init(cluster, nodeMap);
+        defaultPool.init(cluster, nodeMap);
+
+        assertTrue(defaultPool.canAdd(topology1));
+        defaultPool.addTopology(topology1);
+        assertTrue(defaultPool.canAdd(topology2));
+        defaultPool.addTopology(topology2);
+
+        // Only 1 node is in the default-pool because only one node was scheduled already
+        assertEquals(4, defaultPool.slotsAvailable());
+        assertEquals(1, defaultPool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(1, cluster.getAssignmentById("topology1").getSlots().size());
+        assertNull(cluster.getAssignmentById("topology2"));
+
+        defaultPool.scheduleAsNeeded(new NodePool[]{freePool});
+        // We steal a node from the free pool to handle the extra
+        assertEquals(8, defaultPool.slotsAvailable());
+        assertEquals(2, defaultPool.nodesAvailable());
+        assertEquals(3 * 4, freePool.slotsAvailable());
+        assertEquals(3, freePool.nodesAvailable());
+        assertEquals(2, cluster.getAssignmentById("topology1").getSlots().size());
+        assertEquals(4, cluster.getAssignmentById("topology2").getSlots().size());
+
+        NodePool.NodeAndSlotCounts nsCount1 = defaultPool.getNodeAndSlotCountIfSlotsWereTaken(1);
+        NodePool.NodeAndSlotCounts nsCount3 = defaultPool.getNodeAndSlotCountIfSlotsWereTaken(3);
+        NodePool.NodeAndSlotCounts nsCount4 = defaultPool.getNodeAndSlotCountIfSlotsWereTaken(4);
+        NodePool.NodeAndSlotCounts nsCount5 = defaultPool.getNodeAndSlotCountIfSlotsWereTaken(5);
+        assertEquals(1, nsCount1.nodes);
+        assertEquals(4, nsCount1.slots);
+        assertEquals(1, nsCount3.nodes);
+        assertEquals(4, nsCount3.slots);
+        assertEquals(1, nsCount4.nodes);
+        assertEquals(4, nsCount4.slots);
+        assertEquals(2, nsCount5.nodes);
+        assertEquals(8, nsCount5.slots);
+
+        Collection<Node> nodes = defaultPool.takeNodesBySlots(3);
+        assertEquals(1, nodes.size());
+        assertEquals(4, Node.countFreeSlotsAlive(nodes));
+        assertEquals(4, Node.countTotalSlotsAlive(nodes));
+        assertEquals(1, defaultPool.nodesAvailable());
+        assertEquals(1 * 4, defaultPool.slotsAvailable());
+
+        Collection<Node> nodes2 = defaultPool.takeNodes(3); // Only 1 should be left
+        assertEquals(1, nodes2.size());
+        assertEquals(4, Node.countFreeSlotsAlive(nodes2));
+        assertEquals(4, Node.countTotalSlotsAlive(nodes2));
+        assertEquals(0, defaultPool.nodesAvailable());
+        assertEquals(0, defaultPool.slotsAvailable());
+
+        assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology1"));
+        assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology2"));
+    }
+
+    @Test
+    public void testIsolatedPoolSimple() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+        FreePool freePool = new FreePool();
+        IsolatedPool isolatedPool = new IsolatedPool(5);
+        ExecutorDetails executor1 = ed(1);
+        ExecutorDetails executor2 = ed(2);
+        ExecutorDetails executor3 = ed(3);
+        ExecutorDetails executor4 = ed(4);
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        conf1.put(Config.TOPOLOGY_ISOLATED_MACHINES, 4);
+        Map<ExecutorDetails, String> execMap1 = new HashMap<>();
+        execMap1.put(executor1, "spout1");
+        execMap1.put(executor2, "bolt1");
+        execMap1.put(executor3, "bolt2");
+        execMap1.put(executor4, "bolt4");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 4, execMap1, "user");
+        Topologies topologies = new Topologies(toTopMap(topology1));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            topologies, new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        // assign one node so it is not in the pool
+        nodeMap.get("super0").assign("topology1", Arrays.asList(executor1), cluster);
+        freePool.init(cluster, nodeMap);
+        isolatedPool.init(cluster, nodeMap);
+
+        assertTrue(isolatedPool.canAdd(topology1));
+        isolatedPool.addTopology(topology1);
+
+        // Isolated topologies cannot have their resources stolen
+        assertEquals(0, isolatedPool.slotsAvailable());
+        assertEquals(0, isolatedPool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(1, cluster.getAssignmentById("topology1").getSlots().size());
+
+        isolatedPool.scheduleAsNeeded(new NodePool[]{freePool});
+        assertEquals(0, isolatedPool.slotsAvailable());
+        assertEquals(0, isolatedPool.nodesAvailable());
+        assertEquals(1 * 4, freePool.slotsAvailable());
+        assertEquals(1, freePool.nodesAvailable());
+
+        Set<WorkerSlot> assignedSlots = cluster.getAssignmentById("topology1").getSlots();
+        // 4 slots on 4 machines
+        assertEquals(4, assignedSlots.size());
+        assertEquals(4, getNodeIds(assignedSlots).size());
+
+        assertEquals("Scheduled Isolated on 4 Nodes", cluster.getStatusMap().get("topology1"));
+    }
+
+    @Test
+    public void testIsolatedPoolBigAsk() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+        FreePool freePool = new FreePool();
+        IsolatedPool isolatedPool = new IsolatedPool(5);
+        ExecutorDetails executor1 = ed(1);
+        ExecutorDetails executor2 = ed(2);
+        ExecutorDetails executor3 = ed(3);
+        ExecutorDetails executor4 = ed(4);
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        conf1.put(Config.TOPOLOGY_ISOLATED_MACHINES, 4);
+        Map<ExecutorDetails, String> execMap1 = new HashMap<>();
+        execMap1.put(executor1, "spout1");
+        execMap1.put(executor2, "bolt1");
+        execMap1.put(executor3, "bolt2");
+        execMap1.put(executor4, "bolt4");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 10, execMap1, "user");
+        Topologies topologies = new Topologies(toTopMap(topology1));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            topologies, new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        // assign one node so it is not in the pool
+        nodeMap.get("super0").assign("topology1", Arrays.asList(executor1), cluster);
+        freePool.init(cluster, nodeMap);
+        isolatedPool.init(cluster, nodeMap);
+
+        assertTrue(isolatedPool.canAdd(topology1));
+        isolatedPool.addTopology(topology1);
+
+        // Isolated topologies cannot have their resources stolen
+        assertEquals(0, isolatedPool.slotsAvailable());
+        assertEquals(0, isolatedPool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(1, cluster.getAssignmentById("topology1").getSlots().size());
+
+        isolatedPool.scheduleAsNeeded(new NodePool[]{freePool});
+        assertEquals(0, isolatedPool.slotsAvailable());
+        assertEquals(0, isolatedPool.nodesAvailable());
+        assertEquals(1 * 4, freePool.slotsAvailable());
+        assertEquals(1, freePool.nodesAvailable());
+
+        Set<WorkerSlot> assignedSlots = cluster.getAssignmentById("topology1").getSlots();
+        // 4 slots on 4 machines
+        assertEquals(4, assignedSlots.size());
+        assertEquals(4, getNodeIds(assignedSlots).size());
+
+        assertEquals("Scheduled Isolated on 4 Nodes", cluster.getStatusMap().get("topology1"));
+    }
+
+    @Test
+    public void testIsolatedPoolComplex() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+        FreePool freePool = new FreePool();
+        IsolatedPool isolatedPool = new IsolatedPool(5);
+        ExecutorDetails executor1 = ed(1);
+        ExecutorDetails executor2 = ed(2);
+        ExecutorDetails executor3 = ed(3);
+        ExecutorDetails executor4 = ed(4);
+        ExecutorDetails executor11 = ed(11);
+        ExecutorDetails executor12 = ed(12);
+        ExecutorDetails executor13 = ed(13);
+        ExecutorDetails executor14 = ed(14);
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        Map<ExecutorDetails, String> execMap1 = new HashMap<>();
+        execMap1.put(executor1, "spout1");
+        execMap1.put(executor2, "bolt1");
+        execMap1.put(executor3, "bolt2");
+        execMap1.put(executor4, "bolt4");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 4, execMap1, "user");
+
+        Map<String, Object> conf2 = new HashMap<>();
+        conf2.put(Config.TOPOLOGY_NAME, "topology-name-2");
+        conf2.put(Config.TOPOLOGY_ISOLATED_MACHINES, 2);
+        Map<ExecutorDetails, String> execMap2 = new HashMap<>();
+        execMap2.put(executor11, "spout11");
+        execMap2.put(executor12, "bolt12");
+        execMap2.put(executor13, "bolt13");
+        execMap2.put(executor14, "bolt14");
+        TopologyDetails topology2 = new TopologyDetails("topology2", conf2, new StormTopology(), 4, execMap2, "user");
+
+        Topologies topologies = new Topologies(toTopMap(topology1, topology2));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            topologies, new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        // assign one node so it is not in the pool
+        nodeMap.get("super0").assign("topology1", Arrays.asList(executor1), cluster);
+        freePool.init(cluster, nodeMap);
+        isolatedPool.init(cluster, nodeMap);
+
+        assertTrue(isolatedPool.canAdd(topology1));
+        isolatedPool.addTopology(topology1);
+        assertTrue(isolatedPool.canAdd(topology2));
+        isolatedPool.addTopology(topology2);
+
+        // nodes can be stolen from non-isolated tops in the pool
+        assertEquals(4, isolatedPool.slotsAvailable());
+        assertEquals(1, isolatedPool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(1, cluster.getAssignmentById("topology1").getSlots().size());
+        assertNull(cluster.getAssignmentById("topology2"));
+
+        isolatedPool.scheduleAsNeeded(new NodePool[]{freePool});
+        // We steal 2 nodes from the free pool to handle the extra (but still only 1 node for the non-isolated top)
+        assertEquals(4, isolatedPool.slotsAvailable());
+        assertEquals(1, isolatedPool.nodesAvailable());
+        assertEquals(2 * 4, freePool.slotsAvailable());
+        assertEquals(2, freePool.nodesAvailable());
+
+        Set<WorkerSlot> assignedSlots1 = cluster.getAssignmentById("topology1").getSlots();
+        // 4 slots on 1 machine
+        assertEquals(4, assignedSlots1.size());
+        assertEquals(1, getNodeIds(assignedSlots1).size());
+
+        Set<WorkerSlot> assignedSlots2 = cluster.getAssignmentById("topology2").getSlots();
+        // 4 slots on 2 machines
+        assertEquals(4, assignedSlots2.size());
+        assertEquals(2, getNodeIds(assignedSlots2).size());
+
+        NodePool.NodeAndSlotCounts nsCount1 = isolatedPool.getNodeAndSlotCountIfSlotsWereTaken(1);
+        NodePool.NodeAndSlotCounts nsCount3 = isolatedPool.getNodeAndSlotCountIfSlotsWereTaken(3);
+        NodePool.NodeAndSlotCounts nsCount4 = isolatedPool.getNodeAndSlotCountIfSlotsWereTaken(4);
+        NodePool.NodeAndSlotCounts nsCount5 = isolatedPool.getNodeAndSlotCountIfSlotsWereTaken(5);
+        assertEquals(1, nsCount1.nodes);
+        assertEquals(4, nsCount1.slots);
+        assertEquals(1, nsCount3.nodes);
+        assertEquals(4, nsCount3.slots);
+        assertEquals(1, nsCount4.nodes);
+        assertEquals(4, nsCount4.slots);
+        assertEquals(1, nsCount5.nodes); // Only 1 node can be stolen right now
+        assertEquals(4, nsCount5.slots);
+
+        Collection<Node> nodes = isolatedPool.takeNodesBySlots(3);
+        assertEquals(1, nodes.size());
+        assertEquals(4, Node.countFreeSlotsAlive(nodes));
+        assertEquals(4, Node.countTotalSlotsAlive(nodes));
+        assertEquals(0, isolatedPool.nodesAvailable());
+        assertEquals(0 * 4, isolatedPool.slotsAvailable());
+
+        Set<WorkerSlot> assignedSlots1After = cluster.getAssignmentById("topology1").getSlots();
+        // 0 slots on 0 machines (topology1 was evicted)
+        assertEquals(0, assignedSlots1After.size());
+        assertEquals(0, getNodeIds(assignedSlots1After).size());
+
+        Set<WorkerSlot> assignedSlots2After = cluster.getAssignmentById("topology2").getSlots();
+        // 4 slots on 2 machines
+        assertEquals(4, assignedSlots2After.size());
+        assertEquals(2, getNodeIds(assignedSlots2After).size());
+
+        Collection<Node> nodes2 = isolatedPool.takeNodes(3); // Cannot steal from the isolated scheduler
+        assertEquals(0, nodes2.size());
+        assertEquals(0, Node.countFreeSlotsAlive(nodes2));
+        assertEquals(0, Node.countTotalSlotsAlive(nodes2));
+        assertEquals(0, isolatedPool.nodesAvailable());
+        assertEquals(0, isolatedPool.slotsAvailable());
+
+        assertEquals("Scheduled Isolated on 1 Nodes", cluster.getStatusMap().get("topology1"));
+        assertEquals("Scheduled Isolated on 2 Nodes", cluster.getStatusMap().get("topology2"));
+    }
+
+    @Test
+    public void testIsolatedPoolComplex2() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+        FreePool freePool = new FreePool();
+        // like before but now we can only hold 2 nodes max. Don't go over
+        IsolatedPool isolatedPool = new IsolatedPool(2);
+        ExecutorDetails executor1 = ed(1);
+        ExecutorDetails executor2 = ed(2);
+        ExecutorDetails executor3 = ed(3);
+        ExecutorDetails executor4 = ed(4);
+        ExecutorDetails executor11 = ed(11);
+        ExecutorDetails executor12 = ed(12);
+        ExecutorDetails executor13 = ed(13);
+        ExecutorDetails executor14 = ed(14);
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        Map<ExecutorDetails, String> execMap1 = new HashMap<>();
+        execMap1.put(executor1, "spout1");
+        execMap1.put(executor2, "bolt1");
+        execMap1.put(executor3, "bolt2");
+        execMap1.put(executor4, "bolt4");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 4, execMap1, "user");
+
+        Map<String, Object> conf2 = new HashMap<>();
+        conf2.put(Config.TOPOLOGY_NAME, "topology-name-2");
+        conf2.put(Config.TOPOLOGY_ISOLATED_MACHINES, 2);
+        Map<ExecutorDetails, String> execMap2 = new HashMap<>();
+        execMap2.put(executor11, "spout11");
+        execMap2.put(executor12, "bolt12");
+        execMap2.put(executor13, "bolt13");
+        execMap2.put(executor14, "bolt14");
+        TopologyDetails topology2 = new TopologyDetails("topology2", conf2, new StormTopology(), 4, execMap2, "user");
+
+        Topologies topologies = new Topologies(toTopMap(topology1, topology2));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            topologies, new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        // assign one node so it is not in the pool
+        nodeMap.get("super0").assign("topology1", Arrays.asList(executor1), cluster);
+        freePool.init(cluster, nodeMap);
+        isolatedPool.init(cluster, nodeMap);
+
+        assertTrue(isolatedPool.canAdd(topology1));
+        isolatedPool.addTopology(topology1);
+        assertTrue(isolatedPool.canAdd(topology2));
+        isolatedPool.addTopology(topology2);
+
+        // nodes can be stolen from non-isolated tops in the pool
+        assertEquals(4, isolatedPool.slotsAvailable());
+        assertEquals(1, isolatedPool.nodesAvailable());
+        assertEquals(4 * 4, freePool.slotsAvailable());
+        assertEquals(4, freePool.nodesAvailable());
+        assertEquals(1, cluster.getAssignmentById("topology1").getSlots().size());
+        assertNull(cluster.getAssignmentById("topology2"));
+
+        isolatedPool.scheduleAsNeeded(new NodePool[]{freePool});
+        // We steal 1 node from the free pool and 1 from ourself to handle the extra
+        assertEquals(0, isolatedPool.slotsAvailable());
+        assertEquals(0, isolatedPool.nodesAvailable());
+        assertEquals(3 * 4, freePool.slotsAvailable());
+        assertEquals(3, freePool.nodesAvailable());
+
+        Set<WorkerSlot> assignedSlots1 = cluster.getAssignmentById("topology1").getSlots();
+        // 0 slots on 0 machines
+        assertEquals(0, assignedSlots1.size());
+        assertEquals(0, getNodeIds(assignedSlots1).size());
+
+        Set<WorkerSlot> assignedSlots2 = cluster.getAssignmentById("topology2").getSlots();
+        // 4 slots on 2 machines
+        assertEquals(4, assignedSlots2.size());
+        assertEquals(2, getNodeIds(assignedSlots2).size());
+
+        // The text can be off for a bit until we schedule again
+        isolatedPool.scheduleAsNeeded(new NodePool[]{freePool});
+        assertEquals("Max Nodes(2) for this user would be exceeded. 1 more nodes needed to run topology.",
+            cluster.getStatusMap().get("topology1"));
+        assertEquals("Scheduled Isolated on 2 Nodes", cluster.getStatusMap().get("topology2"));
+    }
+
+    @Test
+    public void testMultitenantScheduler() {
+        Map<String, SupervisorDetails> supers = genSupervisors(10);
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 4,
+            mkEdMap(new Object[]{"spout1", 0, 5}, new Object[]{"bolt1", 5, 10},
+                new Object[]{"bolt2", 10, 15}, new Object[]{"bolt3", 15, 20}), "userC");
+
+        Map<String, Object> conf2 = new HashMap<>();
+        conf2.put(Config.TOPOLOGY_NAME, "topology-name-2");
+        conf2.put(Config.TOPOLOGY_ISOLATED_MACHINES, 2);
+        TopologyDetails topology2 = new TopologyDetails("topology2", conf2, new StormTopology(), 4,
+            mkEdMap(new Object[]{"spout11", 0, 5}, new Object[]{"bolt12", 5, 6},
+                new Object[]{"bolt13", 6, 7}, new Object[]{"bolt14", 7, 10}), "userA");
+
+        Map<String, Object> conf3 = new HashMap<>();
+        conf3.put(Config.TOPOLOGY_NAME, "topology-name-3");
+        conf3.put(Config.TOPOLOGY_ISOLATED_MACHINES, 5);
+        TopologyDetails topology3 = new TopologyDetails("topology3", conf3, new StormTopology(), 10,
+            mkEdMap(new Object[]{"spout21", 0, 10}, new Object[]{"bolt22", 10, 20},
+                new Object[]{"bolt23", 20, 30}, new Object[]{"bolt24", 30, 40}), "userB");
+
+        Topologies topologies = new Topologies(toTopMap(topology1, topology2, topology3));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, new HashMap<>(),
+            topologies, new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        Map<String, Object> conf = new HashMap<>();
+        Map<String, Integer> userPools = new HashMap<>();
+        userPools.put("userA", 5);
+        userPools.put("userB", 5);
+        conf.put(DaemonConfig.MULTITENANT_SCHEDULER_USER_POOLS, userPools);
+
+        MultitenantScheduler scheduler = new MultitenantScheduler();
+        nodeMap.get("super0").assign("topology1", Arrays.asList(ed(1)), cluster);
+        nodeMap.get("super1").assign("topology2", Arrays.asList(ed(5)), cluster);
+        scheduler.prepare(conf, new StormMetricsRegistry());
+        try {
+            scheduler.schedule(topologies, cluster);
+
+            SchedulerAssignment assignment = cluster.getAssignmentById("topology1");
+            Set<WorkerSlot> assignedSlots = assignment.getSlots();
+            // 4 slots on 1 machine, all executors assigned
+            assertEquals(4, assignedSlots.size());
+            assertEquals(1, getNodeIds(assignedSlots).size());
+            assertEquals(20, assignment.getExecutors().size());
+
+            assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology1"));
+            assertEquals("Scheduled Isolated on 2 Nodes", cluster.getStatusMap().get("topology2"));
+            assertEquals("Scheduled Isolated on 5 Nodes", cluster.getStatusMap().get("topology3"));
+        } finally {
+            scheduler.cleanup();
+        }
+    }
+
+    @Test
+    public void testForceFreeSlotInBadState() {
+        Map<String, SupervisorDetails> supers = genSupervisors(1);
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 4,
+            mkEdMap(new Object[]{"spout1", 0, 5}, new Object[]{"bolt1", 5, 10},
+                new Object[]{"bolt2", 10, 15}, new Object[]{"bolt3", 15, 20}), "userC");
+
+        Map<ExecutorDetails, WorkerSlot> executorToSlot = new HashMap<>();
+        executorToSlot.put(new ExecutorDetails(0, 5), new WorkerSlot("super0", 1));
+        executorToSlot.put(new ExecutorDetails(5, 10), new WorkerSlot("super0", 20));
+        executorToSlot.put(new ExecutorDetails(10, 15), new WorkerSlot("super0", 1));
+        executorToSlot.put(new ExecutorDetails(15, 20), new WorkerSlot("super0", 1));
+        Map<String, SchedulerAssignmentImpl> existingAssignments = new HashMap<>();
+        existingAssignments.put("topology1", new SchedulerAssignmentImpl("topology1", executorToSlot, null, null));
+
+        Topologies topologies = new Topologies(toTopMap(topology1));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, existingAssignments,
+            topologies, new HashMap<>());
+        Map<String, Node> nodeMap = Node.getAllNodesFrom(cluster);
+
+        Map<String, Object> conf = new HashMap<>();
+        Map<String, Integer> userPools = new HashMap<>();
+        userPools.put("userA", 5);
+        userPools.put("userB", 5);
+        conf.put(DaemonConfig.MULTITENANT_SCHEDULER_USER_POOLS, userPools);
+
+        MultitenantScheduler scheduler = new MultitenantScheduler();
+        nodeMap.get("super0").assign("topology1", Arrays.asList(ed(1)), cluster);
+        scheduler.prepare(conf, new StormMetricsRegistry());
+        try {
+            scheduler.schedule(topologies, cluster);
+
+            SchedulerAssignment assignment = cluster.getAssignmentById("topology1");
+            Set<WorkerSlot> assignedSlots = assignment.getSlots();
+            // 4 slots on 1 machine, all executors assigned
+            assertEquals(4, assignedSlots.size());
+            assertEquals(1, getNodeIds(assignedSlots).size());
+
+            assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology1"));
+        } finally {
+            scheduler.cleanup();
+        }
+    }
+
+    @Test
+    public void testMultitenantSchedulerBadStartingState() {
+        Map<String, SupervisorDetails> supers = genSupervisors(5);
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 1,
+            mkEdMap(new Object[]{"spout1", 0, 1}), "userC");
+
+        Map<String, Object> conf2 = new HashMap<>();
+        conf2.put(Config.TOPOLOGY_NAME, "topology-name-2");
+        conf2.put(Config.TOPOLOGY_ISOLATED_MACHINES, 2);
+        TopologyDetails topology2 = new TopologyDetails("topology2", conf2, new StormTopology(), 2,
+            mkEdMap(new Object[]{"spout11", 1, 2}, new Object[]{"bolt11", 3, 4}), "userA");
+
+        Map<String, Object> conf3 = new HashMap<>();
+        conf3.put(Config.TOPOLOGY_NAME, "topology-name-3");
+        conf3.put(Config.TOPOLOGY_ISOLATED_MACHINES, 1);
+        TopologyDetails topology3 = new TopologyDetails("topology3", conf3, new StormTopology(), 1,
+            mkEdMap(new Object[]{"spout21", 2, 3}), "userB");
+
+        WorkerSlot workerSlotWithMultipleAssignments = new WorkerSlot("super1", 1);
+        Map<String, SchedulerAssignmentImpl> existingAssignments = new HashMap<>();
+        Map<ExecutorDetails, WorkerSlot> execToSlot2 = new HashMap<>();
+        execToSlot2.put(new ExecutorDetails(1, 1), workerSlotWithMultipleAssignments);
+        existingAssignments.put("topology2", new SchedulerAssignmentImpl("topology2", execToSlot2, null, null));
+        Map<ExecutorDetails, WorkerSlot> execToSlot3 = new HashMap<>();
+        execToSlot3.put(new ExecutorDetails(2, 2), workerSlotWithMultipleAssignments);
+        existingAssignments.put("topology3", new SchedulerAssignmentImpl("topology3", execToSlot3, null, null));
+
+        Topologies topologies = new Topologies(toTopMap(topology1, topology2, topology3));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, existingAssignments,
+            topologies, new HashMap<>());
+
+        Map<String, Object> conf = new HashMap<>();
+        Map<String, Integer> userPools = new HashMap<>();
+        userPools.put("userA", 2);
+        userPools.put("userB", 1);
+        conf.put(DaemonConfig.MULTITENANT_SCHEDULER_USER_POOLS, userPools);
+
+        MultitenantScheduler scheduler = new MultitenantScheduler();
+        scheduler.prepare(conf, new StormMetricsRegistry());
+        try {
+            scheduler.schedule(topologies, cluster);
+
+            SchedulerAssignment assignment = cluster.getAssignmentById("topology1");
+            Set<WorkerSlot> assignedSlots = assignment.getSlots();
+            assertEquals(1, assignedSlots.size());
+
+            assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology1"));
+            assertEquals("Scheduled Isolated on 2 Nodes", cluster.getStatusMap().get("topology2"));
+            assertEquals("Scheduled Isolated on 1 Nodes", cluster.getStatusMap().get("topology3"));
+        } finally {
+            scheduler.cleanup();
+        }
+    }
+
+    @Test
+    public void testExistingAssignmentSlotNotFoundInSupervisor() {
+        Map<String, SupervisorDetails> supers = genSupervisors(1);
+        int portNotReportedBySupervisor = 6;
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 1,
+            mkEdMap(new Object[]{"spout11", 0, 1}), "userA");
+
+        Map<ExecutorDetails, WorkerSlot> execToSlot = new HashMap<>();
+        execToSlot.put(new ExecutorDetails(0, 0), new WorkerSlot("super0", portNotReportedBySupervisor));
+        Map<String, SchedulerAssignmentImpl> existingAssignments = new HashMap<>();
+        existingAssignments.put("topology1", new SchedulerAssignmentImpl("topology1", execToSlot, null, null));
+
+        Topologies topologies = new Topologies(toTopMap(topology1));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, existingAssignments,
+            topologies, new HashMap<>());
+
+        Map<String, Object> conf = new HashMap<>();
+        MultitenantScheduler scheduler = new MultitenantScheduler();
+        scheduler.prepare(conf, new StormMetricsRegistry());
+        try {
+            scheduler.schedule(topologies, cluster);
+
+            SchedulerAssignment assignment = cluster.getAssignmentById("topology1");
+            Set<WorkerSlot> assignedSlots = assignment.getSlots();
+            assertEquals(1, assignedSlots.size());
+
+            assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology1"));
+        } finally {
+            scheduler.cleanup();
+        }
+    }
+
+    @Test
+    public void testExistingAssignmentSlotOnDeadSupervisor() {
+        Map<String, SupervisorDetails> supers = genSupervisors(1);
+        String deadSupervisor = "super1";
+        int portNotReportedBySupervisor = 6;
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 2,
+            mkEdMap(new Object[]{"spout11", 0, 1}, new Object[]{"bolt12", 1, 2}), "userA");
+
+        Map<String, Object> conf2 = new HashMap<>();
+        conf2.put(Config.TOPOLOGY_NAME, "topology-name-2");
+        TopologyDetails topology2 = new TopologyDetails("topology2", conf2, new StormTopology(), 2,
+            mkEdMap(new Object[]{"spout21", 4, 5}, new Object[]{"bolt22", 5, 6}), "userA");
+
+        WorkerSlot workerSlotWithMultipleAssignments = new WorkerSlot(deadSupervisor, 1);
+        Map<String, SchedulerAssignmentImpl> existingAssignments = new HashMap<>();
+
+        Map<ExecutorDetails, WorkerSlot> execToSlot1 = new HashMap<>();
+        execToSlot1.put(new ExecutorDetails(0, 0), workerSlotWithMultipleAssignments);
+        execToSlot1.put(new ExecutorDetails(1, 1), new WorkerSlot(deadSupervisor, 3));
+        existingAssignments.put("topology1", new SchedulerAssignmentImpl("topology1", execToSlot1, null, null));
+
+        Map<ExecutorDetails, WorkerSlot> execToSlot2 = new HashMap<>();
+        execToSlot2.put(new ExecutorDetails(4, 4), workerSlotWithMultipleAssignments);
+        execToSlot2.put(new ExecutorDetails(5, 5), new WorkerSlot(deadSupervisor, portNotReportedBySupervisor));
+        existingAssignments.put("topology2", new SchedulerAssignmentImpl("topology2", execToSlot2, null, null));
+
+        Topologies topologies = new Topologies(toTopMap(topology1, topology2));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, existingAssignments,
+            topologies, new HashMap<>());
+
+        Map<String, Object> conf = new HashMap<>();
+        MultitenantScheduler scheduler = new MultitenantScheduler();
+        scheduler.prepare(conf, new StormMetricsRegistry());
+        try {
+            scheduler.schedule(topologies, cluster);
+
+            SchedulerAssignment assignment1 = cluster.getAssignmentById("topology1");
+            assertEquals(2, assignment1.getSlots().size());
+            assertEquals(2, assignment1.getExecutors().size());
+            assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology1"));
+
+            SchedulerAssignment assignment2 = cluster.getAssignmentById("topology2");
+            assertEquals(2, assignment2.getSlots().size());
+            assertEquals(2, assignment2.getExecutors().size());
+            assertEquals("Fully Scheduled", cluster.getStatusMap().get("topology2"));
+        } finally {
+            scheduler.cleanup();
+        }
+    }
+
+    @Test
+    public void testIsolatedPoolSchedulingWithNodesWithDifferentNumberOfSlots() {
+        SupervisorDetails super1 = new SupervisorDetails("super1", "host2", Collections.emptyList(),
+            Arrays.asList(1, 2, 3, 4, 5));
+        SupervisorDetails super2 = new SupervisorDetails("super2", "host2", Collections.emptyList(),
+            Arrays.asList(1, 2));
+        Map<String, SupervisorDetails> supers = new HashMap<>();
+        supers.put("super1", super1);
+        supers.put("super2", super2);
+
+        Map<String, Object> conf1 = new HashMap<>();
+        conf1.put(Config.TOPOLOGY_NAME, "topology-name-1");
+        conf1.put(Config.TOPOLOGY_ISOLATED_MACHINES, 1);
+        TopologyDetails topology1 = new TopologyDetails("topology1", conf1, new StormTopology(), 7,
+            mkEdMap(new Object[]{"spout21", 0, 7}), "userA");
+
+        Map<ExecutorDetails, WorkerSlot> execToSlot = new HashMap<>();
+        execToSlot.put(new ExecutorDetails(0, 0), new WorkerSlot("super1", 1));
+        execToSlot.put(new ExecutorDetails(1, 1), new WorkerSlot("super1", 2));
+        execToSlot.put(new ExecutorDetails(2, 2), new WorkerSlot("super1", 3));
+        execToSlot.put(new ExecutorDetails(3, 3), new WorkerSlot("super1", 4));
+        execToSlot.put(new ExecutorDetails(4, 4), new WorkerSlot("super2", 1));
+        execToSlot.put(new ExecutorDetails(5, 5), new WorkerSlot("super2", 2));
+        Map<String, SchedulerAssignmentImpl> existingAssignments = new HashMap<>();
+        existingAssignments.put("topology1", new SchedulerAssignmentImpl("topology1", execToSlot, null, null));
+
+        Topologies topologies = new Topologies(toTopMap(topology1));
+        Cluster cluster = new Cluster(new StandaloneINimbus(), newResourceMetrics(), supers, existingAssignments,
+            topologies, new HashMap<>());
+
+        Map<String, Object> conf = new HashMap<>();
+        Map<String, Integer> userPools = new HashMap<>();
+        userPools.put("userA", 2);
+        conf.put(DaemonConfig.MULTITENANT_SCHEDULER_USER_POOLS, userPools);
+
+        MultitenantScheduler scheduler = new MultitenantScheduler();
+        scheduler.prepare(conf, new StormMetricsRegistry());
+        try {
+            scheduler.schedule(topologies, cluster);
+        } finally {
+            scheduler.cleanup();
+        }
+        assertEquals("Scheduled Isolated on 2 Nodes", cluster.getStatusMap().get("topology1"));
+    }
+}


### PR DESCRIPTION
 ## Summary                                    

See #8445                                                                                                                                                                                 

  Second phase of porting Clojure tests to Java. Ports 21 test functions from 2                                                                                                                                                               
  Clojure files to Java/JUnit 5.
                                                                                                                                                                                                                                              
  ## Changes                                                                                                                                                                                                                                

  | Clojure source | Java target | Tests |                                                                                                                                                                                                    
  |---|---|---|
  | `storm-core/test/clj/org/apache/storm/scheduler_test.clj` | `storm-server/.../scheduler/SchedulerModelTest.java` | 4 |                                                                                                                    
  | `storm-core/test/clj/org/apache/storm/scheduler/multitenant_scheduler_test.clj` | `storm-server/.../scheduler/multitenant/MultitenantSchedulerTest.java` | 17 |                                                                         

  ### SchedulerModelTest (4 tests)                                                                                                                                                                                                            
   
  - `testSupervisorDetails` — SchedulerAssignmentImpl assign/unassign/query                                                                                                                                                                   
  - `testTopologies` — TopologyDetails.selectExecutorToComponent, Topologies.getById/getByName                                                                                                                                              
  - `testCluster` — comprehensive Cluster class coverage (scheduling, ports, slots, assign, free)                                                                                                                                             
  - `testSortSlots` — EvenScheduler.sortSlots round-robin ordering
                                                                                                                                                                                                                                              
  ### MultitenantSchedulerTest (17 tests)                                                                                                                                                                                                   
                                                                                                                                                                                                                                              
  - Node, FreePool, DefaultPool, IsolatedPool unit tests                                                                                                                                                                                      
  - End-to-end MultitenantScheduler tests with user pools
  - Edge cases: bad starting state, duplicate slot assignments, dead supervisors,                                                                                                                                                             
    slots not reported by supervisor, nodes with different slot counts                                                                                                                                                                        
                                                                                                                                                                                                                                              
  ## Context                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                              
  Phase 2 of 8 in the Clojure-to-Java test port. The `multitenant_scheduler_test`                                                                                                                                                             
  had no Java equivalent — this is entirely new coverage for the multitenant scheduler.
  Clojure files are not deleted yet (cleanup happens in Phase 8).                                                                                                                                                                             
                                                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                                                                
                                                                                                                                                                                                                                            
  - [x] `mvn test -pl storm-server -Dtest="SchedulerModelTest,MultitenantSchedulerTest"` — 21 tests, all pass                                                                                                                                 
   
  🤖 Generated with [Claude Code](https://claude.com/claude-code)                