### PR TITLE
utils: use WeakReference in BatchInserter to fix ThreadLocal retention of JCQueue

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/utils/JCQueue.java
+++ b/storm-client/src/jvm/org/apache/storm/utils/JCQueue.java
@@ -19,6 +19,7 @@
 package org.apache.storm.utils;
 
 import java.io.Closeable;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.storm.metrics2.StormMetricRegistry;
@@ -345,11 +346,16 @@ public class JCQueue implements Closeable {
     /* Not thread safe. Have one instance per producer thread or synchronize externally */
     private static class BatchInserter implements Inserter {
         private final int batchSz;
-        private final JCQueue queue;
+        // WeakReference breaks the ThreadLocal retention cycle: thdLocalBatcher is an instance field
+        // of JCQueue, so the ThreadLocalMap key (the ThreadLocal object) is kept strongly reachable
+        // via value(BatchInserter) -> queue(JCQueue) -> field. A WeakReference here cuts that path,
+        // allowing the key to become weakly-reachable and the entry to be expunged once the JCQueue
+        // is no longer externally referenced.
+        private final WeakReference<JCQueue> queueRef;
         private final ArrayList<Object> currentBatch;
 
         BatchInserter(JCQueue queue, int batchSz) {
-            this.queue = queue;
+            this.queueRef = new WeakReference<>(queue);
             this.batchSz = batchSz;
             this.currentBatch = new ArrayList<>(batchSz + 1);
         }
@@ -402,6 +408,13 @@ public class JCQueue implements Closeable {
             if (currentBatch.isEmpty()) {
                 return;
             }
+            JCQueue queue = queueRef.get();
+            if (queue == null) {
+                // The JCQueue was GC'd (topology stopped on a long-lived thread, e.g. LocalCluster).
+                // Nothing to flush; discard the buffered batch and return cleanly.
+                currentBatch.clear();
+                return;
+            }
             boolean wasFull = currentBatch.size() >= batchSize();
             int publishCount = queue.tryPublishInternal(currentBatch);
             int retryCount = 0;
@@ -430,6 +443,13 @@ public class JCQueue implements Closeable {
         @Override
         public boolean tryFlush() {
             if (currentBatch.isEmpty()) {
+                return true;
+            }
+            JCQueue queue = queueRef.get();
+            if (queue == null) {
+                // The JCQueue was GC'd (topology stopped on a long-lived thread, e.g. LocalCluster).
+                // Nothing to flush; discard the buffered batch and report success.
+                currentBatch.clear();
                 return true;
             }
             boolean wasFull = currentBatch.size() >= batchSize();

--- a/storm-client/test/jvm/org/apache/storm/utils/JCQueueTest.java
+++ b/storm-client/test/jvm/org/apache/storm/utils/JCQueueTest.java
@@ -15,8 +15,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.ref.WeakReference;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.storm.metrics2.StormMetricRegistry;
@@ -228,6 +231,46 @@ public class JCQueueTest {
         assertFalse(inserter.tryPublish(4L));       // full batch, queue full -> tryFlush fails
         // A full batch that could not be published must be read as heavy load (grow), not light load (shrink).
         assertEquals(3, inserter.batchSize());
+    }
+
+    @Test
+    public void testQueueIsCollectedAfterLongLivedProducerPublishes() {
+        Assertions.assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            ExecutorService producerPool = Executors.newSingleThreadExecutor();
+            try {
+                WeakReference<JCQueue> ref = publishFromLongLivedThread(producerPool);
+                assertTrue(awaitGarbageCollection(ref),
+                    "JCQueue was not garbage collected — BatchInserter may still hold a strong reference to it");
+            } finally {
+                producerPool.shutdownNow();
+            }
+        });
+    }
+
+    // Publishes a few tuples from a pooled thread so that the BatchInserter's ThreadLocal entry is
+    // created on that thread. Once .get() returns the lambda is done and its closure ref is gone;
+    // when the method returns the local `queue` variable goes out of scope. The only remaining
+    // reference is the WeakReference — if it is not cleared after GC, the ThreadLocal cycle is still live.
+    private WeakReference<JCQueue> publishFromLongLivedThread(ExecutorService pool) throws Exception {
+        JCQueue queue = createQueue("leak", 100, 1024);
+        pool.submit(() -> {
+            try {
+                for (long i = 0; i < 10; i++) {
+                    queue.publish(i);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }).get();
+        return new WeakReference<>(queue);
+    }
+
+    private boolean awaitGarbageCollection(WeakReference<JCQueue> ref) throws InterruptedException {
+        for (int i = 0; i < 50 && ref.get() != null; i++) {
+            System.gc();
+            Thread.sleep(100);
+        }
+        return ref.get() == null;
     }
 
     /** Drive the inserter with full flushes until the effective batch size reaches the target. */


### PR DESCRIPTION
Fixes #8810

## Problem

`BatchInserter` held a **strong** `JCQueue queue` reference, and inserter instances live in **instance-field** `ThreadLocal`s on the same `JCQueue`. This creates a cycle that prevents the normal ThreadLocal weak-key expunge path from ever firing:

```
Thread
  └─ ThreadLocalMap
       key (weak):    JCQueue.thdLocalBatcher     ← the ThreadLocal object
       value (strong): BatchInserter
                         └─ queue: JCQueue (strong)
                                └─ thdLocalBatcher: ThreadLocal  ← key is now strongly reachable!
```

The weak key in `ThreadLocalMap` becomes eligible for expunge only when it is *not* strongly reachable. Here it always is — via `value → queue → field` — so the entry is never cleaned up, and the `JCQueue` (recv queue, overflow queue, metrics, batch buffer) is retained for as long as the producer thread lives.

In production this is harmless: Storm runs workers as dedicated JVM processes where threads and queues share a lifetime. In `LocalCluster`, embedded deployments, or test harnesses that repeatedly start/stop topologies on long-lived threads, each stopped topology can strand its `JCQueue` instances.

## Fix

Store the `JCQueue` as a `WeakReference` inside `BatchInserter`. This cuts the `value → JCQueue` strong path:

```
Thread
  └─ ThreadLocalMap
       key (weak):    JCQueue.thdLocalBatcher
       value (strong): BatchInserter
                         └─ queueRef: WeakReference → JCQueue   (no longer a strong path to the key)
```

When the last external strong ref to the `JCQueue` is dropped, the `thdLocalBatcher` field (and therefore the `ThreadLocalMap` key) becomes weakly-reachable, and the entry is expunged on the next `ThreadLocal` access by the producer thread. `BatchInserter` is then released too.

`flush()` and `tryFlush()` dereference the `WeakReference` once at entry and bail out silently if the queue was already collected (the topology is dead; in-flight tuples are already lost). `publish()` and `tryPublish()` need no changes — they only touch `currentBatch`.

## Note for PR #8796

`DynamicBatchInserter` (introduced in #8796) extends `BatchInserter` and its own overrides (`batchSize()`, `afterFlush()`) never access `queue` directly, so this fix covers it automatically — no separate change is needed there.

## Test plan

- [ ] `mvn test -pl storm-client -Dtest=JCQueueTest` passes
- [ ] Optionally: reproduce with a `LocalCluster` that repeatedly submits/kills a topology and verify the `JCQueue` instances are no longer retained after kill

🤖 Generated with [Claude Code](https://claude.com/claude-code)