### PR TITLE
verify-release-file.sh: check .sha512 files with sha512sum -c

### DIFF
--- a/dev-tools/rc/verify-release-file.sh
+++ b/dev-tools/rc/verify-release-file.sh
@@ -35,12 +35,10 @@ else
 fi
 
 # checking SHA
-GPG_SHA_FILE="/tmp/${TARGET_FILE}_GPG.sha512"
-gpg --print-md SHA512 ${TARGET_FILE} > ${GPG_SHA_FILE}
 SHA_TARGET_FILE="${TARGET_FILE}.sha512"
 
 echo ">> checking SHA file... (${SHA_TARGET_FILE})"
-diff /tmp/${TARGET_FILE}_GPG.sha512 ${SHA_TARGET_FILE}
+sha512sum -c ${SHA_TARGET_FILE}
 
 if [ $? -eq 0 ];
 then


### PR DESCRIPTION
## What is the purpose of the change

`dev-tools/rc/verify-release-file.sh` always reports `SHA file is not correct` for release candidates, even when the checksum is valid. The script compares the output of `gpg --print-md SHA512` (uppercase hash, split in 8-char blocks across multiple lines) textually with the published `.sha512` file, but release `.sha512` files are generated in `sha512sum` format (lowercase continuous hash followed by the file name), so the `diff` never matches.

This replaces the `gpg --print-md` + `diff` comparison with `sha512sum -c`, which verifies the checksum regardless of formatting.

## How was the change tested

Ran the script against the `apache-storm-2.8.9-rc1` artifacts from `dist.apache.org`:

- before: `Signature seems correct` / `SHA file is not correct` (false negative on every file)
- after: `Signature seems correct` / `apache-storm-2.8.9-src.tar.gz: OK — SHA file is correct`

🤖 Generated with [Claude Code](https://claude.com/claude-code)