### PR TITLE
Bump dev-tools/cluster Docker image to Java 25

### DIFF
--- a/dev-tools/cluster/Dockerfile
+++ b/dev-tools/cluster/Dockerfile
@@ -25,7 +25,7 @@
 #       storm-dist/binary/final-package/target
 #
 # or simply `docker compose up --build` from this directory.
-FROM eclipse-temurin:21-jre-jammy
+FROM eclipse-temurin:25-jre-jammy
 
 ARG STORM_VERSION=3.0.0-SNAPSHOT
 

--- a/dev-tools/cluster/README.md
+++ b/dev-tools/cluster/README.md
@@ -41,7 +41,7 @@ detailed under [Metrics & reports](#metrics--reports-prometheus--grafana).
 
 | File | Purpose |
 |------|---------|
-| `Dockerfile` | Runtime image `FROM eclipse-temurin:21-jre`, unpacks the built dist into `/opt/storm`. |
+| `Dockerfile` | Runtime image `FROM eclipse-temurin:25-jre`, unpacks the built dist into `/opt/storm`. |
 | `Dockerfile.dockerignore` | Keeps the build context to just the dist tarball. |
 | `storm.yaml` | Cluster config (ZK + Nimbus seeds + slots), bind-mounted into every daemon. |
 | `docker-compose.yml` | dev ZooKeeper, Nimbus, supervisor1, supervisor2, UI, Pushgateway, graphite-exporter, Prometheus, Grafana. |


### PR DESCRIPTION
Followup to #8893 on master the local dev cluster image in devtoolscluster was still running on a Java 21.
Since the distribution is now compiled with Java 25 the classes would no longer load on the old base image. This bumps the runtime base image from `eclipse-temurin-21-jre-jammy` to `eclipse-temurin-25-jre-jammy` and updates the corresponding line in the README file.

Tested on local running `build-image.sh` script.