### PR TITLE
docs: fix 'recieved' -> 'received' typo in IAutoCredentials Javadoc

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/IAutoCredentials.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/IAutoCredentials.java
@@ -39,7 +39,7 @@ public interface IAutoCredentials {
 
 
     /**
-     * Called to update the subject on the worker side when new credentials are recieved. This means that populateSubject has already been
+     * Called to update the subject on the worker side when new credentials are received. This means that populateSubject has already been
      * called on this subject.
      *
      * @param subject     the subject to optionally put credentials in.


### PR DESCRIPTION
Javadoc-only typo fix in `storm-client/src/jvm/org/apache/storm/security/auth/IAutoCredentials.java` line 42:
`credentials are recieved` → `credentials are received`.

No code change, no behavior change — this is only the English word spelling in a single Javadoc sentence. CI skipping this is expected for doc-only changes.