### PR TITLE
Set the CORS filter credentials parameter explicitly instead of a header name the filter ignores

### DIFF
--- a/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
+++ b/storm-webapp/src/main/java/org/apache/storm/daemon/ui/UIHelpers.java
@@ -324,7 +324,7 @@ public class UIHelpers {
                 CrossOriginFilter.ALLOWED_HEADERS_PARAM,
                 "X-Requested-With, X-Requested-By, Access-Control-Allow-Origin,"
                         + " Content-Type, Content-Length, Accept, Origin");
-        filterHolder.setInitParameter(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "*");
+        filterHolder.setInitParameter(CrossOriginFilter.ALLOW_CREDENTIALS_PARAM, "false");
         return filterHolder;
     }
 

--- a/storm-webapp/src/test/java/org/apache/storm/daemon/ui/UIHelpersTest.java
+++ b/storm-webapp/src/test/java/org/apache/storm/daemon/ui/UIHelpersTest.java
@@ -30,6 +30,8 @@ import org.apache.storm.generated.TopologyPageInfo;
 import org.apache.storm.generated.TopologyStats;
 import org.apache.storm.utils.Time;
 import net.minidev.json.JSONValue;
+import org.eclipse.jetty.ee10.servlet.FilterHolder;
+import org.eclipse.jetty.ee10.servlets.CrossOriginFilter;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
@@ -723,5 +725,16 @@ class UIHelpersTest {
         SslContextFactory factory = connector.getConnectionFactory(SslConnectionFactory.class).getSslContextFactory();
         assertEquals(expectedProtocols, new LinkedHashSet<>(Arrays.asList(factory.getExcludeProtocols())));
         assertEquals(expectedCiphers, new LinkedHashSet<>(Arrays.asList(factory.getExcludeCipherSuites())));
+    }
+
+    @Test
+    public void testCorsFilterHandleSetsExplicitInitParameters() {
+        FilterHolder filterHolder = UIHelpers.corsFilterHandle();
+        assertEquals("*", filterHolder.getInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM));
+        assertEquals("GET, POST, PUT", filterHolder.getInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM));
+        assertEquals("X-Requested-With, X-Requested-By, Access-Control-Allow-Origin,"
+                + " Content-Type, Content-Length, Accept, Origin",
+                filterHolder.getInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM));
+        assertEquals("false", filterHolder.getInitParameter(CrossOriginFilter.ALLOW_CREDENTIALS_PARAM));
     }
 }


### PR DESCRIPTION
`corsFilterHandle` passed `CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER`, a response header name, where an init-param name was expected, so Jetty ignored the line and the filter ran on its own defaults.

Sets `ALLOW_CREDENTIALS_PARAM` explicitly and pins all four init-params in `UIHelpersTest`.