### PR TITLE
storm-core: fix 'seperate' -> 'separate' in configuration.h comment

### DIFF
--- a/storm-core/src/native/worker-launcher/impl/configuration.h
+++ b/storm-core/src/native/worker-launcher/impl/configuration.h
@@ -31,7 +31,7 @@ void read_config(const char* config_file);
 char *get_value(const char* key);
 
 //function to return array of values pointing to the key. Values are
-//comma seperated strings.
+//comma separated strings.
 char ** get_values(const char* key);
 
 /**


### PR DESCRIPTION
Trivial spelling fix in a comment inside `storm-core/src/native/worker-launcher/impl/configuration.h`.