### PR TITLE
Bump Java baseline to 25 on master

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -22,7 +22,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  # Compile once on the minimum supported JDK (21) and share artifacts with test jobs
+  # Compile once on JDK 25 and share artifacts with test jobs
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -38,11 +38,11 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.10'
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
       - name: Ensure a clean state without storm artifacts
         run: rm -rf ~/.m2/repository/org/apache/storm
       - name: Build project (compile + install, skip tests)
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        java: [ 21, 25 ]
+        java: [ 25 ]
         module: [ Client, Server, Core, External, Integration-Test ]
         experimental: [false]
       fail-fast: false

--- a/.github/workflows/nightlies.yaml
+++ b/.github/workflows/nightlies.yaml
@@ -40,11 +40,11 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.10'
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
       - name: Ensure a clean state without storm artifacts
         run: rm -rf ~/.m2/repository/org/apache/storm
       - name: Set up project dependencies

--- a/.github/workflows/snapshots.yaml
+++ b/.github/workflows/snapshots.yaml
@@ -40,11 +40,11 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.10'
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
       - id: extract_version
         name: Extract project version
         shell: bash

--- a/.github/workflows/update-license-files.yml
+++ b/.github/workflows/update-license-files.yml
@@ -42,11 +42,11 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Ensure clean state without storm artifacts
         run: rm -rf ~/.m2/repository/org/apache/storm

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     </issueManagement>
 
     <properties>
-        <javaVersion>21</javaVersion>
+        <javaVersion>25</javaVersion>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <maven.javadoc.failOnWarnings>false</maven.javadoc.failOnWarnings>
 


### PR DESCRIPTION
## Summary

- Bumps `javaVersion` in `pom.xml` from 21 to 25
- Updates the `maven.yaml` CI build job to use JDK 25 and drops Java 21 from the test matrix (now runs exclusively on 25)
- Updates `nightlies.yaml`, `snapshots.yaml`, and `update-license-files.yml` to use JDK 25

## Motivation

Java 25 is the next LTS after 21. The key driver is **JEP 491** ("Synchronize Virtual Threads without Pinning"), delivered in Java 24 and carried into the 25 LTS. Before this fix, virtual threads blocked inside `synchronized` blocks would pin their carrier thread — under load this could exhaust the carrier pool. On Java 25 the VT unmounts cleanly while waiting, which removes the main blocker for adopting virtual threads in Storm's I/O-bound paths (Netty transport, bolt external calls, ZK/Nimbus heartbeat paths) without first rewriting every `synchronized` block to `ReentrantLock`.

This was discussed on the dev@ list as part of the 3.0.0 planning thread.

## Test plan

- [ ] CI passes on JDK 25 (maven.yaml build + test matrix)
- [ ] Nightly and snapshot workflows resolve JDK 25 via Temurin without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)