### PR TITLE
Drop malformed tuple payloads instead of killing the receiving worker

### DIFF
--- a/docs/Metrics.md
+++ b/docs/Metrics.md
@@ -295,12 +295,14 @@ Be aware that the `__system` bolt is an actual bolt so regular bolt metrics desc
     "dequeuedMessages": 0,
     "enqueued": {
       "/127.0.0.1:49952": 389951
-    }
+    },
+    "deserializationFailures": 0
 }
 ```
 
 `dequeuedMessages` is a throwback to older code where there was an internal queue between the server and the bolts/spouts.  That is no longer the case and the value can be ignored.
 `enqueued` is a map between the address of the remote worker and the number of tuples that were sent from it to this worker.
+`deserializationFailures` is the number of incoming messages that failed to deserialize and were dropped.
 
 ##### Send (Netty Client)
 

--- a/storm-client/src/jvm/org/apache/storm/messaging/DeserializingConnectionCallback.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/DeserializingConnectionCallback.java
@@ -12,12 +12,19 @@
 
 package org.apache.storm.messaging;
 
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import com.esotericsoftware.kryo.KryoException;
 import org.apache.storm.Config;
 import org.apache.storm.daemon.worker.WorkerState;
 import org.apache.storm.metric.api.IMetric;
@@ -26,12 +33,32 @@ import org.apache.storm.task.GeneralTopologyContext;
 import org.apache.storm.tuple.AddressedTuple;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.ObjectReader;
+import org.apache.storm.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * A class that is called when a TaskMessage arrives.
  */
 public class DeserializingConnectionCallback implements IConnectionCallback, IMetric {
+    private static final Logger LOG = LoggerFactory.getLogger(DeserializingConnectionCallback.class);
+
+    // A tuple that cannot be decoded is dropped instead of killing the worker; anything outside this set keeps
+    // the fatal handling in StormServerHandler.
+    private static final Set<Class<?>> TOLERATED_DESERIALIZATION_FAILURES = new HashSet<>(Arrays.asList(
+        IOException.class,
+        KryoException.class,
+        IllegalArgumentException.class,
+        NegativeArraySizeException.class,
+        ClassCastException.class,
+        ArrayIndexOutOfBoundsException.class,
+        BufferUnderflowException.class,
+        NullPointerException.class,
+        ClassNotFoundException.class));
+
+    static final String DESERIALIZATION_FAILURES_KEY = "deserializationFailures";
+
     private final WorkerState.ILocalTransferCallback cb;
     private final Map<String, Object> conf;
     private final GeneralTopologyContext context;
@@ -47,6 +74,7 @@ public class DeserializingConnectionCallback implements IConnectionCallback, IMe
     // Track serialized size of messages.
     private final boolean sizeMetricsEnabled;
     private final ConcurrentHashMap<String, AtomicLong> byteCounts = new ConcurrentHashMap<>();
+    private final AtomicLong deserializationFailures = new AtomicLong(0L);
 
 
     public DeserializingConnectionCallback(final Map<String, Object> conf, final GeneralTopologyContext context,
@@ -63,23 +91,42 @@ public class DeserializingConnectionCallback implements IConnectionCallback, IMe
         KryoTupleDeserializer des = this.des.get();
         ArrayList<AddressedTuple> ret = new ArrayList<>(batch.size());
         for (TaskMessage message : batch) {
-            Tuple tuple = des.deserialize(message.message());
-            AddressedTuple addrTuple = new AddressedTuple(message.task(), tuple);
-            updateMetrics(tuple.getSourceTask(), message);
-            ret.add(addrTuple);
+            try {
+                Tuple tuple = des.deserialize(message.message());
+                AddressedTuple addrTuple = new AddressedTuple(message.task(), tuple);
+                updateMetrics(tuple.getSourceTask(), message);
+                ret.add(addrTuple);
+            } catch (Exception e) {
+                if (!isToleratedDeserializationFailure(e)) {
+                    throw e;
+                }
+                deserializationFailures.incrementAndGet();
+                LOG.error("Failed to deserialize a message of {} bytes destined for task {}, dropping it",
+                          message.message().length, message.task(), e);
+            }
         }
         cb.transfer(ret);
     }
 
+    private static boolean isToleratedDeserializationFailure(Exception e) {
+        for (Class<?> klass : TOLERATED_DESERIALIZATION_FAILURES) {
+            if (Utils.exceptionCauseIsInstanceOf(klass, e)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
-     * Returns serialized byte count traffic metrics.
+     * Returns serialized byte count traffic metrics and the count of dropped deserialization failures.
      *
-     * @return Map of metric counts, or null if disabled
+     * @return Map of metric counts, or null when size metrics are disabled and no failures occurred
      */
     @Override
     public Object getValueAndReset() {
+        long failures = deserializationFailures.getAndSet(0L);
         if (!sizeMetricsEnabled) {
-            return null;
+            return failures > 0 ? Collections.singletonMap(DESERIALIZATION_FAILURES_KEY, failures) : null;
         }
         HashMap<String, Long> outMap = new HashMap<>();
         for (Map.Entry<String, AtomicLong> ent : byteCounts.entrySet()) {
@@ -87,6 +134,9 @@ public class DeserializingConnectionCallback implements IConnectionCallback, IMe
             if (count.get() > 0) {
                 outMap.put(ent.getKey(), count.getAndSet(0L));
             }
+        }
+        if (failures > 0) {
+            outMap.put(DESERIALIZATION_FAILURES_KEY, failures);
         }
         return outMap;
     }

--- a/storm-client/src/jvm/org/apache/storm/messaging/DeserializingConnectionCallback.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/DeserializingConnectionCallback.java
@@ -12,11 +12,11 @@
 
 package org.apache.storm.messaging;
 
+import com.esotericsoftware.kryo.KryoException;
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import com.esotericsoftware.kryo.KryoException;
 import org.apache.storm.Config;
 import org.apache.storm.daemon.worker.WorkerState;
 import org.apache.storm.metric.api.IMetric;
@@ -33,7 +32,6 @@ import org.apache.storm.task.GeneralTopologyContext;
 import org.apache.storm.tuple.AddressedTuple;
 import org.apache.storm.tuple.Tuple;
 import org.apache.storm.utils.ObjectReader;
-import org.apache.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,16 +52,21 @@ public class DeserializingConnectionCallback implements IConnectionCallback, IMe
         ClassCastException.class,
         ArrayIndexOutOfBoundsException.class,
         BufferUnderflowException.class,
-        NullPointerException.class,
         ClassNotFoundException.class));
 
-    static final String DESERIALIZATION_FAILURES_KEY = "deserializationFailures";
+    // Drop-log rate limits: the first INDIVIDUAL_DROP_LOG_LIMIT failures are logged in full,
+    // then one summary line per DROP_LOG_SUMMARY_INTERVAL further failures, and a run of
+    // CONSECUTIVE_DROP_WARN_THRESHOLD failures without a successful deserialization logs
+    // a single WARN.
+    private static final int INDIVIDUAL_DROP_LOG_LIMIT = 10;
+    private static final int DROP_LOG_SUMMARY_INTERVAL = 100;
+    private static final long CONSECUTIVE_DROP_WARN_THRESHOLD = 1000L;
 
     private final WorkerState.ILocalTransferCallback cb;
     private final Map<String, Object> conf;
     private final GeneralTopologyContext context;
 
-    private final ThreadLocal<KryoTupleDeserializer> des =
+    private ThreadLocal<KryoTupleDeserializer> des =
         new ThreadLocal<KryoTupleDeserializer>() {
             @Override
             protected KryoTupleDeserializer initialValue() {
@@ -76,6 +79,10 @@ public class DeserializingConnectionCallback implements IConnectionCallback, IMe
     private final ConcurrentHashMap<String, AtomicLong> byteCounts = new ConcurrentHashMap<>();
     private final AtomicLong deserializationFailures = new AtomicLong(0L);
 
+    // Log-limit counters are separate from the deserializationFailures metric: metric reads
+    // reset that counter, which would restart the limits.
+    private final AtomicLong totalDropCount = new AtomicLong(0L);
+    private final AtomicLong consecutiveDropCount = new AtomicLong(0L);
 
     public DeserializingConnectionCallback(final Map<String, Object> conf, final GeneralTopologyContext context,
                                            WorkerState.ILocalTransferCallback callback) {
@@ -84,6 +91,11 @@ public class DeserializingConnectionCallback implements IConnectionCallback, IMe
         cb = callback;
         sizeMetricsEnabled = ObjectReader.getBoolean(conf.get(Config.TOPOLOGY_SERIALIZED_MESSAGE_SIZE_METRICS), false);
 
+    }
+
+    // Package-private for testing.
+    void setDeserializer(KryoTupleDeserializer replacement) {
+        this.des = ThreadLocal.withInitial(() -> replacement);
     }
 
     @Override
@@ -96,37 +108,55 @@ public class DeserializingConnectionCallback implements IConnectionCallback, IMe
                 AddressedTuple addrTuple = new AddressedTuple(message.task(), tuple);
                 updateMetrics(tuple.getSourceTask(), message);
                 ret.add(addrTuple);
+                if (consecutiveDropCount.get() != 0L) {
+                    consecutiveDropCount.set(0L);
+                }
             } catch (Exception e) {
                 if (!isToleratedDeserializationFailure(e)) {
                     throw e;
                 }
                 deserializationFailures.incrementAndGet();
-                LOG.error("Failed to deserialize a message of {} bytes destined for task {}, dropping it",
-                          message.message().length, message.task(), e);
+                long totalDrops = totalDropCount.incrementAndGet();
+                if (totalDrops <= INDIVIDUAL_DROP_LOG_LIMIT) {
+                    LOG.error("Failed to deserialize a message of {} bytes destined for task {}, dropping it",
+                              message.message().length, message.task(), e);
+                } else if ((totalDrops - INDIVIDUAL_DROP_LOG_LIMIT)
+                           % DROP_LOG_SUMMARY_INTERVAL == 0) {
+                    LOG.error("Dropped {} further messages that failed to deserialize "
+                              + "since the last summary. Total Drop Count= {}",
+                              DROP_LOG_SUMMARY_INTERVAL, totalDrops, e);
+                }
+                long consecutiveDrops = consecutiveDropCount.incrementAndGet();
+                if (consecutiveDrops == CONSECUTIVE_DROP_WARN_THRESHOLD) {
+                    LOG.warn("{} consecutive messages have failed to deserialize, indicating "
+                             + "a persistent fault such as a class missing from the classpath",
+                             consecutiveDrops, e);
+                }
             }
         }
         cb.transfer(ret);
     }
 
     private static boolean isToleratedDeserializationFailure(Exception e) {
-        for (Class<?> klass : TOLERATED_DESERIALIZATION_FAILURES) {
-            if (Utils.exceptionCauseIsInstanceOf(klass, e)) {
-                return true;
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            for (Class<?> klass : TOLERATED_DESERIALIZATION_FAILURES) {
+                if (klass.isInstance(t)) {
+                    return true;
+                }
             }
         }
         return false;
     }
 
     /**
-     * Returns serialized byte count traffic metrics and the count of dropped deserialization failures.
+     * Returns serialized byte count traffic metrics.
      *
-     * @return Map of metric counts, or null when size metrics are disabled and no failures occurred
+     * @return Map of metric counts, or null when size metrics are disabled
      */
     @Override
     public Object getValueAndReset() {
-        long failures = deserializationFailures.getAndSet(0L);
         if (!sizeMetricsEnabled) {
-            return failures > 0 ? Collections.singletonMap(DESERIALIZATION_FAILURES_KEY, failures) : null;
+            return null;
         }
         HashMap<String, Long> outMap = new HashMap<>();
         for (Map.Entry<String, AtomicLong> ent : byteCounts.entrySet()) {
@@ -135,10 +165,15 @@ public class DeserializingConnectionCallback implements IConnectionCallback, IMe
                 outMap.put(ent.getKey(), count.getAndSet(0L));
             }
         }
-        if (failures > 0) {
-            outMap.put(DESERIALIZATION_FAILURES_KEY, failures);
-        }
         return outMap;
+    }
+
+    /**
+     * Returns the number of messages dropped because deserialization failed since the last call,
+     * and resets the count.
+     */
+    public long getAndResetDeserializationFailures() {
+        return deserializationFailures.getAndSet(0L);
     }
 
     /**

--- a/storm-client/src/jvm/org/apache/storm/messaging/netty/Server.java
+++ b/storm-client/src/jvm/org/apache/storm/messaging/netty/Server.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 import org.apache.storm.Config;
 import org.apache.storm.grouping.Load;
 import org.apache.storm.messaging.ConnectionWithStatus;
+import org.apache.storm.messaging.DeserializingConnectionCallback;
 import org.apache.storm.messaging.IConnectionCallback;
 import org.apache.storm.messaging.TaskMessage;
 import org.apache.storm.metric.api.IMetric;
@@ -240,6 +241,11 @@ class Server extends ConnectionWithStatus implements IStatefulObject, ISaslServe
             }
         }
         ret.put("enqueued", enqueued);
+
+        if (cb instanceof DeserializingConnectionCallback) {
+            DeserializingConnectionCallback callback = (DeserializingConnectionCallback) cb;
+            ret.put("deserializationFailures", callback.getAndResetDeserializationFailures());
+        }
 
         // Report messageSizes metric, if enabled (non-null).
         if (cb instanceof IMetric) {

--- a/storm-client/src/jvm/org/apache/storm/serialization/KryoTupleDeserializer.java
+++ b/storm-client/src/jvm/org/apache/storm/serialization/KryoTupleDeserializer.java
@@ -78,6 +78,9 @@ public class KryoTupleDeserializer implements ITupleDeserializer {
             int taskId = kryoInput.readInt(true);
             int streamId = kryoInput.readInt(true);
             String componentName = context.getComponentId(taskId);
+            if (componentName == null) {
+                throw new IllegalArgumentException("Received a tuple from unknown task " + taskId);
+            }
             String streamName = ids.getStreamName(componentName, streamId);
             MessageId id = MessageId.deserialize(kryoInput);
             List<Object> values = kryo.deserializeFrom(kryoInput);

--- a/storm-client/test/jvm/org/apache/storm/messaging/DeserializingConnectionCallbackTest.java
+++ b/storm-client/test/jvm/org/apache/storm/messaging/DeserializingConnectionCallbackTest.java
@@ -12,23 +12,57 @@
 
 package org.apache.storm.messaging;
 
+import com.esotericsoftware.kryo.KryoException;
+import com.esotericsoftware.kryo.io.Output;
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.storm.Config;
 import org.apache.storm.daemon.worker.WorkerState;
+import org.apache.storm.serialization.KryoTupleDeserializer;
+import org.apache.storm.serialization.KryoTupleSerializer;
 import org.apache.storm.task.GeneralTopologyContext;
+import org.apache.storm.testing.TestWordCounter;
+import org.apache.storm.testing.TestWordSpout;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.tuple.AddressedTuple;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.MessageId;
+import org.apache.storm.tuple.TupleImpl;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DeserializingConnectionCallbackTest {
     private static final byte[] messageBytes = new byte[3];
     private static TaskMessage message;
+
+    private static final String SOURCE_COMPONENT = "1";
+    private static final String DEST_COMPONENT = "2";
+    private static final int SOURCE_TASK_ID = 1;
+    private static final int DEST_TASK_ID = 2;
+    private static final byte[] JAVA_STREAM_HEADER = {(byte) 0xAC, (byte) 0xED, 0x00, 0x05};
+
+    private GeneralTopologyContext context;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -36,6 +70,13 @@ public class DeserializingConnectionCallbackTest {
         message = mock(TaskMessage.class);
         when(message.task()).thenReturn(456); // destination taskId
         when(message.message()).thenReturn(messageBytes);
+
+        TopologyBuilder builder = new TopologyBuilder();
+        builder.setSpout(SOURCE_COMPONENT, new TestWordSpout(true), 1);
+        builder.setBolt(DEST_COMPONENT, new TestWordCounter(), 1).fieldsGrouping(SOURCE_COMPONENT, new Fields("word"));
+        context = mock(GeneralTopologyContext.class);
+        when(context.getRawTopology()).thenReturn(builder.createTopology());
+        when(context.getComponentId(SOURCE_TASK_ID)).thenReturn(SOURCE_COMPONENT);
     }
 
 
@@ -76,5 +117,182 @@ public class DeserializingConnectionCallbackTest {
         metrics = withMetrics.getValueAndReset();
         assertTrue(metrics instanceof Map);
         assertEquals(6L, ((Map<?, ?>) metrics).get("123-456"));
+    }
+
+    @Test
+    public void testBatchWithCorruptMessageDropsOnlyCorruptMessage() {
+        Map<String, Object> conf = baseConf();
+        byte[] corrupt = new byte[]{1, 2, 3};
+        assertThrows(RuntimeException.class,
+                     () -> new KryoTupleDeserializer(conf, context).deserialize(corrupt));
+
+        assertBatchDeliversOnlyValidMessages(conf, corrupt);
+    }
+
+    @Test
+    public void testTruncatedKryoPayloadDroppedAndBatchContinues() {
+        Map<String, Object> conf = baseConf();
+        byte[] full = serializedTuple(conf, new Values("a-string-long-enough-to-survive-truncation", 7));
+        byte[] truncated = Arrays.copyOf(full, full.length - 10);
+
+        assertThrows(KryoException.class, () -> new KryoTupleDeserializer(conf, context).deserialize(truncated));
+
+        assertBatchDeliversOnlyValidMessages(conf, truncated);
+    }
+
+    @Test
+    public void testUnknownSourceTaskDroppedAndBatchContinues() {
+        Map<String, Object> conf = baseConf();
+        Output out = new Output(16, 32);
+        out.writeInt(9999, true); // source task that does not exist in the topology
+        out.writeInt(1, true);    // default stream id
+        byte[] unknownTask = out.toBytes();
+
+        assertThrows(NullPointerException.class, () -> new KryoTupleDeserializer(conf, context).deserialize(unknownTask));
+
+        assertBatchDeliversOnlyValidMessages(conf, unknownTask);
+    }
+
+    @Test
+    public void testJavaFallbackMissingClassDroppedAndBatchContinues() {
+        Map<String, Object> conf = baseConf();
+        conf.put(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION, true);
+        byte[] bytes = serializedTuple(conf, Collections.singletonList(new JavaSerializedValue()));
+        byte[] missingClass = replaceAll(bytes, "JavaSerializedValue", "JavaSerializedValuf");
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                               () -> new KryoTupleDeserializer(conf, context).deserialize(missingClass));
+        assertTrue(Utils.exceptionCauseIsInstanceOf(ClassNotFoundException.class, thrown),
+                   "expected a ClassNotFoundException in the cause chain but was: " + thrown);
+
+        assertBatchDeliversOnlyValidMessages(conf, missingClass);
+    }
+
+    @Test
+    public void testJavaFallbackNegativeLengthDroppedAndBatchContinues() {
+        Map<String, Object> conf = baseConf();
+        conf.put(Config.TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION, true);
+        byte[] bytes = serializedTuple(conf, Collections.singletonList(new JavaSerializedValue()));
+
+        // SerializableSerializer writes the java-serialization byte count right before the stream header;
+        // an all-bits-set count makes it allocate a negative-length array.
+        int headerIdx = indexOf(bytes, JAVA_STREAM_HEADER, 0);
+        assertTrue(headerIdx >= 4, "java serialization header not found in tuple payload");
+        for (int i = 1; i <= 4; i++) {
+            bytes[headerIdx - i] = (byte) 0xFF;
+        }
+
+        assertThrows(NegativeArraySizeException.class, () -> new KryoTupleDeserializer(conf, context).deserialize(bytes));
+
+        assertBatchDeliversOnlyValidMessages(conf, bytes);
+    }
+
+    @Test
+    public void testIoExceptionFailureDroppedAndBatchContinues() {
+        Map<String, Object> conf = baseConf();
+        conf.put(Config.TOPOLOGY_TUPLE_COMPRESSION_ENABLE, true);
+        byte[] fakeZstd = {(byte) 0x28, (byte) 0xB5, (byte) 0x2F, (byte) 0xFD, 0x00, 0x01, 0x02, 0x03};
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                                               () -> new KryoTupleDeserializer(conf, context).deserialize(fakeZstd.clone()));
+        assertTrue(Utils.exceptionCauseIsInstanceOf(IOException.class, thrown),
+                   "expected an IOException in the cause chain but was: " + thrown);
+
+        assertBatchDeliversOnlyValidMessages(conf, fakeZstd);
+    }
+
+    @Test
+    public void testNonToleratedExceptionPropagates() throws Exception {
+        WorkerState.ILocalTransferCallback transfer = mock(WorkerState.ILocalTransferCallback.class);
+        DeserializingConnectionCallback callback = new DeserializingConnectionCallback(baseConf(), context, transfer);
+        KryoTupleDeserializer failing = mock(KryoTupleDeserializer.class);
+        when(failing.deserialize(any(byte[].class))).thenThrow(new IllegalStateException("injected"));
+        replaceDeserializer(callback, failing);
+
+        assertThrows(IllegalStateException.class,
+                     () -> callback.recv(Collections.singletonList(taskMessage(new byte[]{1}))));
+
+        verify(transfer, never()).transfer(any());
+        assertNull(callback.getValueAndReset());
+    }
+
+    private static void replaceDeserializer(DeserializingConnectionCallback callback,
+                                            KryoTupleDeserializer replacement) throws Exception {
+        Field field = DeserializingConnectionCallback.class.getDeclaredField("des");
+        field.setAccessible(true);
+        field.set(callback, new ThreadLocal<KryoTupleDeserializer>() {
+            @Override
+            protected KryoTupleDeserializer initialValue() {
+                return replacement;
+            }
+        });
+    }
+
+    private void assertBatchDeliversOnlyValidMessages(Map<String, Object> conf, byte[] badPayload) {
+        WorkerState.ILocalTransferCallback transfer = mock(WorkerState.ILocalTransferCallback.class);
+        DeserializingConnectionCallback callback = new DeserializingConnectionCallback(conf, context, transfer);
+
+        callback.recv(Arrays.asList(
+            taskMessage(serializedTuple(conf, new Values("nathan", 1))),
+            taskMessage(badPayload),
+            taskMessage(serializedTuple(conf, new Values("golda", 2)))));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ArrayList<AddressedTuple>> captor = ArgumentCaptor.forClass(ArrayList.class);
+        verify(transfer).transfer(captor.capture());
+        List<AddressedTuple> delivered = captor.getValue();
+        assertEquals(2, delivered.size());
+        assertEquals(DEST_TASK_ID, delivered.get(0).getDest());
+        assertEquals(new Values("nathan", 1), delivered.get(0).getTuple().getValues());
+        assertEquals(DEST_TASK_ID, delivered.get(1).getDest());
+        assertEquals(new Values("golda", 2), delivered.get(1).getTuple().getValues());
+
+        Object metrics = callback.getValueAndReset();
+        assertTrue(metrics instanceof Map, "expected the deserialization failure to be counted");
+        assertEquals(1L, ((Map<?, ?>) metrics).get(DeserializingConnectionCallback.DESERIALIZATION_FAILURES_KEY));
+        assertNull(callback.getValueAndReset());
+    }
+
+    private Map<String, Object> baseConf() {
+        Map<String, Object> conf = new HashMap<>(Utils.readStormConfig());
+        return conf;
+    }
+
+    private byte[] serializedTuple(Map<String, Object> conf, List<Object> values) {
+        TupleImpl tuple = new TupleImpl(context, values, SOURCE_COMPONENT, SOURCE_TASK_ID,
+                                        Utils.DEFAULT_STREAM_ID, MessageId.makeUnanchored());
+        return new KryoTupleSerializer(conf, context).serialize(tuple);
+    }
+
+    private static TaskMessage taskMessage(byte[] payload) {
+        return new TaskMessage(DEST_TASK_ID, payload);
+    }
+
+    private static byte[] replaceAll(byte[] src, String from, String to) {
+        byte[] out = src.clone();
+        byte[] fromBytes = from.getBytes(StandardCharsets.US_ASCII);
+        byte[] toBytes = to.getBytes(StandardCharsets.US_ASCII);
+        int idx = indexOf(out, fromBytes, 0);
+        while (idx >= 0) {
+            System.arraycopy(toBytes, 0, out, idx, toBytes.length);
+            idx = indexOf(out, fromBytes, idx + toBytes.length);
+        }
+        return out;
+    }
+
+    private static int indexOf(byte[] src, byte[] pattern, int from) {
+        outer:
+        for (int i = from; i <= src.length - pattern.length; i++) {
+            for (int j = 0; j < pattern.length; j++) {
+                if (src[i + j] != pattern[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    private static class JavaSerializedValue implements Serializable {
     }
 }

--- a/storm-client/test/jvm/org/apache/storm/messaging/DeserializingConnectionCallbackTest.java
+++ b/storm-client/test/jvm/org/apache/storm/messaging/DeserializingConnectionCallbackTest.java
@@ -16,7 +16,6 @@ import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.io.Output;
 import java.io.IOException;
 import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -148,7 +147,7 @@ public class DeserializingConnectionCallbackTest {
         out.writeInt(1, true);    // default stream id
         byte[] unknownTask = out.toBytes();
 
-        assertThrows(NullPointerException.class, () -> new KryoTupleDeserializer(conf, context).deserialize(unknownTask));
+        assertThrows(IllegalArgumentException.class, () -> new KryoTupleDeserializer(conf, context).deserialize(unknownTask));
 
         assertBatchDeliversOnlyValidMessages(conf, unknownTask);
     }
@@ -202,30 +201,39 @@ public class DeserializingConnectionCallbackTest {
     }
 
     @Test
+    public void testFailuresCountedSeparatelyFromSizeMetrics() {
+        Map<String, Object> conf = baseConf();
+        conf.put(Config.TOPOLOGY_SERIALIZED_MESSAGE_SIZE_METRICS, Boolean.TRUE);
+        WorkerState.ILocalTransferCallback transfer = mock(WorkerState.ILocalTransferCallback.class);
+        DeserializingConnectionCallback callback = new DeserializingConnectionCallback(conf, context, transfer);
+
+        callback.recv(Arrays.asList(
+            taskMessage(serializedTuple(conf, new Values("nathan", 1))),
+            taskMessage(new byte[]{1, 2, 3})));
+
+        Object metrics = callback.getValueAndReset();
+        assertTrue(metrics instanceof Map);
+        assertEquals(1, ((Map<?, ?>) metrics).size());
+        assertTrue(((Map<?, ?>) metrics).containsKey("1-2"));
+
+        assertEquals(1L, callback.getAndResetDeserializationFailures());
+        assertEquals(0L, callback.getAndResetDeserializationFailures());
+    }
+
+    @Test
     public void testNonToleratedExceptionPropagates() throws Exception {
         WorkerState.ILocalTransferCallback transfer = mock(WorkerState.ILocalTransferCallback.class);
         DeserializingConnectionCallback callback = new DeserializingConnectionCallback(baseConf(), context, transfer);
         KryoTupleDeserializer failing = mock(KryoTupleDeserializer.class);
         when(failing.deserialize(any(byte[].class))).thenThrow(new IllegalStateException("injected"));
-        replaceDeserializer(callback, failing);
+        callback.setDeserializer(failing);
 
         assertThrows(IllegalStateException.class,
                      () -> callback.recv(Collections.singletonList(taskMessage(new byte[]{1}))));
 
         verify(transfer, never()).transfer(any());
+        assertEquals(0L, callback.getAndResetDeserializationFailures());
         assertNull(callback.getValueAndReset());
-    }
-
-    private static void replaceDeserializer(DeserializingConnectionCallback callback,
-                                            KryoTupleDeserializer replacement) throws Exception {
-        Field field = DeserializingConnectionCallback.class.getDeclaredField("des");
-        field.setAccessible(true);
-        field.set(callback, new ThreadLocal<KryoTupleDeserializer>() {
-            @Override
-            protected KryoTupleDeserializer initialValue() {
-                return replacement;
-            }
-        });
     }
 
     private void assertBatchDeliversOnlyValidMessages(Map<String, Object> conf, byte[] badPayload) {
@@ -247,9 +255,7 @@ public class DeserializingConnectionCallbackTest {
         assertEquals(DEST_TASK_ID, delivered.get(1).getDest());
         assertEquals(new Values("golda", 2), delivered.get(1).getTuple().getValues());
 
-        Object metrics = callback.getValueAndReset();
-        assertTrue(metrics instanceof Map, "expected the deserialization failure to be counted");
-        assertEquals(1L, ((Map<?, ?>) metrics).get(DeserializingConnectionCallback.DESERIALIZATION_FAILURES_KEY));
+        assertEquals(1L, callback.getAndResetDeserializationFailures());
         assertNull(callback.getValueAndReset());
     }
 

--- a/storm-client/test/jvm/org/apache/storm/messaging/netty/ServerTest.java
+++ b/storm-client/test/jvm/org/apache/storm/messaging/netty/ServerTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package org.apache.storm.messaging.netty;
+
+import java.util.Map;
+import org.apache.storm.messaging.DeserializingConnectionCallback;
+import org.apache.storm.utils.Utils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ServerTest {
+
+    @Test
+    public void testGetStateReportsDeserializationFailures() {
+        DeserializingConnectionCallback cb = mock(DeserializingConnectionCallback.class);
+        when(cb.getAndResetDeserializationFailures()).thenReturn(7L, 0L);
+        Server server = new Server(Utils.readStormConfig(), 0, cb, null);
+        try {
+            Object state = server.getState();
+            assertTrue(state instanceof Map);
+            assertEquals(7L, ((Map<?, ?>) state).get("deserializationFailures"));
+
+            // the key stays present once the count has been read
+            assertEquals(0L, ((Map<?, ?>) server.getState()).get("deserializationFailures"));
+        } finally {
+            server.close();
+        }
+    }
+}


### PR DESCRIPTION
Closes #9074

Upgrade note: a malformed message body no longer kills the receiving worker, including the IOException case. Previously a channel-level IOException closed the connection and lost every message still queued on it; now the one undecodable message is dropped and the connection, along with the rest of the batch, keeps going. Payloads that used to tear down a connection mid-stream will instead show up as deserializationFailures counts, rate-limited ERROR logs, and a WARN when failures persist.

What this changes

DeserializingConnectionCallback.recv() wraps only the deserialization of each message in a try/catch. When the failure matches a known decode-time exception type, the message is dropped and the loop continues with the next message in the batch. Tuple addressing and metrics updates run after the try, so a failure there propagates rather than dropping a validly decoded tuple or inflating the count. Anything outside the tolerated set is rethrown and keeps today's behavior: StormServerHandler.exceptionCaught, then Utils.handleUncaughtException, then worker exit. Errors are never caught.

The tolerated set is the set of exception types a garbage or hostile byte stream can already produce during tuple decode, matched by walking each failure's cause chain:

IOException, KryoException, IllegalArgumentException, NegativeArraySizeException, ClassCastException, ArrayIndexOutOfBoundsException, BufferUnderflowException, ClassNotFoundException

Mapping to wire-level failure modes: truncated or negative length fields (ArrayIndexOutOfBoundsException, NegativeArraySizeException, BufferUnderflowException), unregistered classes under topology.kryo.register with registration required (IllegalArgumentException, thrown directly by Kryo.getRegistration when a name reference resolves to a class with no registration), classes present only on the sending side (ClassNotFoundException), wrong runtime types (ClassCastException), and kryo's own decode failures (KryoException) plus underlying stream problems (IOException). A tuple whose source task id does not exist in the topology is rejected up front by KryoTupleDeserializer with an IllegalArgumentException naming the task, instead of coming out of the stream lookup as a NullPointerException.

I did not broaden StormServerHandler.ALLOWED_EXCEPTIONS. That whitelist is about transport-level channel errors and closing the connection; a payload that fails to decode is an application-level event, and handling it where the decode happens is what keeps the rest of the batch alive. The whitelist stays as the backstop for anything that still escapes.

Observability

Drop logging is rate-limited. The first 10 failures are logged in full; after that, one summary line per 100 further failures carries the running total. A run of 1000 consecutive failures without a successful deserialization additionally logs a WARN, and the consecutive count resets on the next success. This keeps a hostile peer from filling the log volume, and keeps a real problem such as a class missing from the worker classpath visible as a WARN rather than silent no-progress with a stack trace per tuple. Failures are also counted in a deserializationFailures counter published as a top-level key of __recv-iconnection through Server.getState(), always present including 0, and documented in docs/Metrics.md.

What this does not fix

A frame declaring a huge positive array or collection length can still kill the worker: kryo pre-allocates from the length field, the allocation fails with an OutOfMemoryError, and recv() catches Exception, not Error. Catching Error would be wrong. NegativeArraySizeException, the wrap-around case, is tolerated; the large-positive case is not, and this is unchanged from master. Bounding allocations on the kryo path, along the lines of the maxarray and maxbytes limits the java-serialization fallback bridge gets in #9075, is follow-up work.

Interaction with at-least-once spouts

A message that deterministically fails to decode is dropped but never acked. With the kafka spout in at-least-once mode the offset never commits, uncommitted offsets on that partition climb to maxUncommittedOffsets (default 10,000,000), and the spout stops polling the partition, so the topology makes no progress on it and the symptom is climbing lag. On master the same input produces a worker crash loop that also never commits the offset. The real fix is an eventual permanent drop or dead-letter so the offset can advance; that is follow-up work as well.

Tests

8 cases in DeserializingConnectionCallbackTest, driving recv() through the real deserializer where possible: one tolerant drop per interesting exception type (verify log, counter, and batch continuation), an IOException mid-batch that skips exactly the bad message while a good message later in the same batch still lands, rethrow of a non-tolerated exception, a failure thrown after a successful decode propagating without being dropped or counted as a deserialization failure, and the failure counter staying separate from the size metrics and resetting after a read.

Also verified on a live 3.0.1-SNAPSHOT cluster: replaying a 27-byte frame carrying an unregistered class against a worker port kills the worker on master (terminating server, then process exit and supervisor restart) and on this branch produces the log line "Failed to deserialize a message of 27 bytes destined for task 2, dropping it" with the worker surviving and the topology staying active.
