### PR TITLE
storm-submit-tools: modernize Java code, no API surface changes

### DIFF
--- a/storm-submit-tools/src/main/java/org/apache/storm/submit/command/DependencyResolverMain.java
+++ b/storm-submit-tools/src/main/java/org/apache/storm/submit/command/DependencyResolverMain.java
@@ -19,12 +19,11 @@
 package org.apache.storm.submit.command;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 
 import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -33,6 +32,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import net.minidev.json.JSONValue;
 
@@ -70,7 +70,7 @@ public class DependencyResolverMain {
      * @throws ParseException If there's parsing error on option parse.
      * @throws MalformedURLException If proxy URL is malformed.
      */
-    public static void main(String[] args) throws ParseException, MalformedURLException {
+    public static void main(String[] args) throws ParseException, MalformedURLException, URISyntaxException {
         Options options = buildOptions();
         CommandLineParser parser = new DefaultParser();
         CommandLine commandLine = parser.parse(options, args);
@@ -117,26 +117,19 @@ public class DependencyResolverMain {
 
             List<ArtifactResult> artifactResults = resolver.resolve(dependencies);
 
-            Iterable<ArtifactResult> missingArtifacts = filterMissingArtifacts(artifactResults);
-            if (missingArtifacts.iterator().hasNext()) {
+            List<ArtifactResult> missingArtifacts = artifactResults.stream()
+                    .filter(ArtifactResult::isMissing)
+                    .collect(Collectors.toList());
+            if (!missingArtifacts.isEmpty()) {
                 printMissingArtifactsToSysErr(missingArtifacts);
                 throw new RuntimeException("Some artifacts are not resolved");
             }
 
             System.out.println(JSONValue.toJSONString(transformArtifactResultToArtifactToPaths(artifactResults)));
             System.out.flush();
-        } catch (Throwable e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private static Iterable<ArtifactResult> filterMissingArtifacts(List<ArtifactResult> artifactResults) {
-        return Iterables.filter(artifactResults, new Predicate<ArtifactResult>() {
-            @Override
-            public boolean apply(ArtifactResult artifactResult) {
-                return artifactResult.isMissing();
-            }
-        });
     }
 
     private static void printMissingArtifactsToSysErr(Iterable<ArtifactResult> missingArtifacts) {
@@ -173,14 +166,15 @@ public class DependencyResolverMain {
         return remoteRepositories;
     }
 
-    private static Proxy parseProxyArg(String proxyUrl, String proxyUsername, String proxyPassword) throws MalformedURLException {
-        URL url = new URL(proxyUrl);
+    private static Proxy parseProxyArg(String proxyUrl, String proxyUsername, String proxyPassword)
+            throws MalformedURLException, URISyntaxException {
+        URI uri = new URI(proxyUrl);
         if (StringUtils.isNotEmpty(proxyUsername) && StringUtils.isNotEmpty(proxyPassword)) {
             AuthenticationBuilder authBuilder = new AuthenticationBuilder();
             authBuilder.addUsername(proxyUsername).addPassword(proxyPassword);
-            return new Proxy(url.getProtocol(), url.getHost(), url.getPort(), authBuilder.build());
+            return new Proxy(uri.getScheme(), uri.getHost(), uri.getPort(), authBuilder.build());
         } else {
-            return new Proxy(url.getProtocol(), url.getHost(), url.getPort());
+            return new Proxy(uri.getScheme(), uri.getHost(), uri.getPort());
         }
     }
 

--- a/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/Booter.java
+++ b/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/Booter.java
@@ -27,10 +27,10 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.RemoteRepository;
 
-/**
- * Manage mvn repository.
- */
-public class Booter {
+public final class Booter {
+    private Booter() {
+    }
+
     public static RepositorySystem newRepositorySystem() {
         return RepositorySystemFactory.newRepositorySystem();
     }
@@ -38,20 +38,12 @@ public class Booter {
     public static RepositorySystemSession newRepositorySystemSession(
         RepositorySystem system, String localRepoPath) {
         DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
-
-        LocalRepository localRepo =
-                new LocalRepository(new File(localRepoPath).getAbsolutePath());
+        LocalRepository localRepo = new LocalRepository(new File(localRepoPath).getAbsolutePath());
         session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
-
         return session;
     }
 
     public static RemoteRepository newCentralRepository() {
         return new RemoteRepository.Builder("central", "default", "https://repo1.maven.org/maven2/").build();
-    }
-
-    public static RemoteRepository newLocalRepository() {
-        return new RemoteRepository.Builder("local",
-                "default", "file://" + System.getProperty("user.home") + "/.m2/repository").build();
     }
 }

--- a/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/DependencyResolver.java
+++ b/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/DependencyResolver.java
@@ -108,15 +108,12 @@ public class DependencyResolver {
     public List<ArtifactResult> resolve(List<Dependency> dependencies) throws
             DependencyResolutionException, ArtifactResolutionException {
 
-        if (dependencies.size() == 0) {
-            return Collections.EMPTY_LIST;
+        if (dependencies.isEmpty()) {
+            return Collections.emptyList();
         }
 
         CollectRequest collectRequest = new CollectRequest();
-        collectRequest.setRoot(dependencies.get(0));
-        for (int idx = 1; idx < dependencies.size(); idx++) {
-            collectRequest.addDependency(dependencies.get(idx));
-        }
+        collectRequest.setDependencies(dependencies);
 
         for (RemoteRepository repository : remoteRepositories) {
             collectRequest.addRepository(repository);

--- a/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/RepositorySystemFactory.java
+++ b/storm-submit-tools/src/main/java/org/apache/storm/submit/dependency/RepositorySystemFactory.java
@@ -28,10 +28,10 @@ import org.eclipse.aether.spi.connector.transport.TransporterFactory;
 import org.eclipse.aether.transport.file.FileTransporterFactory;
 import org.eclipse.aether.transport.http.HttpTransporterFactory;
 
-/**
- * Get maven repository instance.
- */
-public class RepositorySystemFactory {
+public final class RepositorySystemFactory {
+    private RepositorySystemFactory() {
+    }
+
     public static RepositorySystem newRepositorySystem() {
         DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
         locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
@@ -47,5 +47,4 @@ public class RepositorySystemFactory {
 
         return locator.getService(RepositorySystem.class);
     }
-
 }


### PR DESCRIPTION
Safe modernization of the dependency resolver tool, keeping maven-resolver 1.9.27 and the existing transport-http stack:

- Drop Guava Iterables.filter/Predicate for Stream API + method ref
- Replace deprecated new URL(String) with URI/URI.toURL (URL ctor is flagged for removal in JDK 20+)
- catch (Throwable) -> catch (Exception); let Errors propagate
- DependencyResolver: setRoot(deps[0])+addDependency(rest) was a subtle bug (the first dep was promoted to "root" of the resolution which alters scope/exclusion handling); replaced with setDependencies(deps)
- Collections.EMPTY_LIST -> Collections.emptyList(); size()==0 -> isEmpty()
- Drop unused Booter.newLocalRepository()
- Make RepositorySystemFactory and Booter final + private ctor

Note on a possible Resolver 2.x / supplier-pattern upgrade: the maven-resolver-supplier artifact in the 2.x line is still alpha (last release 2.0.0-alpha-8); Maven 4 is at rc-5 with a new org.apache.maven.api.Session abstraction that is a much larger code change. Keeping the existing DefaultServiceLocator path until that ecosystem stabilizes; the Java cleanups here apply regardless of which supplier path we eventually pick.
