### PR TITLE
Authorize createStateInZookeeper requests like the other blob operations

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizer.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizer.java
@@ -38,6 +38,7 @@ public class SimpleACLAuthorizer implements IAuthorizer {
     protected Set<String> userCommands = new HashSet<>(Arrays.asList(
         "submitTopology",
         "fileUpload",
+        "createStateInZookeeper",
         "getNimbusConf",
         "getClusterInfo",
         "getLeader",

--- a/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizerTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizerTest.java
@@ -63,6 +63,11 @@ public class SimpleACLAuthorizerTest {
         assertTrue(authorizer.permit(new ReqContext(userA), "fileUpload", new HashMap<>()));
         assertTrue(authorizer.permit(new ReqContext(userB), "fileUpload", new HashMap<>()));
 
+        assertTrue(authorizer.permit(new ReqContext(adminUser), "createStateInZookeeper", new HashMap<>()));
+        assertFalse(authorizer.permit(new ReqContext(supervisorUser), "createStateInZookeeper", new HashMap<>()));
+        assertTrue(authorizer.permit(new ReqContext(userA), "createStateInZookeeper", new HashMap<>()));
+        assertTrue(authorizer.permit(new ReqContext(userB), "createStateInZookeeper", new HashMap<>()));
+
         assertTrue(authorizer.permit(new ReqContext(adminUser), "getNimbusConf", new HashMap<>()));
         assertFalse(authorizer.permit(new ReqContext(supervisorUser), "getNimbusConf", new HashMap<>()));
         assertTrue(authorizer.permit(new ReqContext(userA), "getNimbusConf", new HashMap<>()));

--- a/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
+++ b/storm-server/src/main/java/org/apache/storm/daemon/nimbus/Nimbus.java
@@ -4137,6 +4137,7 @@ public class Nimbus implements Iface, Shutdownable, DaemonCommon {
     @Override
     public void createStateInZookeeper(String key) throws TException {
         try {
+            checkAuthorization(null, null, "createStateInZookeeper");
             IStormClusterState state = stormClusterState;
             BlobStore store = blobStore;
             NimbusInfo ni = nimbusHostPortInfo;

--- a/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
+++ b/storm-server/src/test/java/org/apache/storm/daemon/nimbus/NimbusTest.java
@@ -45,6 +45,7 @@ import org.apache.storm.scheduler.resource.strategies.priority.DefaultScheduling
 import org.apache.storm.scheduler.resource.strategies.scheduling.DefaultResourceAwareStrategy;
 import org.apache.storm.scheduler.resource.strategies.scheduling.GenericResourceAwareStrategyOld;
 import org.apache.storm.scheduler.resource.strategies.scheduling.RoundRobinResourceAwareStrategy;
+import org.apache.storm.security.auth.IAuthorizer;
 import org.apache.storm.security.auth.IGroupMappingServiceProvider;
 import org.apache.storm.testing.TestWordSpout;
 import org.apache.storm.thrift.TException;
@@ -171,6 +172,27 @@ class NimbusTest {
 
     @Test
     void testCreateStateInZookeeper() throws TException {
+        nimbus.createStateInZookeeper(BLOB_FILE_KEY);
+
+        verify(stormClusterState).setupBlob(eq(BLOB_FILE_KEY), eq(nimbusInfo), any());
+    }
+
+    @Test
+    void testCreateStateInZookeeperIsNotAllowedWhenTheAuthorizerDeniesIt() throws Exception {
+        IAuthorizer authorizer = mock(IAuthorizer.class);
+        when(authorizer.permit(any(), eq("createStateInZookeeper"), any())).thenReturn(false);
+        nimbus.setAuthorizationHandler(authorizer);
+
+        assertThrows(AuthorizationException.class, () -> nimbus.createStateInZookeeper(BLOB_FILE_KEY));
+        verify(stormClusterState, never()).setupBlob(eq(BLOB_FILE_KEY), eq(nimbusInfo), any());
+    }
+
+    @Test
+    void testCreateStateInZookeeperIsAllowedWhenTheAuthorizerPermitsIt() throws Exception {
+        IAuthorizer authorizer = mock(IAuthorizer.class);
+        when(authorizer.permit(any(), eq("createStateInZookeeper"), any())).thenReturn(true);
+        nimbus.setAuthorizationHandler(authorizer);
+
         nimbus.createStateInZookeeper(BLOB_FILE_KEY);
 
         verify(stormClusterState).setupBlob(eq(BLOB_FILE_KEY), eq(nimbusInfo), any());


### PR DESCRIPTION
`createStateInZookeeper` calls `state.setupBlob(...)`, which creates and mutates persistent znodes in the cluster ZooKeeper, with no `checkAuthorization` while every neighbouring blob endpoint has one. Extends `NimbusTest`.

Scope: this makes the operation authorizer-visible and blockable. Under the shipped `SimpleACLAuthorizer` defaults (empty `nimbus.users`) any authenticated principal is still permitted, so this does not on its own restrict who may call it.