### PR TITLE
Make storm more windows friendly

### DIFF
--- a/storm-client/test/jvm/org/apache/storm/security/auth/AutoSSLTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/AutoSSLTest.java
@@ -79,10 +79,7 @@ public class AutoSSLTest {
         Files.write(temp.toPath(), lines, StandardCharsets.UTF_8);
         File baseDir = null;
         try {
-            baseDir = new File("/tmp/autossl-test-" + UUID.randomUUID());
-            if (!baseDir.mkdir()) {
-                throw new IOException("failed to create base directory");
-            }
+            baseDir = Files.createTempDirectory("autossl-test").toFile();
             AutoSSL assl = new TestAutoSSL(baseDir.getPath());
 
             LOG.debug("base dir is; " + baseDir);

--- a/storm-client/test/jvm/org/apache/storm/security/auth/ShellBasedGroupsMappingTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/ShellBasedGroupsMappingTest.java
@@ -26,6 +26,8 @@ import org.apache.storm.utils.Time;
 import org.apache.storm.utils.Time.SimulatedTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -57,6 +59,7 @@ public class ShellBasedGroupsMappingTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testCanGetGroups() throws Exception {
         try (SimulatedTime ignored = new SimulatedTime()) {
             groupsMapping.prepare(topoConf);
@@ -69,6 +72,7 @@ public class ShellBasedGroupsMappingTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testWillCacheGroups() throws Exception {
         try (SimulatedTime ignored = new SimulatedTime()) {
             groupsMapping.prepare(topoConf);
@@ -82,6 +86,7 @@ public class ShellBasedGroupsMappingTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void testWillExpireCache() throws Exception {
         try (SimulatedTime ignored = new SimulatedTime()) {
             groupsMapping.prepare(topoConf);

--- a/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizerTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizerTest.java
@@ -18,6 +18,8 @@ import org.apache.storm.security.auth.IGroupMappingServiceProvider;
 import org.apache.storm.security.auth.ReqContext;
 import org.apache.storm.utils.ConfigUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import javax.security.auth.Subject;
 import java.security.Principal;
@@ -34,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SimpleACLAuthorizerTest {
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void SimpleACLUserAuthTest() {
         Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
         Collection<String> adminUserSet = new HashSet<>(Collections.singletonList("admin"));
@@ -196,6 +199,7 @@ public class SimpleACLAuthorizerTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void SimpleACLNimbusUserAuthTest() {
         Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
         Collection<String> adminUserSet = new HashSet<>(Collections.singletonList("admin"));
@@ -222,6 +226,7 @@ public class SimpleACLAuthorizerTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void SimpleACLTopologyReadOnlyUserAuthTest() {
         Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
 

--- a/storm-server/src/test/java/org/apache/storm/security/auth/AuthTest.java
+++ b/storm-server/src/test/java/org/apache/storm/security/auth/AuthTest.java
@@ -45,6 +45,8 @@ import org.apache.storm.utils.NimbusClient;
 import org.apache.storm.utils.Time;
 import org.apache.storm.utils.Utils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -401,6 +403,7 @@ public class AuthTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void simpleAclUserAuthTest() {
         Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
         clusterConf.put(Config.NIMBUS_ADMINS, Collections.singletonList("admin"));
@@ -489,6 +492,7 @@ public class AuthTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void simpleAclNimbusUsersAuthTest() {
         Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
         clusterConf.put(Config.NIMBUS_ADMINS, Collections.singletonList("admin"));
@@ -546,6 +550,7 @@ public class AuthTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void simpleAclSameUserAuthTest() {
         Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
         clusterConf.put(Config.NIMBUS_ADMINS, Collections.singletonList("admin"));
@@ -575,6 +580,7 @@ public class AuthTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void shellBaseGroupsMappingTest() throws Exception {
         Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
         ShellBasedGroupsMapping groups = new ShellBasedGroupsMapping();
@@ -595,6 +601,7 @@ public class AuthTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void impersonationAuthorizerTest() throws Exception {
         final String impersonatingUser = "admin";
         final String userBeingImpersonated = System.getProperty("user.name");


### PR DESCRIPTION
There are lots of errors when I run tests on windows. This PR addresses the easy ones only.

- Fixed a test case where a temp direcotory path was hardcoded - changed to `Files.createTempDirectory()`
- Disable 11 test cases on windows where Unsupported operation was used (Getting user groups as `id -Gn <user>` command)
  - The Exception is thrown here: `org.apache.storm.utils.ShellUtils#getGroupsForUserCommand()`

I'm not sure wether I should create a windows alternative somehow or it is enough to disable these test cases on windows.