### PR TITLE
Improve RELEASING.md accuracy and completeness

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,12 +15,12 @@ Apache Storm follows the basic idea of [Semantic Versioning](https://semver.org/
 
 ## Preparation
 
-- We strongly encourage you to read the [Apache release signing page](http://www.apache.org/dev/release-signing.html), the [release distribution page](http://www.apache.org/dev/release-distribution.html#sigs-and-sums), as well as the [release publishing](http://www.apache.org/dev/release-publishing), [release policy](http://www.apache.org/legal/release-policy.html) and [Maven publishing](https://infra.apache.org/publishing-maven-artifacts.html) pages. ASF has common guidelines that apply to all projects.
-- Ensure you can log in to http://repository.apache.org. You should use your Apache ID username and password.
+- We strongly encourage you to read the [Apache release signing page](https://www.apache.org/dev/release-signing.html), the [release distribution page](https://www.apache.org/dev/release-distribution.html#sigs-and-sums), as well as the [release publishing](https://www.apache.org/dev/release-publishing), [release policy](https://www.apache.org/legal/release-policy.html) and [Maven publishing](https://infra.apache.org/publishing-maven-artifacts.html) pages. ASF has common guidelines that apply to all projects.
+- Ensure you can log in to https://repository.apache.org. You should use your Apache ID username and password.
 - Install a SVN client, and ensure you can access the https://dist.apache.org/repos/dist/dev/storm/ and https://dist.apache.org/repos/dist/release/storm/ repositories. You should be able to access these with your Apache ID username and password.
 - During the release phase, artifacts will be uploaded to https://repository.apache.org. This means Maven needs to know your LDAP credentials. It is recommended that you use Maven's mechanism for [password encryption](https://maven.apache.org/guides/mini/guide-encryption.html). Please configure this in your `${user.home}/.m2/settings.xml`:
   
-```
+```xml
     <settings>
   ...
     <servers>
@@ -42,35 +42,57 @@ Apache Storm follows the basic idea of [Semantic Versioning](https://semver.org/
 ``` 
 - Ensure you have a signed GPG key, and that the GPG key is listed in the Storm KEYS file at https://dist.apache.org/repos/dist/release/storm/KEYS. The key should be hooked into the Apache web of trust (https://keyserver.ubuntu.com for example)
    - set up the key as the default one to be used during the signing operations that the GPG Maven plugin will request (your OS GPG agent can do this)
+   - If your key is not yet in the KEYS file, add it:
+     ```bash
+     svn checkout https://dist.apache.org/repos/dist/release/storm/
+     gpg --export --armor <YOUR_KEY_ID> >> storm/KEYS
+     svn commit storm/KEYS -m "Add GPG key for release manager <YOUR NAME>"
+     ```
 - Compile environment:
   - some tests currently rely on the following packages being available locally:
     - NodeJS
     - Python3
-  - some tests will require Docker to be running since they will create/launch containers (make sure `/var/run/docker.sock` has the correct permissions, otherwise you migh see the error `Could not find a valid Docker environment`)
+  - some tests will require Docker to be running since they will create/launch containers (make sure `/var/run/docker.sock` has the correct permissions, otherwise you might see the error `Could not find a valid Docker environment`)
 
 
 
-If you are setting up a new MINOR version release, create a new branch based on `master` branch, e.g. `2.6.x-branch`. Then on master branch, set the version to a higher MINOR version (with SNAPSHOT), e.g. `mvn versions:set -DnewVersion=2.3.0-SNAPSHOT -P dist,rat,externals,examples`.
-In this way, you create a new release line and then you can create PATCH version releases from it, e.g. `2.8.1`.
+If you are setting up a new MINOR version release, create a new branch based on `master` branch, e.g. `2.7.x-branch`. Then on master branch, set the version to a higher MINOR version (with SNAPSHOT), e.g. `mvn versions:set -DnewVersion=2.8.0-SNAPSHOT -P dist,rat,externals,examples`.
+In this way, you create a new release line and then you can create PATCH version releases from it, e.g. `2.7.1`.
 
 ## Setting up a vote
 
 1. Checkout to the branch to be released.
 
-2. Run `mvn release:prepare -P dist,rat,externals,examples` followed `mvn release:perform -P dist,rat,externals,examples`. 
+2. Run `mvn release:prepare -P dist,rat,externals,examples` followed by `mvn release:perform -P dist,rat,externals,examples`. 
 This will create all the artifacts that will eventually be available in maven central. This step may seem simple, 
 but a lot can go wrong (mainly flaky tests). Note that this will create and push two commits with the commit message 
 starting with "[maven-release-plugin]" and it will also create and publish a git tag, e.g. `v2.8.1`. Note: the full build can take up to 30 minutes to complete.
 
-3. Once you get a successful maven release, a “staging repository” will be created at http://repository.apache.org 
-in the “open” state, meaning it is still writable. You will need to close it, making it read-only. You can find more 
+   If the build fails mid-way, run `mvn release:clean` to remove generated files before retrying.
+
+3. Once you get a successful maven release, a "staging repository" will be created at https://repository.apache.org 
+in the "open" state, meaning it is still writable. You will need to close it, making it read-only. You can find more 
 information on this step [here](https://infra.apache.org/publishing-maven-artifacts.html).
 
-4. Checkout to the git tag that was published by Step 1 above, e.g. `git checkout tags/v2.8.1 -b v2.8.1`. 
-Then build it with `mvn clean install -DskipTests`. Run `mvn package` for `storm-dist/binary` and `storm-dist/source` 
-to create the actual distributions.
+   Note the staging repository ID (e.g. `orgapachestorm-1234`) shown in the Maven console output, or find it in the
+   Nexus UI under **Staging Repositories** at https://repository.apache.org/#stagingRepositories. You will need this
+   ID in the vote email template.
+
+4. Checkout to the git tag that was published by Step 2 above, e.g. `git checkout tags/v2.8.1 -b v2.8.1`. 
+Then build and package the distributions:
+```bash
+mvn clean install -DskipTests -P dist
+cd storm-dist/binary && mvn package && cd ../..
+cd storm-dist/source && mvn package && cd ../..
+```
 
 5. Generate checksums for the *.tar.gz and *.zip distribution files, e.g.
+
+   > **macOS note:** use `shasum -a 512` in place of `sha512sum`.
+
+   > The Maven build may already have generated `.sha512` files in the target directories; verify they exist before
+   > running the commands below.
+
 ```bash
 pushd storm-dist/source/target
 sha512sum apache-storm-2.8.1-src.zip > apache-storm-2.8.1-src.zip.sha512
@@ -89,7 +111,7 @@ popd
 
 8. Run `dev-tools/release_notes.py` for the release version, piping the output to a RELEASE_NOTES.html file. Move that file to the svn release directory, sign it, and generate checksums, e.g.
 ```bash
-export GITHUB_TOKEN=MY_PERSONAL_ACCESS_TOKEN_FOR_GI
+export GITHUB_TOKEN=<your-github-pat>
 python3 dev-tools/release_notes.py <id-of-the-github-milestone> > RELEASE_NOTES.html
 gpg --armor --output RELEASE_NOTES.html.asc --detach-sig RELEASE_NOTES.html
 sha512sum RELEASE_NOTES.html > RELEASE_NOTES.html.sha512
@@ -106,20 +128,25 @@ To obtain the ID of a GitHub milestone:
 - Click on the milestone you want to create release notes for. 
 - Look at the URL in your browser. It will look like this: `https://github.com/apache/storm/milestone/40`, where the last number is the milestone ID.
 
-9. Move the release files from steps 4,5 and 8 to the svn directory from Step 6. Example of the set of files:
+9. Move the release files from steps 4, 5 and 8 to the svn directory from Step 6. Example of the set of files:
    ```
    apache-storm-2.8.3-src.tar.gz         apache-storm-2.8.3-src.zip         apache-storm-2.8.3.tar.gz         apache-storm-2.8.3.zip         RELEASE_NOTES.html
    apache-storm-2.8.3-src.tar.gz.asc     apache-storm-2.8.3-src.zip.asc     apache-storm-2.8.3.tar.gz.asc     apache-storm-2.8.3.zip.asc     RELEASE_NOTES.html.asc
    apache-storm-2.8.3-src.tar.gz.sha512  apache-storm-2.8.3-src.zip.sha512  apache-storm-2.8.3.tar.gz.sha512  apache-storm-2.8.3.zip.sha512  RELEASE_NOTES.html.sha512
    ```
 
- Add and commit the files. This makes them available in the Apache staging repo.
+10. Add and commit the files to SVN. This makes them available in the Apache staging repo.
+```bash
+cd <your-svn-checkout>/apache-storm-x.x.x-rcx
+svn add *
+svn commit -m "Add release candidate apache-storm-x.x.x-rcx"
+```
 
 11. Start the VOTE thread. The vote should follow the [ASF voting process](https://www.apache.org/foundation/voting.html). 
 Sample Template sent to dev@storm.apache.org
 
 ```
-Subject: [VOTE] Release Apache Storm [VERSION]] (rcN)
+Subject: [VOTE] Release Apache Storm [VERSION] (rcN)
 
 Hi folks,
 
@@ -132,7 +159,7 @@ Storm Source and Binary Release with sha512 signature files are here:
     https://dist.apache.org/repos/dist/dev/storm/apache-storm-[VERSION]-rcN/
 The release artifacts are signed with the following key:
     https://keyserver.ubuntu.com/pks/lookup?op=index&fingerprint=on&search=[KEY]
-    in this file https://www.apache.org/dist/storm/KEYS
+    in this file https://downloads.apache.org/storm/KEYS
 
 The release was made from the Apache Storm [VERSION] tag at:
     https://github.com/apache/storm/tree/v[VERSION]
@@ -168,7 +195,7 @@ Thanks!
 
 0. Announce the results. Use the following template:
 
-```agsl
+```text
 Subject: [VOTE][RESULT] Storm [VERSION] Release Candidate [N]
 
 Dear Community,
@@ -189,9 +216,9 @@ Thanks to everyone who contributed to this release.
 [RELEASE MANAGER NAME]
 ```
 
-1. `svn mv https://dist.apache.org/repos/dist/dev/storm/apache-storm-x.x.x-rcx https://dist.apache.org/repos/dist/release/storm/apache-storm-x.x.x`. This will make the release artifacts available on dist.apache.org and the artifacts will start replicating to mirrors.
+1. `svn mv https://dist.apache.org/repos/dist/dev/storm/apache-storm-x.x.x-rcx https://dist.apache.org/repos/dist/release/storm/apache-storm-x.x.x -m "Publish Apache Storm x.x.x release"`. This will make the release artifacts available on dist.apache.org and the artifacts will start replicating to mirrors.
 
-2. Go to http://repository.apache.org and release the staging repository
+2. Go to https://repository.apache.org and release the staging repository.
 
 3. Wait at least 24 hrs. for the mirrors to catch up.
 
@@ -203,17 +230,17 @@ the site as described in the storm-site README to publish the site.
 
 6. Announce the new release to dev@storm.apache.org, user@storm.apache.org, and announce@apache.org. You will need to use your @apache.org email to do this.
 
-7. Delete any outdated releases from the https://dist.apache.org/repos/dist/release/storm/ repository. See [when to archive](http://www.apache.org/legal/release-policy.html#when-to-archive). 
+7. Delete any outdated releases from the https://dist.apache.org/repos/dist/release/storm/ repository. See [when to archive](https://www.apache.org/legal/release-policy.html#when-to-archive). 
 
 8. Delete any outdated releases from the storm-site releases directory, and republish the site.
 
-10. Create a release on [GitHub](https://github.com/apache/storm/releases). Generate the release notes with the GitHub tooling.
+9. Create a release on [GitHub](https://github.com/apache/storm/releases). Generate the release notes with the GitHub tooling.
 
-11. Create a new release for [Storm Docker](https://github.com/apache/storm-docker). Example of a version release [here](https://github.com/apache/storm-docker/commit/177a1534bf910c2271845f4eaedef7c040559fbc). After that is done, a PR to [docker-library](https://github.com/docker-library/official-images) must be submitted, so that the new docker-storm version is officially released. Example of such a PR is [here](https://github.com/docker-library/official-images/pull/21525#issuecomment-4526751672).
+10. Create a new release for [Storm Docker](https://github.com/apache/storm-docker). Example of a version release [here](https://github.com/apache/storm-docker/commit/177a1534bf910c2271845f4eaedef7c040559fbc). After that is done, a PR to [docker-library](https://github.com/docker-library/official-images) must be submitted, so that the new docker-storm version is officially released. Example of such a PR is [here](https://github.com/docker-library/official-images/pull/21525#issuecomment-4526751672).
 
-12. Post, promote, celebrate. ;) Annoucement email can be sent to announce@apache.org using the following template:
+11. Post, promote, celebrate. ;) Announcement email can be sent to announce@apache.org using the following template:
 
-```agsl
+```text
 Subject: [ANNOUNCE] Apache Storm [VERSION] Released
 
 The Apache Storm community is pleased to announce the release of Apache
@@ -254,17 +281,15 @@ The Apache Storm Team
 
 ## Cleaning up if the vote fails
 
-1. Sent email to dev@storm.apache.org 
+1. Go to https://repository.apache.org and drop the staging repository.
 
-2. Go to http://repository.apache.org and drop the staging repository.
+2. Delete the staged distribution files from https://dist.apache.org/repos/dist/dev/storm/.
 
-3. Delete the staged distribution files from https://dist.apache.org/repos/dist/dev/storm/
+3. Delete the git tag.
 
-4. Delete the git tag.
+4. Send a [VOTE][CANCELED] message to dev@storm.apache.org using the following format:
 
-5. Send a [VOTE][CANCELED] message using the following format:
-
-```agsl
+```text
 Subject: [VOTE][CANCELED] Storm [VERSION] Release Candidate [N]
 
 This release candidate Storm Release candidate [VERSION] rcN https://dist.apache.org/repos/dist/dev/storm/apache-storm-[VERSION]-rcN/ has been canceled.
@@ -285,9 +310,9 @@ Please note this list is not exhaustive and only includes some of the common ste
 3. Set up a standalone cluster using apache-storm-xxx.zip, apache-storm-xxx.tar.gz, the Apache Storm distribution created from step 2, separately;
 4. Launch WordCountTopology and ThroughputVsLatency topology and check logs, UI metrics, etc;
 5. Test basic UI functionalities such as jstack, heap dump, deactivate, activate, rebalance, change log level, log search, kill topology;
-6. Test basic CLI such as kill, list, deactivate, deactivate, rebalance, etc.
+6. Test basic CLI such as kill, list, deactivate, activate, rebalance, etc.
 
-It's also preferable to set up a standalone secure Apache Storm cluster and test basic funcionalities on it.
+It's also preferable to set up a standalone secure Apache Storm cluster and test basic functionalities on it.
 
 Don't feel the pressure to do everything listed above. After you finish your review, reply to the corresponding email thread with your vote, summarize the work you have performed and elaborate the issues
 you have found if any. Also please feel free to update the checklist if you think anything important is missing there. 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,8 +54,6 @@ Apache Storm follows the basic idea of [Semantic Versioning](https://semver.org/
     - Python3
   - some tests will require Docker to be running since they will create/launch containers (make sure `/var/run/docker.sock` has the correct permissions, otherwise you might see the error `Could not find a valid Docker environment`)
 
-
-
 If you are setting up a new MINOR version release, create a new branch based on `master` branch, e.g. `2.7.x-branch`. Then on master branch, set the version to a higher MINOR version (with SNAPSHOT), e.g. `mvn versions:set -DnewVersion=2.8.0-SNAPSHOT -P dist,rat,externals,examples`.
 In this way, you create a new release line and then you can create PATCH version releases from it, e.g. `2.7.1`.
 
@@ -63,28 +61,29 @@ In this way, you create a new release line and then you can create PATCH version
 
 1. Checkout to the branch to be released.
 
-2. Run `mvn release:prepare -P dist,rat,externals,examples` followed by `mvn release:perform -P dist,rat,externals,examples`. 
-This will create all the artifacts that will eventually be available in maven central. This step may seem simple, 
-but a lot can go wrong (mainly flaky tests). Note that this will create and push two commits with the commit message 
-starting with "[maven-release-plugin]" and it will also create and publish a git tag, e.g. `v2.8.1`. Note: the full build can take up to 30 minutes to complete.
+2. Run `mvn release:prepare -P dist,rat,externals,examples` followed by `mvn release:perform -P dist,rat,externals,examples`.
+   This will create all the artifacts that will eventually be available in maven central. This step may seem simple,
+   but a lot can go wrong (mainly flaky tests). Note that this will create and push two commits with the commit message
+   starting with "[maven-release-plugin]" and it will also create and publish a git tag, e.g. `v2.8.1`. Note: the full build can take up to 30 minutes to complete.
 
    If the build fails mid-way, run `mvn release:clean` to remove generated files before retrying.
 
-3. Once you get a successful maven release, a "staging repository" will be created at https://repository.apache.org 
-in the "open" state, meaning it is still writable. You will need to close it, making it read-only. You can find more 
-information on this step [here](https://infra.apache.org/publishing-maven-artifacts.html).
+3. Once you get a successful maven release, a "staging repository" will be created at https://repository.apache.org
+   in the "open" state, meaning it is still writable. You will need to close it, making it read-only. You can find more
+   information on this step [here](https://infra.apache.org/publishing-maven-artifacts.html).
 
    Note the staging repository ID (e.g. `orgapachestorm-1234`) shown in the Maven console output, or find it in the
    Nexus UI under **Staging Repositories** at https://repository.apache.org/#stagingRepositories. You will need this
    ID in the vote email template.
 
-4. Checkout to the git tag that was published by Step 2 above, e.g. `git checkout tags/v2.8.1 -b v2.8.1`. 
-Then build and package the distributions:
-```bash
-mvn clean install -DskipTests -P dist
-cd storm-dist/binary && mvn package && cd ../..
-cd storm-dist/source && mvn package && cd ../..
-```
+4. Checkout to the git tag that was published by Step 2 above, e.g. `git checkout tags/v2.8.1 -b v2.8.1`.
+   Then build and package the distributions:
+
+   ```bash
+   mvn clean install -DskipTests -P dist
+   cd storm-dist/binary && mvn package && cd ../..
+   cd storm-dist/source && mvn package && cd ../..
+   ```
 
 5. Generate checksums for the *.tar.gz and *.zip distribution files, e.g.
 
@@ -93,42 +92,45 @@ cd storm-dist/source && mvn package && cd ../..
    > The Maven build may already have generated `.sha512` files in the target directories; verify they exist before
    > running the commands below.
 
-```bash
-pushd storm-dist/source/target
-sha512sum apache-storm-2.8.1-src.zip > apache-storm-2.8.1-src.zip.sha512
-sha512sum apache-storm-2.8.1-src.tar.gz > apache-storm-2.8.1-src.tar.gz.sha512
-popd
+   ```bash
+   pushd storm-dist/source/target
+   sha512sum apache-storm-2.8.1-src.zip > apache-storm-2.8.1-src.zip.sha512
+   sha512sum apache-storm-2.8.1-src.tar.gz > apache-storm-2.8.1-src.tar.gz.sha512
+   popd
 
-pushd storm-dist/binary/final-package/target
-sha512sum apache-storm-2.8.1.zip > apache-storm-2.8.1.zip.sha512
-sha512sum apache-storm-2.8.1.tar.gz > apache-storm-2.8.1.tar.gz.sha512
-popd
-```
+   pushd storm-dist/binary/final-package/target
+   sha512sum apache-storm-2.8.1.zip > apache-storm-2.8.1.zip.sha512
+   sha512sum apache-storm-2.8.1.tar.gz > apache-storm-2.8.1.tar.gz.sha512
+   popd
+   ```
 
 6. Create a directory in the dist svn repo for the release candidate: https://dist.apache.org/repos/dist/dev/storm/apache-storm-x.x.x-rcx
 
-7. Before generating the release notes, please double check if all merged pull requests for the version being released are assigned the milestone in question. They won't be placed in the release notes otherwise
+7. Before generating the release notes, please double check if all merged pull requests for the version being released are assigned the milestone in question. They won't be placed in the release notes otherwise.
 
 8. Run `dev-tools/release_notes.py` for the release version, piping the output to a RELEASE_NOTES.html file. Move that file to the svn release directory, sign it, and generate checksums, e.g.
-```bash
-export GITHUB_TOKEN=<your-github-pat>
-python3 dev-tools/release_notes.py <id-of-the-github-milestone> > RELEASE_NOTES.html
-gpg --armor --output RELEASE_NOTES.html.asc --detach-sig RELEASE_NOTES.html
-sha512sum RELEASE_NOTES.html > RELEASE_NOTES.html.sha512
-```
 
-To create a personal access token:
+   ```bash
+   export GITHUB_TOKEN=<your-github-pat>
+   python3 dev-tools/release_notes.py <id-of-the-github-milestone> > RELEASE_NOTES.html
+   gpg --armor --output RELEASE_NOTES.html.asc --detach-sig RELEASE_NOTES.html
+   sha512sum RELEASE_NOTES.html > RELEASE_NOTES.html.sha512
+   ```
 
-- Go to your GitHub account settings. 
-- Navigate to **Developer Settings** > **Personal Access Tokens** > **Tokens (classic)**. 
-- Generate a token with the `public_repo` scope.
+   To create a personal access token:
 
-To obtain the ID of a GitHub milestone:
-- Visit the [milestone overview](https://github.com/apache/storm/milestones). 
-- Click on the milestone you want to create release notes for. 
-- Look at the URL in your browser. It will look like this: `https://github.com/apache/storm/milestone/40`, where the last number is the milestone ID.
+   - Go to your GitHub account settings.
+   - Navigate to **Developer Settings** > **Personal Access Tokens** > **Tokens (classic)**.
+   - Generate a token with the `public_repo` scope.
+
+   To obtain the ID of a GitHub milestone:
+
+   - Visit the [milestone overview](https://github.com/apache/storm/milestones).
+   - Click on the milestone you want to create release notes for.
+   - Look at the URL in your browser. It will look like this: `https://github.com/apache/storm/milestone/40`, where the last number is the milestone ID.
 
 9. Move the release files from steps 4, 5 and 8 to the svn directory from Step 6. Example of the set of files:
+
    ```
    apache-storm-2.8.3-src.tar.gz         apache-storm-2.8.3-src.zip         apache-storm-2.8.3.tar.gz         apache-storm-2.8.3.zip         RELEASE_NOTES.html
    apache-storm-2.8.3-src.tar.gz.asc     apache-storm-2.8.3-src.zip.asc     apache-storm-2.8.3.tar.gz.asc     apache-storm-2.8.3.zip.asc     RELEASE_NOTES.html.asc
@@ -136,101 +138,111 @@ To obtain the ID of a GitHub milestone:
    ```
 
 10. Add and commit the files to SVN. This makes them available in the Apache staging repo.
-```bash
-cd <your-svn-checkout>/apache-storm-x.x.x-rcx
-svn add *
-svn commit -m "Add release candidate apache-storm-x.x.x-rcx"
-```
 
-11. Start the VOTE thread. The vote should follow the [ASF voting process](https://www.apache.org/foundation/voting.html). 
-Sample Template sent to dev@storm.apache.org
+    ```bash
+    cd <your-svn-checkout>/apache-storm-x.x.x-rcx
+    svn add *
+    svn commit -m "Add release candidate apache-storm-x.x.x-rcx"
+    ```
 
-```
-Subject: [VOTE] Release Apache Storm [VERSION] (rcN)
+11. Start the VOTE thread. The vote should follow the [ASF voting process](https://www.apache.org/foundation/voting.html).
 
-Hi folks,
+    *Sample template, sent to dev@storm.apache.org:*
 
-I have posted a [Nth] release candidate for the Apache Storm [VERSION] release and it is ready for testing.
+    ```
+    Subject: [VOTE] Release Apache Storm [VERSION] (rcN)
 
-The Nexus staging repository is here:
+    Hi folks,
+
+    I have posted a [Nth] release candidate for the Apache Storm [VERSION] release and it is ready for testing.
+
+    The Nexus staging repository is here:
+        https://repository.apache.org/content/repositories/orgapachestorm-[REPO_NUM]
+
+    Storm Source and Binary Release with sha512 signature files are here:
+        https://dist.apache.org/repos/dist/dev/storm/apache-storm-[VERSION]-rcN/
+    The release artifacts are signed with the following key:
+        https://keyserver.ubuntu.com/pks/lookup?op=index&fingerprint=on&search=[KEY]
+        in this file https://downloads.apache.org/storm/KEYS
+
+    The release was made from the Apache Storm [VERSION] tag at:
+        https://github.com/apache/storm/tree/v[VERSION]
+
+    Full list of changes in this release:
+        https://dist.apache.org/repos/dist/dev/storm/apache-storm-[VERSION]-rcN/RELEASE_NOTES.html
+
+    To use it in a maven build set the version for Storm to [VERSION] and add the following URL to your settings.xml file:
     https://repository.apache.org/content/repositories/orgapachestorm-[REPO_NUM]
 
-Storm Source and Binary Release with sha512 signature files are here:
-    https://dist.apache.org/repos/dist/dev/storm/apache-storm-[VERSION]-rcN/
-The release artifacts are signed with the following key:
-    https://keyserver.ubuntu.com/pks/lookup?op=index&fingerprint=on&search=[KEY]
-    in this file https://downloads.apache.org/storm/KEYS
+    The release was made using the Storm release process, documented on the GitHub repository:
+    https://github.com/apache/storm/blob/master/RELEASING.md
 
-The release was made from the Apache Storm [VERSION] tag at:
-    https://github.com/apache/storm/tree/v[VERSION]
+    Please vote on releasing these packages as Apache Storm [VERSION]. The vote is open for at least the next 72 hours.
+    "How to vote" is described here: https://github.com/apache/storm/blob/master/RELEASING.md#how-to-vote-on-a-release-candidate
+    When voting, please list the actions taken to verify the release.
 
-Full list of changes in this release: 
-    https://dist.apache.org/repos/dist/dev/storm/apache-storm-[VERSION]-rcN/RELEASE_NOTES.html
+    Only votes from the Storm PMC are binding, but everyone is welcome to check the release candidate and vote.
+    The vote passes if at least three binding +1 votes are cast.
 
-To use it in a maven build set the version for Storm to [VERSION] and add the following URL to your settings.xml file:
-https://repository.apache.org/content/repositories/orgapachestorm-[REPO_NUM]
+    [ ] +1 Release this package as Apache Storm [VERSION]
+    [ ]  0 No opinion
+    [ ] -1 Do not release this package because...
 
-The release was made using the Storm release process, documented on the GitHub repository:
-https://github.com/apache/storm/blob/master/RELEASING.md
+    Thanks to everyone who contributed to this release.
 
-Please vote on releasing these packages as Apache Storm [VERSION]. The vote is open for at least the next 72 hours.
-"How to vote" is described here: https://github.com/apache/storm/blob/master/RELEASING.md#how-to-vote-on-a-release-candidate
-When voting, please list the actions taken to verify the release.
-
-Only votes from the Storm PMC are binding, but everyone is welcome to check the release candidate and vote.
-The vote passes if at least three binding +1 votes are cast.
-
-[ ] +1 Release this package as Apache Storm [VERSION]
-[ ]  0 No opinion
-[ ] -1 Do not release this package because...
-
-Thanks to everyone who contributed to this release.
-
-Thanks!
-[Release Manager Name]
-```
+    Thanks!
+    [Release Manager Name]
+    ```
 
 
 ## Releasing if the vote succeeds
 
 0. Announce the results. Use the following template:
 
-```text
-Subject: [VOTE][RESULT] Storm [VERSION] Release Candidate [N]
+   ```text
+   Subject: [VOTE][RESULT] Storm [VERSION] Release Candidate [N]
 
-Dear Community,
+   Dear Community,
 
-The voting for releasing Apache Storm [VERSION] Release Candidate [N] has passed with # +1 votes (# binding) and # +0 or -1 votes.
-+1 votes:
-* ###### / binding
-* ############
+   The voting for releasing Apache Storm [VERSION] Release Candidate [N] has passed with # +1 votes (# binding) and # +0 or -1 votes.
+   +1 votes:
+   * ###### / binding
+   * ############
 
-Vote thread can be found at:
-https://lists.apache.org/thread.html/##############
+   Vote thread can be found at:
+   https://lists.apache.org/thread.html/##############
 
-Thanks everyone for taking the time to review and vote for the release!
-We will continue the rest of release process and send out the announcement email in the coming days.
+   Thanks everyone for taking the time to review and vote for the release!
+   We will continue the rest of release process and send out the announcement email in the coming days.
 
-Thanks to everyone who contributed to this release.
+   Thanks to everyone who contributed to this release.
 
-[RELEASE MANAGER NAME]
-```
+   [RELEASE MANAGER NAME]
+   ```
 
-1. `svn mv https://dist.apache.org/repos/dist/dev/storm/apache-storm-x.x.x-rcx https://dist.apache.org/repos/dist/release/storm/apache-storm-x.x.x -m "Publish Apache Storm x.x.x release"`. This will make the release artifacts available on dist.apache.org and the artifacts will start replicating to mirrors.
+1. Move the release candidate to the release directory and publish it:
+
+   ```bash
+   svn mv https://dist.apache.org/repos/dist/dev/storm/apache-storm-x.x.x-rcx \
+          https://dist.apache.org/repos/dist/release/storm/apache-storm-x.x.x \
+          -m "Publish Apache Storm x.x.x release"
+   ```
+
+   This will make the release artifacts available on dist.apache.org and the artifacts will start replicating to mirrors.
 
 2. Go to https://repository.apache.org and release the staging repository.
 
 3. Wait at least 24 hrs. for the mirrors to catch up.
 
-4. Check out the [storm-site](https://github.com/apache/storm-site) repository, and follow the README to generate release specific documentation for 
-the site. Compose a new blog post announcement for the new release. Update the downloads page. Finally, commit and push 
-the site as described in the storm-site README to publish the site.
+4. Check out the [storm-site](https://github.com/apache/storm-site) repository, and follow the README to generate release specific documentation for
+   the site. Compose a new blog post announcement for the new release. Update the downloads page. Finally, commit and push
+   the site as described in the storm-site README to publish the site.
 
 5. Update `doap_Storm.rdf` with the new release version.
 
 6. Announce the new release to dev@storm.apache.org, user@storm.apache.org, and announce@apache.org. You will need to use your @apache.org email to do this.
 
-7. Delete any outdated releases from the https://dist.apache.org/repos/dist/release/storm/ repository. See [when to archive](https://www.apache.org/legal/release-policy.html#when-to-archive). 
+7. Delete any outdated releases from the https://dist.apache.org/repos/dist/release/storm/ repository. See [when to archive](https://www.apache.org/legal/release-policy.html#when-to-archive).
 
 8. Delete any outdated releases from the storm-site releases directory, and republish the site.
 
@@ -240,44 +252,44 @@ the site as described in the storm-site README to publish the site.
 
 11. Post, promote, celebrate. ;) Announcement email can be sent to announce@apache.org using the following template:
 
-```text
-Subject: [ANNOUNCE] Apache Storm [VERSION] Released
+    ```text
+    Subject: [ANNOUNCE] Apache Storm [VERSION] Released
 
-The Apache Storm community is pleased to announce the release of Apache
-Storm version [VERSION].
+    The Apache Storm community is pleased to announce the release of Apache
+    Storm version [VERSION].
 
-Apache Storm is a distributed, fault-tolerant, and high-performance
-realtime computation system that provides strong guarantees on the
-processing of data. You can read more about Apache Storm on the project
-website:
+    Apache Storm is a distributed, fault-tolerant, and high-performance
+    realtime computation system that provides strong guarantees on the
+    processing of data. You can read more about Apache Storm on the project
+    website:
 
-https://storm.apache.org/
+    https://storm.apache.org/
 
-Downloads of source and binary distributions are listed in our download
-section:
+    Downloads of source and binary distributions are listed in our download
+    section:
 
-https://storm.apache.org/downloads.html
+    https://storm.apache.org/downloads.html
 
-You can read more about this release in the following blog post:
+    You can read more about this release in the following blog post:
 
-https://storm.apache.org/[YEAR]/[MONTH]/[DAY]/storm[VERSION]-released.html
+    https://storm.apache.org/[YEAR]/[MONTH]/[DAY]/storm[VERSION]-released.html
 
-Distribution artifacts are available in Maven Central at the following
-coordinates:
+    Distribution artifacts are available in Maven Central at the following
+    coordinates:
 
-groupId: org.apache.storm
-artifactId: storm-{component}
-version: [VERSION]
+    groupId: org.apache.storm
+    artifactId: storm-{component}
+    version: [VERSION]
 
-The full list of changes is available here [1]. Please let us know [2] if
-you encounter any problems.
+    The full list of changes is available here [1]. Please let us know [2] if
+    you encounter any problems.
 
-Regards,
-The Apache Storm Team
+    Regards,
+    The Apache Storm Team
 
-[1] https://downloads.apache.org/storm/apache-storm-[VERSION]/RELEASE_NOTES.html
-[2] https://github.com/apache/storm/issues
-```
+    [1] https://downloads.apache.org/storm/apache-storm-[VERSION]/RELEASE_NOTES.html
+    [2] https://github.com/apache/storm/issues
+    ```
 
 ## Cleaning up if the vote fails
 
@@ -289,14 +301,14 @@ The Apache Storm Team
 
 4. Send a [VOTE][CANCELED] message to dev@storm.apache.org using the following format:
 
-```text
-Subject: [VOTE][CANCELED] Storm [VERSION] Release Candidate [N]
+   ```text
+   Subject: [VOTE][CANCELED] Storm [VERSION] Release Candidate [N]
 
-This release candidate Storm Release candidate [VERSION] rcN https://dist.apache.org/repos/dist/dev/storm/apache-storm-[VERSION]-rcN/ has been canceled.
-New vote request will be sent out on RC[N+1] with further updates.
+   This release candidate Storm Release candidate [VERSION] rcN https://dist.apache.org/repos/dist/dev/storm/apache-storm-[VERSION]-rcN/ has been canceled.
+   New vote request will be sent out on RC[N+1] with further updates.
 
-[RELEASE MANAGER NAME]
-```
+   [RELEASE MANAGER NAME]
+   ```
 
 # How to vote on a release candidate
 


### PR DESCRIPTION
## Summary

Several inaccuracies, missing steps, and minor errors have accumulated in `RELEASING.md`. This PR addresses all of them in one pass.

**P1 – Critical (process correctness)**
- Step 4: add `-P dist` flag to `mvn clean install` and explicit `mvn package` commands for `storm-dist/binary` and `storm-dist/source` submodules — without these the distribution artifacts are never built
- Step 3: add note to record the Nexus staging repository ID; it is required in the vote email template
- Step 2: add `mvn release:clean` recovery note for mid-build failures
- Step 9/10: split "move files" from "svn add + svn commit" into two numbered steps, filling the 9→11 gap and providing the actual SVN commands
- Step 1 of vote (`svn mv`): add `-m "..."` commit message flag (SVN requires it)
- Fix step reference "Step 1" → "Step 2" in step 4

**P2 – High (missing guidance)**
- Add GPG KEYS file maintenance instructions (svn checkout, `gpg --export --armor`, svn commit) — currently missing, leaving release managers without guidance on adding their key
- Add macOS `shasum -a 512` note for step 5
- Clarify Maven may already generate `.sha512` files so release managers don't overwrite them needlessly
- Fix truncated `GITHUB_TOKEN` placeholder (`MY_PERSONAL_ACCESS_TOKEN_FOR_GI` → `<your-github-pat>`)

**P3 – Medium (broken links / formatting)**
- Fix all `http://` links to `https://` (lines 18, 19, 194, 206, 257, 259)
- Fix KEYS URL: `www.apache.org/dist/storm/KEYS` → `downloads.apache.org/storm/KEYS`
- Fix `[VERSION]]` → `[VERSION]` in vote email subject
- Change ` ```agsl ` code fences → ` ```text ` for email templates (agsl is not a recognized language)
- Add missing "by" in "followed by `mvn release:perform`"
- Fix version example inconsistency (`2.6.x-branch` / `2.3.0-SNAPSHOT` → `2.7.x-branch` / `2.8.0-SNAPSHOT`)
- Fix "Releasing if vote succeeds" step numbering gap (8 → 10, skipping 9)

**P4 – Low (typos and step ordering)**
- Fix typos: `migh` → `might`, `Annoucement` → `Announcement`, `Sent email` → `Send a`, `deactivate, deactivate` → `deactivate, activate`, `funcionalities` → `functionalities`
- Reorder "Cleaning up if vote fails": artifact cleanup steps (drop staging repo, delete SVN files, delete tag) now come before the cancellation email

## Test plan

- [ ] Read through the full document to verify the flow makes sense end-to-end
- [ ] Verify all URLs are reachable
- [ ] Confirm step numbering is now contiguous in both "Setting up a vote" (1–11) and "Releasing if the vote succeeds" (0–11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)