### PR TITLE
Evaluate authorization for requests that carry no principal

### DIFF
--- a/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizer.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizer.java
@@ -13,6 +13,7 @@
 package org.apache.storm.security.auth.authorizer;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -136,8 +137,9 @@ public class SimpleACLAuthorizer implements IAuthorizer {
      */
     @Override
     public boolean permit(ReqContext context, String operation, Map<String, Object> topoConf) {
-        String principal = context.principal().getName();
-        String user = ptol.toLocal(context.principal());
+        Principal requester = context.principal();
+        String principal = requester == null ? null : requester.getName();
+        String user = ptol.toLocal(requester);
         Set<String> userGroups = new HashSet<>();
 
         if (groupMappingServiceProvider != null) {

--- a/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/SupervisorSimpleACLAuthorizer.java
+++ b/storm-client/src/jvm/org/apache/storm/security/auth/authorizer/SupervisorSimpleACLAuthorizer.java
@@ -13,6 +13,7 @@
 package org.apache.storm.security.auth.authorizer;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -91,8 +92,9 @@ public class SupervisorSimpleACLAuthorizer implements IAuthorizer {
      */
     @Override
     public boolean permit(ReqContext context, String operation, Map<String, Object> topoConf) {
-        String principal = context.principal().getName();
-        String user = ptol.toLocal(context.principal());
+        Principal requester = context.principal();
+        String principal = requester == null ? null : requester.getName();
+        String user = ptol.toLocal(requester);
         Set<String> userGroups = new HashSet<>();
 
         if (groupMappingServiceProvider != null) {

--- a/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizerTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SimpleACLAuthorizerTest.java
@@ -356,6 +356,44 @@ public class SimpleACLAuthorizerTest {
         assertFalse(authorizer.permit(new ReqContext(userB), "getTopologyInfo", topoConf));
     }
 
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void requestWithoutPrincipalIsDeniedWhenNimbusUsersAreConfigured() {
+        Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
+        clusterConf.put(Config.NIMBUS_USERS, new HashSet<>(Collections.singletonList("user-a")));
+
+        IAuthorizer authorizer = new SimpleACLAuthorizer();
+        authorizer.prepare(clusterConf);
+
+        assertFalse(authorizer.permit(contextWithoutPrincipal(), "getNimbusConf", new HashMap<>()));
+        assertTrue(authorizer.permit(new ReqContext(createSubject("user-a")), "getNimbusConf", new HashMap<>()));
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void requestWithoutPrincipalKeepsTheAllowAllBehaviourOfEmptyLists() {
+        IAuthorizer authorizer = new SimpleACLAuthorizer();
+        authorizer.prepare(ConfigUtils.readStormConfig());
+
+        assertTrue(authorizer.permit(contextWithoutPrincipal(), "getNimbusConf", new HashMap<>()));
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void requestWithoutPrincipalIsDeniedForTopologyOperations() {
+        IAuthorizer authorizer = new SimpleACLAuthorizer();
+        authorizer.prepare(ConfigUtils.readStormConfig());
+
+        Map<String, Object> topoConf = new HashMap<>();
+        topoConf.put(Config.TOPOLOGY_USERS, new HashSet<>(Collections.singletonList("user-a")));
+
+        assertFalse(authorizer.permit(contextWithoutPrincipal(), "killTopology", topoConf));
+    }
+
+    private ReqContext contextWithoutPrincipal() {
+        return new ReqContext(new Subject());
+    }
+
     private Subject createSubject(String name) {
         Set<Principal> principalSet = new HashSet<>();
         principalSet.add(createPrincipal(name));

--- a/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SupervisorSimpleACLAuthorizerTest.java
+++ b/storm-client/test/jvm/org/apache/storm/security/auth/authorizer/SupervisorSimpleACLAuthorizerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.security.auth.authorizer;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.security.auth.Subject;
+import org.apache.storm.Config;
+import org.apache.storm.security.auth.IAuthorizer;
+import org.apache.storm.security.auth.ReqContext;
+import org.apache.storm.utils.ConfigUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SupervisorSimpleACLAuthorizerTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void requestWithoutPrincipalIsDenied() {
+        IAuthorizer authorizer = new SupervisorSimpleACLAuthorizer();
+        authorizer.prepare(ConfigUtils.readStormConfig());
+
+        Map<String, Object> topoConf = new HashMap<>();
+        topoConf.put(Config.TOPOLOGY_USERS, new HashSet<>(Collections.singletonList("user-a")));
+
+        assertFalse(authorizer.permit(new ReqContext(new Subject()), "getLocalAssignmentForStorm", topoConf));
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    public void nimbusUserIsStillAllowedItsCommands() {
+        Map<String, Object> clusterConf = ConfigUtils.readStormConfig();
+        clusterConf.put(Config.NIMBUS_DAEMON_USERS, new HashSet<>(Collections.singletonList("nimbus-daemon")));
+
+        IAuthorizer authorizer = new SupervisorSimpleACLAuthorizer();
+        authorizer.prepare(clusterConf);
+
+        assertTrue(authorizer.permit(new ReqContext(subjectOf("nimbus-daemon")),
+            "sendSupervisorAssignments", new HashMap<>()));
+    }
+
+    private Subject subjectOf(String name) {
+        Set<Principal> principals = new HashSet<>();
+        principals.add(() -> name);
+        return new Subject(true, principals, new HashSet<>(), new HashSet<>());
+    }
+}


### PR DESCRIPTION
## Summary

`SimpleACLAuthorizer.permit` and `SupervisorSimpleACLAuthorizer.permit` dereferenced `context.principal()` directly, so a request that carries no principal ended in a `NullPointerException` instead of an authorization decision. Over the UI this surfaced as HTTP 500 rather than 403.

Both now read the principal defensively, the way `SimpleWhitelistAuthorizer` and `DRPCSimpleACLAuthorizer` already do. `IPrincipalToLocal.toLocal(Principal)` is null-safe already.

## Behaviour

No decision logic changes. A request without a principal simply follows the rules that were already written: it matches no admin, supervisor or nimbus entry; it keeps the allow-all behaviour when `nimbus.users` and `nimbus.groups` are both empty; and it is denied as soon as a list is configured or a topology-level ACL applies.

## Testing

- `mvn -pl storm-client test -DskipITs` — 661 tests, 0 failures
- `mvn -pl storm-server test -DskipITs` — 490 tests, 0 failures
- New cases cover a principal-less request against configured lists, against empty lists, and against a topology operation, for both authorizers.
