### PR TITLE
ci: add ASF allowlist check for GitHub Actions (Dependabot guard)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -7,7 +7,12 @@ github:
   homepage: https://storm.apache.org/
   protected_branches:
     # Prevent force pushes to primary branches
-    master: {}
+    master:
+      # Block merges when the ASF allowlist check fails (e.g. a Dependabot
+      # PR that bumps a GitHub Action to a version not on the ASF allowlist).
+      required_status_checks:
+        contexts:
+          - asf-allowlist-check
   custom_subjects:
     new_pr: "[PR] {title} ({repository})"
     close_pr: "Re: [PR] {title} ({repository})"

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ASF Allowlist Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches: [ "master", "2.x" ]
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: apache/infrastructure-actions/allowlist-check@main
+        with:
+          # Storm uses both .yml and .yaml workflow files. The check uses
+          # Python's glob.glob(), which does not support brace expansion, so
+          # use *.y*ml to match both extensions in a single pattern.
+          scan-glob: ".github/**/*.y*ml"


### PR DESCRIPTION
## What

Adds a CI check that validates every referenced GitHub Action against the [ASF allowlist](https://github.com/apache/infrastructure-actions/tree/main/allowlist-check), and wires it in as a required status check on `master`.

## Why

Dependabot's `github-actions` ecosystem updater opens PRs that bump action versions. Without this guard, an update could point us at an action that is **not** on the ASF allowlist, which would only surface later (or get merged). This makes the violation fail fast on the PR.

## How

- **New workflow** `.github/workflows/asf-allowlist-check.yml`
  - Runs `apache/infrastructure-actions/allowlist-check@main`.
  - Triggers on `pull_request` (and `push` to `master`/`2.x`) limited to `paths: .github/**` — exactly the files Dependabot's github-actions updater touches.
  - `scan-glob: ".github/**/*.{yml,yaml}"` because Storm mixes both `.yml` and `.yaml` workflow files (the action's default only matches `.yml`).
  - `permissions: contents: read`, `persist-credentials: false` per ASF guidance.
- **`.asf.yaml`**: adds `asf-allowlist-check` to `required_status_checks.contexts` on `master` so failing PRs are blocked from merging (branch protection on ASF repos is managed via `.asf.yaml`, not the GitHub UI).