### PR TITLE
Check the calling principal against the topology owner in uploadNewCredentials

### DIFF
--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -3862,21 +3862,25 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
             checkAuthorization(topoName, topoConf, "uploadNewCredentials");
             String realPrincipal = (String) topoConf.get(Config.TOPOLOGY_SUBMITTER_PRINCIPAL);
             String realUser = (String) topoConf.get(Config.TOPOLOGY_SUBMITTER_USER);
-            String expectedOwner = null;
-            if (credentials.is_set_topoOwner()) {
-                expectedOwner = credentials.get_topoOwner();
-            } else {
-                Principal p = ReqContext.context().principal();
-                if (p != null) {
-                    expectedOwner = principalToLocal.toLocal(p);
-                }
+            String caller = null;
+            Principal p = ReqContext.context().principal();
+            if (p != null) {
+                caller = principalToLocal.toLocal(p);
             }
-            // expectedOwner being null means that security is disabled (which why are we uploading credentials with security disabled???
-            if (expectedOwner == null) {
+            // caller being null means that security is disabled (which why are we uploading credentials with security disabled???
+            if (caller == null) {
                 LOG.warn("Please check you settings. Credentials are being uploaded to {} with security disabled.", topoId);
-            } else if (!realPrincipal.equals(expectedOwner) && !realUser.equals(expectedOwner)) {
-                throw new AuthorizationException(topoId + " is expected to be owned by " + expectedOwner
+            } else if (!realPrincipal.equals(caller) && !realUser.equals(caller)) {
+                throw new AuthorizationException(topoId + " is expected to be owned by " + caller
                     + " but is actually owned by " + realPrincipal);
+            }
+            // topoOwner is just the owner the client expects, so it can only reject a mismatch, never stand in for the caller.
+            if (credentials.is_set_topoOwner()) {
+                String expectedOwner = credentials.get_topoOwner();
+                if (!expectedOwner.equals(realPrincipal) && !expectedOwner.equals(realUser)) {
+                    throw new AuthorizationException(topoId + " is expected to be owned by " + expectedOwner
+                        + " but is actually owned by " + realPrincipal);
+                }
             }
 
             synchronized (credUpdateLock) {

--- a/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
@@ -31,8 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import javax.security.auth.Subject;
 
-import javax.security.auth.Subject;
-
+import com.codahale.metrics.Meter;
 import net.minidev.json.JSONValue;
 import org.apache.commons.io.FileUtils;
 import org.apache.storm.Config;
@@ -42,6 +41,7 @@ import org.apache.storm.blobstore.KeySequenceNumber;
 import org.apache.storm.blobstore.LocalFsBlobStore;
 import org.apache.storm.cluster.IStormClusterState;
 import org.apache.storm.generated.AuthorizationException;
+import org.apache.storm.generated.Credentials;
 import org.apache.storm.generated.InvalidTopologyException;
 import org.apache.storm.generated.KeyNotFoundException;
 import org.apache.storm.generated.ListBlobsResult;
@@ -71,6 +71,7 @@ import org.apache.storm.utils.ServerUtils;
 import org.apache.storm.utils.Time;
 import org.apache.storm.utils.Utils;
 import org.apache.storm.utils.WrappedAuthorizationException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -85,6 +86,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -95,6 +97,7 @@ import static org.mockito.Mockito.when;
 
 class NimbusTest {
     private static final String BLOB_FILE_KEY = "file-key";
+    private static final String TOPO_NAME = "topo";
     private static final String TOPO_ID = "topology1-1-1";
 
     @Mock
@@ -111,6 +114,8 @@ class NimbusTest {
     private ILeaderElector leaderElector;
     @Mock
     private IGroupMappingServiceProvider groupMapper;
+    @Mock
+    private TopoCache topoCache;
 
     private Nimbus nimbus;
 
@@ -120,6 +125,11 @@ class NimbusTest {
 
         Map<String, Object> conf = Map.of(DaemonConfig.NIMBUS_MONITOR_FREQ_SECS, 10);
         nimbus = new Nimbus(conf, iNimbus, stormClusterState, nimbusInfo, localBlobStore, leaderElector, groupMapper, metricRegistry);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ReqContext.reset();
     }
 
     @Test
@@ -270,6 +280,58 @@ class NimbusTest {
 
         assertThrows(AuthorizationException.class, () -> nimbus.listBlobs(""));
         verify(localBlobStore, never()).listKeys();
+    }
+
+    @Test
+    void testUploadNewCredentialsRejectsACallerWhoIsNotTheOwner() throws Exception {
+        Nimbus nimbus = makeNimbusOwningTopology(TOPO_NAME, TOPO_ID, "alice");
+        setCaller("bob");
+
+        // bob claims the topology is owned by alice, which it is, but bob is not alice
+        Credentials creds = new Credentials(Map.of("key", "value"));
+        creds.set_topoOwner("alice");
+
+        assertThrows(AuthorizationException.class, () -> nimbus.uploadNewCredentials(TOPO_NAME, creds));
+        verify(stormClusterState, never()).setCredentials(eq(TOPO_ID), any(), any());
+    }
+
+    @Test
+    void testUploadNewCredentialsAcceptsTheOwner() throws Exception {
+        Nimbus nimbus = makeNimbusOwningTopology(TOPO_NAME, TOPO_ID, "alice");
+        setCaller("alice");
+
+        Credentials creds = new Credentials(Map.of("key", "value"));
+        creds.set_topoOwner("alice");
+        nimbus.uploadNewCredentials(TOPO_NAME, creds);
+
+        verify(stormClusterState).setCredentials(eq(TOPO_ID), eq(creds), any());
+    }
+
+    @Test
+    void testUploadNewCredentialsRejectsAnOwnerMismatchClaimedByTheOwner() throws Exception {
+        Nimbus nimbus = makeNimbusOwningTopology(TOPO_NAME, TOPO_ID, "alice");
+        setCaller("alice");
+
+        // alice expects the topology to be owned by bob, so the push must not happen
+        Credentials creds = new Credentials(Map.of("key", "value"));
+        creds.set_topoOwner("bob");
+
+        assertThrows(AuthorizationException.class, () -> nimbus.uploadNewCredentials(TOPO_NAME, creds));
+        verify(stormClusterState, never()).setCredentials(eq(TOPO_ID), any(), any());
+    }
+
+    private Nimbus makeNimbusOwningTopology(String topoName, String topoId, String owner) throws Exception {
+        Map<String, Object> topoConf = new HashMap<>();
+        topoConf.put(Config.TOPOLOGY_SUBMITTER_PRINCIPAL, owner);
+        topoConf.put(Config.TOPOLOGY_SUBMITTER_USER, owner);
+        when(stormClusterState.getTopoId(topoName)).thenReturn(Optional.of(topoId));
+        when(topoCache.readTopoConf(eq(topoId), any())).thenReturn(topoConf);
+        when(metricRegistry.registerMeter(anyString())).thenReturn(new Meter());
+
+        Map<String, Object> conf = Map.of(DaemonConfig.NIMBUS_MONITOR_FREQ_SECS, 10,
+            Config.STORM_PRINCIPAL_TO_LOCAL_PLUGIN, DefaultPrincipalToLocal.class.getName());
+        return new Nimbus(conf, iNimbus, stormClusterState, nimbusInfo, localBlobStore, topoCache, leaderElector, groupMapper,
+            metricRegistry);
     }
 
     @Test


### PR DESCRIPTION
The owner check read its expected value from `credentials.get_topoOwner()`, i.e. from data the caller supplied, and never compared it to the caller own principal. The exception text ("is expected to be owned by X but is actually owned by Y") shows a caller-equals-owner binding was intended.

The expected owner is now derived from the authenticated principal. Extends `NimbusTest`.

Behaviour change: `storm upload-credentials -u <owner> <topology>` run by anyone other than the owner now fails, including members of the topology `topology.users` / `topology.groups` and `nimbus.admins`. Please say if you would rather keep an admin exemption.