### PR TITLE
Validate the worker id in profile-docker-container

### DIFF
--- a/storm-core/src/native/worker-launcher/impl/main.c
+++ b/storm-core/src/native/worker-launcher/impl/main.c
@@ -243,8 +243,16 @@ int main(int argc, char **argv) {
       exit_code = INVALID_ARGUMENT_NUMBER;
     } else {
       const char * worker_id = argv[optind++];
-      int pid = get_docker_container_pid(worker_id);
-      exit_code = profile_oci_container(pid, argv[optind]);
+      // Validate the worker id (a type 4 UUID, the same shape as a container
+      // id) before it is used to build the docker command line.
+      if (!validate_container_id(worker_id)) {
+        fprintf(ERRORFILE, "ERROR: Bad worker id in profile-docker-container: %s\n", worker_id);
+        fflush(ERRORFILE);
+        exit_code = INVALID_ARGUMENT_NUMBER;
+      } else {
+        int pid = get_docker_container_pid(worker_id);
+        exit_code = profile_oci_container(pid, argv[optind]);
+      }
     }
   } else if (strcasecmp("profiler", command) == 0) {
     if (argc != 5) {

--- a/storm-core/src/native/worker-launcher/impl/worker-launcher.c
+++ b/storm-core/src/native/worker-launcher/impl/worker-launcher.c
@@ -1249,6 +1249,12 @@ int get_docker_container_pid(const char *worker_id) {
   fflush(LOGFILE);
   FILE *inspect_docker = popen(docker_inspect_command, "r");
   int pid = -1;
+  if (inspect_docker == NULL) {
+    fprintf(ERRORFILE,
+            "ERROR: Could not run %s in get_docker_container_pid\n", docker_inspect_command);
+    fflush(ERRORFILE);
+    goto cleanup;
+  }
   int res = fscanf(inspect_docker, "%d", &pid);
   if (pclose(inspect_docker) != 0 || res <= 0) {
     fprintf(ERRORFILE,


### PR DESCRIPTION
profile-docker-container now checks the worker id with validate_container_id before get_docker_container_pid builds the docker command line, and get_docker_container_pid returns pid -1 instead of dereferencing a NULL stream when popen fails.

Stacked on #9008 (targets that branch); GitHub will retarget this to master once #9008 merges.

## How this was tested
Built the worker-launcher native tree with `autoreconf -i && ./configure && make check` (autotools, compiled with `-Werror`); the test suite passes.
