### PR TITLE
fix(webapp): guard Flux viewer against js-yaml 5.x empty-input throw (2.x)

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -17,11 +17,11 @@ name: Cypress E2E Tests
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "2.x" ]
     paths:
       - 'storm-webapp/**'
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "2.x" ]
     paths:
       - 'storm-webapp/**'
   workflow_dispatch:

--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/flux.html
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/WEB-INF/flux.html
@@ -70,7 +70,14 @@
 
       function parseAndRender() {
         var input = document.getElementById('taInput').value;
-        var doc = jsyaml.load(input);
+        var doc;
+        try {
+          doc = jsyaml.load(input);
+        } catch (e) {
+          // js-yaml >=5 throws on empty/comment-only input instead of
+          // returning undefined (see migrate_v4_to_v5); treat as no document.
+          return;
+        }
 	if(doc==null){
 	   return;
 	}


### PR DESCRIPTION
2.x companion to #8889.

2.x already merged js-yaml 5.2.0 (#8863), which carries a **latent runtime bug**: js-yaml 5.x changed `load('')` to throw `YAMLException: expected a document, but the input is empty` instead of returning `undefined` (see the [v4→v5 migration guide](https://github.com/nodeca/js-yaml/blob/master/docs/migrate_v4_to_v5.md)).

The Flux Topology Viewer (`flux.html`) calls `parseAndRender()` on page load while the textarea holds only `# YAML Definition`, so `jsyaml.load(input)` now throws before the `if (doc == null) return;` guard — the viewer fails to render.

This slipped through on 2.x because `cypress-tests.yml` only triggered on `master`, so 2.x PRs never ran the e2e suite that catches it (this is exactly what happened with #8863).

### Fix
- Wrap `jsyaml.load()` in `try/catch`, treating empty/comment-only/malformed input as "no document".
- Broaden `cypress-tests.yml` to also run on `2.x`.