### PR TITLE
Skip stale worker heartbeats from orphaned worker directories

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/timer/ReportWorkerHeartbeats.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/timer/ReportWorkerHeartbeats.java
@@ -15,6 +15,7 @@ package org.apache.storm.daemon.supervisor.timer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.storm.Config;
 import org.apache.storm.daemon.supervisor.Supervisor;
 import org.apache.storm.daemon.supervisor.SupervisorUtils;
 import org.apache.storm.generated.LSWorkerHeartbeat;
@@ -23,6 +24,8 @@ import org.apache.storm.generated.SupervisorWorkerHeartbeats;
 import org.apache.storm.thrift.TException;
 import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.utils.NimbusClient;
+import org.apache.storm.utils.ObjectReader;
+import org.apache.storm.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,10 +39,12 @@ public class ReportWorkerHeartbeats implements Runnable {
 
     private Supervisor supervisor;
     private Map<String, Object> conf;
+    private final int workerTimeoutSecs;
 
     public ReportWorkerHeartbeats(Map<String, Object> conf, Supervisor supervisor) {
         this.conf = conf;
         this.supervisor = supervisor;
+        this.workerTimeoutSecs = ObjectReader.getInt(conf.get(Config.SUPERVISOR_WORKER_TIMEOUT_SECS));
     }
 
     @Override
@@ -59,7 +64,7 @@ public class ReportWorkerHeartbeats implements Runnable {
         }
     }
 
-    private SupervisorWorkerHeartbeats getSupervisorWorkerHeartbeatsFromLocal(Map<String, LSWorkerHeartbeat> localHeartbeats) {
+    SupervisorWorkerHeartbeats getSupervisorWorkerHeartbeatsFromLocal(Map<String, LSWorkerHeartbeat> localHeartbeats) {
         SupervisorWorkerHeartbeats supervisorWorkerHeartbeats = new SupervisorWorkerHeartbeats();
 
         List<SupervisorWorkerHeartbeat> heartbeatList = new ArrayList<>();
@@ -67,6 +72,18 @@ public class ReportWorkerHeartbeats implements Runnable {
         for (LSWorkerHeartbeat lsWorkerHeartbeat : localHeartbeats.values()) {
             // local worker heartbeat can be null cause some error/exception
             if (null == lsWorkerHeartbeat) {
+                continue;
+            }
+
+            // Skip stale heartbeats left by worker directories that were never cleaned up
+            // (e.g. a worker that died before the supervisor finished cleanup). Such a worker
+            // has not heartbeat within the timeout, so it is already considered dead; forwarding
+            // it would make Nimbus repeatedly read the (often deleted) topology conf and log noise.
+            // A live worker always refreshes its heartbeat well within the timeout.
+            long hbAgeSecs = Time.deltaSecsLong(lsWorkerHeartbeat.get_time_secs());
+            if (hbAgeSecs > workerTimeoutSecs) {
+                LOG.debug("Skipping stale heartbeat for topology {}: age {}s > worker timeout {}s",
+                    lsWorkerHeartbeat.get_topology_id(), hbAgeSecs, workerTimeoutSecs);
                 continue;
             }
 

--- a/storm-server/src/main/java/org/apache/storm/daemon/supervisor/timer/ReportWorkerHeartbeats.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/supervisor/timer/ReportWorkerHeartbeats.java
@@ -21,6 +21,7 @@ import org.apache.storm.daemon.supervisor.SupervisorUtils;
 import org.apache.storm.generated.LSWorkerHeartbeat;
 import org.apache.storm.generated.SupervisorWorkerHeartbeat;
 import org.apache.storm.generated.SupervisorWorkerHeartbeats;
+import org.apache.storm.shade.com.google.common.annotations.VisibleForTesting;
 import org.apache.storm.thrift.TException;
 import org.apache.storm.utils.ConfigUtils;
 import org.apache.storm.utils.NimbusClient;
@@ -64,6 +65,7 @@ public class ReportWorkerHeartbeats implements Runnable {
         }
     }
 
+    @VisibleForTesting
     SupervisorWorkerHeartbeats getSupervisorWorkerHeartbeatsFromLocal(Map<String, LSWorkerHeartbeat> localHeartbeats) {
         SupervisorWorkerHeartbeats supervisorWorkerHeartbeats = new SupervisorWorkerHeartbeats();
 

--- a/storm-server/src/test/java/org/apache/storm/daemon/supervisor/timer/ReportWorkerHeartbeatsTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/supervisor/timer/ReportWorkerHeartbeatsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.daemon.supervisor.timer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.storm.Config;
+import org.apache.storm.daemon.supervisor.Supervisor;
+import org.apache.storm.generated.LSWorkerHeartbeat;
+import org.apache.storm.generated.SupervisorWorkerHeartbeat;
+import org.apache.storm.generated.SupervisorWorkerHeartbeats;
+import org.apache.storm.utils.Time;
+import org.junit.jupiter.api.Test;
+
+public class ReportWorkerHeartbeatsTest {
+
+    private static final int WORKER_TIMEOUT_SECS = 30;
+    private static final String SUPERVISOR_ID = "test-supervisor";
+
+    private static LSWorkerHeartbeat mkHeartbeat(String topologyId, long timeSecs) {
+        LSWorkerHeartbeat hb = new LSWorkerHeartbeat();
+        hb.set_topology_id(topologyId);
+        hb.set_time_secs(timeSecs);
+        return hb;
+    }
+
+    private ReportWorkerHeartbeats mkReporter() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(Config.SUPERVISOR_WORKER_TIMEOUT_SECS, WORKER_TIMEOUT_SECS);
+        Supervisor supervisor = mock(Supervisor.class);
+        when(supervisor.getId()).thenReturn(SUPERVISOR_ID);
+        return new ReportWorkerHeartbeats(conf, supervisor);
+    }
+
+    private static Set<String> reportedTopologies(SupervisorWorkerHeartbeats heartbeats) {
+        return heartbeats.get_worker_heartbeats().stream()
+            .map(SupervisorWorkerHeartbeat::get_storm_id)
+            .collect(Collectors.toSet());
+    }
+
+    @Test
+    public void freshHeartbeatsAreReportedAndStaleOnesAreFilteredOut() {
+        try (Time.SimulatedTime ignored = new Time.SimulatedTime()) {
+            Time.advanceTimeSecs(100_000);
+            long now = Time.currentTimeSecsLong();
+
+            Map<String, LSWorkerHeartbeat> local = new LinkedHashMap<>();
+            // live worker: heartbeat just refreshed
+            local.put("w-fresh", mkHeartbeat("topo-fresh", now));
+            // exactly at the timeout boundary is still considered alive (age == timeout, not > timeout)
+            local.put("w-boundary", mkHeartbeat("topo-boundary", now - WORKER_TIMEOUT_SECS));
+            // just past the timeout: the worker is already considered dead
+            local.put("w-stale", mkHeartbeat("topo-stale", now - WORKER_TIMEOUT_SECS - 1));
+            // orphaned worker directory left behind long ago for a topology that no longer exists
+            local.put("w-orphan", mkHeartbeat("topo-orphan", now - 86_400));
+
+            SupervisorWorkerHeartbeats result = mkReporter().getSupervisorWorkerHeartbeatsFromLocal(local);
+
+            assertEquals(SUPERVISOR_ID, result.get_supervisor_id());
+            assertEquals(Set.of("topo-fresh", "topo-boundary"), reportedTopologies(result));
+        }
+    }
+
+    @Test
+    public void nullLocalHeartbeatsAreSkipped() {
+        try (Time.SimulatedTime ignored = new Time.SimulatedTime()) {
+            Time.advanceTimeSecs(100_000);
+            long now = Time.currentTimeSecsLong();
+
+            Map<String, LSWorkerHeartbeat> local = new LinkedHashMap<>();
+            local.put("w-null", null);
+            local.put("w-fresh", mkHeartbeat("topo-fresh", now));
+
+            SupervisorWorkerHeartbeats result = mkReporter().getSupervisorWorkerHeartbeatsFromLocal(local);
+
+            assertEquals(Set.of("topo-fresh"), reportedTopologies(result));
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes #8786.

The supervisor builds the heartbeat batch it sends to Nimbus from every worker directory present on disk (`SupervisorUtils.readWorkerHeartbeats` → `ReportWorkerHeartbeats.getSupervisorWorkerHeartbeatsFromLocal`), with no check on whether the worker is still alive. When a worker directory is left behind — e.g. a worker that died before the supervisor finished `Container.cleanUpForRestart()` — its frozen heartbeat keeps being reported on every reporting round. Orphaned directories are only reclaimed when `ReadClusterState` is constructed at supervisor startup, not from the periodic sync loop, so at runtime the stale heartbeat is reported indefinitely until the next supervisor restart.

Because the reported topology is usually no longer assigned (and its conf may already be deleted), Nimbus repeatedly tries to read the topology conf while processing that heartbeat and floods its log with `Exception when getting heartbeat timeout` / `NotAliveException`. STORM-4022 only suppressed the `NotAliveException` logging on the Nimbus side; the underlying behavior — the supervisor reporting heartbeats for dead/orphaned workers — was never addressed, and the generic-exception branch still logs.

This change filters stale heartbeats out in `ReportWorkerHeartbeats`: any heartbeat whose age exceeds `supervisor.worker.timeout.secs` is skipped and not forwarded to Nimbus. That is the same timeout `Slot` uses to decide a worker is dead, so a worker past it is already considered dead and should not be reported. A live worker always refreshes its heartbeat well within the timeout, so no valid heartbeat is ever dropped; a heartbeat exactly at the boundary (age == timeout) is still reported.

## How was the change tested

Added `ReportWorkerHeartbeatsTest` (driven by `Time.SimulatedTime`) covering `getSupervisorWorkerHeartbeatsFromLocal`:

- a fresh heartbeat is reported;
- a heartbeat exactly at the timeout boundary (age == timeout) is still reported;
- a heartbeat just past the timeout (age == timeout + 1) is filtered out;
- a long-stale orphaned heartbeat (a day old) is filtered out;
- null local heartbeats continue to be skipped.