### PR TITLE
Evaluate nimbus.groups when nimbus.users is empty

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizer.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizer.java
@@ -157,7 +157,11 @@ public class SimpleACLAuthorizer implements IAuthorizer {
         }
 
         if (userCommands.contains(operation)) {
-            return nimbusUsers.size() == 0 || nimbusUsers.contains(user) || checkUserGroupAllowed(userGroups, nimbusGroups);
+            // Only an empty nimbus.users AND an empty nimbus.groups means no restriction is configured.
+            if (nimbusUsers.size() == 0 && nimbusGroups.size() == 0) {
+                return true;
+            }
+            return nimbusUsers.contains(user) || checkUserGroupAllowed(userGroups, nimbusGroups);
         }
 
         if (topoCommands.contains(operation)) {

--- a/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizerTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizerTest.java
@@ -227,6 +227,57 @@ public class SimpleACLAuthorizerTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
+    public void SimpleACLNimbusGroupAuthTest() {
+        Subject userA = createSubject("user-a");
+        Subject userInGroup = createSubject("user-in-readonly-group");
+        Subject userB = createSubject("user-b");
+
+        // neither nimbus.users nor nimbus.groups is set, so there is no restriction
+        IAuthorizer authorizer = prepareNimbusAuthorizer(null, null);
+        assertTrue(authorizer.permit(new ReqContext(userA), "submitTopology", new HashMap<>()));
+        assertTrue(authorizer.permit(new ReqContext(userInGroup), "submitTopology", new HashMap<>()));
+        assertTrue(authorizer.permit(new ReqContext(userB), "getClusterInfo", new HashMap<>()));
+
+        // only nimbus.users is set
+        authorizer = prepareNimbusAuthorizer(Collections.singletonList("user-a"), null);
+        assertTrue(authorizer.permit(new ReqContext(userA), "submitTopology", new HashMap<>()));
+        assertFalse(authorizer.permit(new ReqContext(userInGroup), "submitTopology", new HashMap<>()));
+        assertFalse(authorizer.permit(new ReqContext(userB), "getClusterInfo", new HashMap<>()));
+
+        // only nimbus.groups is set
+        authorizer = prepareNimbusAuthorizer(null, Collections.singletonList("group-readonly"));
+        assertTrue(authorizer.permit(new ReqContext(userInGroup), "submitTopology", new HashMap<>()));
+        assertFalse(authorizer.permit(new ReqContext(userA), "submitTopology", new HashMap<>()));
+        assertFalse(authorizer.permit(new ReqContext(userB), "fileUpload", new HashMap<>()));
+        assertFalse(authorizer.permit(new ReqContext(userB), "getClusterInfo", new HashMap<>()));
+
+        // both nimbus.users and nimbus.groups are set
+        authorizer = prepareNimbusAuthorizer(Collections.singletonList("user-a"), Collections.singletonList("group-readonly"));
+        assertTrue(authorizer.permit(new ReqContext(userA), "submitTopology", new HashMap<>()));
+        assertTrue(authorizer.permit(new ReqContext(userInGroup), "submitTopology", new HashMap<>()));
+        assertFalse(authorizer.permit(new ReqContext(userB), "submitTopology", new HashMap<>()));
+    }
+
+    private IAuthorizer prepareNimbusAuthorizer(Collection<String> nimbusUsers, Collection<String> nimbusGroups) {
+        Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
+        clusterConf.put(Config.STORM_GROUP_MAPPING_SERVICE_PROVIDER_PLUGIN,
+                        SimpleACLTopologyReadOnlyGroupAuthTestMock.class.getName());
+
+        if (nimbusUsers != null) {
+            clusterConf.put(Config.NIMBUS_USERS, new HashSet<>(nimbusUsers));
+        }
+
+        if (nimbusGroups != null) {
+            clusterConf.put(Config.NIMBUS_GROUPS, new HashSet<>(nimbusGroups));
+        }
+
+        IAuthorizer authorizer = new SimpleACLAuthorizer();
+        authorizer.prepare(clusterConf);
+        return authorizer;
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
     public void SimpleACLTopologyReadOnlyUserAuthTest() {
         Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
 


### PR DESCRIPTION
`SimpleACLAuthorizer.permit()` short-circuited on `nimbusUsers.size() == 0` and allowed the call, so `nimbus.groups` was never consulted when `nimbus.users` was left empty. An operator locking the cluster down by group alone therefore got no restriction at all.

All four combinations are now evaluated; both-empty still means no restriction, which is the shipped default. Extends `SimpleACLAuthorizerTest`.

Note: a cluster that set `nimbus.groups` without `nimbus.users` will now restrict user-level commands to members of those groups. That includes `NimbusClient.getConfiguredClientAs`, which calls `getLeader()` on every connection.