### PR TITLE
fix(topology_lag): Kafka Topology Lag breaking when no offsets are commited for topic/partition

### DIFF
--- a/external/storm-kafka-monitor/pom.xml
+++ b/external/storm-kafka-monitor/pom.xml
@@ -65,6 +65,18 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <!-- version will be inherited -->
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtil.java
+++ b/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtil.java
@@ -19,9 +19,8 @@
 package org.apache.storm.kafka.monitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -69,10 +68,10 @@ public class KafkaOffsetLagUtil {
                 printUsageAndExit(options, OPTION_GROUP_ID_LONG + " and " + OPTION_BOOTSTRAP_BROKERS_LONG + " are required");
             }
             NewKafkaSpoutOffsetQuery newKafkaSpoutOffsetQuery =
-                new NewKafkaSpoutOffsetQuery(commandLine.getOptionValue(OPTION_TOPIC_LONG),
-                    commandLine.getOptionValue(OPTION_BOOTSTRAP_BROKERS_LONG),
-                    commandLine.getOptionValue(OPTION_GROUP_ID_LONG), securityProtocol, saslMechanism,
-                    commandLine.getOptionValue(OPTION_CONSUMER_CONFIG_LONG));
+                    new NewKafkaSpoutOffsetQuery(commandLine.getOptionValue(OPTION_TOPIC_LONG),
+                            commandLine.getOptionValue(OPTION_BOOTSTRAP_BROKERS_LONG),
+                            commandLine.getOptionValue(OPTION_GROUP_ID_LONG), securityProtocol, saslMechanism,
+                            commandLine.getOptionValue(OPTION_CONSUMER_CONFIG_LONG));
             List<KafkaOffsetLagResult> results = getOffsetLags(newKafkaSpoutOffsetQuery);
 
             Map<String, Map<Integer, KafkaPartitionOffsetLag>> keyedResult = keyByTopicAndPartition(results);
@@ -84,7 +83,7 @@ public class KafkaOffsetLagUtil {
     }
 
     private static Map<String, Map<Integer, KafkaPartitionOffsetLag>> keyByTopicAndPartition(
-        List<KafkaOffsetLagResult> results) {
+            List<KafkaOffsetLagResult> results) {
         Map<String, Map<Integer, KafkaPartitionOffsetLag>> resultKeyedByTopic = new HashMap<>();
 
         for (KafkaOffsetLagResult result : results) {
@@ -96,7 +95,7 @@ public class KafkaOffsetLagUtil {
             }
 
             topicResultKeyedByPartition.put(result.getPartition(),
-                                            new KafkaPartitionOffsetLag(result.getConsumerCommittedOffset(), result.getLogHeadOffset()));
+                    new KafkaPartitionOffsetLag(result.getConsumerCommittedOffset(), result.getLogHeadOffset()));
         }
 
         return resultKeyedByTopic;
@@ -114,7 +113,7 @@ public class KafkaOffsetLagUtil {
         options.addOption(OPTION_TOPIC_SHORT, OPTION_TOPIC_LONG,
                 true,
                 "REQUIRED Topics (comma separated list) for fetching log head and spout committed "
-                      + "offset");
+                        + "offset");
         options.addOption(OPTION_BOOTSTRAP_BROKERS_SHORT, OPTION_BOOTSTRAP_BROKERS_LONG,
                 true,
                 "Comma separated list of bootstrap broker hosts for new "
@@ -137,6 +136,7 @@ public class KafkaOffsetLagUtil {
 
     /**
      * Get offset lags.
+     *
      * @param newKafkaSpoutOffsetQuery represents the information needed to query kafka for log head and spout offsets
      * @return log head offset, spout offset and lag for each partition
      */
@@ -172,12 +172,13 @@ public class KafkaOffsetLagUtil {
                 }
             }
             consumer.assign(topicPartitionList);
+            Map<TopicPartition, OffsetAndMetadata> committedOffsets = consumer.committed(new HashSet<>(topicPartitionList));
+            consumer.seekToEnd(topicPartitionList);
             for (TopicPartition topicPartition : topicPartitionList) {
-                Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed(Collections.singleton(topicPartition));
-                long committedOffset = resolveCommittedOffset(offsetAndMetadata, topicPartition);
-                consumer.seekToEnd(toArrayList(topicPartition));
+                OffsetAndMetadata partitionOffset = committedOffsets.get(topicPartition);
+                long committedOffset = partitionOffset != null ? partitionOffset.offset() : -1;
                 result.add(new KafkaOffsetLagResult(topicPartition.topic(), topicPartition.partition(), committedOffset,
-                                                    consumer.position(topicPartition)));
+                        consumer.position(topicPartition)));
             }
         } finally {
             if (consumer != null) {
@@ -185,24 +186,6 @@ public class KafkaOffsetLagUtil {
             }
         }
         return result;
-    }
-
-    /**
-     * Read the committed offset for a partition out of the map returned by
-     * {@link org.apache.kafka.clients.consumer.KafkaConsumer#committed(java.util.Set)}.
-     * Returns {@code -1} when no offset is committed (the map's value for the partition is null).
-     */
-    private static long resolveCommittedOffset(Map<TopicPartition, OffsetAndMetadata> committedOffsets, TopicPartition topicPartition) {
-        OffsetAndMetadata partitionOffset = committedOffsets.get(topicPartition);
-        return partitionOffset != null ? partitionOffset.offset() : -1;
-    }
-
-    private static Collection<TopicPartition> toArrayList(final TopicPartition tp) {
-        return new ArrayList<TopicPartition>(1) {
-            {
-                add(tp);
-            }
-        };
     }
 
 }

--- a/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtil.java
+++ b/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtil.java
@@ -174,7 +174,7 @@ public class KafkaOffsetLagUtil {
             consumer.assign(topicPartitionList);
             for (TopicPartition topicPartition : topicPartitionList) {
                 Map<TopicPartition, OffsetAndMetadata> offsetAndMetadata = consumer.committed(Collections.singleton(topicPartition));
-                long committedOffset = offsetAndMetadata != null ? offsetAndMetadata.get(topicPartition).offset() : -1;
+                long committedOffset = resolveCommittedOffset(offsetAndMetadata, topicPartition);
                 consumer.seekToEnd(toArrayList(topicPartition));
                 result.add(new KafkaOffsetLagResult(topicPartition.topic(), topicPartition.partition(), committedOffset,
                                                     consumer.position(topicPartition)));
@@ -185,6 +185,16 @@ public class KafkaOffsetLagUtil {
             }
         }
         return result;
+    }
+
+    /**
+     * Read the committed offset for a partition out of the map returned by
+     * {@link org.apache.kafka.clients.consumer.KafkaConsumer#committed(java.util.Set)}.
+     * Returns {@code -1} when no offset is committed (the map's value for the partition is null).
+     */
+    private static long resolveCommittedOffset(Map<TopicPartition, OffsetAndMetadata> committedOffsets, TopicPartition topicPartition) {
+        OffsetAndMetadata partitionOffset = committedOffsets.get(topicPartition);
+        return partitionOffset != null ? partitionOffset.offset() : -1;
     }
 
     private static Collection<TopicPartition> toArrayList(final TopicPartition tp) {

--- a/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtil.java
+++ b/external/storm-kafka-monitor/src/main/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtil.java
@@ -68,10 +68,10 @@ public class KafkaOffsetLagUtil {
                 printUsageAndExit(options, OPTION_GROUP_ID_LONG + " and " + OPTION_BOOTSTRAP_BROKERS_LONG + " are required");
             }
             NewKafkaSpoutOffsetQuery newKafkaSpoutOffsetQuery =
-                    new NewKafkaSpoutOffsetQuery(commandLine.getOptionValue(OPTION_TOPIC_LONG),
-                            commandLine.getOptionValue(OPTION_BOOTSTRAP_BROKERS_LONG),
-                            commandLine.getOptionValue(OPTION_GROUP_ID_LONG), securityProtocol, saslMechanism,
-                            commandLine.getOptionValue(OPTION_CONSUMER_CONFIG_LONG));
+                new NewKafkaSpoutOffsetQuery(commandLine.getOptionValue(OPTION_TOPIC_LONG),
+                    commandLine.getOptionValue(OPTION_BOOTSTRAP_BROKERS_LONG),
+                    commandLine.getOptionValue(OPTION_GROUP_ID_LONG), securityProtocol, saslMechanism,
+                    commandLine.getOptionValue(OPTION_CONSUMER_CONFIG_LONG));
             List<KafkaOffsetLagResult> results = getOffsetLags(newKafkaSpoutOffsetQuery);
 
             Map<String, Map<Integer, KafkaPartitionOffsetLag>> keyedResult = keyByTopicAndPartition(results);
@@ -83,7 +83,7 @@ public class KafkaOffsetLagUtil {
     }
 
     private static Map<String, Map<Integer, KafkaPartitionOffsetLag>> keyByTopicAndPartition(
-            List<KafkaOffsetLagResult> results) {
+        List<KafkaOffsetLagResult> results) {
         Map<String, Map<Integer, KafkaPartitionOffsetLag>> resultKeyedByTopic = new HashMap<>();
 
         for (KafkaOffsetLagResult result : results) {
@@ -95,7 +95,7 @@ public class KafkaOffsetLagUtil {
             }
 
             topicResultKeyedByPartition.put(result.getPartition(),
-                    new KafkaPartitionOffsetLag(result.getConsumerCommittedOffset(), result.getLogHeadOffset()));
+                                            new KafkaPartitionOffsetLag(result.getConsumerCommittedOffset(), result.getLogHeadOffset()));
         }
 
         return resultKeyedByTopic;
@@ -113,7 +113,7 @@ public class KafkaOffsetLagUtil {
         options.addOption(OPTION_TOPIC_SHORT, OPTION_TOPIC_LONG,
                 true,
                 "REQUIRED Topics (comma separated list) for fetching log head and spout committed "
-                        + "offset");
+                      + "offset");
         options.addOption(OPTION_BOOTSTRAP_BROKERS_SHORT, OPTION_BOOTSTRAP_BROKERS_LONG,
                 true,
                 "Comma separated list of bootstrap broker hosts for new "
@@ -136,7 +136,6 @@ public class KafkaOffsetLagUtil {
 
     /**
      * Get offset lags.
-     *
      * @param newKafkaSpoutOffsetQuery represents the information needed to query kafka for log head and spout offsets
      * @return log head offset, spout offset and lag for each partition
      */

--- a/external/storm-kafka-monitor/src/test/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtilTest.java
+++ b/external/storm-kafka-monitor/src/test/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtilTest.java
@@ -42,7 +42,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
-@Testcontainers
+/**
+ * Integration test — requires a Docker daemon. Skipped automatically when Docker is unavailable.
+ */
+@Testcontainers(disabledWithoutDocker = true)
 class KafkaOffsetLagUtilTest {
 
     private static final String TOPIC = "lag-test-topic";

--- a/external/storm-kafka-monitor/src/test/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtilTest.java
+++ b/external/storm-kafka-monitor/src/test/java/org/apache/storm/kafka/monitor/KafkaOffsetLagUtilTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.kafka.monitor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class KafkaOffsetLagUtilTest {
+
+    private static final String TOPIC = "lag-test-topic";
+    private static final String GROUP_ID = "lag-test-group";
+    private static final int PARTITIONS = 2;
+    private static final long COMMITTED_OFFSET_PARTITION_0 = 7L;
+
+    @Container
+    private static final KafkaContainer KAFKA = new KafkaContainer(DockerImageName.parse("apache/kafka:4.0.0"));
+
+    @BeforeAll
+    static void seedKafka() throws Exception {
+        Properties adminProps = new Properties();
+        adminProps.put("bootstrap.servers", KAFKA.getBootstrapServers());
+        try (Admin admin = Admin.create(adminProps)) {
+            admin.createTopics(Collections.singletonList(new NewTopic(TOPIC, PARTITIONS, (short) 1))).all().get();
+        }
+        produceOneRecordToEachPartition();
+        commitOffsetForPartitionZeroOnly();
+    }
+
+    @Test
+    void getOffsetLagsReportsCommittedOffsetForCommittedPartitionsAndMinusOneForUncommittedPartitions() throws Exception {
+        NewKafkaSpoutOffsetQuery query = new NewKafkaSpoutOffsetQuery(
+                TOPIC, KAFKA.getBootstrapServers(), GROUP_ID, null, null, null);
+
+        List<KafkaOffsetLagResult> results = KafkaOffsetLagUtil.getOffsetLags(query);
+
+        assertEquals(PARTITIONS, results.size(), "Expected one result per partition");
+        Map<Integer, Long> committedByPartition = new HashMap<>();
+        for (KafkaOffsetLagResult r : results) {
+            committedByPartition.put(r.getPartition(), r.getConsumerCommittedOffset());
+        }
+        assertNotNull(committedByPartition.get(0));
+        assertEquals(COMMITTED_OFFSET_PARTITION_0, committedByPartition.get(0),
+                "Partition with a committed offset should report it");
+        // Regression assertion: pre-fix this NPE'd inside the monitor and surfaced as ClassCastException upstream.
+        assertEquals(-1L, committedByPartition.get(1),
+                "Partition with no committed offset should report -1, not throw");
+    }
+
+    private static void produceOneRecordToEachPartition() {
+        Properties producerProps = new Properties();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps)) {
+            for (int p = 0; p < PARTITIONS; p++) {
+                producer.send(new ProducerRecord<>(TOPIC, p, "k", "v"));
+            }
+            producer.flush();
+        }
+    }
+
+    private static void commitOffsetForPartitionZeroOnly() {
+        Properties consumerProps = new Properties();
+        consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.getBootstrapServers());
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+        consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps)) {
+            TopicPartition p0 = new TopicPartition(TOPIC, 0);
+            consumer.commitSync(Collections.singletonMap(p0, new OffsetAndMetadata(COMMITTED_OFFSET_PARTITION_0)));
+        }
+    }
+}

--- a/storm-core/src/jvm/org/apache/storm/utils/TopologySpoutLag.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/TopologySpoutLag.java
@@ -177,9 +177,11 @@ public class TopologySpoutLag {
                         } else {
                             // json-smart parses unquoted plain text leniently as a String, so we can land here
                             // when the monitor printed an error message instead of JSON; surface it as the error.
+                            LOGGER.debug("Monitor returned non-JSON output, treating as error: {}", resultFromMonitor);
                             errorMsg = resultFromMonitor;
                         }
                     } catch (ParseException e) {
+                        LOGGER.debug("JSON parsing failed, assuming message as error message: {}", resultFromMonitor);
                         errorMsg = resultFromMonitor;
                     }
                 } finally {

--- a/storm-core/src/jvm/org/apache/storm/utils/TopologySpoutLag.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/TopologySpoutLag.java
@@ -170,9 +170,16 @@ public class TopologySpoutLag {
                 try {
                     String resultFromMonitor = new ShellCommandRunnerImpl().execCommand(commands.toArray(new String[0]));
 
-                    result = parseMonitorOutput(resultFromMonitor);
-                    if (result == null) {
-                        // parsing failed or did not yield a Map -> treat output as error message
+                    try {
+                        Object parsed = JSONValue.parseWithException(resultFromMonitor);
+                        if (parsed instanceof Map) {
+                            result = (Map<String, Object>) parsed;
+                        } else {
+                            // json-smart parses unquoted plain text leniently as a String, so we can land here
+                            // when the monitor printed an error message instead of JSON; surface it as the error.
+                            errorMsg = resultFromMonitor;
+                        }
+                    } catch (ParseException e) {
                         errorMsg = resultFromMonitor;
                     }
                 } finally {
@@ -198,27 +205,5 @@ public class TopologySpoutLag {
 
     private static Map<String, Object> getLagResultForNewKafkaSpout(String spoutId, SpoutSpec spoutSpec) throws IOException {
         return getLagResultForKafka(spoutId, spoutSpec);
-    }
-
-    /**
-     * Parse the stdout from {@code storm-kafka-monitor}. Returns the parsed JSON map on success,
-     * or {@code null} when the output is not parseable as a JSON object — which happens when the
-     * monitor printed a plaintext error string (json-smart parses unquoted text leniently as a
-     * String rather than throwing). The caller treats {@code null} as "monitor failed; surface
-     * the raw stdout as the error message".
-     */
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> parseMonitorOutput(String resultFromMonitor) {
-        try {
-            Object parsed = JSONValue.parseWithException(resultFromMonitor);
-            if (parsed instanceof Map) {
-                return (Map<String, Object>) parsed;
-            }
-            LOGGER.debug("JSON parsing did not yield a Map, assuming message as error message: {}", resultFromMonitor);
-            return null;
-        } catch (ParseException e) {
-            LOGGER.debug("JSON parsing failed, assuming message as error message: {}", resultFromMonitor);
-            return null;
-        }
     }
 }

--- a/storm-core/src/jvm/org/apache/storm/utils/TopologySpoutLag.java
+++ b/storm-core/src/jvm/org/apache/storm/utils/TopologySpoutLag.java
@@ -170,11 +170,9 @@ public class TopologySpoutLag {
                 try {
                     String resultFromMonitor = new ShellCommandRunnerImpl().execCommand(commands.toArray(new String[0]));
 
-                    try {
-                        result = (Map<String, Object>) JSONValue.parseWithException(resultFromMonitor);
-                    } catch (ParseException e) {
-                        LOGGER.debug("JSON parsing failed, assuming message as error message: {}", resultFromMonitor);
-                        // json parsing fail -> error received
+                    result = parseMonitorOutput(resultFromMonitor);
+                    if (result == null) {
+                        // parsing failed or did not yield a Map -> treat output as error message
                         errorMsg = resultFromMonitor;
                     }
                 } finally {
@@ -200,5 +198,27 @@ public class TopologySpoutLag {
 
     private static Map<String, Object> getLagResultForNewKafkaSpout(String spoutId, SpoutSpec spoutSpec) throws IOException {
         return getLagResultForKafka(spoutId, spoutSpec);
+    }
+
+    /**
+     * Parse the stdout from {@code storm-kafka-monitor}. Returns the parsed JSON map on success,
+     * or {@code null} when the output is not parseable as a JSON object — which happens when the
+     * monitor printed a plaintext error string (json-smart parses unquoted text leniently as a
+     * String rather than throwing). The caller treats {@code null} as "monitor failed; surface
+     * the raw stdout as the error message".
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> parseMonitorOutput(String resultFromMonitor) {
+        try {
+            Object parsed = JSONValue.parseWithException(resultFromMonitor);
+            if (parsed instanceof Map) {
+                return (Map<String, Object>) parsed;
+            }
+            LOGGER.debug("JSON parsing did not yield a Map, assuming message as error message: {}", resultFromMonitor);
+            return null;
+        } catch (ParseException e) {
+            LOGGER.debug("JSON parsing failed, assuming message as error message: {}", resultFromMonitor);
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes the silent failure of the topology spout lag query, where the Storm UI's "Topology Lag" panel stops working with this warning being logged repeatedly for every Kafka spout:

```
  TopologySpoutLag [WARN] Exception thrown while getting lag for spout id: <spoutId>
  TopologySpoutLag [WARN] Exception message:null
  java.lang.ClassCastException
```

The regression was introduced by the Kafka client bump from 3.9.0 → 4.x (#8243). Two issues, on the same code path:

  1. KafkaOffsetLagUtil — NPE on partitions with no committed offset. 
  2. TopologySpoutLag — ClassCastException swallows the real error. When the kafka-monitor subprocess fails (the NPE above, or any other failure: broker unreachable, auth failure, bad config, etc.), it prints a plain-text error to stdout.

Together, (1) restores correct lag reporting for partitions with no committed offset, and (2) ensures any future monitor failure is reported usefully instead of as a generic `ClassCastException` with a null message.

## How was the change tested

### **Integration test**

 - `KafkaOffsetLagUtilTest#getOffsetLagsReportsCommittedOffsetForCommittedPartitionsAndMinusOneForUncommittedPartitions` creates a 2-partition topic, commits an offset on partition 0 only, and calls the production `KafkaOffsetLagUtil.getOffsetLags(...)` end-to-end. Asserts the committed offset is reported for partition 0 and `-1` for partition 1 (the regression case — pre-fix this NPE'd inside the monitor and surfaced as `ClassCastException` upstream in `TopologySpoutLag`).

### Manual verification on a Storm 2.8.7 cluster
- Built storm-core and storm-kafka-monitor JARs and replaced them on the storm-ui node.
- Confirmed the previously-failing spouts (managementKafka, secondaryKafka, Instructions, …) now return lag results in the UI with no TopologySpoutLag warnings in ui.log.
- For a spout with a fresh consumer group (no committed offsets yet), confirmed lag reports correctly instead of throwing.

Issue: https://github.com/apache/storm/issues/8588