### PR TITLE
build(deps): batch open Dependabot version updates

### DIFF
--- a/examples/storm-jms-examples/pom.xml
+++ b/examples/storm-jms-examples/pom.xml
@@ -33,7 +33,7 @@
 
     <name>Storm JMS Examples</name>
     <properties>
-        <spring.version>7.0.8</spring.version>
+        <spring.version>7.0.9</spring.version>
     </properties>
     <dependencies>
         <dependency>

--- a/examples/storm-jms-examples/pom.xml
+++ b/examples/storm-jms-examples/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.xbean</groupId>
             <artifactId>xbean-spring</artifactId>
-            <version>4.31</version>
+            <version>5.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <hdrhistogram.version>2.2.2</hdrhistogram.version>
         <hamcrest.version>3.0</hamcrest.version>
         <jedis.version>7.5.3</jedis.version>
-        <activemq.version>6.3.0</activemq.version>
+        <activemq.version>6.3.1</activemq.version>
         <commons-logging.version>1.4.0</commons-logging.version>
 
         <jackson.version>2.22.1</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1110,7 +1110,7 @@
                             <artifactId>checkstyle</artifactId>
                             <!-- If you change this, you should also update the storm_checkstyle.xml file to be
                             based on the google_checks.xml from the version of checkstyle you are choosing. -->
-                            <version>13.9.0</version>
+                            <version>14.0.0</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <awaitility.version>4.3.0</awaitility.version>
         <hdrhistogram.version>2.2.2</hdrhistogram.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <jedis.version>7.5.3</jedis.version>
+        <jedis.version>8.0.1</jedis.version>
         <activemq.version>6.3.1</activemq.version>
         <commons-logging.version>1.4.0</commons-logging.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <activemq.version>6.3.1</activemq.version>
         <commons-logging.version>1.4.0</commons-logging.version>
 
-        <jackson.version>2.22.1</jackson.version>
+        <jackson.version>2.22.2</jackson.version>
         <jackson.databind.version>2.22.2</jackson.databind.version>
         <storm.kafka.client.version>4.3.1</storm.kafka.client.version>
         <testcontainers.version>1.21.4</testcontainers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <commons-io.version>2.22.0</commons-io.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-exec.version>1.6.0</commons-exec.version>
-        <commons-collections.version>4.5.0</commons-collections.version>
+        <commons-collections.version>4.6.0</commons-collections.version>
         <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <commons-codec.version>1.22.1</commons-codec.version>
         <commons-text.version>1.15.0</commons-text.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
         <log4j.version>2.26.1</log4j.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <metrics.version>4.2.39</metrics.version>
+        <metrics.version>4.2.40</metrics.version>
         <mockito.version>5.23.0</mockito.version>
         <zookeeper.version>3.9.5</zookeeper.version>
         <snappy.version>1.1.10.8</snappy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 
         <!-- dependency versions -->
         <commons-compress.version>1.28.0</commons-compress.version>
-        <zstd-jni.version>1.5.7-12</zstd-jni.version>
+        <zstd-jni.version>1.5.7-15</zstd-jni.version>
         <commons-io.version>2.22.0</commons-io.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-exec.version>1.6.0</commons-exec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <jaxb-version>2.3.1</jaxb-version>
         <rocksdb-jni-version>10.10.1.1</rocksdb-jni-version>
         <json-smart.version>2.6.0</json-smart.version>
-        <byte-buddy.version>1.18.11</byte-buddy.version>
+        <byte-buddy.version>1.18.12</byte-buddy.version>
         <gson.version>2.14.0</gson.version>
 
         <!-- see intellij profile below... This fixes an annoyance with intellij -->

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <commons-text.version>1.15.0</commons-text.version>
         <commons-cli.version>1.11.0</commons-cli.version>
         <curator.version>5.9.0</curator.version>
-        <jetty.version>12.1.11</jetty.version>
+        <jetty.version>12.1.12</jetty.version>
         <snakeyaml.version>2.6</snakeyaml.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpclient.core.version>4.4.16</httpclient.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <commons-logging.version>1.4.0</commons-logging.version>
 
         <jackson.version>2.22.1</jackson.version>
-        <jackson.databind.version>2.22.1</jackson.databind.version>
+        <jackson.databind.version>2.22.2</jackson.databind.version>
         <storm.kafka.client.version>4.3.1</storm.kafka.client.version>
         <testcontainers.version>1.21.4</testcontainers.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <objensis.version>3.6</objensis.version>
         <jakarta.servlet.version>6.1.0</jakarta.servlet.version>
         <thrift.version>0.24.0</thrift.version>
-        <junit.jupiter.version>6.1.2</junit.jupiter.version>
+        <junit.jupiter.version>6.1.3</junit.jupiter.version>
         <surefire.version>3.5.6</surefire.version>
         <awaitility.version>4.3.0</awaitility.version>
         <hdrhistogram.version>2.2.2</hdrhistogram.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <snakeyaml.version>2.6</snakeyaml.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpclient.core.version>4.4.16</httpclient.core.version>
-        <jctools.version>4.0.6</jctools.version>
+        <jctools.version>4.0.7</jctools.version>
         <jgrapht.version>1.5.3</jgrapht.version>
         <guava.version>33.6.0-jre</guava.version>
         <auto-service.version>1.1.1</auto-service.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1007,7 +1007,7 @@
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
-                <version>7.2.1</version>
+                <version>7.2.2</version>
             </dependency>
             <dependency>
                 <groupId>commons-collections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <jgrapht.version>1.5.3</jgrapht.version>
         <guava.version>33.6.0-jre</guava.version>
         <auto-service.version>1.1.1</auto-service.version>
-        <netty-tcnative.version>2.0.81.Final</netty-tcnative.version>
+        <netty-tcnative.version>2.0.82.Final</netty-tcnative.version>
         <netty.version>4.2.17.Final</netty.version>
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
         <log4j.version>2.26.1</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -977,7 +977,7 @@
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>
-                <version>1.12.1</version>
+                <version>1.12.2</version>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
              above, so this is bumped explicitly rather than tracking the newest release. -->
         <iceberg.version>1.11.0</iceberg.version>
         <kryo.version>5.6.2</kryo.version>
-        <objensis.version>3.5</objensis.version>
+        <objensis.version>3.6</objensis.version>
         <jakarta.servlet.version>6.1.0</jakarta.servlet.version>
         <thrift.version>0.24.0</thrift.version>
         <junit.jupiter.version>6.1.2</junit.jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <guava.version>33.6.0-jre</guava.version>
         <auto-service.version>1.1.1</auto-service.version>
         <netty-tcnative.version>2.0.81.Final</netty-tcnative.version>
-        <netty.version>4.2.16.Final</netty.version>
+        <netty.version>4.2.17.Final</netty.version>
         <sysout-over-slf4j.version>1.0.2</sysout-over-slf4j.version>
         <log4j.version>2.26.1</log4j.version>
         <slf4j.version>2.0.18</slf4j.version>

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "bootstrap": "5.3.8",
         "cytoscape": "3.34.0",
-        "cytoscape-dagre": "4.0.0",
+        "cytoscape-dagre": "4.0.1",
         "dagre": "0.8.5",
         "datatables.net": "3.0.0",
         "datatables.net-bs5": "3.0.0",
@@ -1795,9 +1795,9 @@
       }
     },
     "node_modules/cytoscape-dagre": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-4.0.0.tgz",
-      "integrity": "sha512-wsDgi1hHpWfslQxe/Gd/xCCeg2YUDrzwulhHOSI7fMfll92FFVY2AWhSRulLiOVcyDE4zz0rRd/+1TBTw+ew5Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-4.0.1.tgz",
+      "integrity": "sha512-hyNdh8Vp1nwzBcjHnM4c71G81bFhPmQYLXD2HM9AZIvl+8TrMzWEOPW45hF/XOBQiEguPcDQzi6VrXR1XBcXOA==",
       "license": "MIT",
       "peerDependencies": {
         "cytoscape": "^3.2.22"

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -14,7 +14,7 @@
         "dagre": "0.8.5",
         "datatables.net": "3.0.0",
         "datatables.net-bs5": "3.0.0",
-        "datatables.net-dt": "3.0.0",
+        "datatables.net-dt": "3.0.2",
         "domurl": "2.3.4",
         "esprima": "4.0.1",
         "jquery": "4.0.0",
@@ -1842,13 +1842,19 @@
       }
     },
     "node_modules/datatables.net-dt": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-3.0.0.tgz",
-      "integrity": "sha512-zWsEU7rSTnbKwTNH5W2OeVbDP9/HnwS6QyXePzoeZ0Dk9mzQUoAa2hGy35EVmLRwurD+Xqm2RoApOdeDDRnozQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-3.0.2.tgz",
+      "integrity": "sha512-qG0T4hCIfjo+VK6in/anSxwufRNGKiAEp53y+/gBsWp8R7Ik0ZB++J4pq8qAFEKmnSPFIcGSKk1sLLzpXbvcIw==",
       "license": "MIT",
       "dependencies": {
-        "datatables.net": "3.0.0"
+        "datatables.net": "3.0.2"
       }
+    },
+    "node_modules/datatables.net-dt/node_modules/datatables.net": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-3.0.2.tgz",
+      "integrity": "sha512-+fsSiPEtqfTGQuEla0hpURiYYrjSL5yLlEnUMGy6QFoVtic8vAvJ9Ibwb00772v/jTd8G1kOfJLq34233vhEqw==",
+      "license": "MIT"
     },
     "node_modules/dayjs": {
       "version": "1.11.20",

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -13,7 +13,7 @@
         "cytoscape-dagre": "4.0.1",
         "dagre": "0.8.5",
         "datatables.net": "3.0.0",
-        "datatables.net-bs5": "3.0.0",
+        "datatables.net-bs5": "3.0.2",
         "datatables.net-dt": "3.0.2",
         "domurl": "2.3.4",
         "esprima": "4.0.1",
@@ -1833,13 +1833,19 @@
       "license": "MIT"
     },
     "node_modules/datatables.net-bs5": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/datatables.net-bs5/-/datatables.net-bs5-3.0.0.tgz",
-      "integrity": "sha512-GkvSGsYfhO4lmaM1uyDOCNK5UY1VTr93km5Z6+t0iGM1l1PU4DGrjxFdFB+N5eTKRgGWvRsNng92sdIUfmkTsw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/datatables.net-bs5/-/datatables.net-bs5-3.0.2.tgz",
+      "integrity": "sha512-u4/h/G6UGg2IdOEznULU/tAwJ7ieAi3L4AHjNZdQPNuCJ+ErEycDeCK3Z++BlDm2absX8E9YRPyVH5jmJnzzow==",
       "license": "MIT",
       "dependencies": {
-        "datatables.net": "3.0.0"
+        "datatables.net": "3.0.2"
       }
+    },
+    "node_modules/datatables.net-bs5/node_modules/datatables.net": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-3.0.2.tgz",
+      "integrity": "sha512-+fsSiPEtqfTGQuEla0hpURiYYrjSL5yLlEnUMGy6QFoVtic8vAvJ9Ibwb00772v/jTd8G1kOfJLq34233vhEqw==",
+      "license": "MIT"
     },
     "node_modules/datatables.net-dt": {
       "version": "3.0.2",

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -12,7 +12,7 @@
         "cytoscape": "3.34.2",
         "cytoscape-dagre": "4.0.1",
         "dagre": "0.8.5",
-        "datatables.net": "3.0.0",
+        "datatables.net": "3.0.2",
         "datatables.net-bs5": "3.0.2",
         "datatables.net-dt": "3.0.2",
         "domurl": "2.3.4",
@@ -1827,9 +1827,9 @@
       }
     },
     "node_modules/datatables.net": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-3.0.0.tgz",
-      "integrity": "sha512-6p19AYaAZEghnlTI3fLNrGFrJ8aioC47E0BQmLT3YnNcL1cZHfIlc2EsN5OL0bljIZRDIXJYoaIr7nB2AZQy1Q==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-3.0.2.tgz",
+      "integrity": "sha512-+fsSiPEtqfTGQuEla0hpURiYYrjSL5yLlEnUMGy6QFoVtic8vAvJ9Ibwb00772v/jTd8G1kOfJLq34233vhEqw==",
       "license": "MIT"
     },
     "node_modules/datatables.net-bs5": {
@@ -1841,12 +1841,6 @@
         "datatables.net": "3.0.2"
       }
     },
-    "node_modules/datatables.net-bs5/node_modules/datatables.net": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-3.0.2.tgz",
-      "integrity": "sha512-+fsSiPEtqfTGQuEla0hpURiYYrjSL5yLlEnUMGy6QFoVtic8vAvJ9Ibwb00772v/jTd8G1kOfJLq34233vhEqw==",
-      "license": "MIT"
-    },
     "node_modules/datatables.net-dt": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/datatables.net-dt/-/datatables.net-dt-3.0.2.tgz",
@@ -1855,12 +1849,6 @@
       "dependencies": {
         "datatables.net": "3.0.2"
       }
-    },
-    "node_modules/datatables.net-dt/node_modules/datatables.net": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-3.0.2.tgz",
-      "integrity": "sha512-+fsSiPEtqfTGQuEla0hpURiYYrjSL5yLlEnUMGy6QFoVtic8vAvJ9Ibwb00772v/jTd8G1kOfJLq34233vhEqw==",
-      "license": "MIT"
     },
     "node_modules/dayjs": {
       "version": "1.11.20",

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -25,7 +25,7 @@
         "mustache": "4.2.0",
         "typeahead.js": "0.11.1",
         "vis-data": "8.0.4",
-        "vis-network": "10.1.0"
+        "vis-network": "10.1.2"
       },
       "devDependencies": {
         "css-loader": "^7.1.1",
@@ -5707,9 +5707,9 @@
       }
     },
     "node_modules/vis-network": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-10.1.0.tgz",
-      "integrity": "sha512-D7b5p/C6SwWv1BlH9EDdtP0Tje/PJzSBWKef9qy2DyTC14QB7KBcnAZxIyW2m7mFYyfoeR+k5GF747zDcIhaKA==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-10.1.2.tgz",
+      "integrity": "sha512-1Kj7GD7XNjygliqRWXv/VPT1X/2eKz2e09PvwDtETHwuvKJ0emid7/PmWoFqCMypun8rLbjgmalSfPkiVZ8ZMg==",
       "license": "(Apache-2.0 OR MIT)",
       "funding": {
         "type": "opencollective",

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -33,7 +33,7 @@
         "cypress": "^15.21.1",
         "express": "^5.2.1",
         "mini-css-extract-plugin": "^2.10.2",
-        "start-server-and-test": "^3.0.11",
+        "start-server-and-test": "^3.0.12",
         "terser-webpack-plugin": "^5.6.1",
         "webpack": "^5.110.1",
         "webpack-cli": "^7.2.2"
@@ -147,9 +147,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/tlds": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
-      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -811,14 +811,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -3041,9 +3041,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
-      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+      "version": "18.2.5",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.5.tgz",
+      "integrity": "sha512-+gEA7rLfaNWx9JzawWPrPetSZwT16NUqHtECDgjyAJreXcs4TM7tx2Pa+VVJJK0YHM83ybrVdaT6UekHH50FJQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5052,9 +5052,9 @@
       }
     },
     "node_modules/start-server-and-test": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-3.0.11.tgz",
-      "integrity": "sha512-NRapOwJl6jr1DNSaQ+SRukHI2OKcFZA2Iv2tfTW9fI/S+6YmJGiwacR+0MG3o5p39lY4xWUOE5JFkKJBZUjxuQ==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-3.0.12.tgz",
+      "integrity": "sha512-JhW9LiYXqJxyzmgMvBQ6JxVcz16wV+c5IE6rTHofqLBKjSE075Yr9e6sTr8QgrkHMHlHqkDegzKpQfVKxwauJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5064,7 +5064,7 @@
         "execa": "5.1.1",
         "lazy-ass": "2.0.3",
         "tree-kill": "1.2.2",
-        "wait-on": "9.0.10"
+        "wait-on": "9.1.0"
       },
       "bin": {
         "server-test": "src/bin/start.js",
@@ -5696,14 +5696,14 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.10.tgz",
-      "integrity": "sha512-rCoJEhvMr0X6alHmwc9abbrA5ZrLZFKpFQVKPNFwl2h7DapXOGdmimIHDtLOWhT4PjhZhxFEtZoQgEXbkDWdZw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.1.0.tgz",
+      "integrity": "sha512-PymrLXHLBM1Ju/Xspb2ADUhbPSMvbnuNvy/mN2hWtpbJ3da0h3Ky1LqwKPG5QSVR57liyO0iUpfipYl/s5qNvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.16.0",
-        "joi": "^18.2.1",
+        "axios": "^1.18.1",
+        "joi": "^18.2.3",
         "lodash": "^4.18.1",
         "minimist": "^1.2.8",
         "rxjs": "^7.8.2"

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -20,7 +20,7 @@
         "jquery": "4.0.0",
         "jquery-blockui": "2.7.0",
         "js-cookie": "3.0.8",
-        "js-yaml": "5.2.2",
+        "js-yaml": "5.4.1",
         "moment": "2.30.1",
         "mustache": "4.2.0",
         "typeahead.js": "0.11.1",
@@ -3125,9 +3125,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.5",
       "dependencies": {
         "bootstrap": "5.3.8",
-        "cytoscape": "3.34.0",
+        "cytoscape": "3.34.2",
         "cytoscape-dagre": "4.0.1",
         "dagre": "0.8.5",
         "datatables.net": "3.0.0",
@@ -1786,9 +1786,9 @@
       }
     },
     "node_modules/cytoscape": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
-      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "version": "3.34.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.2.tgz",
+      "integrity": "sha512-Cm2jaj1X/PBNlzV9yH8zcfGOxO7U+CJ/+mxSBVPSchLaugdp4jtlGx5qaHtPRZ6tgiZ5P+o1XoRfJA+ba6KM3g==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -30,7 +30,7 @@
       "devDependencies": {
         "css-loader": "^7.1.1",
         "css-minimizer-webpack-plugin": "^8.0.0",
-        "cypress": "^15.19.0",
+        "cypress": "^15.21.1",
         "express": "^5.2.1",
         "mini-css-extract-plugin": "^2.10.2",
         "start-server-and-test": "^3.0.11",
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+      "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
       "dev": true,
       "funding": [
         {
@@ -1139,6 +1139,27 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/chrome-remote-interface": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.33.3.tgz",
+      "integrity": "sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
+      },
+      "bin": {
+        "chrome-remote-interface": "bin/client.js"
+      }
+    },
+    "node_modules/chrome-remote-interface/node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
@@ -1700,9 +1721,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/cypress": {
-      "version": "15.19.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.19.0.tgz",
-      "integrity": "sha512-kjy1u3SWlMRWS5qffH3U+bXx1PqPP7qwhIzEY3UtERcW2r/8zy5uk6uSwa75pYXJyYFVP1SO8mAn/avZUvUbfg==",
+      "version": "15.21.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.21.1.tgz",
+      "integrity": "sha512-ogHpHMj0XNlZA5MGzjg8SWHf0eMw9lTwVQRKjpcT1GzNTxNUjwnHA8YCG6nOJ8ThU+XZaUxJgpMYZnJ//8aDaw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1712,12 +1733,13 @@
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "@types/tmp": "^0.2.3",
-        "arch": "^2.2.0",
+        "arch": "^3.0.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "buffer": "^5.7.1",
         "cachedir": "^2.4.0",
         "chalk": "^4.1.0",
+        "chrome-remote-interface": "0.33.3",
         "ci-info": "^4.1.0",
         "cli-table3": "0.6.1",
         "commander": "^6.2.1",
@@ -1743,7 +1765,6 @@
         "systeminformation": "^5.31.1",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
-        "tslib": "1.14.1",
         "untildify": "^4.0.0",
         "yauzl": "^3.3.1"
       },
@@ -1763,13 +1784,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/cypress/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/cytoscape": {
       "version": "3.34.0",
@@ -6010,6 +6024,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yauzl": {
       "version": "3.3.2",

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -28,7 +28,7 @@
         "vis-network": "10.1.2"
       },
       "devDependencies": {
-        "css-loader": "^7.1.1",
+        "css-loader": "^7.1.5",
         "css-minimizer-webpack-plugin": "^8.0.0",
         "cypress": "^15.21.1",
         "express": "^5.2.1",
@@ -1468,9 +1468,9 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
-      "integrity": "sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.5.tgz",
+      "integrity": "sha512-Q7iAfQkU2twNBryKX/vGAlE+GAmkF7quhSzAGNK8fBimxk3+tqg245rH52UPb9dioBolBc8rP0ihmHBaDTJQBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -36,7 +36,7 @@
         "start-server-and-test": "^3.0.12",
         "terser-webpack-plugin": "^5.6.1",
         "webpack": "^5.110.1",
-        "webpack-cli": "^7.2.2"
+        "webpack-cli": "^7.2.3"
       }
     },
     "node_modules/@cypress/request": {
@@ -5778,9 +5778,9 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.2.tgz",
-      "integrity": "sha512-lD0pALneslq8FfV+rwvm1BMW0AFAJrHHhNupAGN4asYjMvqrtRsenU4iKpiBo09gS4ntMxKGUxl9jhTEzVt0oA==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.3.tgz",
+      "integrity": "sha512-vDFU7jrfCctnN7jJQWPl+V26B51GLp11prVZXg50oeonsgeBzSTJEWmXkjHsOjTgMjlPOQM8GWLh33X9RN/0ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5806,7 +5806,7 @@
       "peerDependencies": {
         "js-yaml": "^4.0.0 || ^5.0.0",
         "json5": "^2.2.3",
-        "toml": "^3.0.0 || ^4.0.0",
+        "toml": "^3.0.0 || ^4.0.0 || ^5.0.0",
         "webpack": "^5.101.0",
         "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
         "webpack-dev-server": "^5.0.0 || ^6.0.0"

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -24,7 +24,7 @@
         "moment": "2.30.1",
         "mustache": "4.2.0",
         "typeahead.js": "0.11.1",
-        "vis-data": "8.0.4",
+        "vis-data": "8.0.5",
         "vis-network": "10.1.2"
       },
       "devDependencies": {
@@ -5652,9 +5652,9 @@
       }
     },
     "node_modules/vis-data": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.4.tgz",
-      "integrity": "sha512-TsN0sMHqIRpdfg6TNPtfdINpkgxtnQP6JNWCaiSwvou5seXqKiP5eERkaBg+Y56wyJ4FZTeOEs/dEmWEPrpltQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.5.tgz",
+      "integrity": "sha512-tRQKcTGaclo60rTY1j4v7BgD9v5jfD3wl+JgR1q6I4AI7go3QH5OjMCLIuZPpL2sf4IRMlwyPlRLnK4m+Phjsw==",
       "license": "(Apache-2.0 OR MIT)",
       "funding": {
         "type": "opencollective",

--- a/storm-webapp/package-lock.json
+++ b/storm-webapp/package-lock.json
@@ -35,7 +35,7 @@
         "mini-css-extract-plugin": "^2.10.2",
         "start-server-and-test": "^3.0.11",
         "terser-webpack-plugin": "^5.6.1",
-        "webpack": "^5.109.2",
+        "webpack": "^5.110.1",
         "webpack-cli": "^7.2.2"
       }
     },
@@ -2159,20 +2159,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2184,39 +2170,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esrecurse/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/etag": {
@@ -3537,16 +3490,16 @@
       }
     },
     "node_modules/minimizer-webpack-plugin": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
-      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.8.0.tgz",
+      "integrity": "sha512-2cT9+goJfBhtMz+gJqejSf09ClgmYhPhccRb/fb0ztVbixt0BkO8mRuI26FoPPuUNkRk6iEDryWAIouc5W8eJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@jridgewell/trace-mapping": "^0.3.31",
         "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
+        "schema-utils": "^4.3.3",
+        "terser": "^5.51.0"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -5331,9 +5284,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "version": "5.51.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.51.2.tgz",
+      "integrity": "sha512-bWnjSNscmuI+GJze6ZupnHP8G/cTcsJF+bXCeQknk2SHQsgbNJnLrqiH9jZ2W4STPVXH2mDKKRX3iwPhc9Cn/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5776,9 +5729,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.109.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
-      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
+      "version": "5.110.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.110.1.tgz",
+      "integrity": "sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5792,11 +5745,10 @@
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.24.4",
         "es-module-lexer": "^2.1.0",
-        "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "graceful-fs": "^4.2.11",
         "mime-db": "^1.54.0",
-        "minimizer-webpack-plugin": "^5.6.1",
+        "minimizer-webpack-plugin": "^5.7.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -28,7 +28,7 @@
     "moment": "2.30.1",
     "mustache": "4.2.0",
     "typeahead.js": "0.11.1",
-    "vis-data": "8.0.4",
+    "vis-data": "8.0.5",
     "vis-network": "10.1.2"
   },
   "devDependencies": {

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "bootstrap": "5.3.8",
-    "cytoscape": "3.34.0",
+    "cytoscape": "3.34.2",
     "cytoscape-dagre": "4.0.1",
     "dagre": "0.8.5",
     "datatables.net": "3.0.0",

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -16,7 +16,7 @@
     "cytoscape": "3.34.2",
     "cytoscape-dagre": "4.0.1",
     "dagre": "0.8.5",
-    "datatables.net": "3.0.0",
+    "datatables.net": "3.0.2",
     "datatables.net-dt": "3.0.2",
     "datatables.net-bs5": "3.0.2",
     "domurl": "2.3.4",

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -39,7 +39,7 @@
     "mini-css-extract-plugin": "^2.10.2",
     "start-server-and-test": "^3.0.11",
     "terser-webpack-plugin": "^5.6.1",
-    "webpack": "^5.109.2",
+    "webpack": "^5.110.1",
     "webpack-cli": "^7.2.2"
   }
 }

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -32,7 +32,7 @@
     "vis-network": "10.1.2"
   },
   "devDependencies": {
-    "css-loader": "^7.1.1",
+    "css-loader": "^7.1.5",
     "css-minimizer-webpack-plugin": "^8.0.0",
     "cypress": "^15.21.1",
     "express": "^5.2.1",

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -37,7 +37,7 @@
     "cypress": "^15.21.1",
     "express": "^5.2.1",
     "mini-css-extract-plugin": "^2.10.2",
-    "start-server-and-test": "^3.0.11",
+    "start-server-and-test": "^3.0.12",
     "terser-webpack-plugin": "^5.6.1",
     "webpack": "^5.110.1",
     "webpack-cli": "^7.2.2"

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -24,7 +24,7 @@
     "jquery": "4.0.0",
     "jquery-blockui": "2.7.0",
     "js-cookie": "3.0.8",
-    "js-yaml": "5.2.2",
+    "js-yaml": "5.4.1",
     "moment": "2.30.1",
     "mustache": "4.2.0",
     "typeahead.js": "0.11.1",

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bootstrap": "5.3.8",
     "cytoscape": "3.34.0",
-    "cytoscape-dagre": "4.0.0",
+    "cytoscape-dagre": "4.0.1",
     "dagre": "0.8.5",
     "datatables.net": "3.0.0",
     "datatables.net-dt": "3.0.2",

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "css-loader": "^7.1.1",
     "css-minimizer-webpack-plugin": "^8.0.0",
-    "cypress": "^15.19.0",
+    "cypress": "^15.21.1",
     "express": "^5.2.1",
     "mini-css-extract-plugin": "^2.10.2",
     "start-server-and-test": "^3.0.11",

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -18,7 +18,7 @@
     "dagre": "0.8.5",
     "datatables.net": "3.0.0",
     "datatables.net-dt": "3.0.2",
-    "datatables.net-bs5": "3.0.0",
+    "datatables.net-bs5": "3.0.2",
     "domurl": "2.3.4",
     "esprima": "4.0.1",
     "jquery": "4.0.0",

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -40,6 +40,6 @@
     "start-server-and-test": "^3.0.12",
     "terser-webpack-plugin": "^5.6.1",
     "webpack": "^5.110.1",
-    "webpack-cli": "^7.2.2"
+    "webpack-cli": "^7.2.3"
   }
 }

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -17,7 +17,7 @@
     "cytoscape-dagre": "4.0.0",
     "dagre": "0.8.5",
     "datatables.net": "3.0.0",
-    "datatables.net-dt": "3.0.0",
+    "datatables.net-dt": "3.0.2",
     "datatables.net-bs5": "3.0.0",
     "domurl": "2.3.4",
     "esprima": "4.0.1",

--- a/storm-webapp/package.json
+++ b/storm-webapp/package.json
@@ -29,7 +29,7 @@
     "mustache": "4.2.0",
     "typeahead.js": "0.11.1",
     "vis-data": "8.0.4",
-    "vis-network": "10.1.0"
+    "vis-network": "10.1.2"
   },
   "devDependencies": {
     "css-loader": "^7.1.1",


### PR DESCRIPTION
Collects the currently open, green Dependabot version updates into a single branch so the full suite runs once over the combined set instead of once per PR.

### Maven

| Dependency | From | To | PR |
| --- | --- | --- | --- |
| `activemq.version` | 6.3.0 | 6.3.1 | #9024 |
| `byte-buddy.version` | 1.18.11 | 1.18.12 | #9018 |
| `com.puppycrawl.tools:checkstyle` | 13.9.0 | 14.0.0 | #9039 |
| `com.fasterxml.jackson:jackson-bom` | 2.22.1 | 2.22.2 | #9032 |
| `com.fasterxml.jackson.core:jackson-databind` | 2.22.1 | 2.22.2 | #9026 |
| `com.fasterxml.woodstox:woodstox-core` | 7.2.1 | 7.2.2 | #9028 |
| `com.github.luben:zstd-jni` | 1.5.7-12 | 1.5.7-15 | #9034 |
| `io.netty:netty-bom` | 4.2.16.Final | 4.2.17.Final | #9022 |
| `jetty.version` | 12.1.11 | 12.1.12 | #9019 |
| `metrics.version` | 4.2.39 | 4.2.40 | #9021 |
| `netty-tcnative.version` | 2.0.81.Final | 2.0.82.Final | #9027 |
| `org.apache.avro:avro` | 1.12.1 | 1.12.2 | #9020 |
| `org.apache.commons:commons-collections4` | 4.5.0 | 4.6.0 | #9030 |
| `org.apache.xbean:xbean-spring` | 4.31 | 5.0.0 | #9038 |
| `org.jctools:jctools-core` | 4.0.6 | 4.0.7 | #9023 |
| `org.junit:junit-bom` | 6.1.2 | 6.1.3 | #9031 |
| `org.objenesis:objenesis` | 3.5 | 3.6 | #9025 |
| `redis.clients:jedis` | 7.5.3 | 8.0.1 | #9033 |
| `spring.version` | 7.0.8 | 7.0.9 | #9029 |

### npm (`storm-webapp`)

| Dependency | From | To | PR |
| --- | --- | --- | --- |
| `cytoscape` | 3.34.0 | 3.34.2 | #9063 |
| `cytoscape-dagre` | 4.0.0 | 4.0.1 | #9058 |
| `datatables.net` | 3.0.0 | 3.0.2 | #9060 |
| `datatables.net-bs5` | 3.0.0 | 3.0.2 | #9057 |
| `datatables.net-dt` | 3.0.0 | 3.0.2 | #9055 |
| `js-yaml` | 5.2.2 | 5.4.1 | #9059 |
| `vis-data` | 8.0.4 | 8.0.5 | #9061 |
| `vis-network` | 10.1.0 | 10.1.2 | #9056 |
| `css-loader` (dev) | 7.1.4 | 7.1.5 | #9065 |
| `cypress` (dev) | 15.19.0 | 15.21.1 | #9054 |
| `start-server-and-test` (dev) | 3.0.11 | 3.0.12 | #9066 |
| `webpack` (dev) | 5.109.2 | 5.110.1 | #9062 |
| `webpack-cli` (dev) | 7.2.2 | 7.2.3 | #9064 |

### Not included

- **Guava 33.6.0-jre → 33.7.1-jre** (#9036, #9052) — fails `dedup-libs` in the binary distribution: Guava 33.7.1 pulls in `jspecify` 1.0.1 while the daemon classpath still resolves `jspecify` 1.0.0, and the packaging step refuses to assemble shadowed jars. Needs `jspecify` aligned first, so it is kept out of this branch.

### Notes

- The `/examples` Dependabot PRs (#9035, #9037, #9040–#9051, #9053) target the same properties in the root `pom.xml` as their counterparts above, so they are already covered here and can be closed once this lands.
- The `datatables.net*` lockfile entries were merged by hand: with `datatables.net`, `-dt` and `-bs5` all at 3.0.2 the nested `node_modules/datatables.net*/node_modules/datatables.net` copies are redundant and were dropped, leaving a single hoisted 3.0.2 entry.
- The build failure originally reported on #9057 was a Maven Central 502 while resolving `junit-jupiter-engine`, not a real breakage.
