### PR TITLE
scheduler: replace reflection with @VisibleForTesting in IsolationSchedulerTest

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/scheduler/IsolationScheduler.java
+++ b/storm-server/src/main/java/org/apache/storm/scheduler/IsolationScheduler.java
@@ -26,6 +26,7 @@ import java.util.TreeMap;
 import org.apache.commons.lang3.Validate;
 import org.apache.storm.DaemonConfig;
 import org.apache.storm.metric.StormMetricsRegistry;
+import org.apache.storm.shade.com.google.common.annotations.VisibleForTesting;
 import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -309,7 +310,8 @@ public class IsolationScheduler implements IScheduler {
     //                                                         need fewer evictions
     //   3. (tertiary)  host name,                 ascending  — deterministic order
     //                                                         for testability
-    private LinkedList<HostAssignableSlots> hostAssignableSlots(Cluster cluster) {
+    @VisibleForTesting
+    LinkedList<HostAssignableSlots> hostAssignableSlots(Cluster cluster) {
         List<WorkerSlot> assignableSlots = cluster.getAssignableSlots();
         Map<String, List<WorkerSlot>> hostAssignableSlots = new HashMap<String, List<WorkerSlot>>();
         Map<String, Integer> hostFreeSlotCounts = new HashMap<String, Integer>();

--- a/storm-server/src/test/java/org/apache/storm/scheduler/IsolationSchedulerTest.java
+++ b/storm-server/src/test/java/org/apache/storm/scheduler/IsolationSchedulerTest.java
@@ -12,7 +12,6 @@
 
 package org.apache.storm.scheduler;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -50,14 +49,6 @@ public class IsolationSchedulerTest {
                            topologies, new HashMap<String, Object>());
     }
 
-    @SuppressWarnings("unchecked")
-    private static LinkedList<IsolationScheduler.HostAssignableSlots> hostAssignableSlots(
-        IsolationScheduler scheduler, Cluster cluster) throws Exception {
-        Method method = IsolationScheduler.class.getDeclaredMethod("hostAssignableSlots", Cluster.class);
-        method.setAccessible(true);
-        return (LinkedList<IsolationScheduler.HostAssignableSlots>) method.invoke(scheduler, cluster);
-    }
-
     private static List<String> hostOrder(LinkedList<IsolationScheduler.HostAssignableSlots> slots) {
         List<String> hosts = new ArrayList<>();
         for (IsolationScheduler.HostAssignableSlots slot : slots) {
@@ -67,7 +58,7 @@ public class IsolationSchedulerTest {
     }
 
     @Test
-    public void hostAssignableSlots_prefersHostWithMoreFreeSlots() throws Exception {
+    public void hostAssignableSlots_prefersHostWithMoreFreeSlots() {
         Map<String, SupervisorDetails> supervisors = new HashMap<>();
         supervisors.put("sup-busy", mkSupervisor("sup-busy", "host-busy", 2));
         supervisors.put("sup-free", mkSupervisor("sup-free", "host-free", 2));
@@ -83,7 +74,7 @@ public class IsolationSchedulerTest {
                        Collections.singletonList(filler.getExecutors().iterator().next()));
 
         LinkedList<IsolationScheduler.HostAssignableSlots> ranked =
-            hostAssignableSlots(new IsolationScheduler(), cluster);
+            new IsolationScheduler().hostAssignableSlots(cluster);
 
         assertEquals(2, ranked.size());
         assertEquals("host-free", ranked.get(0).getHostName());
@@ -94,7 +85,7 @@ public class IsolationSchedulerTest {
     }
 
     @Test
-    public void hostAssignableSlots_breaksTiesByHostName() throws Exception {
+    public void hostAssignableSlots_breaksTiesByHostName() {
         Map<String, SupervisorDetails> supervisors = new HashMap<>();
         supervisors.put("sup-a", mkSupervisor("sup-a", "host-aaa", 2));
         supervisors.put("sup-b", mkSupervisor("sup-b", "host-bbb", 2));
@@ -102,7 +93,7 @@ public class IsolationSchedulerTest {
         Cluster cluster = mkCluster(supervisors, new Topologies());
 
         LinkedList<IsolationScheduler.HostAssignableSlots> ranked =
-            hostAssignableSlots(new IsolationScheduler(), cluster);
+            new IsolationScheduler().hostAssignableSlots(cluster);
 
         assertEquals(2, ranked.size());
         assertEquals(2, ranked.get(0).getWorkerSlots().size());


### PR DESCRIPTION
## Summary

- Makes `IsolationScheduler#hostAssignableSlots` package-private and annotates it with `@VisibleForTesting`
- Removes the reflection-based wrapper in `IsolationSchedulerTest` that called `setAccessible(true)` to reach the private method
- Tests now call `hostAssignableSlots` directly; `throws Exception` removed from both test signatures

## Motivation

As suggested in https://github.com/apache/storm/pull/8709#discussion_r3463986567 — reflection-based test helpers are fragile (silently break on method renames, signature changes, or module boundary changes) and harder to maintain. The `@VisibleForTesting` pattern is already used elsewhere in `storm-server` (e.g. `Supervisor.java`) and makes the intent explicit without exposing the method publicly.

## Test plan

- [ ] `mvn test -pl storm-server -Dtest=IsolationSchedulerTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)