### PR TITLE
docs: fix 'occured' -> 'occurred' in LocallyCachedBlob Javadoc

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedBlob.java
+++ b/storm-server/src/main/java/org/apache/storm/localizer/LocallyCachedBlob.java
@@ -159,7 +159,7 @@ public abstract class LocallyCachedBlob {
     protected abstract void commitNewVersion(long version) throws IOException;
 
     /**
-     * Clean up any temporary files.  This will be called after updating a blob, either successfully or if an error has occured.
+     * Clean up any temporary files.  This will be called after updating a blob, either successfully or if an error has occurred.
      * The goal is to find any files that may be left over and remove them so space is not leaked.
      * PRECONDITION: this can only be called with a lock on this instance held.
      */


### PR DESCRIPTION
Trivial spelling fix on the `cleanup()` Javadoc in `storm-server/.../localizer/LocallyCachedBlob.java`:

`This will be called after updating a blob, either successfully or if an error has occurred.`

No functional changes.