### PR TITLE
Fix Y2038 worker heartbeat overflow by migrating timestamps to i64

### DIFF
--- a/docs/Cluster-State-Serialization.md
+++ b/docs/Cluster-State-Serialization.md
@@ -122,3 +122,34 @@ non-Thrift Java-serialization variant).
 The zstd codec is provided by Apache Commons Compress
 (`org.apache.commons:commons-compress`) backed by the `com.github.luben:zstd-jni`
 native binding.
+
+## Heartbeat timestamps and the year 2038
+
+Since STORM-7897, the `time_secs` field of `ClusterWorkerHeartbeat`,
+`SupervisorWorkerHeartbeat` and `LSWorkerHeartbeat` is a 64-bit integer
+(`i64`), and all heartbeat writers and timeout checks use the long-based
+clock (`Time.currentTimeSecsLong()` / `Time.deltaSecsLong(...)`). Earlier
+releases carried these timestamps as `i32` seconds, which overflows on
+2038-01-19T03:14:07Z and would have caused Nimbus to treat live workers
+as dead.
+
+`uptime_secs` fields remain `i32`: they are relative durations, not
+absolute timestamps. `Time.currentTimeSecs()` and `Time.deltaSecs(int)`
+are deprecated but retained for such relative-duration callers.
+
+### Upgrade implications
+
+Thrift tags `i32` and `i64` values differently on the wire, so heartbeat
+blobs written by a pre-upgrade daemon do **not** deserialize under the
+new schema: the reader skips the mistyped field and the blob then fails
+required-field validation with a `TProtocolException`. In practice:
+
+1. **A full-cluster upgrade is required.** Do not run a mixed-version
+   cluster across Nimbus, Supervisors and workers: heartbeats do not
+   round-trip between the old and new schema in either direction.
+2. **In-flight heartbeats are dropped once, then self-heal.** Nimbus
+   times workers out by *receipt* time, so a dropped heartbeat is
+   replaced on the next report interval; supervisors rewrite their
+   on-disk `LSWorkerHeartbeat` local state the same way. Expect at most
+   one report cycle of staleness around the restart, which is within the
+   normal tolerance of a full-cluster bounce.

--- a/storm-client/src/jvm/org/apache/storm/cluster/ClusterUtils.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/ClusterUtils.java
@@ -262,7 +262,7 @@ public class ClusterUtils {
         Map<ExecutorInfo, ExecutorStats> executorStatsMap = workerHeartbeat.get_executor_stats();
         for (ExecutorInfo executor : executors) {
             if (executorStatsMap.containsKey(executor)) {
-                int time = workerHeartbeat.get_time_secs();
+                long time = workerHeartbeat.get_time_secs();
                 int uptime = workerHeartbeat.get_uptime_secs();
                 ExecutorStats executorStats = workerHeartbeat.get_executor_stats().get(executor);
                 ExecutorBeat executorBeat = new ExecutorBeat(time, uptime, executorStats);

--- a/storm-client/src/jvm/org/apache/storm/cluster/ExecutorBeat.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/ExecutorBeat.java
@@ -15,17 +15,17 @@ package org.apache.storm.cluster;
 import org.apache.storm.generated.ExecutorStats;
 
 public class ExecutorBeat {
-    private final int timeSecs;
+    private final long timeSecs;
     private final int uptime;
     private final ExecutorStats stats;
 
-    public ExecutorBeat(int timeSecs, int uptime, ExecutorStats stats) {
+    public ExecutorBeat(long timeSecs, int uptime, ExecutorStats stats) {
         this.timeSecs = timeSecs;
         this.uptime = uptime;
         this.stats = stats;
     }
 
-    public int getTimeSecs() {
+    public long getTimeSecs() {
         return timeSecs;
     }
 

--- a/storm-client/src/jvm/org/apache/storm/cluster/PaceMakerStateStorage.java
+++ b/storm-client/src/jvm/org/apache/storm/cluster/PaceMakerStateStorage.java
@@ -149,7 +149,7 @@ public class PaceMakerStateStorage implements IStateStorage {
         while (true) {
             try {
                 byte[] ret = null;
-                int latestTimeSecs = 0;
+                long latestTimeSecs = 0;
                 boolean gotResponse = false;
 
                 HBMessage message = new HBMessage(HBServerMessageType.GET_PULSE, HBMessageData.path(path));

--- a/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
+++ b/storm-client/src/jvm/org/apache/storm/daemon/worker/Worker.java
@@ -387,7 +387,7 @@ public class Worker implements Shutdownable, DaemonCommon {
 
     public void doHeartBeat() throws IOException {
         LocalState state = ConfigUtils.workerState(workerState.conf, workerState.workerId);
-        LSWorkerHeartbeat lsWorkerHeartbeat = new LSWorkerHeartbeat(Time.currentTimeSecs(), workerState.topologyId,
+        LSWorkerHeartbeat lsWorkerHeartbeat = new LSWorkerHeartbeat(Time.currentTimeSecsLong(), workerState.topologyId,
                                                                     workerState.localExecutors.stream()
                                                                                               .map(executor -> new ExecutorInfo(
                                                                                                   executor.get(0).intValue(),

--- a/storm-client/src/jvm/org/apache/storm/generated/ClusterWorkerHeartbeat.java
+++ b/storm-client/src/jvm/org/apache/storm/generated/ClusterWorkerHeartbeat.java
@@ -30,7 +30,7 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
 
   private static final org.apache.storm.thrift.protocol.TField STORM_ID_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("storm_id", org.apache.storm.thrift.protocol.TType.STRING, (short)1);
   private static final org.apache.storm.thrift.protocol.TField EXECUTOR_STATS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("executor_stats", org.apache.storm.thrift.protocol.TType.MAP, (short)2);
-  private static final org.apache.storm.thrift.protocol.TField TIME_SECS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("time_secs", org.apache.storm.thrift.protocol.TType.I32, (short)3);
+  private static final org.apache.storm.thrift.protocol.TField TIME_SECS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("time_secs", org.apache.storm.thrift.protocol.TType.I64, (short)3);
   private static final org.apache.storm.thrift.protocol.TField UPTIME_SECS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("uptime_secs", org.apache.storm.thrift.protocol.TType.I32, (short)4);
 
   private static final org.apache.storm.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new ClusterWorkerHeartbeatStandardSchemeFactory();
@@ -38,7 +38,7 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
 
   private @org.apache.storm.thrift.annotation.Nullable java.lang.String storm_id; // required
   private @org.apache.storm.thrift.annotation.Nullable java.util.Map<ExecutorInfo,ExecutorStats> executor_stats; // required
-  private int time_secs; // required
+  private long time_secs; // required
   private int uptime_secs; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
@@ -126,7 +126,7 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
             new org.apache.storm.thrift.meta_data.StructMetaData(org.apache.storm.thrift.protocol.TType.STRUCT, ExecutorInfo.class), 
             new org.apache.storm.thrift.meta_data.StructMetaData(org.apache.storm.thrift.protocol.TType.STRUCT, ExecutorStats.class))));
     tmpMap.put(_Fields.TIME_SECS, new org.apache.storm.thrift.meta_data.FieldMetaData("time_secs", org.apache.storm.thrift.TFieldRequirementType.REQUIRED, 
-        new org.apache.storm.thrift.meta_data.FieldValueMetaData(org.apache.storm.thrift.protocol.TType.I32)));
+        new org.apache.storm.thrift.meta_data.FieldValueMetaData(org.apache.storm.thrift.protocol.TType.I64)));
     tmpMap.put(_Fields.UPTIME_SECS, new org.apache.storm.thrift.meta_data.FieldMetaData("uptime_secs", org.apache.storm.thrift.TFieldRequirementType.REQUIRED, 
         new org.apache.storm.thrift.meta_data.FieldValueMetaData(org.apache.storm.thrift.protocol.TType.I32)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
@@ -139,7 +139,7 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
   public ClusterWorkerHeartbeat(
     java.lang.String storm_id,
     java.util.Map<ExecutorInfo,ExecutorStats> executor_stats,
-    int time_secs,
+    long time_secs,
     int uptime_secs)
   {
     this();
@@ -252,11 +252,11 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
     }
   }
 
-  public int get_time_secs() {
+  public long get_time_secs() {
     return this.time_secs;
   }
 
-  public void set_time_secs(int time_secs) {
+  public void set_time_secs(long time_secs) {
     this.time_secs = time_secs;
     set_time_secs_isSet(true);
   }
@@ -319,7 +319,7 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
       if (value == null) {
         unset_time_secs();
       } else {
-        set_time_secs((java.lang.Integer)value);
+        set_time_secs((java.lang.Long)value);
       }
       break;
 
@@ -438,7 +438,7 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
     if (is_set_executor_stats())
       hashCode = hashCode * 8191 + executor_stats.hashCode();
 
-    hashCode = hashCode * 8191 + time_secs;
+    hashCode = hashCode * 8191 + org.apache.storm.thrift.TBaseHelper.hashCode(time_secs);
 
     hashCode = hashCode * 8191 + uptime_secs;
 
@@ -634,8 +634,8 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
             }
             break;
           case 3: // TIME_SECS
-            if (schemeField.type == org.apache.storm.thrift.protocol.TType.I32) {
-              struct.time_secs = iprot.readI32();
+            if (schemeField.type == org.apache.storm.thrift.protocol.TType.I64) {
+              struct.time_secs = iprot.readI64();
               struct.set_time_secs_isSet(true);
             } else { 
               org.apache.storm.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
@@ -682,7 +682,7 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
         oprot.writeFieldEnd();
       }
       oprot.writeFieldBegin(TIME_SECS_FIELD_DESC);
-      oprot.writeI32(struct.time_secs);
+      oprot.writeI64(struct.time_secs);
       oprot.writeFieldEnd();
       oprot.writeFieldBegin(UPTIME_SECS_FIELD_DESC);
       oprot.writeI32(struct.uptime_secs);
@@ -714,7 +714,7 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
           _iter827.getValue().write(oprot);
         }
       }
-      oprot.writeI32(struct.time_secs);
+      oprot.writeI64(struct.time_secs);
       oprot.writeI32(struct.uptime_secs);
     }
 
@@ -738,7 +738,7 @@ public class ClusterWorkerHeartbeat implements org.apache.storm.thrift.TBase<Clu
         }
       }
       struct.set_executor_stats_isSet(true);
-      struct.time_secs = iprot.readI32();
+      struct.time_secs = iprot.readI64();
       struct.set_time_secs_isSet(true);
       struct.uptime_secs = iprot.readI32();
       struct.set_uptime_secs_isSet(true);

--- a/storm-client/src/jvm/org/apache/storm/generated/LSWorkerHeartbeat.java
+++ b/storm-client/src/jvm/org/apache/storm/generated/LSWorkerHeartbeat.java
@@ -28,7 +28,7 @@ package org.apache.storm.generated;
 public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorkerHeartbeat, LSWorkerHeartbeat._Fields>, java.io.Serializable, Cloneable, Comparable<LSWorkerHeartbeat> {
   private static final org.apache.storm.thrift.protocol.TStruct STRUCT_DESC = new org.apache.storm.thrift.protocol.TStruct("LSWorkerHeartbeat");
 
-  private static final org.apache.storm.thrift.protocol.TField TIME_SECS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("time_secs", org.apache.storm.thrift.protocol.TType.I32, (short)1);
+  private static final org.apache.storm.thrift.protocol.TField TIME_SECS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("time_secs", org.apache.storm.thrift.protocol.TType.I64, (short)1);
   private static final org.apache.storm.thrift.protocol.TField TOPOLOGY_ID_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("topology_id", org.apache.storm.thrift.protocol.TType.STRING, (short)2);
   private static final org.apache.storm.thrift.protocol.TField EXECUTORS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("executors", org.apache.storm.thrift.protocol.TType.LIST, (short)3);
   private static final org.apache.storm.thrift.protocol.TField PORT_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("port", org.apache.storm.thrift.protocol.TType.I32, (short)4);
@@ -36,7 +36,7 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
   private static final org.apache.storm.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new LSWorkerHeartbeatStandardSchemeFactory();
   private static final org.apache.storm.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new LSWorkerHeartbeatTupleSchemeFactory();
 
-  private int time_secs; // required
+  private long time_secs; // required
   private @org.apache.storm.thrift.annotation.Nullable java.lang.String topology_id; // required
   private @org.apache.storm.thrift.annotation.Nullable java.util.List<ExecutorInfo> executors; // required
   private int port; // required
@@ -120,7 +120,7 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
   static {
     java.util.Map<_Fields, org.apache.storm.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.storm.thrift.meta_data.FieldMetaData>(_Fields.class);
     tmpMap.put(_Fields.TIME_SECS, new org.apache.storm.thrift.meta_data.FieldMetaData("time_secs", org.apache.storm.thrift.TFieldRequirementType.REQUIRED, 
-        new org.apache.storm.thrift.meta_data.FieldValueMetaData(org.apache.storm.thrift.protocol.TType.I32)));
+        new org.apache.storm.thrift.meta_data.FieldValueMetaData(org.apache.storm.thrift.protocol.TType.I64)));
     tmpMap.put(_Fields.TOPOLOGY_ID, new org.apache.storm.thrift.meta_data.FieldMetaData("topology_id", org.apache.storm.thrift.TFieldRequirementType.REQUIRED, 
         new org.apache.storm.thrift.meta_data.FieldValueMetaData(org.apache.storm.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.EXECUTORS, new org.apache.storm.thrift.meta_data.FieldMetaData("executors", org.apache.storm.thrift.TFieldRequirementType.REQUIRED, 
@@ -136,7 +136,7 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
   }
 
   public LSWorkerHeartbeat(
-    int time_secs,
+    long time_secs,
     java.lang.String topology_id,
     java.util.List<ExecutorInfo> executors,
     int port)
@@ -184,11 +184,11 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
     this.port = 0;
   }
 
-  public int get_time_secs() {
+  public long get_time_secs() {
     return this.time_secs;
   }
 
-  public void set_time_secs(int time_secs) {
+  public void set_time_secs(long time_secs) {
     this.time_secs = time_secs;
     set_time_secs_isSet(true);
   }
@@ -299,7 +299,7 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
       if (value == null) {
         unset_time_secs();
       } else {
-        set_time_secs((java.lang.Integer)value);
+        set_time_secs((java.lang.Long)value);
       }
       break;
 
@@ -426,7 +426,7 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
   public int hashCode() {
     int hashCode = 1;
 
-    hashCode = hashCode * 8191 + time_secs;
+    hashCode = hashCode * 8191 + org.apache.storm.thrift.TBaseHelper.hashCode(time_secs);
 
     hashCode = hashCode * 8191 + ((is_set_topology_id()) ? 131071 : 524287);
     if (is_set_topology_id())
@@ -600,8 +600,8 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
         }
         switch (schemeField.id) {
           case 1: // TIME_SECS
-            if (schemeField.type == org.apache.storm.thrift.protocol.TType.I32) {
-              struct.time_secs = iprot.readI32();
+            if (schemeField.type == org.apache.storm.thrift.protocol.TType.I64) {
+              struct.time_secs = iprot.readI64();
               struct.set_time_secs_isSet(true);
             } else { 
               org.apache.storm.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
@@ -657,7 +657,7 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
 
       oprot.writeStructBegin(STRUCT_DESC);
       oprot.writeFieldBegin(TIME_SECS_FIELD_DESC);
-      oprot.writeI32(struct.time_secs);
+      oprot.writeI64(struct.time_secs);
       oprot.writeFieldEnd();
       if (struct.topology_id != null) {
         oprot.writeFieldBegin(TOPOLOGY_ID_FIELD_DESC);
@@ -697,7 +697,7 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
     @Override
     public void write(org.apache.storm.thrift.protocol.TProtocol prot, LSWorkerHeartbeat struct) throws org.apache.storm.thrift.TException {
       org.apache.storm.thrift.protocol.TTupleProtocol oprot = (org.apache.storm.thrift.protocol.TTupleProtocol) prot;
-      oprot.writeI32(struct.time_secs);
+      oprot.writeI64(struct.time_secs);
       oprot.writeString(struct.topology_id);
       {
         oprot.writeI32(struct.executors.size());
@@ -712,7 +712,7 @@ public class LSWorkerHeartbeat implements org.apache.storm.thrift.TBase<LSWorker
     @Override
     public void read(org.apache.storm.thrift.protocol.TProtocol prot, LSWorkerHeartbeat struct) throws org.apache.storm.thrift.TException {
       org.apache.storm.thrift.protocol.TTupleProtocol iprot = (org.apache.storm.thrift.protocol.TTupleProtocol) prot;
-      struct.time_secs = iprot.readI32();
+      struct.time_secs = iprot.readI64();
       struct.set_time_secs_isSet(true);
       struct.topology_id = iprot.readString();
       struct.set_topology_id_isSet(true);

--- a/storm-client/src/jvm/org/apache/storm/generated/SupervisorWorkerHeartbeat.java
+++ b/storm-client/src/jvm/org/apache/storm/generated/SupervisorWorkerHeartbeat.java
@@ -30,14 +30,14 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
 
   private static final org.apache.storm.thrift.protocol.TField STORM_ID_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("storm_id", org.apache.storm.thrift.protocol.TType.STRING, (short)1);
   private static final org.apache.storm.thrift.protocol.TField EXECUTORS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("executors", org.apache.storm.thrift.protocol.TType.LIST, (short)2);
-  private static final org.apache.storm.thrift.protocol.TField TIME_SECS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("time_secs", org.apache.storm.thrift.protocol.TType.I32, (short)3);
+  private static final org.apache.storm.thrift.protocol.TField TIME_SECS_FIELD_DESC = new org.apache.storm.thrift.protocol.TField("time_secs", org.apache.storm.thrift.protocol.TType.I64, (short)3);
 
   private static final org.apache.storm.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new SupervisorWorkerHeartbeatStandardSchemeFactory();
   private static final org.apache.storm.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new SupervisorWorkerHeartbeatTupleSchemeFactory();
 
   private @org.apache.storm.thrift.annotation.Nullable java.lang.String storm_id; // required
   private @org.apache.storm.thrift.annotation.Nullable java.util.List<ExecutorInfo> executors; // required
-  private int time_secs; // required
+  private long time_secs; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.storm.thrift.TFieldIdEnum {
@@ -119,7 +119,7 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
         new org.apache.storm.thrift.meta_data.ListMetaData(org.apache.storm.thrift.protocol.TType.LIST, 
             new org.apache.storm.thrift.meta_data.StructMetaData(org.apache.storm.thrift.protocol.TType.STRUCT, ExecutorInfo.class))));
     tmpMap.put(_Fields.TIME_SECS, new org.apache.storm.thrift.meta_data.FieldMetaData("time_secs", org.apache.storm.thrift.TFieldRequirementType.REQUIRED, 
-        new org.apache.storm.thrift.meta_data.FieldValueMetaData(org.apache.storm.thrift.protocol.TType.I32)));
+        new org.apache.storm.thrift.meta_data.FieldValueMetaData(org.apache.storm.thrift.protocol.TType.I64)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.storm.thrift.meta_data.FieldMetaData.addStructMetaDataMap(SupervisorWorkerHeartbeat.class, metaDataMap);
   }
@@ -130,7 +130,7 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
   public SupervisorWorkerHeartbeat(
     java.lang.String storm_id,
     java.util.List<ExecutorInfo> executors,
-    int time_secs)
+    long time_secs)
   {
     this();
     this.storm_id = storm_id;
@@ -234,11 +234,11 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
     }
   }
 
-  public int get_time_secs() {
+  public long get_time_secs() {
     return this.time_secs;
   }
 
-  public void set_time_secs(int time_secs) {
+  public void set_time_secs(long time_secs) {
     this.time_secs = time_secs;
     set_time_secs_isSet(true);
   }
@@ -279,7 +279,7 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
       if (value == null) {
         unset_time_secs();
       } else {
-        set_time_secs((java.lang.Integer)value);
+        set_time_secs((java.lang.Long)value);
       }
       break;
 
@@ -376,7 +376,7 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
     if (is_set_executors())
       hashCode = hashCode * 8191 + executors.hashCode();
 
-    hashCode = hashCode * 8191 + time_secs;
+    hashCode = hashCode * 8191 + org.apache.storm.thrift.TBaseHelper.hashCode(time_secs);
 
     return hashCode;
   }
@@ -549,8 +549,8 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
             }
             break;
           case 3: // TIME_SECS
-            if (schemeField.type == org.apache.storm.thrift.protocol.TType.I32) {
-              struct.time_secs = iprot.readI32();
+            if (schemeField.type == org.apache.storm.thrift.protocol.TType.I64) {
+              struct.time_secs = iprot.readI64();
               struct.set_time_secs_isSet(true);
             } else { 
               org.apache.storm.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
@@ -588,7 +588,7 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
         oprot.writeFieldEnd();
       }
       oprot.writeFieldBegin(TIME_SECS_FIELD_DESC);
-      oprot.writeI32(struct.time_secs);
+      oprot.writeI64(struct.time_secs);
       oprot.writeFieldEnd();
       oprot.writeFieldStop();
       oprot.writeStructEnd();
@@ -616,7 +616,7 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
           _iter924.write(oprot);
         }
       }
-      oprot.writeI32(struct.time_secs);
+      oprot.writeI64(struct.time_secs);
     }
 
     @Override
@@ -636,7 +636,7 @@ public class SupervisorWorkerHeartbeat implements org.apache.storm.thrift.TBase<
         }
       }
       struct.set_executors_isSet(true);
-      struct.time_secs = iprot.readI32();
+      struct.time_secs = iprot.readI64();
       struct.set_time_secs_isSet(true);
     }
   }

--- a/storm-client/src/jvm/org/apache/storm/stats/ClientStatsUtil.java
+++ b/storm-client/src/jvm/org/apache/storm/stats/ClientStatsUtil.java
@@ -85,7 +85,7 @@ public class ClientStatsUtil {
         ret.put("storm-id", topoId);
         ret.put(EXECUTOR_STATS, executorStats);
         ret.put(UPTIME, uptime);
-        ret.put(TIME_SECS, Time.currentTimeSecs());
+        ret.put(TIME_SECS, Time.currentTimeSecsLong());
 
         return ret;
     }
@@ -119,7 +119,7 @@ public class ClientStatsUtil {
         ClusterWorkerHeartbeat ret = new ClusterWorkerHeartbeat();
         ret.set_uptime_secs(getByKeyOr0(heartbeat, UPTIME).intValue());
         ret.set_storm_id((String) heartbeat.get("storm-id"));
-        ret.set_time_secs(getByKeyOr0(heartbeat, TIME_SECS).intValue());
+        ret.set_time_secs(getByKeyOr0(heartbeat, TIME_SECS).longValue());
 
         Map<ExecutorInfo, ExecutorStats> convertedStats = new HashMap<>();
 

--- a/storm-client/src/jvm/org/apache/storm/utils/Time.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/Time.java
@@ -150,12 +150,43 @@ public class Time {
         return (long) (1000 * secs);
     }
 
+    /**
+     * Current time in seconds since the epoch, as an int.
+     *
+     * @deprecated the int representation overflows on 2038-01-19T03:14:07Z. Use
+     *     {@link #currentTimeSecsLong()} for absolute timestamps; this method remains
+     *     valid only for short relative durations such as uptime.
+     */
+    @Deprecated
     public static int currentTimeSecs() {
         return (int) (currentTimeMillis() / 1000);
     }
 
+    /**
+     * Current time in seconds since the epoch, as a long. Safe past the 2038
+     * int-seconds overflow; use this for all absolute timestamps.
+     */
+    public static long currentTimeSecsLong() {
+        return currentTimeMillis() / 1000;
+    }
+
+    /**
+     * Seconds elapsed since {@code timeInSeconds}, as an int.
+     *
+     * @deprecated int epoch-seconds overflow on 2038-01-19T03:14:07Z. Use
+     *     {@link #deltaSecsLong(long)} when the reference point is an absolute timestamp.
+     */
+    @Deprecated
     public static int deltaSecs(int timeInSeconds) {
         return Time.currentTimeSecs() - timeInSeconds;
+    }
+
+    /**
+     * Seconds elapsed since {@code timeInSeconds} (an absolute epoch timestamp), as a long.
+     * Safe past the 2038 int-seconds overflow.
+     */
+    public static long deltaSecsLong(long timeInSeconds) {
+        return currentTimeSecsLong() - timeInSeconds;
     }
 
     public static long deltaMs(long timeInMilliseconds) {

--- a/storm-client/src/py/storm/ttypes.py
+++ b/storm-client/src/py/storm/ttypes.py
@@ -7678,8 +7678,8 @@ class ClusterWorkerHeartbeat(object):
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
-                if ftype == TType.I32:
-                    self.time_secs = iprot.readI32()
+                if ftype == TType.I64:
+                    self.time_secs = iprot.readI64()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -7711,8 +7711,8 @@ class ClusterWorkerHeartbeat(object):
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.time_secs is not None:
-            oprot.writeFieldBegin('time_secs', TType.I32, 3)
-            oprot.writeI32(self.time_secs)
+            oprot.writeFieldBegin('time_secs', TType.I64, 3)
+            oprot.writeI64(self.time_secs)
             oprot.writeFieldEnd()
         if self.uptime_secs is not None:
             oprot.writeFieldBegin('uptime_secs', TType.I32, 4)
@@ -8239,8 +8239,8 @@ class LSWorkerHeartbeat(object):
             if ftype == TType.STOP:
                 break
             if fid == 1:
-                if ftype == TType.I32:
-                    self.time_secs = iprot.readI32()
+                if ftype == TType.I64:
+                    self.time_secs = iprot.readI64()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -8276,8 +8276,8 @@ class LSWorkerHeartbeat(object):
             return
         oprot.writeStructBegin('LSWorkerHeartbeat')
         if self.time_secs is not None:
-            oprot.writeFieldBegin('time_secs', TType.I32, 1)
-            oprot.writeI32(self.time_secs)
+            oprot.writeFieldBegin('time_secs', TType.I64, 1)
+            oprot.writeI64(self.time_secs)
             oprot.writeFieldEnd()
         if self.topology_id is not None:
             oprot.writeFieldBegin('topology_id', TType.STRING, 2)
@@ -9183,8 +9183,8 @@ class SupervisorWorkerHeartbeat(object):
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
-                if ftype == TType.I32:
-                    self.time_secs = iprot.readI32()
+                if ftype == TType.I64:
+                    self.time_secs = iprot.readI64()
                 else:
                     iprot.skip(ftype)
             else:
@@ -9210,8 +9210,8 @@ class SupervisorWorkerHeartbeat(object):
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.time_secs is not None:
-            oprot.writeFieldBegin('time_secs', TType.I32, 3)
-            oprot.writeI32(self.time_secs)
+            oprot.writeFieldBegin('time_secs', TType.I64, 3)
+            oprot.writeI64(self.time_secs)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -13264,7 +13264,7 @@ ClusterWorkerHeartbeat.thrift_spec = (
     None,  # 0
     (1, TType.STRING, 'storm_id', 'UTF8', None, ),  # 1
     (2, TType.MAP, 'executor_stats', (TType.STRUCT, [ExecutorInfo, None], TType.STRUCT, [ExecutorStats, None], False), None, ),  # 2
-    (3, TType.I32, 'time_secs', None, None, ),  # 3
+    (3, TType.I64, 'time_secs', None, None, ),  # 3
     (4, TType.I32, 'uptime_secs', None, None, ),  # 4
 )
 all_structs.append(ThriftSerializedObject)
@@ -13305,7 +13305,7 @@ LSSupervisorAssignments.thrift_spec = (
 all_structs.append(LSWorkerHeartbeat)
 LSWorkerHeartbeat.thrift_spec = (
     None,  # 0
-    (1, TType.I32, 'time_secs', None, None, ),  # 1
+    (1, TType.I64, 'time_secs', None, None, ),  # 1
     (2, TType.STRING, 'topology_id', 'UTF8', None, ),  # 2
     (3, TType.LIST, 'executors', (TType.STRUCT, [ExecutorInfo, None], False), None, ),  # 3
     (4, TType.I32, 'port', None, None, ),  # 4
@@ -13382,7 +13382,7 @@ SupervisorWorkerHeartbeat.thrift_spec = (
     None,  # 0
     (1, TType.STRING, 'storm_id', 'UTF8', None, ),  # 1
     (2, TType.LIST, 'executors', (TType.STRUCT, [ExecutorInfo, None], False), None, ),  # 2
-    (3, TType.I32, 'time_secs', None, None, ),  # 3
+    (3, TType.I64, 'time_secs', None, None, ),  # 3
 )
 all_structs.append(SupervisorWorkerHeartbeats)
 SupervisorWorkerHeartbeats.thrift_spec = (

--- a/storm-client/src/storm.thrift
+++ b/storm-client/src/storm.thrift
@@ -551,7 +551,7 @@ struct StormBase {
 struct ClusterWorkerHeartbeat {
     1: required string storm_id;
     2: required map<ExecutorInfo,ExecutorStats> executor_stats;
-    3: required i32 time_secs;
+    3: required i64 time_secs;
     4: required i32 uptime_secs;
 }
 
@@ -586,7 +586,7 @@ struct LSSupervisorAssignments {
 }
 
 struct LSWorkerHeartbeat {
-   1: required i32 time_secs;
+   1: required i64 time_secs;
    2: required string topology_id;
    3: required list<ExecutorInfo> executors
    4: required i32 port;
@@ -688,7 +688,7 @@ struct OwnerResourceSummary {
 struct SupervisorWorkerHeartbeat {
   1: required string storm_id;
   2: required list<ExecutorInfo> executors
-  3: required i32 time_secs;
+  3: required i64 time_secs;
 }
 
 struct SupervisorWorkerHeartbeats {

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/HeartbeatCache.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/HeartbeatCache.java
@@ -47,17 +47,17 @@ public class HeartbeatCache {
 
     private static class ExecutorCache {
         private Boolean isTimedOut;
-        private Integer nimbusTimeSecs;
-        private Integer executorReportedTimeSecs;
+        private Long nimbusTimeSecs;
+        private Long executorReportedTimeSecs;
 
         ExecutorCache(Map<String, Object> newBeat) {
             if (newBeat != null) {
-                executorReportedTimeSecs = (Integer) newBeat.getOrDefault(ClientStatsUtil.TIME_SECS, 0);
+                executorReportedTimeSecs = ((Number) newBeat.getOrDefault(ClientStatsUtil.TIME_SECS, 0L)).longValue();
             } else {
-                executorReportedTimeSecs = 0;
+                executorReportedTimeSecs = 0L;
             }
 
-            nimbusTimeSecs = Time.currentTimeSecs();
+            nimbusTimeSecs = Time.currentTimeSecsLong();
             isTimedOut = false;
         }
 
@@ -65,18 +65,18 @@ public class HeartbeatCache {
             return isTimedOut;
         }
 
-        public synchronized Integer getNimbusTimeSecs() {
+        public synchronized Long getNimbusTimeSecs() {
             return nimbusTimeSecs;
         }
 
         public synchronized void updateTimeout(Integer timeout) {
-            isTimedOut = Time.deltaSecs(getNimbusTimeSecs()) >= timeout;
+            isTimedOut = Time.deltaSecsLong(getNimbusTimeSecs()) >= timeout;
         }
 
         // Used for RPC heartbeats: nimbusTimeSecs is refreshed on every heartbeat so that
         // idle-but-alive executors (whose stats TIME_SECS may not advance) are not falsely timed out.
         public synchronized void updateFromRpcHb(Integer timeout) {
-            nimbusTimeSecs = Time.currentTimeSecs();
+            nimbusTimeSecs = Time.currentTimeSecsLong();
             updateTimeout(timeout);
         }
 
@@ -84,9 +84,9 @@ public class HeartbeatCache {
         // TIME_SECS advances, preserving zombie detection for legacy topologies.
         public synchronized void updateFromZkHb(Integer timeout, Map<String, Object> newBeat) {
             if (newBeat != null) {
-                Integer newReportedTime = (Integer) newBeat.getOrDefault(ClientStatsUtil.TIME_SECS, 0);
+                Long newReportedTime = ((Number) newBeat.getOrDefault(ClientStatsUtil.TIME_SECS, 0L)).longValue();
                 if (!newReportedTime.equals(executorReportedTimeSecs)) {
-                    nimbusTimeSecs = Time.currentTimeSecs();
+                    nimbusTimeSecs = Time.currentTimeSecsLong();
                 }
                 executorReportedTimeSecs = newReportedTime;
             }
@@ -224,7 +224,7 @@ public class HeartbeatCache {
             ExecutorCache executorCache = topoCache.get(exec);
             //null isTimedOut means worker never reported any heartbeat
             boolean isTimedOut = executorCache == null ? true : executorCache.isTimedOut();
-            Integer delta = startTime == null ? null : Time.deltaSecs(startTime.intValue());
+            Long delta = startTime == null ? null : Time.deltaSecsLong(startTime);
             if (startTime != null && ((delta < taskLaunchSecs) || !isTimedOut)) {
                 ret.add(exec);
             } else {

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/Slot.java
@@ -724,7 +724,7 @@ public class Slot extends Thread implements AutoCloseable, BlobChangingCallback 
 
         LSWorkerHeartbeat hb = dynamicState.container.readHeartbeat();
         if (hb != null) {
-            long hbAgeMs = (Time.currentTimeSecs() - hb.get_time_secs()) * 1000;
+            long hbAgeMs = Time.deltaSecsLong(hb.get_time_secs()) * 1000;
             long hbTimeoutMs = getHbTimeoutMs(staticState, dynamicState);
             if (hbAgeMs <= hbTimeoutMs) {
                 return dynamicState.withState(MachineState.RUNNING);
@@ -820,7 +820,7 @@ public class Slot extends Thread implements AutoCloseable, BlobChangingCallback 
             return killContainerFor(KillReason.HB_NULL, dynamicState, staticState);
         }
 
-        long timeDiffMs = (Time.currentTimeSecs() - hb.get_time_secs()) * 1000;
+        long timeDiffMs = Time.deltaSecsLong(hb.get_time_secs()) * 1000;
         long hbTimeoutMs = getHbTimeoutMs(staticState, dynamicState);
         if (timeDiffMs > hbTimeoutMs) {
             LOG.warn("SLOT {}: HB is too old {} > {} for topology: {}",

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/timer/SupervisorHeartbeat.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/timer/SupervisorHeartbeat.java
@@ -74,7 +74,7 @@ public class SupervisorHeartbeat implements Runnable {
         if (validatedNumaMap != null) {
             for (Map.Entry<String, Object> numaMapEntry : validatedNumaMap.entrySet()) {
                 SupervisorInfo supervisorInfo = new SupervisorInfo();
-                supervisorInfo.set_time_secs(Time.currentTimeSecs());
+                supervisorInfo.set_time_secs(Time.currentTimeSecsLong());
                 supervisorInfo.set_hostname(supervisor.getHostName());
                 supervisorInfo.set_assignment_id(
                         supervisor.getAssignmentId() + ServerConstants.NUMA_ID_SEPARATOR + numaMapEntry.getKey()
@@ -106,7 +106,7 @@ public class SupervisorHeartbeat implements Runnable {
         if (totalSupervisorNormalizedResources.getTotalCpu() > 0
             && totalSupervisorNormalizedResources.getTotalMemoryMb() > 0 && !allPortList.isEmpty()) {
             SupervisorInfo supervisorInfo = new SupervisorInfo();
-            supervisorInfo.set_time_secs(Time.currentTimeSecs());
+            supervisorInfo.set_time_secs(Time.currentTimeSecsLong());
             supervisorInfo.set_hostname(supervisor.getHostName());
             supervisorInfo.set_assignment_id(supervisor.getAssignmentId());
             supervisorInfo.set_server_port(supervisor.getThriftServerPort());

--- a/storm-server/src/main/java/org/apache/storm/stats/StatsUtil.java
+++ b/storm-server/src/main/java/org/apache/storm/stats/StatsUtil.java
@@ -1885,7 +1885,7 @@ public class StatsUtil {
         supervisorWorkerHeartbeat.set_storm_id(stormId);
         supervisorWorkerHeartbeat
             .set_executors(Collections.singletonList(new ExecutorInfo(executorId.get(0).intValue(), executorId.get(1).intValue())));
-        supervisorWorkerHeartbeat.set_time_secs(Time.currentTimeSecs());
+        supervisorWorkerHeartbeat.set_time_secs(Time.currentTimeSecsLong());
         return supervisorWorkerHeartbeat;
     }
 

--- a/storm-server/src/test/java/org/apache/storm/daemon/nimbus/Y2038HeartbeatTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/nimbus/Y2038HeartbeatTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.storm.daemon.nimbus;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.storm.generated.Assignment;
+import org.apache.storm.generated.ClusterWorkerHeartbeat;
+import org.apache.storm.generated.LSWorkerHeartbeat;
+import org.apache.storm.generated.NodeInfo;
+import org.apache.storm.stats.ClientStatsUtil;
+import org.apache.storm.thrift.TDeserializer;
+import org.apache.storm.thrift.TException;
+import org.apache.storm.thrift.TSerializer;
+import org.apache.storm.thrift.protocol.TBinaryProtocol;
+import org.apache.storm.thrift.protocol.TField;
+import org.apache.storm.thrift.protocol.TList;
+import org.apache.storm.thrift.protocol.TStruct;
+import org.apache.storm.thrift.protocol.TType;
+import org.apache.storm.thrift.transport.TMemoryBuffer;
+import org.apache.storm.thrift.transport.TMemoryInputTransport;
+import org.apache.storm.utils.Time;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the Y2038 heartbeat overflow (STORM issue #7897).
+ *
+ * <p>Worker heartbeat timestamps were carried as i32 seconds, which overflows on
+ * 2038-01-19T03:14:07Z. These tests pin the post-2038 behavior: heartbeat
+ * {@code time_secs} must survive serialization as a 64-bit value, and the Nimbus
+ * {@link HeartbeatCache} must not flag fresh post-2038 heartbeats as timed out.
+ */
+class Y2038HeartbeatTest {
+    private static final String TOPO_ID = "y2038-topology-1";
+    private static final int TIMEOUT_SECS = 30;
+    /** 2040-01-01T00:00:00Z — comfortably past the 2038 i32 rollover. */
+    private static final long POST_2038_EPOCH_SECS = 2_208_988_800L;
+    /** 2023-11-14T22:13:20Z — a plausible pre-2038 heartbeat timestamp. */
+    private static final int LEGACY_EPOCH_SECS = 1_700_000_000;
+
+    /**
+     * A post-2038 epoch must round-trip through ClusterWorkerHeartbeat serialization
+     * without narrowing. Uses the dynamic field API so this test compiles against both
+     * the i32 and i64 schema; with the i32 schema the Long value is rejected.
+     */
+    @Test
+    void testCwhTimeSecsSurvivesPost2038RoundTrip() throws Exception {
+        ClusterWorkerHeartbeat hb = new ClusterWorkerHeartbeat();
+        hb.set_storm_id(TOPO_ID);
+        hb.set_executor_stats(new HashMap<>());
+        hb.set_uptime_secs(120);
+        hb.setFieldValue(ClusterWorkerHeartbeat._Fields.TIME_SECS, POST_2038_EPOCH_SECS);
+
+        TSerializer ser = new TSerializer(new TBinaryProtocol.Factory());
+        byte[] bytes = ser.serialize(hb);
+        ClusterWorkerHeartbeat read = new ClusterWorkerHeartbeat();
+        TDeserializer des = new TDeserializer(new TBinaryProtocol.Factory());
+        des.deserialize(read, bytes);
+
+        long timeSecs = ((Number) read.getFieldValue(ClusterWorkerHeartbeat._Fields.TIME_SECS)).longValue();
+        assertTrue(timeSecs > Integer.MAX_VALUE, "time_secs must not be narrowed to i32");
+        assertEquals(POST_2038_EPOCH_SECS, timeSecs, "time_secs must round-trip unchanged");
+    }
+
+    /**
+     * A fresh heartbeat received after 2038 must not be flagged as timed out.
+     * The beat map carries TIME_SECS as a Long, matching what the post-fix
+     * heartbeat writer produces.
+     */
+    @Test
+    void testHeartbeatCacheNoFalseTimeoutPost2038() {
+        try (Time.SimulatedTime ignored = new Time.SimulatedTime()) {
+            Time.advanceTime(POST_2038_EPOCH_SECS * 1000L);
+
+            HeartbeatCache cache = new HeartbeatCache();
+            Set<List<Integer>> allExecutors = Collections.singleton(Arrays.asList(1, 1));
+            Assignment assignment = mkAssignment(POST_2038_EPOCH_SECS, 1, 1);
+
+            cache.updateFromZkHeartbeat(TOPO_ID, mkZkExecutorBeats(1, 1, POST_2038_EPOCH_SECS), allExecutors,
+                TIMEOUT_SECS);
+            Time.advanceTimeSecs(1);
+            cache.timeoutOldHeartbeats(TOPO_ID, TIMEOUT_SECS);
+
+            Set<List<Integer>> alive = cache.getAliveExecutors(TOPO_ID, allExecutors, assignment, TIMEOUT_SECS);
+            assertFalse(alive.isEmpty(), "A fresh post-2038 heartbeat must not be flagged as timed out");
+        }
+    }
+
+    /**
+     * Documents why the long-based clock path is required: the int-based
+     * {@code Time.currentTimeSecs()} overflows past 2038.
+     */
+    @Test
+    void testCurrentTimeSecsIntOverflowsPost2038() {
+        try (Time.SimulatedTime ignored = new Time.SimulatedTime()) {
+            Time.advanceTime(POST_2038_EPOCH_SECS * 1000L);
+            assertTrue(Time.currentTimeSecs() < 0,
+                "currentTimeSecs() (int) is expected to overflow past 2038 — long path required");
+        }
+    }
+
+    /**
+     * Wire compatibility: an LSWorkerHeartbeat blob written by the legacy i32 schema
+     * must fail loudly (required-field validation) under the i64 schema, not be
+     * silently misread. Supervisors treat the entry as stale and rebuild local state.
+     */
+    @Test
+    void testLegacyI32LswhBlobFailsValidationUnderI64Schema() throws Exception {
+        byte[] legacyBlob = writeLegacyI32Lswh(LEGACY_EPOCH_SECS, TOPO_ID, 6700);
+
+        LSWorkerHeartbeat read = new LSWorkerHeartbeat();
+        assertThrows(TException.class,
+            () -> read.read(new TBinaryProtocol(new TMemoryInputTransport(legacyBlob))),
+            "A legacy i32 time_secs blob must fail required-field validation under the i64 schema");
+    }
+
+    /**
+     * Startup guard: an executor whose assignment start time is past 2038 must not be
+     * misclassified as dead by getAliveExecutors while inside the launch window.
+     */
+    @Test
+    void testExecutorStartedPost2038NotMisclassifiedDead() {
+        try (Time.SimulatedTime ignored = new Time.SimulatedTime()) {
+            Time.advanceTime(POST_2038_EPOCH_SECS * 1000L);
+
+            HeartbeatCache cache = new HeartbeatCache();
+            Set<List<Integer>> allExecutors = Collections.singleton(Arrays.asList(1, 1));
+            Assignment assignment = mkAssignment(POST_2038_EPOCH_SECS, 1, 1);
+
+            // No heartbeat reported yet; the executor is within the task launch window.
+            Time.advanceTimeSecs(1);
+            Set<List<Integer>> alive = cache.getAliveExecutors(TOPO_ID, allExecutors, assignment, TIMEOUT_SECS);
+            assertFalse(alive.isEmpty(),
+                "An executor launched post-2038 must stay alive during its launch window");
+        }
+    }
+
+    /**
+     * Emulates the wire bytes an old (pre-fix) writer produced for LSWorkerHeartbeat:
+     * field 1 time_secs as i32, field 2 topology_id, field 3 empty executors list,
+     * field 4 port. Field ids and types match the legacy schema.
+     */
+    private byte[] writeLegacyI32Lswh(int timeSecs, String topologyId, int port) throws Exception {
+        TMemoryBuffer buffer = new TMemoryBuffer(128);
+        TBinaryProtocol prot = new TBinaryProtocol(buffer);
+        prot.writeStructBegin(new TStruct("LSWorkerHeartbeat"));
+        prot.writeFieldBegin(new TField("time_secs", TType.I32, (short) 1));
+        prot.writeI32(timeSecs);
+        prot.writeFieldEnd();
+        prot.writeFieldBegin(new TField("topology_id", TType.STRING, (short) 2));
+        prot.writeString(topologyId);
+        prot.writeFieldEnd();
+        prot.writeFieldBegin(new TField("executors", TType.LIST, (short) 3));
+        prot.writeListBegin(new TList(TType.STRUCT, 0));
+        prot.writeListEnd();
+        prot.writeFieldEnd();
+        prot.writeFieldBegin(new TField("port", TType.I32, (short) 4));
+        prot.writeI32(port);
+        prot.writeFieldEnd();
+        prot.writeFieldStop();
+        prot.writeStructEnd();
+        return Arrays.copyOf(buffer.getArray(), buffer.length());
+    }
+
+    private Map<List<Integer>, Map<String, Object>> mkZkExecutorBeats(int taskStart, int taskEnd, long timeSecs) {
+        Map<String, Object> beat = new HashMap<>();
+        beat.put(ClientStatsUtil.TIME_SECS, timeSecs);
+        return Collections.singletonMap(Arrays.asList(taskStart, taskEnd), beat);
+    }
+
+    private Assignment mkAssignment(long startTimeSecs, int... executors) {
+        Assignment assignment = new Assignment();
+        Map<List<Long>, Long> execToStartTime = new HashMap<>();
+        Map<List<Long>, NodeInfo> execToNodePort = new HashMap<>();
+        NodeInfo nodeInfo = new NodeInfo("node1", Collections.singleton(6700L));
+        for (int i = 0; i < executors.length - 1; i += 2) {
+            List<Long> exec = Arrays.asList((long) executors[i], (long) executors[i + 1]);
+            execToStartTime.put(exec, startTimeSecs);
+            execToNodePort.put(exec, nodeInfo);
+        }
+        assignment.set_executor_start_time_secs(execToStartTime);
+        assignment.set_executor_node_port(execToNodePort);
+        return assignment;
+    }
+}

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogCleaner.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/LogCleaner.java
@@ -167,7 +167,7 @@ public class LogCleaner implements Runnable, Closeable {
             Set<Path> oldLogDirs = selectDirsForCleanup(nowMills);
 
             final long nowSecs = TimeUnit.MILLISECONDS.toSeconds(nowMills);
-            SortedSet<Path> deadWorkerDirs = getDeadWorkerDirs((int) nowSecs, oldLogDirs);
+            SortedSet<Path> deadWorkerDirs = getDeadWorkerDirs(nowSecs, oldLogDirs);
 
             LOG.debug("log cleanup: now={} old log dirs {} dead worker dirs {}", nowSecs,
                     oldLogDirs.stream().map(p -> p.getFileName().toString()).collect(joining(",")),
@@ -247,7 +247,7 @@ public class LogCleaner implements Runnable, Closeable {
      * Return a sorted set of paths that were written by workers that are now dead.
      */
     @VisibleForTesting
-    SortedSet<Path> getDeadWorkerDirs(int nowSecs, Set<Path> logDirs) throws Exception {
+    SortedSet<Path> getDeadWorkerDirs(long nowSecs, Set<Path> logDirs) throws Exception {
         if (logDirs.isEmpty()) {
             return new TreeSet<>();
         } else {

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/WorkerLogs.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/logviewer/utils/WorkerLogs.java
@@ -155,7 +155,7 @@ public class WorkerLogs {
      * Return a sorted set of paths that were written by workers that are now active.
      */
     public SortedSet<Path> getAliveWorkerDirs() throws IOException {
-        Set<String> aliveIds = getAliveIds(Time.currentTimeSecs());
+        Set<String> aliveIds = getAliveIds(Time.currentTimeSecsLong());
         Set<Path> logDirs = getAllWorkerDirs();
         return getLogDirs(logDirs, (wid) -> aliveIds.contains(wid));
     }
@@ -199,14 +199,14 @@ public class WorkerLogs {
      *
      * @param nowSecs current time in seconds
      */
-    public Set<String> getAliveIds(int nowSecs) throws IOException {
+    public Set<String> getAliveIds(long nowSecs) throws IOException {
         return SupervisorUtils.readWorkerHeartbeats(stormConf).entrySet().stream()
                 .filter(entry -> Objects.nonNull(entry.getValue()) && !isTimedOut(nowSecs, entry))
                 .map(Map.Entry::getKey)
                 .collect(toCollection(TreeSet::new));
     }
 
-    private boolean isTimedOut(int nowSecs, Map.Entry<String, LSWorkerHeartbeat> entry) {
+    private boolean isTimedOut(long nowSecs, Map.Entry<String, LSWorkerHeartbeat> entry) {
         LSWorkerHeartbeat hb = entry.getValue();
         int workerLogTimeout = getTopologyTimeout(hb);
         return (nowSecs - hb.get_time_secs()) >= workerLogTimeout;

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/utils/LogCleanerTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/logviewer/utils/LogCleanerTest.java
@@ -281,7 +281,7 @@ public class LogCleanerTest {
                 }
 
                 @Override
-                SortedSet<Path> getDeadWorkerDirs(int nowSecs, Set<Path> logDirs) {
+                SortedSet<Path> getDeadWorkerDirs(long nowSecs, Set<Path> logDirs) {
                     SortedSet<Path> dirs = new TreeSet<>();
                     dirs.add(dir1.getFile().toPath());
                     dirs.add(dir2.getFile().toPath());


### PR DESCRIPTION
## What is the purpose of the change
Fixes the Y2038 heartbeat overflow issue. Worker heartbeat timestamps (`time_secs`) were carried as `i32` seconds, which would overflow on 2038-01-19. This change migrates the timestamps to 64-bit values (`i64`) to prevent false timeouts and cluster failures post-2038. It also establishes the expected bounce-upgrade semantics for legacy heartbeats.

## How was the change tested
- Added `Y2038HeartbeatTest` to ensure that 64-bit timestamps round-trip correctly through Thrift serialization.
- Verified that `HeartbeatCache` successfully parses and handles post-2038 heartbeats without flagging them as timed out.
- Tested schema backward-compatibility to ensure legacy `i32` payloads fail validation gracefully during the bounce-upgrade window.

- Fixes #7897 