### PR TITLE
build: run ASF allowlist check on every PR so the required check reports

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -17,9 +17,10 @@ name: ASF Allowlist Check
 
 on:
   workflow_dispatch:
+  # No paths filter on purpose: as a required status check (see .asf.yaml) this
+  # job must report a status on every PR, otherwise PRs that don't touch
+  # .github/** would stay "Expected — waiting for status" and be blocked forever.
   pull_request:
-    paths:
-      - ".github/**"
   push:
     branches: [ "master", "2.x" ]
     paths:


### PR DESCRIPTION
The `asf-allowlist-check` workflow had a `paths: [".github/**"]` filter on its `pull_request` trigger, so it only ran when a PR touched `.github/**`.

Since `asf-allowlist-check` is configured as a **required** status check in `.asf.yaml`, every PR that does *not* touch `.github/**` stayed in the `Expected — waiting for status` state and could never be merged (`mergeStateStatus: BLOCKED`), even with all other builds green.

This drops the `paths` filter on the `pull_request` trigger (mirroring the working setup in [apache/opennlp](https://github.com/apache/opennlp/blob/main/.github/workflows/allowlist-check.yml)) so the check runs and reports a status on **every** PR. The `push` trigger keeps its `paths` filter since branch pushes only need re-validation when workflows change.

No functional change to what the check validates.