### PR TITLE
flux: fix 'recieveed' -> 'received' in LogInfoBolt Javadoc

### DIFF
--- a/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/bolts/LogInfoBolt.java
+++ b/flux/flux-wrappers/src/main/java/org/apache/storm/flux/wrappers/bolts/LogInfoBolt.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Simple bolt that does nothing other than LOG.info() every tuple recieveed.
+ * Simple bolt that does nothing other than LOG.info() every tuple received.
  *
  */
 public class LogInfoBolt extends BaseBasicBolt {


### PR DESCRIPTION
Trivial spelling fix on the class Javadoc of `flux-wrappers/.../LogInfoBolt.java`:

> Simple bolt that does nothing other than LOG.info() every tuple received.